### PR TITLE
Fix Ranged Attack Initial Delay to Include 1.6s | Fix RATK and RACC Checkparam Vals | Add Fix Ranged Weaponskill pDif Values

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -259,6 +259,23 @@ local function cRangedRatio(attacker, defender, params, ignoredDef, tp)
         pdifmin = (cratio * (20 / 19)) - (3 / 19)
     end
 
+    -- Bernoulli distribution, applied for cRatio < 0.5 and 0.75 < cRatio < 1.25
+    -- Other cRatio values are uniformly distributed
+    -- https://www.bluegartr.com/threads/108161-pDif-and-damage?p=5308205&viewfull=1#post5308205
+    local u = math.max(0.0, math.min(0.333, 1.3 * (2.0 - math.abs(cratio - 1)) - 1.96))
+
+    local bernoulli = false
+
+    if (math.random() < u) then
+        bernoulli = true
+    end
+
+    if (bernoulli) then
+        local roundedRatio = math.floor(cratio + 0.5) -- equivalent to rounding
+        pdifmin = roundedRatio
+        pdifmax = roundedRatio
+    end
+
     local pdif = {}
     pdif[1] = pdifmin
     pdif[2] = pdifmax

--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -243,6 +243,16 @@ void CPlayerController::setLastErrMsgTime(time_point _LastErrMsgTime)
     m_errMsgTime = _LastErrMsgTime;
 }
 
+time_point CPlayerController::getLastRangedAttackTime()
+{
+    return m_lastRangedAttackTime;
+}
+
+void CPlayerController::setLastRangedAttackTime(time_point _lastRangedAttackTime)
+{
+    m_lastRangedAttackTime = _lastRangedAttackTime;
+}
+
 time_point CPlayerController::getLastErrMsgTime()
 {
     return m_errMsgTime;

--- a/src/map/ai/controllers/player_controller.h
+++ b/src/map/ai/controllers/player_controller.h
@@ -49,6 +49,8 @@ public:
 
     time_point getLastAttackTime();
     void       setLastAttackTime(time_point);
+    time_point getLastRangedAttackTime();
+    void setLastRangedAttackTime(time_point);
 
     void       setLastErrMsgTime(time_point);
     time_point getLastErrMsgTime();
@@ -57,6 +59,7 @@ public:
 
 protected:
     time_point    m_lastAttackTime{ server_clock::now() };
+    time_point    m_lastRangedAttackTime { server_clock::now() };
     time_point    m_errMsgTime{ server_clock::now() };
     CWeaponSkill* m_lastWeaponSkill{ nullptr };
 };

--- a/src/map/ai/states/range_state.h
+++ b/src/map/ai/states/range_state.h
@@ -52,7 +52,9 @@ protected:
 
 private:
     CBattleEntity* const m_PEntity;
-    duration             m_aimTime;
+    duration             m_aimTime; // The calculated "phase 1" delay based on weapon and job trait reductions
+    const duration m_returnWeaponDelay = std::chrono::milliseconds(1600);  // Phase 2: Putting the weapon back after a shot
+    const duration m_freePhaseTime = std::chrono::milliseconds(1100); // Phase 3: The cooldown after a ranged attack is executed.
     bool                 m_rapidShot{ false };
     position_t           m_startPos;
 };

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -724,7 +724,7 @@ uint16 CBattleEntity::RACC(uint8 skill, float distance, uint16 bonusSkill)
     return acc + std::min<int16>(((100 + getMod(Mod::FOOD_RACCP) * acc) / 100), getMod(Mod::FOOD_RACC_CAP));
 }
 
-uint16 CBattleEntity::GetBaseRACC(uint8 skill, float distance, uint16 bonusSkill)
+uint16 CBattleEntity::GetBaseRACC(uint8 skill, uint16 bonusSkill)
 {
     TracyZoneScoped;
     auto* PWeakness = StatusEffectContainer->GetStatusEffect(EFFECT_WEAKNESS);

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -686,6 +686,17 @@ uint16 CBattleEntity::RATT(uint8 skill, float distance, uint16 bonusSkill)
     return ATT + (ATT * m_modStat[Mod::RATTP] / 100) + std::min<int16>((ATT * m_modStat[Mod::FOOD_RATTP] / 100), m_modStat[Mod::FOOD_RATT_CAP]);
 }
 
+uint16 CBattleEntity::GetBaseRATT(uint8 skill, uint16 bonusSkill)
+{
+    auto* PWeakness = StatusEffectContainer->GetStatusEffect(EFFECT_WEAKNESS);
+    if (PWeakness && PWeakness->GetPower() >= 2)
+    {
+        return 0;
+    }
+    int32 ATT = 8 + GetSkill(skill) + bonusSkill + m_modStat[Mod::RATT] + battleutils::GetRangedAttackBonuses(this) + (STR() * 3) / 4;
+    return ATT + (ATT * m_modStat[Mod::RATTP] / 100) + std::min<int16>((ATT * m_modStat[Mod::FOOD_RATTP] / 100), m_modStat[Mod::FOOD_RATT_CAP]);
+}
+
 uint16 CBattleEntity::RACC(uint8 skill, float distance, uint16 bonusSkill)
 {
     TracyZoneScoped;
@@ -710,6 +721,26 @@ uint16 CBattleEntity::RACC(uint8 skill, float distance, uint16 bonusSkill)
             acc = int32((float)acc * battleutils::GetRangedDistanceCorrection(this, distance));
         }
     }
+    return acc + std::min<int16>(((100 + getMod(Mod::FOOD_RACCP) * acc) / 100), getMod(Mod::FOOD_RACC_CAP));
+}
+
+uint16 CBattleEntity::GetBaseRACC(uint8 skill, float distance, uint16 bonusSkill)
+{
+    TracyZoneScoped;
+    auto* PWeakness = StatusEffectContainer->GetStatusEffect(EFFECT_WEAKNESS);
+    if (PWeakness && PWeakness->GetPower() >= 2)
+    {
+        return 0;
+    }
+    int    skill_level = GetSkill(skill) + bonusSkill;
+    uint16 acc         = skill_level;
+    if (skill_level > 200)
+    {
+        acc = (uint16)(200 + (skill_level - 200) * 0.9);
+    }
+    acc += getMod(Mod::RACC);
+    acc += battleutils::GetRangedAccuracyBonuses(this);
+    acc += (AGI() * 3) / 4;
     return acc + std::min<int16>(((100 + getMod(Mod::FOOD_RACCP) * acc) / 100), getMod(Mod::FOOD_RACC_CAP));
 }
 

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -516,7 +516,9 @@ public:
     uint16 ACC(uint8 attackNumber, uint8 offsetAccuracy);
     uint16 EVA();
     uint16 RATT(uint8 skill, float distance, uint16 bonusSkill = 0);
+    uint16 GetBaseRATT(uint8 skill, uint16 bonusSkill = 0);
     uint16 RACC(uint8 skill, float distance, uint16 bonusSkill = 0);
+    uint16 GetBaseRACC(uint8 skill, uint16 bonusSkill = 0);
 
     uint8 GetSpeed();
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -463,6 +463,7 @@ public:
     bool       m_EquipSwap; // true if equipment was recently changed
     bool       m_EffectsChanged;
     time_point m_LastSynthTime;
+    time_point m_LastRangedAttackTime;
 
     CHAR_SUBSTATE m_Substate;
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11142,21 +11142,9 @@ int CLuaBaseEntity::getRACC()
         return 0;
     }
 
-    CBattleEntity* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
+    auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
 
-    int skill = PEntity->GetSkill(weapon->getSkillType());
-    int acc   = skill;
-
-    if (skill > 200)
-    {
-        acc = (int)(200 + (skill - 200) * 0.9);
-    }
-
-    acc += PEntity->getMod(Mod::RACC);
-    acc += PEntity->AGI() / 2;
-    acc = acc + std::min<int16>(((100 + PEntity->getMod(Mod::FOOD_RACCP)) * acc / 100), PEntity->getMod(Mod::FOOD_RACC_CAP));
-
-    return acc;
+    return PEntity->RACC(weapon->getSkillType(), distance(PEntity->loc.p, PEntity->GetBattleTarget()->loc.p),  weapon->getILvlSkill());
 }
 
 /************************************************************************
@@ -11178,7 +11166,9 @@ uint16 CLuaBaseEntity::getRATT()
         return 0;
     }
 
-    return static_cast<CBattleEntity*>(m_PBaseEntity)->RATT(weapon->getSkillType(), weapon->getILvlSkill());
+    auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
+
+    return PEntity->RATT(weapon->getSkillType(), distance(PEntity->loc.p, PEntity->GetBattleTarget()->loc.p),  weapon->getILvlSkill());
 }
 
 /************************************************************************

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5772,14 +5772,14 @@ void SmallPacket0x0DD(map_session_data_t* const PSession, CCharEntity* const PCh
                 int skill      = ((CItemWeapon*)PChar->getEquip(SLOT_RANGED))->getSkillType();
                 int bonusSkill = ((CItemWeapon*)PChar->getEquip(SLOT_RANGED))->getILvlSkill();
                 PChar->pushPacket(
-                    new CMessageBasicPacket(PChar, PChar, PChar->RACC(skill, bonusSkill), PChar->RATT(skill, bonusSkill), MSGBASIC_CHECKPARAM_RANGE));
+                    new CMessageBasicPacket(PChar, PChar, PChar->GetBaseRACC(skill, bonusSkill), PChar->GetBaseRATT(skill, bonusSkill), MSGBASIC_CHECKPARAM_RANGE));
             }
             else if (PChar->getEquip(SLOT_AMMO) && PChar->getEquip(SLOT_AMMO)->isType(ITEM_WEAPON))
             {
                 int skill      = ((CItemWeapon*)PChar->getEquip(SLOT_AMMO))->getSkillType();
                 int bonusSkill = ((CItemWeapon*)PChar->getEquip(SLOT_AMMO))->getILvlSkill();
                 PChar->pushPacket(
-                    new CMessageBasicPacket(PChar, PChar, PChar->RACC(skill, bonusSkill), PChar->RATT(skill, bonusSkill), MSGBASIC_CHECKPARAM_RANGE));
+                    new CMessageBasicPacket(PChar, PChar, PChar->GetBaseRACC(skill, bonusSkill), PChar->GetBaseRATT(skill, bonusSkill), MSGBASIC_CHECKPARAM_RANGE));
             }
             else
             {
@@ -5802,12 +5802,12 @@ void SmallPacket0x0DD(map_session_data_t* const PSession, CCharEntity* const PCh
             if (PChar->getEquip(SLOT_RANGED) && PChar->getEquip(SLOT_RANGED)->isType(ITEM_WEAPON))
             {
                 int skill = ((CItemWeapon*)PChar->getEquip(SLOT_RANGED))->getSkillType();
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->RACC(skill, distance(PChar->PPet->loc.p, PChar->PPet->GetBattleTarget()->loc.p)), PChar->PPet->RATT(skill, distance(PChar->PPet->loc.p, PChar->PPet->GetBattleTarget()->loc.p)), MSGBASIC_CHECKPARAM_RANGE));
+                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->GetBaseRACC(skill, 0), PChar->PPet->GetBaseRATT(skill, 0), MSGBASIC_CHECKPARAM_RANGE));
             }
             else if (PChar->getEquip(SLOT_AMMO) && PChar->getEquip(SLOT_AMMO)->isType(ITEM_WEAPON))
             {
                 int skill = ((CItemWeapon*)PChar->getEquip(SLOT_AMMO))->getSkillType();
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->RACC(skill, distance(PChar->PPet->loc.p, PChar->PPet->GetBattleTarget()->loc.p)), PChar->PPet->RATT(skill, distance(PChar->PPet->loc.p, PChar->PPet->GetBattleTarget()->loc.p)), MSGBASIC_CHECKPARAM_RANGE));
+                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->GetBaseRACC(skill, 0), PChar->PPet->GetBaseRATT(skill, 0), MSGBASIC_CHECKPARAM_RANGE));
             }
             else
             {


### PR DESCRIPTION
Co-Authored-By: relliko <apolywka@gmail.com>

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Adds an additional 1.6s delay to all ranged attacks.
+ Provides the player with a "you must wait longer" message.

+ Adds Bernoulli distribution to ranged weaponskills such that they will not be exempt unlike melee weaponskills.
+ Changed getRACC and getRATK to use distances and the correct functions rather than individual calcs.
+ Add GetBaseRATK and GetBaseRACC for use in Checkparam packets.

## Steps to test these changes
+ Tested marksmanship (gun + crossbow) to ensure that the delay followed between weapon types accurately. Confirmed against mobs that it does require the 1.6s before another action can be performed.
+ Tested that Checkparam's packets built properly, this is a known good function that was previously used prior to correction so data will be accurate.
+ Bernoulli distribution addition uses known good code to apply the randomization.
