### PR TITLE
Fixed an Issue with ApplyResistance for Bard Songs

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -564,9 +564,14 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
         end
     else -- If a bard song
         if target:isPC() then
-            local secondarySkill = caster:getEquippedItem(xi.slot.RANGED):getSkillType()
+            local secondarySkill = 0
             local gearBonus = caster:getMod(xi.mod.MACC) + caster:getILvlMacc()
-            if secondarySkill == 41 or secondarySkill == 42 then
+
+            if caster:getEquippedItem(xi.slot.RANGED) ~= nil then
+                secondarySkill = caster:getEquippedItem(xi.slot.RANGED):getSkillType()
+            end
+
+            if secondarySkill == xi.skill.WIND_INSTRUMENT or secondarySkill == xi.skill.STRING_INSTRUMENT then
                 magicacc = caster:getSkillLevel(skillType) + (secondarySkill / 3) + gearBonus + dStatAcc
             else
                 magicacc = caster:getSkillLevel(skillType) + gearBonus + dStatAcc


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes a resistance calculation for all Bard songs where there was an error if the user was simply singing. This caused an issue as the rest of the resistance calculation would halt. Added a ranged weapon check to ensure we not try to calculate a skill level for it.

## Steps to test these changes
+ Used horde lullaby and foe lullaby with a wind instrument and didn't receive errors.
+ Used horde lullaby and foe lullaby without a weapon equipped and didn't receive errors.
