### PR TITLE
Make magical mobskills not divide by 0 during MAB calculation.

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -479,7 +479,7 @@ function applyResistanceEffect(caster, target, spell, params)
         end
     end
 
-    if element == nil and skill~= nil and skill >= 32 and skill <= 45 then -- Covers all magic
+    if element == nil and skill ~= nil and skill >= 32 and skill <= 45 then -- Covers all magic
         element = spell:getElement()
     elseif element == nil then -- Cover mobskills
         element = xi.element.NONE

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -304,7 +304,6 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
     if barspellDef == nil then
         barspellDef = 0
     end
-    print(barspellDef)
 
     local mdef = barspellDef + target:getMod(xi.mod.MDEF)
 

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -304,12 +304,17 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
     if barspellDef == nil then
         barspellDef = 0
     end
+    print(barspellDef)
 
     local mdef = barspellDef + target:getMod(xi.mod.MDEF)
-    local matt = mob:getMod(xi.mod.MATT)
-    local mab = matt / mdef
-    local bonusMacc = 0
 
+    if mdef == 0 then
+        mdef = 1
+    end
+
+    local matt = mob:getMod(xi.mod.MATT)
+    local mab = (matt / mdef)
+    local bonusMacc = 0
     mab = utils.clamp(mab, 0.7, 1.3)
 
     if tpeffect == xi.mobskills.magicalTpBonus.DMG_BONUS then
@@ -335,6 +340,8 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
     resist = applyResistanceEffect(mob, target, nil, params) -- Uses magic.lua resistance calcs as this moves to a global use case.
 
     finaldmg = finaldmg * resist
+
+    utils.clamp(finaldmg, 0, 65535)
 
     returninfo.dmg = finaldmg
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where in some cases magical mobskills would be dividing by 0.

## Steps to test these changes
+ Printed out each of the outputs for a mobskill, ensured that it did not return -nan at any point.
+ Tested fireball to ensure it can actually do damage.
