### PR TITLE
Fix EXP Distance Issues | Fix Magical Mob Skills Resist Calcs

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -567,14 +567,14 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
         dStatAcc = dStat
     end
 
-    if skillType ~= xi.skill.SINGING then -- If not a bard song
+    if skillType ~= xi.skill.SINGING and skillType ~= nil then -- If not a bard song
         if target:isPC() then
             local gearBonus = caster:getMod(xi.mod.MACC) + caster:getILvlMacc()
             magicacc = caster:getSkillLevel(skillType) + gearBonus + dStatAcc
         else
             magicacc = utils.getSkillLvl(1, caster:getMainLvl()) + dStatAcc
         end
-    else -- If a bard song
+    elseif skillType ~= nil then -- If a bard song
         if target:isPC() then
             local secondarySkill = 0
             local gearBonus = caster:getMod(xi.mod.MACC) + caster:getILvlMacc()
@@ -591,6 +591,8 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
         else
             magicacc = utils.getSkillLvl(1, caster:getMainLvl()) + dStatAcc
         end
+    else
+        magicacc = dStatAcc
     end
 
     if element ~= xi.magic.ele.NONE then

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4306,25 +4306,24 @@ namespace charutils
                         {
                             exp *= 0.7f;
                         }
-
-                        if (distance(PMember->loc.p, PMob->loc.p) > 100)
-                        {
-                            PMember->pushPacket(new CMessageBasicPacket(PMember, PMember, 0, 0, 37));
-                            return;
-                        }
                     }
 
-                    exp = charutils::AddExpBonus(PMember, exp);
+                    if (distanceSquared(PMember->loc.p, PMob->loc.p) > 100 * 100)
+                    {
+                        PMember->pushPacket(new CMessageBasicPacket(PMember, PMember, 0, 0, 37));
+                        return;
+                    }
 
                     if (PMob->m_ExpPenalty > lua["xi"]["settings"]["main"]["PL_PENALTY"].get<uint16>() * 3)
                     {
                         exp = std::max<float>(0.0, exp - PMob->m_ExpPenalty - (lua["xi"]["settings"]["main"]["PL_PENALTY"].get<uint16>() * 3));
-
                         if (exp == 0.0f)
                         {
                             PMember->pushPacket(new CMessageBasicPacket(PMember, PMember, 0, 0, 21)); // No Experience Gained Message
                         }
                     }
+
+                    exp = charutils::AddExpBonus(PMember, exp);
 
                     charutils::AddExperiencePoints(false, PMember, PMob, (uint32)exp, mobCheck, chainactive);
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes a check issue with magical mob skills related to the resist calculation.
+ Fixes an issue where players could receive EXP from any distance.

## Steps to test these changes
+ Ensured magical mob skills are working again and doing damage.
