### PR TITLE
Fix Beastmen PH Respawns

### DIFF
--- a/modules/era/lua/beastmen_multigroup_spawn_fix.lua
+++ b/modules/era/lua/beastmen_multigroup_spawn_fix.lua
@@ -53,7 +53,7 @@ xi.beastmengroups.zones =
     {xi.zone.VALKURM_DUNES, "Valkurm_Dunes", xi.beastmengroups.VALKURM_DUNES, 3},
     {xi.zone.BUBURIMU_PENINSULA, "Buburimu_Peninsula", xi.beastmengroups.BUBURIMU_PENINSULA, 3},
     {xi.zone.QUFIM_ISLAND, "Qufim_Island", xi.beastmengroups.QUFIM_ISLAND, 3},
-    {xi.zone.GIDDEUS, "Giddeus", xi.beastmengroups.GIDDEUS, 3, },
+    {xi.zone.GIDDEUS, "Giddeus", xi.beastmengroups.GIDDEUS, 3},
     {xi.zone.DANGRUF_WADI, "Dangruf_Wadi", xi.beastmengroups.DANGRUF_WADI, 5},
     {xi.zone.YUGHOTT_GROTTO, "Yughott_Grotto", xi.beastmengroups.YUGHOTT_GROTTO, 5},
     {xi.zone.GHELSBA_OUTPOST, "Ghelsba_Outpost", xi.beastmengroups.GHELSBA_OUTPOST, 5},
@@ -69,7 +69,6 @@ for _, zoneID in pairs(xi.beastmengroups.zones) do
             local spawnedMobs = zone:getMobs()
             for _, mob in pairs(spawnedMobs) do
                 if not mob:isMobType(xi.mobskills.mobType.NOTORIOUS) and mob:getSystem() == xi.ecosystem.BEASTMEN then
-                    local tableLength = #zoneID
                     local mobID = mob:getID()
                     local prevSpawn = 0
                     local originalSpawn = mob:getSpawnPos()

--- a/modules/era/lua/beastmen_multigroup_spawn_fix.lua
+++ b/modules/era/lua/beastmen_multigroup_spawn_fix.lua
@@ -53,7 +53,7 @@ xi.beastmengroups.zones =
     {xi.zone.VALKURM_DUNES, "Valkurm_Dunes", xi.beastmengroups.VALKURM_DUNES, 3},
     {xi.zone.BUBURIMU_PENINSULA, "Buburimu_Peninsula", xi.beastmengroups.BUBURIMU_PENINSULA, 3},
     {xi.zone.QUFIM_ISLAND, "Qufim_Island", xi.beastmengroups.QUFIM_ISLAND, 3},
-    {xi.zone.GIDDEUS, "Giddeus", xi.beastmengroups.GIDDEUS, 3},
+    {xi.zone.GIDDEUS, "Giddeus", xi.beastmengroups.GIDDEUS, 3, },
     {xi.zone.DANGRUF_WADI, "Dangruf_Wadi", xi.beastmengroups.DANGRUF_WADI, 5},
     {xi.zone.YUGHOTT_GROTTO, "Yughott_Grotto", xi.beastmengroups.YUGHOTT_GROTTO, 5},
     {xi.zone.GHELSBA_OUTPOST, "Ghelsba_Outpost", xi.beastmengroups.GHELSBA_OUTPOST, 5},
@@ -69,6 +69,7 @@ for _, zoneID in pairs(xi.beastmengroups.zones) do
             local spawnedMobs = zone:getMobs()
             for _, mob in pairs(spawnedMobs) do
                 if not mob:isMobType(xi.mobskills.mobType.NOTORIOUS) and mob:getSystem() == xi.ecosystem.BEASTMEN then
+                    local tableLength = #zoneID
                     local mobID = mob:getID()
                     local prevSpawn = 0
                     local originalSpawn = mob:getSpawnPos()
@@ -116,6 +117,10 @@ for _, zoneID in pairs(xi.beastmengroups.zones) do
                             index = mobId[2]
                             break
                         end
+                    end
+
+                    if index == 0 or index == nil then
+                        return
                     end
 
                     for _, mobId in pairs(zoneID[3]) do


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Declares an early terminate on the death listener to stop extra execution of DisallowRespawn.
+ Fixes an issue that on or after the 2nd respawn some PH mobs were not respawning normally.

## Steps to test these changes
+ Sat in Giddeus and went through a total of 4 respawn sets of Yagudo Mendicants. All Yagudo respawned each time. 
