### PR TITLE
Setup Resistance Build Piping | Add Permanent Resistance Build to Spells

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -706,8 +706,8 @@ function getEffectResistance(target, effect, returnBuild)
 
     for effectIndex, effectTable in pairs(resTable) do
         if effectIndex == effect then
-            effectres = resTable.effectres
-            buildres = resTable.buildres
+            effectres = effectTable.effectres
+            buildres = effectTable.buildres
             break
         end
     end

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -578,7 +578,7 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
 
     if element ~= xi.magic.ele.NONE then
         if target:isMob() then
-            tryBuildResistance(target, xi.magic.resistMod[element], false)
+            tryBuildResistance(target, xi.magic.resistMod[element], nil, false)
         end
 
         resMod = target:getMod(xi.magic.resistMod[element])
@@ -676,39 +676,44 @@ end
 
 -- Returns the amount of resistance the
 -- target has to the given effect (stun, sleep, etc..)
-function getEffectResistance(target, effect)
+function getEffectResistance(target, effect, returnBuild)
     local effectres = 0
+    local buildres = 0
     local statusres = target:getMod(xi.mod.STATUSRES)
-    if effect == xi.effect.SLEEP_I or effect == xi.effect.SLEEP_II then
-        effectres = xi.mod.SLEEPRES
-    elseif effect == xi.effect.LULLABY then
-        effectres = xi.mod.LULLABYRES
-    elseif effect == xi.effect.POISON then
-        effectres = xi.mod.POISONRES
-    elseif effect == xi.effect.PARALYSIS then
-        effectres = xi.mod.PARALYZERES
-    elseif effect == xi.effect.BLINDNESS then
-        effectres = xi.mod.BLINDRES
-    elseif effect == xi.effect.SILENCE then
-        effectres = xi.mod.SILENCERES
-    elseif effect == xi.effect.PLAGUE or effect == xi.effect.DISEASE then
-        effectres = xi.mod.VIRUSRES
-    elseif effect == xi.effect.PETRIFICATION then
-        effectres = xi.mod.PETRIFYRES
-    elseif effect == xi.effect.BIND then
-        effectres = xi.mod.BINDRES
-    elseif effect == xi.effect.CURSE_I or effect == xi.effect.CURSE_II or effect == xi.effect.BANE then
-        effectres = xi.mod.CURSERES
-    elseif effect == xi.effect.WEIGHT then
-        effectres = xi.mod.GRAVITYRES
-    elseif effect == xi.effect.SLOW or effect == xi.effect.ELEGY then
-        effectres = xi.mod.SLOWRES
-    elseif effect == xi.effect.STUN then
-        effectres = xi.mod.STUNRES
-    elseif effect == xi.effect.CHARM_I or effect == xi.effect.CHARM_II then
-        effectres = xi.mod.CHARMRES
-    elseif effect == xi.effect.AMNESIA then
-        effectres = xi.mod.AMNESIARES
+    local resTable =
+    {
+        [xi.effect.SLEEP_I] = { effectres = xi.mod.SLEEPRES, buildres = xi.mod.SLEEPRESBUILD },
+        [xi.effect.SLEEP_II] = { effectres = xi.mod.SLEEPRES, buildres = xi.mod.SLEEPRESBUILD },
+        [xi.effect.LULLABY] = { effectres = xi.mod.LULLABYRES, buildres = xi.mod.LULLABYRESBUILD },
+        [xi.effect.POISON] = { effectres = xi.mod.POISONRES, buildres = xi.mod.POISONRESBUILD },
+        [xi.effect.PARALYSIS] = { effectres = xi.mod.PARALYZERES, buildres = xi.mod.PARALYZERESBUILD },
+        [xi.effect.BLINDNESS] = { effectres = xi.mod.BLINDRES, buildres = xi.mod.BLINDRESBUILD },
+        [xi.effect.SILENCE] = { effectres = xi.mod.SILENCERES, buildres = xi.mod.SILENCERESBUILD },
+        [xi.effect.PLAGUE] = { effectres = xi.mod.VIRUSRES, buildres = xi.mod.VIRUSRESBUILD },
+        [xi.effect.PETRIFICATION] = { effectres = xi.mod.PETRIFYRES, buildres = xi.mod.PETRIFYRESBUILD },
+        [xi.effect.BIND] = { effectres = xi.mod.BINDRES, buildres = xi.mod.BINDRESBUILD },
+        [xi.effect.CURSE_I] = { effectres = xi.mod.CURSERES, buildres = xi.mod.CURSERESBUILD },
+        [xi.effect.CURSE_II] = { effectres = xi.mod.CURSERES, buildres = xi.mod.CURSERESBUILD },
+        [xi.effect.BANE] = { effectres = xi.mod.CURSERES, buildres = xi.mod.CURSERESBUILD },
+        [xi.effect.WEIGHT] = { effectres = xi.mod.GRAVITYRES, buildres = xi.mod.GRAVITYRESBUILD },
+        [xi.effect.SLOW] = { effectres = xi.mod.SLOWRES, buildres = xi.mod.SLOWRESBUILD },
+        [xi.effect.ELEGY] = { effectres = xi.mod.SLOWRES, buildres = xi.mod.SLOWRESBUILD },
+        [xi.effect.STUN] = { effectres = xi.mod.STUNRES, buildres = xi.mod.STUNRESBUILD },
+        [xi.effect.CHARM_I] = { effectres = xi.mod.CHARMRES, buildres = xi.mod.CHARMRESBUILD },
+        [xi.effect.CHARM_II] = { effectres = xi.mod.CHARMRES, buildres = xi.mod.CHARMRESBUILD },
+        [xi.effect.AMNESIA] = { effectres = xi.mod.AMNESIARES, buildres = xi.mod.AMNESIARESBUILD },
+    }
+
+    for effectIndex, effectTable in pairs(resTable) do
+        if effectIndex == effect then
+            effectres = resTable.effectres
+            buildres = resTable.buildres
+            break
+        end
+    end
+
+    if returnBuild ~= nil then
+        return buildres
     end
 
     if target:isMob() and effectres ~= 0 then
@@ -1373,6 +1378,22 @@ function calculateDuration(duration, magicSkill, spellGroup, caster, target, use
             if caster:hasStatusEffect(xi.effect.STYMIE) then
                 duration = duration + caster:getJobPointLevel(xi.jp.STYMIE_EFFECT)
             end
+        end
+    end
+
+    return math.floor(duration)
+end
+
+function calculateBuildDuration(target, duration, effect)
+
+    if target:isMob() then
+        local buildRes = getEffectResistance(target, effect, true)
+
+        if target:getMod(buildRes) ~= 0 then
+            local builtRes = target:getLocalVar(string.format("[RESBUILD]Base_%s", buildRes))
+
+            duration = duration - (builtRes + target:getMod(buildRes))
+            target:setLocalVar(string.format("[RESBUILD]Base_%s", buildRes), builtRes + target:getMod(buildRes))
         end
     end
 

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1392,12 +1392,16 @@ function calculateBuildDuration(target, duration, effect)
         if target:getMod(buildRes) ~= 0 then
             local builtRes = target:getLocalVar(string.format("[RESBUILD]Base_%s", buildRes))
 
-            duration = duration - (builtRes + target:getMod(buildRes))
+            duration = duration - ((builtRes + target:getMod(buildRes)) / 10) -- Used to add more fidelity to the build. Adding a mod of 30 will be -3 seconds per cast.
             target:setLocalVar(string.format("[RESBUILD]Base_%s", buildRes), builtRes + target:getMod(buildRes))
         end
     end
 
     return math.floor(duration)
+end
+
+function resetBuildPercent(entity, buildRes)
+    entity:setLocalVar(string.format("[RESBUILD]Base_%s", buildRes), 0)
 end
 
 function calculatePotency(basePotency, magicSkill, caster, target)

--- a/scripts/globals/spells/black/bind.lua
+++ b/scripts/globals/spells/black/bind.lua
@@ -27,8 +27,14 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
         --Try to erase a weaker bind.
-        if target:addStatusEffect(params.effect, target:getSpeed(), 0 , duration * resist) then
+        elseif target:addStatusEffect(params.effect, target:getSpeed(), 0 , resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/bindga.lua
+++ b/scripts/globals/spells/black/bindga.lua
@@ -29,8 +29,14 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if (resist >= 0.5) then --Do it!
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
         --Try to erase a weaker bind.
-        if (target:addStatusEffect(xi.effect.BIND, target:getSpeed(), 0, duration*resist)) then
+        elseif (target:addStatusEffect(xi.effect.BIND, target:getSpeed(), 0, resduration)) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/blind.lua
+++ b/scripts/globals/spells/black/blind.lua
@@ -33,7 +33,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
-        if target:addStatusEffect(params.effect, potency, 0 , duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, potency, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/blind_ii.lua
+++ b/scripts/globals/spells/black/blind_ii.lua
@@ -34,7 +34,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
-        if target:addStatusEffect(params.effect, potency, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, potency, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/blindga.lua
+++ b/scripts/globals/spells/black/blindga.lua
@@ -39,7 +39,11 @@ spell_object.onSpellCast = function(caster, target, spell)
 
     if (duration >= 60) then --Do it!
 
-        if (target:addStatusEffect(xi.effect.BLINDNESS, power, 0, duration)) then
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, power, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/break.lua
+++ b/scripts/globals/spells/black/break.lua
@@ -26,7 +26,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then
-        if target:addStatusEffect(params.effect, 1, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/breakga.lua
+++ b/scripts/globals/spells/black/breakga.lua
@@ -26,7 +26,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then
-        if target:addStatusEffect(params.effect, 1, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, 1, 0, duration * resist) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/curse.lua
+++ b/scripts/globals/spells/black/curse.lua
@@ -29,7 +29,11 @@ spell_object.onSpellCast = function(caster, target, spell)
     duration = duration * applyResistanceEffect(caster, target, spell, params)
 
     if (duration >= 150) then --Do it!
-        if (target:addStatusEffect(xi.effect.CURSE_I, power, 0, duration)) then
+        duration = calculateBuildDuration(target, duration, params.effect)
+
+        if duration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif (target:addStatusEffect(xi.effect.CURSE_I, power, 0, duration)) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/graviga.lua
+++ b/scripts/globals/spells/black/graviga.lua
@@ -28,7 +28,11 @@ spell_object.onSpellCast = function(caster, target, spell)
     duration = duration * applyResistanceEffect(caster, target, spell, params)
 
     if (duration >= 30) then --Do it!
-        if (target:addStatusEffect(xi.effect.WEIGHT, power, 0, duration)) then
+        duration = calculateBuildDuration(target, duration, params.effect)
+
+        if duration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif (target:addStatusEffect(xi.effect.WEIGHT, power, 0, duration)) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/gravity.lua
+++ b/scripts/globals/spells/black/gravity.lua
@@ -28,7 +28,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
-        if target:addStatusEffect(params.effect, power, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, power, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/gravity_ii.lua
+++ b/scripts/globals/spells/black/gravity_ii.lua
@@ -28,7 +28,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
-        if target:addStatusEffect(params.effect, power, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, power, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison.lua
+++ b/scripts/globals/spells/black/poison.lua
@@ -31,7 +31,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- effect taken
-        if target:addStatusEffect(params.effect, power, 3, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, power, 3, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison_ii.lua
+++ b/scripts/globals/spells/black/poison_ii.lua
@@ -31,7 +31,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- effect taken
-        if target:addStatusEffect(params.effect, power, 3, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, power, 3, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison_iii.lua
+++ b/scripts/globals/spells/black/poison_iii.lua
@@ -27,7 +27,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- effect taken
-        if target:addStatusEffect(params.effect, power, 3, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, power, 3, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poisonga.lua
+++ b/scripts/globals/spells/black/poisonga.lua
@@ -31,7 +31,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- effect taken
-        if target:addStatusEffect(params.effect, power, 3, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, power, 3, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poisonga_ii.lua
+++ b/scripts/globals/spells/black/poisonga_ii.lua
@@ -31,7 +31,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- effect taken
-        if target:addStatusEffect(params.effect, power, 3, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, power, 3, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poisonga_iii.lua
+++ b/scripts/globals/spells/black/poisonga_iii.lua
@@ -39,9 +39,13 @@ spell_object.onSpellCast = function(caster, target, spell)
 
     local resist = applyResistanceEffect(caster, target, spell, params)
     if (resist == 1 or resist == 0.5) then -- effect taken
-        duration = duration * resist
+        local resduration = duration * resist
 
-        if (target:addStatusEffect(effect, power, 3, duration)) then
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif (target:addStatusEffect(effect, power, 3, resduration)) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/sleep.lua
+++ b/scripts/globals/spells/black/sleep.lua
@@ -24,7 +24,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then
-        if target:addStatusEffect(params.effect, 1, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/sleep_ii.lua
+++ b/scripts/globals/spells/black/sleep_ii.lua
@@ -24,7 +24,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then
-        if target:addStatusEffect(params.effect, 2, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, 2, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/sleepga.lua
+++ b/scripts/globals/spells/black/sleepga.lua
@@ -35,7 +35,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     end
 
     if resist >= 0.5 then
-        if target:addStatusEffect(params.effect, 1, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect

--- a/scripts/globals/spells/black/sleepga_ii.lua
+++ b/scripts/globals/spells/black/sleepga_ii.lua
@@ -24,7 +24,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then
-        if target:addStatusEffect(params.effect, 2, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, 2, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/stun.lua
+++ b/scripts/globals/spells/black/stun.lua
@@ -32,7 +32,13 @@ spell_object.onSpellCast = function(caster, target, spell)
         -- no effect
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     else
-        if (target:addStatusEffect(xi.effect.STUN, 1, 0, duration*resist)) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif (target:addStatusEffect(xi.effect.STUN, 1, 0, resduration)) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/virus.lua
+++ b/scripts/globals/spells/black/virus.lua
@@ -26,9 +26,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.effect = effect
     local resist = applyResistanceEffect(caster, target, spell, params)
     if (resist >= 0.5) then -- effect taken
-        duration = duration * resist
+        local resduration = duration * resist
 
-        if (target:addStatusEffect(effect, 5, 3, duration)) then
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif (target:addStatusEffect(effect, 5, 3, duration)) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/songs/battlefield_elegy.lua
+++ b/scripts/globals/spells/songs/battlefield_elegy.lua
@@ -46,11 +46,17 @@ spell_object.onSpellCast = function(caster, target, spell)
             duration = duration * 2
         end
 
+        duration = duration * resm
+
         -- Ensure the reduction is capped at 50%
         power = utils.clamp(power, 0, 5000)
 
+        duration = calculateBuildDuration(target, duration, params.effect)
+
+        if duration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
         -- Try to overwrite weaker elegy
-        if target:addStatusEffect(xi.effect.ELEGY, power, 0, duration) then
+        elseif target:addStatusEffect(xi.effect.ELEGY, power, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/songs/carnage_elegy.lua
+++ b/scripts/globals/spells/songs/carnage_elegy.lua
@@ -46,11 +46,17 @@ spell_object.onSpellCast = function(caster, target, spell)
             duration = duration * 2
         end
 
+        duration = duration * resm
+
         -- Ensure the reduction is capped at 50%
         power = utils.clamp(power, 0, 5000)
 
+        duration = calculateBuildDuration(target, duration, params.effect)
+
+        if duration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
         -- Try to overwrite weaker elegy
-        if target:addStatusEffect(xi.effect.ELEGY, power, 0, duration) then
+        elseif target:addStatusEffect(xi.effect.ELEGY, power, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/songs/foe_lullaby.lua
+++ b/scripts/globals/spells/songs/foe_lullaby.lua
@@ -36,7 +36,9 @@ spell_object.onSpellCast = function(caster, target, spell)
             duration = duration * 2
         end
 
-        calculateBuildDuration(target, duration, params.effect)
+        duration = duration * resm
+
+        duration = calculateBuildDuration(target, duration, params.effect)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/songs/foe_lullaby.lua
+++ b/scripts/globals/spells/songs/foe_lullaby.lua
@@ -36,7 +36,11 @@ spell_object.onSpellCast = function(caster, target, spell)
             duration = duration * 2
         end
 
-        if target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
+        calculateBuildDuration(target, duration, params.effect)
+
+        if duration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/songs/foe_lullaby_ii.lua
+++ b/scripts/globals/spells/songs/foe_lullaby_ii.lua
@@ -36,7 +36,9 @@ spell_object.onSpellCast = function(caster, target, spell)
             duration = duration * 2
         end
 
-        calculateBuildDuration(target, duration, params.effect)
+        duration = duration * resm
+
+        duration = calculateBuildDuration(target, duration, params.effect)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/songs/foe_lullaby_ii.lua
+++ b/scripts/globals/spells/songs/foe_lullaby_ii.lua
@@ -36,7 +36,11 @@ spell_object.onSpellCast = function(caster, target, spell)
             duration = duration * 2
         end
 
-        if target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
+        calculateBuildDuration(target, duration, params.effect)
+
+        if duration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/songs/foe_requiem.lua
+++ b/scripts/globals/spells/songs/foe_requiem.lua
@@ -51,6 +51,8 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
+    duration = duration * resm
+
     -- Try to overwrite weaker slow / haste
     if canOverwrite(target, effect, power) then
         -- overwrite them

--- a/scripts/globals/spells/songs/foe_requiem_ii.lua
+++ b/scripts/globals/spells/songs/foe_requiem_ii.lua
@@ -51,6 +51,8 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
+    duration = duration * resm
+
     -- Try to overwrite weaker slow / haste
     if canOverwrite(target, effect, power) then
         -- overwrite them

--- a/scripts/globals/spells/songs/foe_requiem_iii.lua
+++ b/scripts/globals/spells/songs/foe_requiem_iii.lua
@@ -51,6 +51,8 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
+    duration = duration * resm
+
     -- Try to overwrite weaker slow / haste
     if canOverwrite(target, effect, power) then
         -- overwrite them

--- a/scripts/globals/spells/songs/foe_requiem_iv.lua
+++ b/scripts/globals/spells/songs/foe_requiem_iv.lua
@@ -51,6 +51,8 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
+    duration = duration * resm
+
     -- Try to overwrite weaker slow / haste
     if canOverwrite(target, effect, power) then
         -- overwrite them

--- a/scripts/globals/spells/songs/foe_requiem_v.lua
+++ b/scripts/globals/spells/songs/foe_requiem_v.lua
@@ -51,6 +51,8 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
+    duration = duration * resm
+
     -- Try to overwrite weaker slow / haste
     if canOverwrite(target, effect, power) then
         -- overwrite them

--- a/scripts/globals/spells/songs/foe_requiem_vi.lua
+++ b/scripts/globals/spells/songs/foe_requiem_vi.lua
@@ -55,6 +55,9 @@ spell_object.onSpellCast = function(caster, target, spell)
     if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
         duration = duration * 2
     end
+
+    duration = duration * resm
+
     -- Try to overwrite weaker slow / haste
     if canOverwrite(target, effect, power) then
         -- overwrite them

--- a/scripts/globals/spells/songs/foe_requiem_vii.lua
+++ b/scripts/globals/spells/songs/foe_requiem_vii.lua
@@ -50,6 +50,9 @@ spell_object.onSpellCast = function(caster, target, spell)
     if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
         duration = duration * 2
     end
+
+    duration = duration * resm
+
     -- Try to overwrite weaker slow / haste
     if canOverwrite(target, effect, power) then
         -- overwrite them

--- a/scripts/globals/spells/songs/horde_lullaby.lua
+++ b/scripts/globals/spells/songs/horde_lullaby.lua
@@ -36,7 +36,13 @@ spell_object.onSpellCast = function(caster, target, spell)
             duration = duration * 2
         end
 
-        if target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
+        duration = duration * resm
+
+        duration = calculateBuildDuration(target, duration, params.effect)
+
+        if duration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/songs/horde_lullaby_ii.lua
+++ b/scripts/globals/spells/songs/horde_lullaby_ii.lua
@@ -36,7 +36,13 @@ spell_object.onSpellCast = function(caster, target, spell)
             duration = duration * 2
         end
 
-        if target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
+        duration = duration * resm
+
+        duration = calculateBuildDuration(target, duration, params.effect)
+
+        if duration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/songs/maidens_virelai.lua
+++ b/scripts/globals/spells/songs/maidens_virelai.lua
@@ -26,6 +26,7 @@ end
 spell_object.onSpellCast = function(caster, target, spell)
     -- local dCHR = (caster:getStat(xi.mod.CHR) - target:getStat(xi.mod.CHR))
     local bonus = 0 -- No idea what value, but seems likely to need this edited later to get retail resist rates.
+    local duration = 30
     local params = {}
     params.diff = nil
     params.attribute = xi.mod.CHR
@@ -36,8 +37,15 @@ spell_object.onSpellCast = function(caster, target, spell)
 
     if (resist >= 0.25 and caster:getCharmChance(target, false) > 0) then
         spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
-        if (caster:isMob()) then
-            target:addStatusEffect(xi.effect.CHARM_I, 0, 0, 30*resist)
+
+        duration = duration * resist
+
+        duration = calculateBuildDuration(target, duration, params.effect)
+
+        if duration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif (caster:isMob()) then
+            target:addStatusEffect(xi.effect.CHARM_I, 0, 0, duration)
             caster:charm(target)
         else
             caster:charmPet(target)

--- a/scripts/globals/spells/songs/massacre_elegy.lua
+++ b/scripts/globals/spells/songs/massacre_elegy.lua
@@ -45,8 +45,14 @@ spell_object.onSpellCast = function(caster, target, spell)
             duration = duration * 2
         end
 
+        duration = duration * resm
+
+        duration = calculateBuildDuration(target, duration, params.effect)
+
+        if duration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
         -- Try to overwrite weaker elegy
-        if target:addStatusEffect(xi.effect.ELEGY, power, 0, duration) then
+        elseif target:addStatusEffect(xi.effect.ELEGY, power, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/white/paralyga.lua
+++ b/scripts/globals/spells/white/paralyga.lua
@@ -41,7 +41,13 @@ spell_object.onSpellCast = function(caster, target, spell)
         local resist = applyResistanceEffect(caster, target, spell, params)
 
         if (resist >= 0.5) then --there are no quarter or less hits, if target resists more than .5 spell is resisted completely
-            if (target:addStatusEffect(xi.effect.PARALYSIS, potency, 0, duration*resist)) then
+            local resduration = duration * resist
+
+            resduration = calculateBuildDuration(target, duration, params.effect)
+
+            if resduration == 0 then
+                spell:setMsg(xi.msg.basic.NONE)
+            elseif (target:addStatusEffect(xi.effect.PARALYSIS, potency, 0, resduration)) then
                 spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
             else
                 -- no effect

--- a/scripts/globals/spells/white/paralyze.lua
+++ b/scripts/globals/spells/white/paralyze.lua
@@ -31,7 +31,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- There are no quarter or less hits, if target resists more than .5 spell is resisted completely
-        if target:addStatusEffect(params.effect, potency, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, potency, 0, duration * resist) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             -- no effect

--- a/scripts/globals/spells/white/paralyze_ii.lua
+++ b/scripts/globals/spells/white/paralyze_ii.lua
@@ -31,7 +31,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then
-        if target:addStatusEffect(params.effect, potency, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, potency, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/silence.lua
+++ b/scripts/globals/spells/white/silence.lua
@@ -25,7 +25,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
-        if target:addStatusEffect(params.effect , 1, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect , 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/white/silencega.lua
+++ b/scripts/globals/spells/white/silencega.lua
@@ -35,7 +35,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if (resist >= 0.5) then --Do it!
-        if (target:addStatusEffect(effectType, 1, 0, duration * resist)) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif (target:addStatusEffect(effectType, 1, 0, resduration)) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/white/slow.lua
+++ b/scripts/globals/spells/white/slow.lua
@@ -32,7 +32,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
-        if target:addStatusEffect(params.effect, power, 0, duration * resist, 0, 1) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, 1) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/slow_ii.lua
+++ b/scripts/globals/spells/white/slow_ii.lua
@@ -31,7 +31,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
-        if target:addStatusEffect(params.effect, power, 0, duration * resist) then
+        local resduration = duration * resist
+
+        resduration = calculateBuildDuration(target, duration, params.effect)
+
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, power, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/slowga.lua
+++ b/scripts/globals/spells/white/slowga.lua
@@ -31,7 +31,11 @@ spell_object.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- Do it!
-        if target:addStatusEffect(params.effect, power, 0, duration * resist, 0, 1) then
+        local resduration = duration * resist
+        resduration = calculateBuildDuration(target, duration, params.effect)
+        if resduration == 0 then
+            spell:setMsg(xi.msg.basic.NONE)
+        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, 1) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1688,6 +1688,24 @@ xi.mod =
     AUGMENT_BLU_MAGIC      = 1036, -- Percent chance for BLU magic to receive 3x WSC value for spell (BLU AF3 Sets)
     GEOMANCY_MP_NO_DEPLETE = 1037, -- Percent chance for Geomancy to cost 0 MP (GEO AF3 Sets)
 
+    -- Permenant Resistance Build Modifiers
+    SLEEPRESBUILD                 = 1138,
+    POISONRESBUILD                = 1139,
+    PARALYZERESBUILD              = 1140,
+    BLINDRESBUILD                 = 1141,
+    SILENCERESBUILD               = 1142,
+    VIRUSRESBUILD                 = 1143,
+    PETRIFYRESBUILD               = 1144,
+    BINDRESBUILD                  = 1145,
+    CURSERESBUILD                 = 1146,
+    GRAVITYRESBUILD               = 1147,
+    SLOWRESBUILD                  = 1148,
+    STUNRESBUILD                  = 1149,
+    CHARMRESBUILD                 = 1150,
+    AMNESIARESBUILD               = 1151,
+    LULLABYRESBUILD               = 1152,
+    DEATHRESBUILD                 = 1153,
+
     -- IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN src/map/modifier.h ASWELL!
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -883,6 +883,24 @@ enum class Mod
     AUGMENT_BLU_MAGIC      = 1036, // Percent chance for BLU magic to receive 3x WSC value for spell (BLU AF3 Sets)
     GEOMANCY_MP_NO_DEPLETE = 1037, // Percent chance for Geomancy to cost 0 MP (GEO AF3 Sets)
 
+    // Permenant Resistance Build Modifiers
+    SLEEPRESBUILD          = 1138,
+    POISONRESBUILD         = 1139,
+    PARALYZERESBUILD       = 1140,
+    BLINDRESBUILD          = 1141,
+    SILENCERESBUILD        = 1142,
+    VIRUSRESBUILD          = 1143,
+    PETRIFYRESBUILD        = 1144,
+    BINDRESBUILD           = 1145,
+    CURSERESBUILD          = 1146,
+    GRAVITYRESBUILD        = 1147,
+    SLOWRESBUILD           = 1148,
+    STUNRESBUILD           = 1149,
+    CHARMRESBUILD          = 1150,
+    AMNESIARESBUILD        = 1151,
+    LULLABYRESBUILD        = 1152,
+    DEATHRESBUILD          = 1153,
+
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/globals/status.lua ASWELL!
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Adds back all resbuild mods.
+ Sets up lua piping to decrease duration based on the mod's value. This stacks cumulatively and is stored as a whole value for the mob via localvar.
+ Adds this function to all applicable enfeebles to try to build permenant res.
+ Cleans up the resistance selector function to reduce cyclomatic complexity and to have it serve a dual purpose for finding these build res values.

## Steps to test these changes
+ Tested with Fafnir as a test mob with a high build rate of 50 and confirmed everything is operating normally.
