### PR TITLE
[core] Fix GetSettings Variable To Allow for Content Restrict

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1510,7 +1510,7 @@ namespace luautils
     {
         TracyZoneScoped;
         TracyZoneCString(variable);
-        return lua["xi"]["settings"][variable].valid() ? lua["xi"]["settings"][variable].get<uint8>() : 0;
+        return lua["xi"]["settings"]["main"][variable].valid() ? lua["xi"]["settings"]["main"][variable].get<uint8>() : 0;
     }
 
     /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Updates the variable location to match the new settings format. This enables content restrict without breaking entities that shouldn't be restricted. 

## Steps to test these changes
+ Restricted content to COP, then checked around for OOE NPCs and did not find any.