### PR TITLE
Remove NM PHs From Beastmen Pruning

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -58,9 +58,11 @@ xi.mob.phOnDespawn = function(ph, phList, chance, cooldown, immediate)
                     if idtable[1] == ph:getID() then
                         DisallowRespawn(ph:getID(), false)
                         table.remove(group[3], it)
+
                         break
                     end
                 end
+
                 break
             end
         end

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -51,6 +51,21 @@ end
 
 -- potential lottery placeholder was killed
 xi.mob.phOnDespawn = function(ph, phList, chance, cooldown, immediate)
+    if ph:getZone():getLocalVar("[BEASTMEN]GroupIndex") ~= 0 then
+        for _, group in pairs(xi.beastmengroups.zones) do
+            if ph:getZoneID() == group[1] then
+                for it, idtable in pairs(group[3]) do
+                    if idtable[1] == ph:getID() then
+                        DisallowRespawn(ph:getID(), false)
+                        table.remove(group[3], it)
+                        break
+                    end
+                end
+                break
+            end
+        end
+    end
+
     if type(immediate) ~= "boolean" then immediate = false end
 
     if xi.settings.main.NM_LOTTERY_CHANCE then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Allows for the removal of all PH mobs from the beastmen multigroup spawn fix.

## Steps to test these changes
+ Waited for a Yagudo Mendicant to respawn. Killed it, ensured no errors.