### PR TITLE
Fix Magical Mobskill and Breath Formulas To Use Proper Resist Calcs

### DIFF
--- a/scripts/globals/abilities/pets/meteorite.lua
+++ b/scripts/globals/abilities/pets/meteorite.lua
@@ -14,10 +14,15 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dint = pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-    local dmg = 500 + dint*1.5 + skill:getTP()/20
-    target:updateEnmityFromDamage(pet, dmg)
-    target:takeDamage(dmg, pet, xi.attackType.MAGICAL, xi.damageType.LIGHT)
-    return dmg
+    local damage = 500 + dint*1.5 + skill:getTP()/20
+
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHT, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHT)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+
+    target:updateEnmityFromDamage(pet, damage)
+    target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHT)
+    return damage
 end
 
 return ability_object

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -70,7 +70,10 @@ end
 local function getSpellBonusAcc(caster, target, spell, params)
     local magicAccBonus = 0
     local castersWeather = caster:getWeather()
-    local skill = spell:getSkillType()
+    local skill = xi.skill.NONE
+    if spell ~= nil then
+        skill = spell:getSkillType()
+    end
     local spellGroup = spell:getSpellGroup()
     local element = spell:getElement()
     local casterJob = caster:getMainJob()
@@ -464,18 +467,27 @@ function applyResistanceEffect(caster, target, spell, params)
     local skill = params.skillType
     local bonus = params.bonus
     local effect = params.effect
+    local element = params.element -- Will be nil if this isn't specified.
+    local magicaccbonus = 0
+    local effectRes = 0
 
     -- If Stymie is active, as long as the mob is not immune then the effect is not resisted
-    if effect ~= nil then -- Dispel's script doesn't have an "effect" to send here, nor should it.
+    if effect ~= nil and skill ~= nil then -- Dispel's script doesn't have an "effect" to send here, nor should it.
         if skill == xi.skill.ENFEEBLING_MAGIC and caster:hasStatusEffect(xi.effect.STYMIE) and target:canGainStatusEffect(effect) then
             caster:delStatusEffect(xi.effect.STYMIE)
             return 1
         end
     end
 
-    local element = spell:getElement()
-    local effectRes = 0
-    local magicaccbonus = getSpellBonusAcc(caster, target, spell, params)
+    if element == nil and skill~= nil and skill >= 32 and skill <= 45 then -- Covers all magic
+        element = spell:getElement()
+    elseif element == nil then -- Cover mobskills
+        element = xi.element.NONE
+    end
+
+    if spell ~= nil then
+        magicaccbonus = getSpellBonusAcc(caster, target, spell, params)
+    end
 
     if bonus ~= nil then
         magicaccbonus = magicaccbonus + bonus

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -133,6 +133,14 @@ local function MobTakeAoEShadow(mob, target, max)
     return math.random(1, max)
 end
 
+local function getBarSpellDefBonus(mob, target, spellElement)
+    if spellElement >= xi.magic.element.FIRE and spellElement <= xi.magic.element.WATER then
+        if target:hasStatusEffect(xi.magic.barSpell[spellElement]) then -- bar- spell magic defense bonus
+            return target:getStatusEffect(xi.magic.barSpell[spellElement]):getSubPower()
+        end
+    end
+end
+
 xi.mobskills.mobRangedMove = function(mob, target, skill, numberofhits, accmod, dmgmod, tpeffect)
     -- this will eventually contian ranged attack code
     return xi.mobskills.mobPhysicalMove(mob, target, skill, numberofhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.RANGED)
@@ -292,24 +300,17 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
     --get all the stuff we need
     local resist = 1
 
-    local mdefBarBonus = 0
-    if
-        element >= xi.magic.element.FIRE and
-        element <= xi.magic.element.WATER and
-        target:hasStatusEffect(xi.magic.barSpell[element])
-    then -- bar- spell magic defense bonus
-        mdefBarBonus = target:getStatusEffect(xi.magic.barSpell[element]):getSubPower()
-    end
-    -- plus 100 forces it to be a number
-    local mab = (100 + mob:getMod(xi.mod.MATT)) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus)
-
-    if mab > 1.3 then
-        mab = 1.3
+    local barspellDef = getBarSpellDefBonus(mob, target, element)
+    if barspellDef == nil then
+        barspellDef = 0
     end
 
-    if mab < 0.7 then
-        mab = 0.7
-    end
+    local mdef = barspellDef + target:getMod(xi.mod.MDEF)
+    local matt = mob:getMod(xi.mod.MATT)
+    local mab = matt / mdef
+    local bonusMacc = 0
+
+    mab = utils.clamp(mab, 0.7, 1.3)
 
     if tpeffect == xi.mobskills.magicalTpBonus.DMG_BONUS then
         damage = damage * (((skill:getTP() / 10)*tpvalue) / 100)
@@ -318,20 +319,22 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
     -- resistence is added last
     local finaldmg = damage * mab * dmgmod
 
-    -- get resistence
-    local avatarAccBonus = 0
-    if mob:isPet() and mob:getMaster() ~= nil then
+    local magicDefense = getElementalDamageReduction(target, element)
+
+    finaldmg = finaldmg * magicDefense
+
+    if mob:isPet() and mob:getMaster():isPC() then
         local master = mob:getMaster()
         if (master:getPetID() >= 0 and master:getPetID() <= 20) then -- check to ensure pet is avatar
-            avatarAccBonus = utils.clamp(master:getSkillLevel(xi.skill.SUMMONING_MAGIC) - master:getMaxSkillLevel(mob:getMainLvl(), xi.job.SMN, xi.skill.SUMMONING_MAGIC), 0, 200)
+            bonusMacc = bonusMacc + utils.clamp(master:getSkillLevel(xi.skill.SUMMONING_MAGIC) - master:getMaxSkillLevel(mob:getMainLvl(), xi.job.SMN, xi.skill.SUMMONING_MAGIC), 0, 200)
         end
     end
 
-    resist = xi.mobskills.applyPlayerResistance(mob, nil, target, mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), avatarAccBonus, element)
+    -- get resistence
+    local params = {diff = (mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT)), skillType = nil, bonus = bonusMacc, element = element, effect = nil}
+    resist = applyResistanceEffect(mob, target, nil, params) -- Uses magic.lua resistance calcs as this moves to a global use case.
 
-    local magicDefense = getElementalDamageReduction(target, element)
-
-    finaldmg = finaldmg * resist * magicDefense
+    finaldmg = finaldmg * resist
 
     returninfo.dmg = finaldmg
 
@@ -449,7 +452,9 @@ xi.mobskills.mobBreathMove = function(mob, target, percent, base, element, cap)
     -- elemental resistence
     if element ~= nil and element > 0 then
         -- no skill available, pass nil
-        local resist = xi.mobskills.applyPlayerResistance(mob, nil, target, mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), 0, element)
+        -- get resistence
+        local params = {diff = (mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT)), skillType = nil, bonus = 0, element = element, effect = nil}
+        local resist = applyResistanceEffect(mob, target, nil, params) -- Uses magic.lua resistance calcs as this moves to a global use case.
 
         -- get elemental damage reduction
         local defense = getElementalDamageReduction(target, element)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Appropriately applies resistances for magical mobskills (mobs and avatars) and breath attacks (mobs and player wyverns).
+ Introduces larger levels of variance via resist rates for damage, thus making the damage must less reliable and consistent.
+ This change heavily favors mobs as they generally will be a higher level than the user, thus driving resist rates into the ground when pets use skills on them.

## Steps to test these changes
+ Tested using SMN merit magical bloodpacts, damage seemed appropriate and showed variance due to resist rates.
+ Tested Wyverns using breath attacks and damage received a significant decrease from base and showed massive variance as soon as the level gap extended beyond 5 levels.
+ Tested bloodpacts against lower mobs which showed to have a lower variance, and against higher mobs which showed to have a high variance.
