### PR TITLE
Magic Accuracy Overhaul | DRG Super Jump Lua Error Cleanup | Add Build Resistance Piping

### DIFF
--- a/scripts/globals/abilities/pets/super_climb.lua
+++ b/scripts/globals/abilities/pets/super_climb.lua
@@ -16,9 +16,9 @@ end
 
 ability_object.onUseAbility = function(pet, target, ability)
     pet:queue(0, function(petArg)
-        petArg:addStatusEffectEx(xi.effect.ALL_MISS, xi.effect.NONE, 2, 3, 5)
-        petArg:addStatusEffectEx(xi.effect.PHYSICAL_SHIELD, xi.effect.NONE, 1, 3, 5)
-        petArg:addStatusEffectEx(xi.effect.MAGIC_SHIELD, xi.effect.NONE, 1, 3, 5)
+        petArg:addStatusEffectEx(xi.effect.ALL_MISS, xi.effect.NONE, 2, 3, 5, 0, 0, 0, xi.effectFlag.NO_LOSS_MESSAGE)
+        petArg:addStatusEffectEx(xi.effect.PHYSICAL_SHIELD, xi.effect.NONE, 1, 3, 5, 0, 0, 0, xi.effectFlag.NO_LOSS_MESSAGE)
+        petArg:addStatusEffectEx(xi.effect.MAGIC_SHIELD, xi.effect.NONE, 1, 3, 5, 0, 0, 0, xi.effectFlag.NO_LOSS_MESSAGE)
         petArg:stun(5000)
     end)
 end

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -709,7 +709,7 @@ function AbilityFinalAdjustments(dmg,mob,skill,target,skilltype,skillparam,shado
     end
 
     -- handle super jump
-    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStausEffect(xi.effect.ALL_MISS):getPower() > 1 then
+    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStatusEffect(xi.effect.ALL_MISS):getPower() > 1 then
         skill:setMsg(xi.msg.basic.JA_MISS_2)
         return 0
     end

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -188,7 +188,7 @@ local function applyRoll(caster, target, inAbility, action, total, isDoubleup, c
         -- bust
         if caster:getID() == target:getID() then
             currentAbility:setMsg(xi.msg.basic.DOUBLEUP_BUST)     -- bust message for the COR rolling
-        elseif target:getStatusEffect(xi.effect.ALL_MISS):getPower() == 2 then -- Handle Super Jump
+        elseif target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStatusEffect(xi.effect.ALL_MISS):getPower() > 1 then -- Handle Super Jump
             currentAbility:setMsg(xi.msg.basic.NO_EFFECT)
         else
             currentAbility:setMsg(xi.msg.basic.DOUBLEUP_BUST_SUB) -- bust message for the target getting the roll

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -362,9 +362,9 @@ xi.job_utils.dragoon.useSuperJump = function(player, target, ability)
 
     -- Prevent the player from performing actions while in the air
     player:queue(0, function(playerArg)
-        playerArg:addStatusEffectEx(xi.effect.ALL_MISS, xi.effect.NONE, 2, 3, 5)
-        playerArg:addStatusEffectEx(xi.effect.PHYSICAL_SHIELD, xi.effect.NONE, 1, 3, 5)
-        playerArg:addStatusEffectEx(xi.effect.MAGIC_SHIELD, xi.effect.NONE, 1, 3, 5)
+        playerArg:addStatusEffectEx(xi.effect.ALL_MISS, xi.effect.NONE, 2, 3, 5, 0, 0, 0, xi.effectFlag.NO_LOSS_MESSAGE)
+        playerArg:addStatusEffectEx(xi.effect.PHYSICAL_SHIELD, xi.effect.NONE, 1, 3, 5, 0, 0, 0, xi.effectFlag.NO_LOSS_MESSAGE)
+        playerArg:addStatusEffectEx(xi.effect.MAGIC_SHIELD, xi.effect.NONE, 1, 3, 5, 0, 0, 0, xi.effectFlag.NO_LOSS_MESSAGE)
         playerArg:stun(5000)
     end)
 

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -374,7 +374,7 @@ xi.job_utils.dragoon.useSuperJump = function(player, target, ability)
         wyvern ~= nil and
         wyvern:getHP() > 0
     then
-        wyvern:useJobAbility(636, wyvern)
+        wyvern:useJobAbility(652, wyvern)
     end
 end
 

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -637,7 +637,7 @@ function getMagicResist(magicHitRate)
     return resist
 end
 
-xi.magic.tryBuildResistance = function(target, resistance, isEnfeeb)
+local function tryBuildResistance(target, resistance, isEnfeeb)
     local isNM = target:isNM()
     local baseRes = target:getLocalVar(string.format("[RES]Base_%s", resistance))
     local castCool = target:getLocalVar(string.format("[RES]CastCool_%s", resistance))

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -637,7 +637,7 @@ function getMagicResist(magicHitRate)
     return resist
 end
 
-local function tryBuildResistance(target, resistance, isEnfeeb)
+function tryBuildResistance(target, resistance, isEnfeeb)
     local isNM = target:isNM()
     local baseRes = target:getLocalVar(string.format("[RES]Base_%s", resistance))
     local castCool = target:getLocalVar(string.format("[RES]CastCool_%s", resistance))

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -589,7 +589,6 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
         bonusAcc = bonusAcc + affinityBonus + elementBonus
     end
 
-
     if target:isPC() then
         magiceva = target:getMod(xi.mod.MEVA) + resMod + effectRes
     else

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -428,12 +428,15 @@ function getCureFinal(caster, spell, basecure, minCure, isBlueMagic)
 end
 
 function isValidHealTarget(caster, target)
-    return target:getAllegiance() == caster:getAllegiance() and
-            (target:getObjType() == xi.objType.PC or
-            target:getObjType() == xi.objType.MOB or
-            target:getObjType() == xi.objType.TRUST or
-            target:getObjType() == xi.objType.FELLOW) and
-            target:getStatusEffect(xi.effect.ALL_MISS):getPower() ==2 -- Handles Super Jump
+    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStatusEffect(xi.effect.ALL_MISS):getPower() > 1 then
+        return false
+    else
+        return target:getAllegiance() == caster:getAllegiance() and
+                (target:getObjType() == xi.objType.PC or
+                target:getObjType() == xi.objType.MOB or
+                target:getObjType() == xi.objType.TRUST or
+                target:getObjType() == xi.objType.FELLOW)
+    end
 end
 
 -- USED FOR DAMAGING MAGICAL SPELLS. Stage 3 of Calculating Magic Damage on wiki

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -475,7 +475,7 @@ xi.mobskills.mobBreathMove = function(mob, target, percent, base, element, cap)
 
     damage = math.floor(damage * combinedDamageTaken)
 
-    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStausEffect(xi.effect.ALL_MISS):getPower() > 1 then
+    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStatusEffect(xi.effect.ALL_MISS):getPower() > 1 then
         return 0
     end
 
@@ -516,8 +516,8 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
     end
 
     -- handle super jump
-    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStausEffect(xi.effect.ALL_MISS):getPower() > 1 then
-        skill:setMsg(xi.msg.basic.SKILL_MISS_)
+    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStatusEffect(xi.effect.ALL_MISS):getPower() > 1 then
+        skill:setMsg(xi.msg.basic.SKILL_MISS)
         return 0
     end
 

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -196,7 +196,7 @@ local pTable =
     [xi.magic.spell.HOLY_II     ] = { xi.mod.MND,  250,    2,  250, 300 },
 }
 
-function tryBuildResistance(target, resistance, isEnfeeb)
+local function tryBuildResistance(target, resistance, isEnfeeb)
     local isNM = target:isNM()
     local baseRes = target:getLocalVar(string.format("[RES]Base_%s", resistance))
     local castCool = target:getLocalVar(string.format("[RES]CastCool_%s", resistance))

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -21,17 +21,17 @@ xi.spells.damage = xi.spells.damage or {}
 -----------------------------------
 -- Tables
 -----------------------------------
--- Structure:       function = { Fire,                 Ice,                   Air,                  Earth,                 Thunder,                 Water,                    Light,                    Dark                     }
-xi.magic.dayStrong           = { xi.day.FIRESDAY,      xi.day.ICEDAY,         xi.day.WINDSDAY,      xi.day.EARTHSDAY,      xi.day.LIGHTNINGDAY,     xi.day.WATERSDAY,         xi.day.LIGHTSDAY,         xi.day.DARKSDAY          }
-xi.magic.dayWeak             = { xi.day.WATERSDAY,     xi.day.FIRESDAY,       xi.day.ICEDAY,        xi.day.WINDSDAY,       xi.day.EARTHSDAY,        xi.day.LIGHTNINGDAY,      xi.day.DARKSDAY,          xi.day.LIGHTSDAY         }
-xi.magic.singleWeatherStrong = { xi.weather.HOT_SPELL, xi.weather.SNOW,       xi.weather.WIND,      xi.weather.DUST_STORM, xi.weather.THUNDER,      xi.weather.RAIN,          xi.weather.AURORAS,       xi.weather.GLOOM         }
-xi.magic.doubleWeatherStrong = { xi.weather.HEAT_WAVE, xi.weather.BLIZZARDS,  xi.weather.GALES,     xi.weather.SAND_STORM, xi.weather.THUNDERSTORMS,xi.weather.SQUALL,        xi.weather.STELLAR_GLARE, xi.weather.DARKNESS      }
-xi.magic.singleWeatherWeak   = { xi.weather.RAIN,      xi.weather.HOT_SPELL,  xi.weather.SNOW,      xi.weather.WIND,       xi.weather.DUST_STORM,   xi.weather.THUNDER,       xi.weather.GLOOM,         xi.weather.AURORAS       }
-xi.magic.doubleWeatherWeak   = { xi.weather.SQUALL,    xi.weather.HEAT_WAVE,  xi.weather.BLIZZARDS, xi.weather.GALES,      xi.weather.SAND_STORM,   xi.weather.THUNDERSTORMS, xi.weather.DARKNESS,      xi.weather.STELLAR_GLARE }
-xi.magic.resistMod           = { xi.mod.FIRE_MEVA,     xi.mod.ICE_MEVA,       xi.mod.WIND_MEVA,     xi.mod.EARTH_MEVA,     xi.mod.THUNDER_MEVA,     xi.mod.WATER_MEVA,        xi.mod.LIGHT_MEVA,        xi.mod.DARK_MEVA         }
-xi.magic.specificDmgTakenMod = { xi.mod.FIRE_SDT,      xi.mod.ICE_SDT,        xi.mod.WIND_SDT,      xi.mod.EARTH_SDT,      xi.mod.THUNDER_SDT,      xi.mod.WATER_SDT,         xi.mod.LIGHT_SDT,         xi.mod.DARK_SDT          }
-xi.magic.absorbMod           = { xi.mod.FIRE_ABSORB,   xi.mod.ICE_ABSORB,     xi.mod.WIND_ABSORB,   xi.mod.EARTH_ABSORB,   xi.mod.LTNG_ABSORB,      xi.mod.WATER_ABSORB,      xi.mod.LIGHT_ABSORB,      xi.mod.DARK_ABSORB       }
-xi.magic.barSpell            = { xi.effect.BARFIRE,    xi.effect.BARBLIZZARD, xi.effect.BARAERO,    xi.effect.BARSTONE,    xi.effect.BARTHUNDER,    xi.effect.BARWATER        }
+-- Structure:       function = { Fire,                         Ice,                         Air,                           Earth,                         Thunder,                           Water,                          Light,                      Dark                      }
+xi.magic.dayStrong           = { xi.day.FIRESDAY,              xi.day.ICEDAY,               xi.day.WINDSDAY,               xi.day.EARTHSDAY,              xi.day.LIGHTNINGDAY,               xi.day.WATERSDAY,               xi.day.LIGHTSDAY,           xi.day.DARKSDAY           }
+xi.magic.dayWeak             = { xi.day.WATERSDAY,             xi.day.FIRESDAY,             xi.day.ICEDAY,                 xi.day.WINDSDAY,               xi.day.EARTHSDAY,                  xi.day.LIGHTNINGDAY,            xi.day.DARKSDAY,            xi.day.LIGHTSDAY          }
+xi.magic.singleWeatherStrong = { xi.weather.HOT_SPELL,         xi.weather.SNOW,             xi.weather.WIND,               xi.weather.DUST_STORM,         xi.weather.THUNDER,                xi.weather.RAIN,                xi.weather.AURORAS,         xi.weather.GLOOM          }
+xi.magic.doubleWeatherStrong = { xi.weather.HEAT_WAVE,         xi.weather.BLIZZARDS,        xi.weather.GALES,              xi.weather.SAND_STORM,         xi.weather.THUNDERSTORMS,          xi.weather.SQUALL,              xi.weather.STELLAR_GLARE,   xi.weather.DARKNESS       }
+xi.magic.singleWeatherWeak   = { xi.weather.RAIN,              xi.weather.HOT_SPELL,        xi.weather.SNOW,               xi.weather.WIND,               xi.weather.DUST_STORM,             xi.weather.THUNDER,             xi.weather.GLOOM,           xi.weather.AURORAS        }
+xi.magic.doubleWeatherWeak   = { xi.weather.SQUALL,            xi.weather.HEAT_WAVE,        xi.weather.BLIZZARDS,          xi.weather.GALES,              xi.weather.SAND_STORM,             xi.weather.THUNDERSTORMS,       xi.weather.DARKNESS,        xi.weather.STELLAR_GLARE  }
+xi.magic.resistMod           = { xi.mod.FIRE_RES,              xi.mod.ICE_RES,              xi.mod.WIND_RES,               xi.mod.EARTH_RES,              xi.mod.THUNDER_RES,                xi.mod.WATER_RES,               xi.mod.LIGHT_RES,           xi.mod.DARK_RES           }
+xi.magic.specificDmgTakenMod = { xi.mod.FIRE_SDT,              xi.mod.ICE_SDT,              xi.mod.WIND_SDT,               xi.mod.EARTH_SDT,              xi.mod.THUNDER_SDT,                xi.mod.WATER_SDT,               xi.mod.LIGHT_SDT,           xi.mod.DARK_SDT           }
+xi.magic.absorbMod           = { xi.mod.FIRE_ABSORB,           xi.mod.ICE_ABSORB,           xi.mod.WIND_ABSORB,            xi.mod.EARTH_ABSORB,           xi.mod.LTNG_ABSORB,                xi.mod.WATER_ABSORB,            xi.mod.LIGHT_ABSORB,        xi.mod.DARK_ABSORB        }
+xi.magic.barSpell            = { xi.effect.BARFIRE,            xi.effect.BARBLIZZARD,       xi.effect.BARAERO,             xi.effect.BARSTONE,            xi.effect.BARTHUNDER,              xi.effect.BARWATER              }
 
 local elementalObi           = { xi.mod.FORCE_FIRE_DWBONUS,    xi.mod.FORCE_ICE_DWBONUS,    xi.mod.FORCE_WIND_DWBONUS,     xi.mod.FORCE_EARTH_DWBONUS,    xi.mod.FORCE_LIGHTNING_DWBONUS,    xi.mod.FORCE_WATER_DWBONUS,     xi.mod.FORCE_LIGHT_DWBONUS, xi.mod.FORCE_DARK_DWBONUS }
 local spellAcc               = { xi.mod.FIREACC,               xi.mod.ICEACC,               xi.mod.WINDACC,                xi.mod.EARTHACC,               xi.mod.THUNDERACC,                 xi.mod.WATERACC,                xi.mod.LIGHTACC,            xi.mod.DARKACC            }
@@ -554,14 +554,18 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     -----------------------------------
     -- Apply level correction.
     -----------------------------------
-    local levelDiff = utils.clamp(caster:getMainLvl() - target:getMainLvl(), -5, 5)
-    magicAcc        = magicAcc + levelDiff * 3
+    local levelDiff = caster:getMainLvl() - target:getMainLvl()
 
     -----------------------------------
     -- STEP 2: Get target magic evasion
     -- Base magic evasion (base magic evasion plus resistances(players), plus elemental defense(mobs)
     -----------------------------------
-    magicEva = target:getMod(xi.mod.MEVA) + resMod
+    if target:isPC() then
+        magiceva = target:getMod(xi.mod.MEVA) + resMod
+    else
+        dLvl = utils.clamp(dLvl, 0, 99) -- Mobs should not have a disadvantage when targeted
+        magiceva = target:getMod(xi.mod.MEVA) + (4 * levelDiff) + resMod
+    end
 
     -----------------------------------
     -- STEP 3: Get Magic Hit Rate
@@ -585,15 +589,6 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
         if randomVar <= (1 - magicHitRate / 100) ^ tierVar then
             resistTier = tierVar
             break
-        end
-    end
-
-    -- Apply extra roll for elemental resistance boons. Testimonial. This needs retail testing.
-    if randomVar > 0.5 then
-        if resMod > 0 then
-            resistTier = resistTier + 1
-        elseif resMod < 0 then
-            resistTier = resistTier - 1
         end
     end
 

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -28,7 +28,7 @@ xi.magic.singleWeatherStrong = { xi.weather.HOT_SPELL,         xi.weather.SNOW, 
 xi.magic.doubleWeatherStrong = { xi.weather.HEAT_WAVE,         xi.weather.BLIZZARDS,        xi.weather.GALES,              xi.weather.SAND_STORM,         xi.weather.THUNDERSTORMS,          xi.weather.SQUALL,              xi.weather.STELLAR_GLARE,   xi.weather.DARKNESS       }
 xi.magic.singleWeatherWeak   = { xi.weather.RAIN,              xi.weather.HOT_SPELL,        xi.weather.SNOW,               xi.weather.WIND,               xi.weather.DUST_STORM,             xi.weather.THUNDER,             xi.weather.GLOOM,           xi.weather.AURORAS        }
 xi.magic.doubleWeatherWeak   = { xi.weather.SQUALL,            xi.weather.HEAT_WAVE,        xi.weather.BLIZZARDS,          xi.weather.GALES,              xi.weather.SAND_STORM,             xi.weather.THUNDERSTORMS,       xi.weather.DARKNESS,        xi.weather.STELLAR_GLARE  }
-xi.magic.resistMod           = { xi.mod.FIRE_RES,              xi.mod.ICE_RES,              xi.mod.WIND_RES,               xi.mod.EARTH_RES,              xi.mod.THUNDER_RES,                xi.mod.WATER_RES,               xi.mod.LIGHT_RES,           xi.mod.DARK_RES           }
+xi.magic.resistMod           = { xi.mod.FIRE_MEVA,             xi.mod.ICE_MEVA,             xi.mod.WIND_MEVA,              xi.mod.EARTH_MEVA,             xi.mod.THUNDER_MEVA,               xi.mod.WATER_MEVA,              xi.mod.LIGHT_MEVA,          xi.mod.DARK_MEVA          }
 xi.magic.specificDmgTakenMod = { xi.mod.FIRE_SDT,              xi.mod.ICE_SDT,              xi.mod.WIND_SDT,               xi.mod.EARTH_SDT,              xi.mod.THUNDER_SDT,                xi.mod.WATER_SDT,               xi.mod.LIGHT_SDT,           xi.mod.DARK_SDT           }
 xi.magic.absorbMod           = { xi.mod.FIRE_ABSORB,           xi.mod.ICE_ABSORB,           xi.mod.WIND_ABSORB,            xi.mod.EARTH_ABSORB,           xi.mod.LTNG_ABSORB,                xi.mod.WATER_ABSORB,            xi.mod.LIGHT_ABSORB,        xi.mod.DARK_ABSORB        }
 xi.magic.barSpell            = { xi.effect.BARFIRE,            xi.effect.BARBLIZZARD,       xi.effect.BARAERO,             xi.effect.BARSTONE,            xi.effect.BARTHUNDER,              xi.effect.BARWATER              }
@@ -385,7 +385,6 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     local spellGroup    = spell and spell:getSpellGroup() or xi.magic.spellGroup.NONE
 
     local magicAcc      = caster:getMod(xi.mod.MACC) + caster:getILvlMacc() + bonusMagicAccuracy
-    local magicEva      = 0
     local magicHitRate  = 0
     local resMod        = 0 -- Some spells may possibly be non elemental.
 
@@ -560,18 +559,19 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     -- STEP 2: Get target magic evasion
     -- Base magic evasion (base magic evasion plus resistances(players), plus elemental defense(mobs)
     -----------------------------------
+    local magiceva = target:getMod(xi.mod.MEVA)
     if target:isPC() then
-        magiceva = target:getMod(xi.mod.MEVA) + resMod
+        magiceva = magiceva + resMod
     else
-        dLvl = utils.clamp(dLvl, 0, 99) -- Mobs should not have a disadvantage when targeted
-        magiceva = target:getMod(xi.mod.MEVA) + (4 * levelDiff) + resMod
+        levelDiff = utils.clamp(levelDiff, 0, 99) -- Mobs should not have a disadvantage when targeted
+        magiceva =  magiceva + (4 * levelDiff) + resMod
     end
 
     -----------------------------------
     -- STEP 3: Get Magic Hit Rate
     -- https://www.bg-wiki.com/ffxi/Magic_Hit_Rate
     -----------------------------------
-    local magicAccDiff = magicAcc - magicEva
+    local magicAccDiff = magicAcc - magiceva
 
     if magicAccDiff < 0 then
         magicHitRate = utils.clamp(50 + math.floor(magicAccDiff / 2), 5, 95)

--- a/scripts/globals/spells/enhancing_spell.lua
+++ b/scripts/globals/spells/enhancing_spell.lua
@@ -408,7 +408,7 @@ xi.spells.enhancing.useEnhancingSpell = function(caster, target, spell)
     -- Handle exceptions and weird behaviour here, before calculating anything.
     ------------------------------------------------------------
 
-    if target:getStatusEffect(xi.effect.ALL_MISS):getPower() == 2 then
+    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStatusEffect(xi.effect.ALL_MISS):getPower() > 1 then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         return 0
     end

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -293,7 +293,7 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
     end
 
     -- handle super jump
-    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStausEffect(xi.effect.ALL_MISS):getPower() > 1 then
+    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStatusEffect(xi.effect.ALL_MISS):getPower() > 1 then
         skill:setMsg(xi.msg.basic.JA_MISS_2)
         return 0
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixed an issue where super jump code could cause lua errors when a mob casted a spell on itself. 
+ Fixes MACC calculations for Enfeebling spells.
+ Added elemental resistance calculation to Enfeebling spells where they were previously only resist effect calculations.
+ Adjusts MACC calculations for elemental spells. Primarily related to MEVA values and their different implementation between players and mobs.
+ Added building resistance piping for enfeeble effects and elemental types. This simply makes a skeleton which currently uses a 2%/1% for element types and 4%/2% for enfeeble effects for NMs and normal mobs respectively.
+ Fixed wyvern not using super jump consistently.
+ Fixed effect wearing messages for super jump.
+ Fixed an issue where some actions were not able to be completed and calced properly due to super jump.

## Steps to test these changes
+ Tested magic accuracy for both elemental and enfeeb on elementals to ensure for elemental resistance checks.
+ Tested magic accuracy on multiple HNMs to check for dStat, dLvl, and effect resistance procs.
+ Ensured lua errors do not occur during any mob self buff or when a player does not have super jump.
+ Tested resistance building by ensuring it resets properly and that the formula cannot exceed 1000 for the given mod.
+ Ensured that there are no messages with super jump or super climb.
+ Ensured the wyvern now consistently uses super climb when the DRG uses super jump.
+ Ensured that certain mobskills and actions calced properly if the player was super jumped.