### PR TITLE
[core] pDIF + Bernoulli Distribution Implementation/Conversion

### DIFF
--- a/modules/init.txt
+++ b/modules/init.txt
@@ -20,7 +20,7 @@
 # | 
 # | renamer
 # | 
-# ---------------------
+# ----------------------
 #
 # Will load everything under the renamer folder.
 #

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -221,19 +221,16 @@ local function cRangedRatio(attacker, defender, params, ignoredDef, tp)
 
     local levelCorrection = 0
     if attacker:getMainLvl() < defender:getMainLvl() then
-        levelCorrection = 0.025 * (defender:getMainLvl() - attacker:getMainLvl())
+        if attacker:hasStatusEffect(xi.effect.FLASHY_SHOT) then
+            levelCorrection = 0
+        else
+            levelCorrection = (defender:getMainLvl() - attacker:getMainLvl()) * 0.025
+        end
     end
 
     cratio = cratio - levelCorrection
     cratio = cratio * atkmulti
-
-    if cratio > 3 - levelCorrection then
-        cratio = 3 - levelCorrection
-    end
-
-    if cratio < 0 then
-        cratio = 0
-    end
+    cratio = utils.clamp(cratio, 0, 3)
 
     -- max
     local pdifmax = 0
@@ -1099,6 +1096,23 @@ function cMeleeRatio(attacker, defender, params, ignoredDef, tp)
         pdifmin = cratio * 1176 / 1024 - 775 / 1024
     else
         pdifmin = cratio - 0.375
+    end
+
+    -- Bernoulli distribution, applied for cRatio < 0.5 and 0.75 < cRatio < 1.25
+    -- Other cRatio values are uniformly distributed
+    -- https://www.bluegartr.com/threads/108161-pDif-and-damage?p=5308205&viewfull=1#post5308205
+    local U = math.max(0.0, math.min(0.333, 1.3 * (2.0 - math.abs(cratio - 1)) - 1.96))
+
+    local bernoulli = false
+
+    if (math.random() < U) then
+        bernoulli = true
+    end
+
+    if (bernoulli) then
+        local roundedRatio = math.floor(cratio + 0.5) -- equivalent to rounding
+        pdifmin = roundedRatio
+        pdifmax = roundedRatio
     end
 
     local critbonus = attacker:getMod(xi.mod.CRIT_DMG_INCREASE) - defender:getMod(xi.mod.CRIT_DEF_BONUS)

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -1101,11 +1101,11 @@ function cMeleeRatio(attacker, defender, params, ignoredDef, tp)
     -- Bernoulli distribution, applied for cRatio < 0.5 and 0.75 < cRatio < 1.25
     -- Other cRatio values are uniformly distributed
     -- https://www.bluegartr.com/threads/108161-pDif-and-damage?p=5308205&viewfull=1#post5308205
-    local U = math.max(0.0, math.min(0.333, 1.3 * (2.0 - math.abs(cratio - 1)) - 1.96))
+    local u = math.max(0.0, math.min(0.333, 1.3 * (2.0 - math.abs(cratio - 1)) - 1.96))
 
     local bernoulli = false
 
-    if (math.random() < U) then
+    if (math.random() < u) then
         bernoulli = true
     end
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1709,8 +1709,8 @@ namespace battleutils
         }
 
         // calculate min/max PDIF
-        float upperLimit = 3.0f;
-        float lowerLimit = 0.0f;
+        float maxPdif = 3.0f;
+        float minPdif = 0.0f;
 
         if (cRatio < 0.9f)
         {
@@ -1731,7 +1731,7 @@ namespace battleutils
         // return random number between the two
         float pdif = xirand::GetRandomNumber(minPdif, maxPdif);
 
-        pdif = std::clamp<float>(pdif, 0, 3)
+        pdif = std::clamp<float>(pdif, 0, 3);
 
         if (isCritical)
         {
@@ -2975,7 +2975,6 @@ namespace battleutils
             wRatio += 1;
         }
 
-        float qRatio     = wRatio;
         float upperLimit = 3.25f;
         float lowerLimit = 0.0f;
 
@@ -2983,12 +2982,12 @@ namespace battleutils
         // Pre-Randomized values excluding Damage Limit+ trait
         // Damage Limit+ trait adds 0.1/rank to these values
         // type : non-crit : crit
-        // 1H : 1.0 : 2.0
-        // H2H & GK : 1.25 : 2.25
-        // 2H : 1.25 : 2.25
-        // Scythe : 1.25 : 2.25
-        // Archery & Throwing : 2.0 : 3.0
-        // Marksmanship : 2.0 : 3.0
+        // 1H : 0 : 2
+        // H2H & GK : 0 : 2.25
+        // 2H : 0 : 2.25
+        // Scythe : 0 : 2.25
+        // Archery & Throwing : 0 : 3
+        // Marksmanship : 0 : 3
 
         // https://www.bluegartr.com/threads/114636-Monster-Avatar-Pet-damage
         // Monster pDIF = Avatar pDIF = Pet pDIF
@@ -3048,7 +3047,7 @@ namespace battleutils
         }
         else if (wRatio < 1.5f)
         {
-            upperLimit = wRatio * 1.25f + writeDeclaration;
+            upperLimit = wRatio * 1.25f;
         }
         else if (wRatio < 2.625f)
         {
@@ -3080,7 +3079,7 @@ namespace battleutils
             lowerLimit = wRatio - 0.375f;
         }
 
-        float pDIF = 0.0f
+        float pDIF = 0.0f;
 
         // Bernoulli distribution, applied for cRatio < 0.5 and 0.75 < cRatio < 1.25
         // Other cRatio values are uniformly distributed
@@ -3097,7 +3096,7 @@ namespace battleutils
             pDIF = xirand::GetRandomNumber(lowerLimit, upperLimit);
         }
 
-        pDIF = std::clamp<float>(pDIF, 0, 3.0)
+        pDIF = std::clamp<float>(pDIF, 0, 3.0);
         pDIF = pDIF * xirand::GetRandomNumber(1.0f, 1.05f);
 
         if (isCritical)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1701,37 +1701,37 @@ namespace battleutils
 
         ratio = std::clamp<float>(ratio, 0, 3);
 
-        // level correct (0.025 not 0.05 like for melee)
-        if (PDefender->GetMLevel() > PAttacker->GetMLevel())
-        {
-            ratio -= 0.025f * (PDefender->GetMLevel() - PAttacker->GetMLevel());
+        // Level Correction
+        float cRatio = ratio;
+
+        if (PDefender->GetMLevel() > PAttacker->GetMLevel()) {
+            cRatio = cRatio - (PDefender->GetMLevel() - PAttacker->GetMLevel()) * 0.025f;
         }
 
         // calculate min/max PDIF
-        float minPdif = 0;
-        float maxPdif = 0;
+        float upperLimit = 3.0f;
+        float lowerLimit = 0.0f;
 
-        if (ratio < 0.9)
+        if (cRatio < 0.9f)
         {
-            minPdif = ratio;
-            maxPdif = (10.0f / 9.0f) * ratio;
+            minPdif = cRatio;
+            maxPdif = cRatio * (10.0f / 9.0f);
         }
-        else if (ratio <= 1.1)
+        else if (cRatio < 1.1f)
         {
-            minPdif = 1;
-            maxPdif = 1;
+            minPdif = 1.0f;
+            maxPdif = 1.0f;
         }
         else
         {
-            minPdif = (-3.0f / 19.0f) + ((20.0f / 19.0f) * ratio);
-            maxPdif = ratio;
+            minPdif = cRatio * (20.0f/19.0f) - (3.0f/19.0f);
+            maxPdif = cRatio;
         }
-
-        minPdif = std::clamp<float>(minPdif, 0, 3);
-        maxPdif = std::clamp<float>(maxPdif, 0, 3);
 
         // return random number between the two
         float pdif = xirand::GetRandomNumber(minPdif, maxPdif);
+
+        pdif = std::clamp<float>(pdif, 0, 3)
 
         if (isCritical)
         {
@@ -2911,9 +2911,17 @@ namespace battleutils
             defense = 1;
         }
 
-        // https://www.bg-wiki.com/bg/PDIF
-        // https://www.bluegartr.com/threads/127523-pDIF-Changes-(Feb.-10th-2016)
+        // Using 2013 model since it is the most up-to-date and tested version of the one used in 75 era
+        // https://www.bg-wiki.com/index.php?title=PDIF&oldid=268066
+        // Note that only player autoattacks use this function, weaponskill pDIF is calculated in scripts/global/weaponskills.lua
+        // Using 2013 model since it is the most up-to-date and tested version of the one used in 75 era
+        // https://www.bg-wiki.com/index.php?title=PDIF&oldid=268066
+        // Note that only player autoattacks use this function, weaponskill pDIF is calculated in scripts/global/weaponskills.lua
         float ratio  = (static_cast<float>(attack)) / (static_cast<float>(defense));
+        float ratioCap = 2.25f;
+
+        ratio = std::clamp<float>(ratio, 0, ratioCap);
+
         float cRatio = ratio;
 
         // Level correction does not happen in Adoulin zones, Legion, or zones in Escha/Reisenjima
@@ -2939,10 +2947,6 @@ namespace battleutils
         uint8 dLvl        = std::abs(attackerLvl - defenderLvl);
         float correction  = static_cast<float>(dLvl) * 0.05f;
 
-        // Assuming the cap for mobs is the same as Avatars
-        // Cap at 38 level diff so 38*0.05 = 1.9
-        float cappedCorrection = std::min(correction, 1.9f);
-
         if (shouldApplyLevelCorrection)
         {
             // Players only get penalties
@@ -2951,7 +2955,7 @@ namespace battleutils
                 if (attackerLvl < defenderLvl)
                 {
                     // Screw the players, no known cap
-                    cRatio -= correction;
+                    cRatio = cRatio - correction;
                 }
             }
             // Mobs, Avatars and pets only get bonuses, no penalties (or they are calculated differently)
@@ -2959,7 +2963,7 @@ namespace battleutils
             {
                 if (attackerLvl > defenderLvl)
                 {
-                    cRatio += cappedCorrection;
+                    cRatio += correction;
                 }
             }
         }
@@ -2972,27 +2976,27 @@ namespace battleutils
         }
 
         float qRatio     = wRatio;
-        float upperLimit = 0.0f;
+        float upperLimit = 3.25f;
         float lowerLimit = 0.0f;
 
-        // https://www.bg-wiki.com/bg/PDIF
+        // https://www.bg-wiki.com/index.php?title=PDIF&oldid=181430
         // Pre-Randomized values excluding Damage Limit+ trait
         // Damage Limit+ trait adds 0.1/rank to these values
         // type : non-crit : crit
-        // 1H : 3.25 : 4.25
-        // H2H & GK : 3.5 : 4.5
-        // 2H : 3.75 : 4.75
-        // Scythe : 4 : 5
-        // Archery & Throwing : 3.25 : 3.25*1.25
-        // Marksmanship : 3.5 : 3.5*1.25
+        // 1H : 1.0 : 2.0
+        // H2H & GK : 1.25 : 2.25
+        // 2H : 1.25 : 2.25
+        // Scythe : 1.25 : 2.25
+        // Archery & Throwing : 2.0 : 3.0
+        // Marksmanship : 2.0 : 3.0
 
         // https://www.bluegartr.com/threads/114636-Monster-Avatar-Pet-damage
         // Monster pDIF = Avatar pDIF = Pet pDIF
 
         auto* targ_weapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_MAIN]);
 
-        // Default for 1H is 3.25
-        float maxRatio = 3.25f;
+        // Default for 1H is 2.0
+        float maxRatio = 2.0f;
 
         if (attackerType == TYPE_MOB || attackerType == TYPE_PET)
         {
@@ -3006,15 +3010,15 @@ namespace battleutils
             {
                 if (targ_weapon->isHandToHand() || targ_weapon->getSkillType() == SKILL_GREAT_KATANA)
                 {
-                    maxRatio = 3.5f;
+                    maxRatio = 2.25f;
                 }
                 else if (targ_weapon->getSkillType() == SKILL_SCYTHE)
                 {
-                    maxRatio = 4.0f;
+                    maxRatio = 2.25f;
                 }
                 else if (targ_weapon->isTwoHanded())
                 {
-                    maxRatio = 3.75f;
+                    maxRatio = 2.25f;
                 }
             }
             // Skipping Ranged since that is handled in a separate function
@@ -3030,59 +3034,71 @@ namespace battleutils
         // There is an additional step here but I am skipping it for now because we do not have the data in the database.
         // The Damage Limit+ trait adds 0.1 to the maxRatio per trait level so a level 80 DRK would get maxRatio += 0.5
 
-        if (wRatio < 0.5)
+        if (wRatio < 0.5f)
         {
-            upperLimit = std::max(wRatio + 0.5f, 0.5f);
+            upperLimit = wRatio + 0.5f;
         }
-        else if (wRatio < 0.7)
+        else if (wRatio < 0.7f)
         {
-            upperLimit = 1;
+            upperLimit = 1.0f;
         }
-        else if (wRatio < 1.2)
+        else if (wRatio < 1.2f)
         {
             upperLimit = wRatio + 0.3f;
         }
-        else if (wRatio < 1.5)
+        else if (wRatio < 1.5f)
         {
-            upperLimit = wRatio * 1.25f;
+            upperLimit = wRatio * 1.25f + writeDeclaration;
+        }
+        else if (wRatio < 2.625f)
+        {
+            upperLimit = wRatio + 0.375f;
         }
         else
         {
-            upperLimit = std::min(wRatio + 0.375f, maxRatio);
+            upperLimit = 3.0f;
         }
 
-        if (wRatio < 0.38)
+        if (wRatio < 0.38f)
         {
-            lowerLimit = std::max(wRatio, 0.5f);
+            lowerLimit = 0.0f;
         }
-        else if (wRatio < 1.25)
+        else if (wRatio < 1.25f)
         {
             lowerLimit = (wRatio * (1176.0f / 1024.0f)) - (448.0f / 1024.0f);
         }
-        else if (wRatio < 1.51)
+        else if (wRatio < 1.51f)
         {
             lowerLimit = 1.0f;
         }
-        else if (wRatio < 2.44)
+        else if (wRatio < 2.44f)
         {
             lowerLimit = (wRatio * (1176.0f / 1024.0f)) - (755.0f / 1024.0f);
         }
         else
         {
-            lowerLimit = std::min(wRatio - 0.375f, maxRatio);
+            lowerLimit = wRatio - 0.375f;
         }
 
-        // https://www.bg-wiki.com/bg/Damage_Limit+
-        // See: "Physical damage limit +n%" is a multiplier to the total pDIF cap.
-        // There is one more step here that I am skipping for Physical Damage +% from gear and augments.
-        // I don't believe support for this modifier exists yet in the project.
-        // Physical Damage +% (PDL) is a flat % increase to the final pDIF cap value
-        // Meaning if a player has PDL+10% and an uppwerLimit of 1 then this would become 1.1
-        // upperLimit = upperLimit * 1.1
+        float pDIF = 0.0f
 
-        qRatio = xirand::GetRandomNumber(lowerLimit, upperLimit);
+        // Bernoulli distribution, applied for cRatio < 0.5 and 0.75 < cRatio < 1.25
+        // Other cRatio values are uniformly distributed
+        // https://www.bluegartr.com/threads/108161-pDif-and-damage?p=5308205&viewfull=1#post5308205
+        float U = std::max<float>(0.0, std::min<float>(0.333, 1.3 * (2.0 - std::abs(wRatio - 1)) - 1.96));
 
-        float pDIF = qRatio * xirand::GetRandomNumber(1.f, 1.05f);
+        bool bernoulli = xirand::GetRandomNumber(0.0f, 1.0f) < U ? true : false;
+
+        if (bernoulli)
+        {
+            pDIF = std::round(wRatio);
+        } else 
+        {
+            pDIF = xirand::GetRandomNumber(lowerLimit, upperLimit);
+        }
+
+        pDIF = std::clamp<float>(pDIF, 0, 3.0)
+        pDIF = pDIF * xirand::GetRandomNumber(1.0f, 1.05f);
 
         if (isCritical)
         {


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

+ Adjusts pDIF values to fit the data @relliko researched with a valid approximation to the 2010 formulas for pDIF based on 2011's known values.
+ Adds the Bernoulli distribution to further randomize pDIF calculations to fit known era sources to be more accurate and true.
+ Minimized line conflicts, left most of LSB's original core skeleton intact. 

## Steps to test these changes

+ All changes were previously tested on a live server with results being within the expected parameters. This merge utilizes those same values to meet the expected parameters.
