### PR TITLE
[core] [skill] Fix Super Jump Targeting | Fix Super Jump Effects and Application

### DIFF
--- a/scripts/globals/abilities/pets/super_climb.lua
+++ b/scripts/globals/abilities/pets/super_climb.lua
@@ -16,6 +16,9 @@ end
 
 ability_object.onUseAbility = function(pet, target, ability)
     pet:queue(0, function(petArg)
+        petArg:addStatusEffectEx(xi.effect.ALL_MISS, xi.effect.NONE, 2, 3, 5)
+        petArg:addStatusEffectEx(xi.effect.PHYSICAL_SHIELD, xi.effect.NONE, 1, 3, 5)
+        petArg:addStatusEffectEx(xi.effect.MAGIC_SHIELD, xi.effect.NONE, 1, 3, 5)
         petArg:stun(5000)
     end)
 end

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -708,6 +708,12 @@ function AbilityFinalAdjustments(dmg,mob,skill,target,skilltype,skillparam,shado
         return 0
     end
 
+    -- handle super jump
+    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStausEffect(xi.effect.ALL_MISS):getPower() > 1 then
+        skill:setMsg(xi.msg.basic.JA_MISS_2)
+        return 0
+    end
+
     -- set message to damage
     -- this is for AoE because its only set once
     skill:setMsg(xi.msg.basic.USES_JA_TAKE_DAMAGE)

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -178,35 +178,33 @@ local function applyRoll(caster, target, inAbility, action, total, isDoubleup, c
         effectpower = effectpower * (caster:getSubLvl() / target:getMainLvl())
     end
 
-    if not target:getStatusEffect(xi.effect.ALL_MISS):getPower() == 2 then
-        if target:addCorsairRoll(caster:getMainJob(), caster:getMerit(xi.merit.BUST_DURATION), corsairRollMods[abilityId][4], effectpower, 0, duration, caster:getID(), total, corsairRollMods[abilityId][5]) == false then
-            -- no effect or otherwise prevented
-            if caster:getID() == target:getID() then                  -- dead code? you can't roll if the same roll is already active. There is no known buff that would prevent a corsair roll.
-                currentAbility:setMsg(xi.msg.basic.ROLL_MAIN_FAIL)    -- no effect for the COR rolling if they had the buff already
-            else
-                currentAbility:setMsg(xi.msg.basic.NO_EFFECT)         -- no effect for the target if they had the buff already. Testing in retail shows it's _not_ xi.msg.basic.ROLL_SUB_FAIL if the roll is already active. There is no known buff that would prevent a corsair roll, so maybe this would be used there if there were one?
-            end
-        elseif total > 11 then
-            -- bust
-            if caster:getID() == target:getID() then
-                currentAbility:setMsg(xi.msg.basic.DOUBLEUP_BUST)     -- bust message for the COR rolling
-            else
-                currentAbility:setMsg(xi.msg.basic.DOUBLEUP_BUST_SUB) -- bust message for the target getting the roll
-            end
+    if target:addCorsairRoll(caster:getMainJob(), caster:getMerit(xi.merit.BUST_DURATION), corsairRollMods[abilityId][4], effectpower, 0, duration, caster:getID(), total, corsairRollMods[abilityId][5]) == false then
+        -- no effect or otherwise prevented
+        if caster:getID() == target:getID() then                  -- dead code? you can't roll if the same roll is already active. There is no known buff that would prevent a corsair roll.
+            currentAbility:setMsg(xi.msg.basic.ROLL_MAIN_FAIL)    -- no effect for the COR rolling if they had the buff already
         else
-            -- success
-            if caster:getID() == target:getID() then
-                if isDoubleup then
-                    currentAbility:setMsg(xi.msg.basic.DOUBLEUP)      -- success on doubleup for COR has different message than from just using Phantom Roll
-                else
-                    currentAbility:setMsg(xi.msg.basic.ROLL_MAIN)     -- success message for the COR rolling the first time
-                end
-            else
-                currentAbility:setMsg(xi.msg.basic.ROLL_SUB)          -- message for the target getting the roll. Always the same, even if it's the COR's first roll.
-            end
+            currentAbility:setMsg(xi.msg.basic.NO_EFFECT)         -- no effect for the target if they had the buff already. Testing in retail shows it's _not_ xi.msg.basic.ROLL_SUB_FAIL if the roll is already active. There is no known buff that would prevent a corsair roll, so maybe this would be used there if there were one?
+        end
+    elseif total > 11 then
+        -- bust
+        if caster:getID() == target:getID() then
+            currentAbility:setMsg(xi.msg.basic.DOUBLEUP_BUST)     -- bust message for the COR rolling
+        elseif target:getStatusEffect(xi.effect.ALL_MISS):getPower() == 2 then -- Handle Super Jump
+            currentAbility:setMsg(xi.msg.basic.NO_EFFECT)
+        else
+            currentAbility:setMsg(xi.msg.basic.DOUBLEUP_BUST_SUB) -- bust message for the target getting the roll
         end
     else
-        currentAbility:setMsg(xi.msg.basic.NO_EFFECT)
+        -- success
+        if caster:getID() == target:getID() then
+            if isDoubleup then
+                currentAbility:setMsg(xi.msg.basic.DOUBLEUP)      -- success on doubleup for COR has different message than from just using Phantom Roll
+            else
+                currentAbility:setMsg(xi.msg.basic.ROLL_MAIN)     -- success message for the COR rolling the first time
+            end
+        else
+            currentAbility:setMsg(xi.msg.basic.ROLL_SUB)          -- message for the target getting the roll. Always the same, even if it's the COR's first roll.
+        end
     end
 
     return total

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -178,31 +178,35 @@ local function applyRoll(caster, target, inAbility, action, total, isDoubleup, c
         effectpower = effectpower * (caster:getSubLvl() / target:getMainLvl())
     end
 
-    if target:addCorsairRoll(caster:getMainJob(), caster:getMerit(xi.merit.BUST_DURATION), corsairRollMods[abilityId][4], effectpower, 0, duration, caster:getID(), total, corsairRollMods[abilityId][5]) == false then
-        -- no effect or otherwise prevented
-        if caster:getID() == target:getID() then                  -- dead code? you can't roll if the same roll is already active. There is no known buff that would prevent a corsair roll.
-            currentAbility:setMsg(xi.msg.basic.ROLL_MAIN_FAIL)    -- no effect for the COR rolling if they had the buff already
-        else
-            currentAbility:setMsg(xi.msg.basic.NO_EFFECT)         -- no effect for the target if they had the buff already. Testing in retail shows it's _not_ xi.msg.basic.ROLL_SUB_FAIL if the roll is already active. There is no known buff that would prevent a corsair roll, so maybe this would be used there if there were one?
-        end
-    elseif total > 11 then
-        -- bust
-        if caster:getID() == target:getID() then
-            currentAbility:setMsg(xi.msg.basic.DOUBLEUP_BUST)     -- bust message for the COR rolling
-        else
-            currentAbility:setMsg(xi.msg.basic.DOUBLEUP_BUST_SUB) -- bust message for the target getting the roll
-        end
-    else
-        -- success
-        if caster:getID() == target:getID() then
-            if isDoubleup then
-                currentAbility:setMsg(xi.msg.basic.DOUBLEUP)      -- success on doubleup for COR has different message than from just using Phantom Roll
+    if not target:getStatusEffect(xi.effect.ALL_MISS):getPower() == 2 then
+        if target:addCorsairRoll(caster:getMainJob(), caster:getMerit(xi.merit.BUST_DURATION), corsairRollMods[abilityId][4], effectpower, 0, duration, caster:getID(), total, corsairRollMods[abilityId][5]) == false then
+            -- no effect or otherwise prevented
+            if caster:getID() == target:getID() then                  -- dead code? you can't roll if the same roll is already active. There is no known buff that would prevent a corsair roll.
+                currentAbility:setMsg(xi.msg.basic.ROLL_MAIN_FAIL)    -- no effect for the COR rolling if they had the buff already
             else
-                currentAbility:setMsg(xi.msg.basic.ROLL_MAIN)     -- success message for the COR rolling the first time
+                currentAbility:setMsg(xi.msg.basic.NO_EFFECT)         -- no effect for the target if they had the buff already. Testing in retail shows it's _not_ xi.msg.basic.ROLL_SUB_FAIL if the roll is already active. There is no known buff that would prevent a corsair roll, so maybe this would be used there if there were one?
+            end
+        elseif total > 11 then
+            -- bust
+            if caster:getID() == target:getID() then
+                currentAbility:setMsg(xi.msg.basic.DOUBLEUP_BUST)     -- bust message for the COR rolling
+            else
+                currentAbility:setMsg(xi.msg.basic.DOUBLEUP_BUST_SUB) -- bust message for the target getting the roll
             end
         else
-            currentAbility:setMsg(xi.msg.basic.ROLL_SUB)          -- message for the target getting the roll. Always the same, even if it's the COR's first roll.
+            -- success
+            if caster:getID() == target:getID() then
+                if isDoubleup then
+                    currentAbility:setMsg(xi.msg.basic.DOUBLEUP)      -- success on doubleup for COR has different message than from just using Phantom Roll
+                else
+                    currentAbility:setMsg(xi.msg.basic.ROLL_MAIN)     -- success message for the COR rolling the first time
+                end
+            else
+                currentAbility:setMsg(xi.msg.basic.ROLL_SUB)          -- message for the target getting the roll. Always the same, even if it's the COR's first roll.
+            end
         end
+    else
+        currentAbility:setMsg(xi.msg.basic.NO_EFFECT)
     end
 
     return total

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -362,6 +362,9 @@ xi.job_utils.dragoon.useSuperJump = function(player, target, ability)
 
     -- Prevent the player from performing actions while in the air
     player:queue(0, function(playerArg)
+        playerArg:addStatusEffectEx(xi.effect.ALL_MISS, xi.effect.NONE, 2, 3, 5)
+        playerArg:addStatusEffectEx(xi.effect.PHYSICAL_SHIELD, xi.effect.NONE, 1, 3, 5)
+        playerArg:addStatusEffectEx(xi.effect.MAGIC_SHIELD, xi.effect.NONE, 1, 3, 5)
         playerArg:stun(5000)
     end)
 

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -430,7 +430,8 @@ function isValidHealTarget(caster, target)
             (target:getObjType() == xi.objType.PC or
             target:getObjType() == xi.objType.MOB or
             target:getObjType() == xi.objType.TRUST or
-            target:getObjType() == xi.objType.FELLOW)
+            target:getObjType() == xi.objType.FELLOW) and
+            target:getStatusEffect(xi.effect.ALL_MISS):getPower() ==2 -- Handles Super Jump
 end
 
 -- USED FOR DAMAGING MAGICAL SPELLS. Stage 3 of Calculating Magic Damage on wiki

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -506,6 +506,10 @@ xi.mobskills.mobBreathMove = function(mob, target, percent, base, element, cap)
 
     damage = math.floor(damage * combinedDamageTaken)
 
+    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStausEffect(xi.effect.ALL_MISS):getPower() > 1 then
+        return 0
+    end
+
     -- Handle Phalanx
     if damage > 0 then
         damage = utils.clamp(damage - target:getMod(xi.mod.PHALANX), 0, 99999)
@@ -539,6 +543,12 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
         attackType== xi.attackType.PHYSICAL
     then
         skill:setMsg(xi.msg.basic.SKILL_MISS)
+        return 0
+    end
+
+    -- handle super jump
+    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStausEffect(xi.effect.ALL_MISS):getPower() > 1 then
+        skill:setMsg(xi.msg.basic.SKILL_MISS_)
         return 0
     end
 

--- a/scripts/globals/spells/enhancing_spell.lua
+++ b/scripts/globals/spells/enhancing_spell.lua
@@ -409,6 +409,11 @@ xi.spells.enhancing.useEnhancingSpell = function(caster, target, spell)
     -- Handle exceptions and weird behaviour here, before calculating anything.
     ------------------------------------------------------------
 
+    if target:getStatusEffect(xi.effect.ALL_MISS):getPower() == 2 then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return 0
+    end
+
     -- TODO: Find a way to replace big if/else chain and still make it look good.
 
     -- Bar-Element (They use addStatusEffect argument 6. Bar-Status current implementation doesn't.)

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -366,6 +366,12 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
         return 0
     end
 
+    -- handle super jump
+    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStausEffect(xi.effect.ALL_MISS):getPower() > 1 then
+        skill:setMsg(xi.msg.basic.JA_MISS_2)
+        return 0
+    end
+
     -- Calculate Blood Pact Damage before stoneskin
     dmg = dmg + dmg * mob:getMod(xi.mod.BP_DAMAGE) / 100
 

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -419,9 +419,12 @@ bool CMobController::TryCastSpell()
 {
     TracyZoneScoped;
 
-     if (PMob->GetBattleTarget()->StatusEffectContainer->HasStatusEffect(EFFECT_ALL_MISS) && PMob->GetBattleTarget()->StatusEffectContainer->GetStatusEffect(EFFECT_ALL_MISS)->GetPower() == 2) // Handles Super Jump
+    if (PMob->GetBattleTarget() != nullptr)
     {
-        return false;
+        if (PMob->GetBattleTarget()->StatusEffectContainer->HasStatusEffect(EFFECT_ALL_MISS) && PMob->GetBattleTarget()->StatusEffectContainer->GetStatusEffect(EFFECT_ALL_MISS)->GetPower() == 2) // Handles Super Jump
+        {
+            return false;
+        }
     }
 
     if (!CanCastSpells())

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -329,6 +329,10 @@ bool CMobController::MobSkill(int wsList)
 
         if (PMobSkill->getValidTargets() == TARGET_ENEMY) // enemy
         {
+            if (PMob->GetBattleTarget()->StatusEffectContainer->HasStatusEffect(EFFECT_ALL_MISS) && PMob->GetBattleTarget()->StatusEffectContainer->GetStatusEffect(EFFECT_ALL_MISS)->GetPower() == 2) // Handles Super Jump
+            {
+                return false;
+            }
             PActionTarget = PTarget;
         }
         else if (PMobSkill->getValidTargets() == TARGET_SELF) // self
@@ -414,6 +418,12 @@ bool CMobController::TrySpecialSkill()
 bool CMobController::TryCastSpell()
 {
     TracyZoneScoped;
+
+     if (PMob->GetBattleTarget()->StatusEffectContainer->HasStatusEffect(EFFECT_ALL_MISS) && PMob->GetBattleTarget()->StatusEffectContainer->GetStatusEffect(EFFECT_ALL_MISS)->GetPower() == 2) // Handles Super Jump
+    {
+        return false;
+    }
+
     if (!CanCastSpells())
     {
         return false;
@@ -456,6 +466,14 @@ bool CMobController::CanCastSpells()
     if (!PMob->SpellContainer->HasSpells())
     {
         return false;
+    }
+
+    if (PMob->GetBattleTarget() != nullptr)
+    {
+        if (PMob->GetBattleTarget()->StatusEffectContainer->HasStatusEffect(EFFECT_ALL_MISS) && PMob->GetBattleTarget()->StatusEffectContainer->GetStatusEffect(EFFECT_ALL_MISS)->GetPower() == 2) // Handles Super Jump
+        {
+            return false;
+        }
     }
 
     // check for spell blockers e.g. silence


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Makes mobs unable to cast spells or use mobskills on a DRG who is super jumped or their wyvern when super climbed.
+ Added Physical Shield and Magic shield as a safeguard against AOE attacks. These are removed at the same time super jump and super climb are removed.
+ Made the DRG and wyvern untargetable by PCs and their effects. (Healing, Enhancing, and Roll Busts).

## Steps to test these changes
+ Confirmed that AOE spells will return 0 damage due to shields using a 2nd char to hold hate.
+ Confirmed that the mob is unable to cast spells or use skills on the DRG/wyvern if they are the only enmity targets. This was tested with both the wyvern out and completely solo.