### PR TITLE
Fix Magical Mobskills | Fix Breath Skills | Fix Magical Weaponskills

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -299,20 +299,17 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
     local returninfo = {}
     --get all the stuff we need
     local resist = 1
+    local barspellDef = 0
 
-    local barspellDef = getBarSpellDefBonus(mob, target, element)
-    if barspellDef == nil then
-        barspellDef = 0
+    if
+        element >= xi.magic.element.FIRE and
+        element <= xi.magic.element.WATER and
+        target:hasStatusEffect(xi.magic.barSpell[element])
+    then -- bar- spell magic defense bonus
+        barspellDef = getBarSpellDefBonus(mob, target, element)
     end
 
-    local mdef = barspellDef + target:getMod(xi.mod.MDEF)
-
-    if mdef == 0 then
-        mdef = 1
-    end
-
-    local matt = mob:getMod(xi.mod.MATT)
-    local mab = (matt / mdef)
+    local mab = (100 + mob:getMod(xi.mod.MATT)) / (100 + target:getMod(xi.mod.MDEF) + barspellDef)
     local bonusMacc = 0
     mab = utils.clamp(mab, 0.7, 1.3)
 
@@ -339,8 +336,6 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
     resist = applyResistanceEffect(mob, target, nil, params) -- Uses magic.lua resistance calcs as this moves to a global use case.
 
     finaldmg = finaldmg * resist
-
-    utils.clamp(finaldmg, 0, 65535)
 
     returninfo.dmg = finaldmg
 

--- a/scripts/globals/mobskills/bomb_toss.lua
+++ b/scripts/globals/mobskills/bomb_toss.lua
@@ -14,8 +14,11 @@ end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
+    print(mob:getWeaponDmg())
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg()*3, xi.magic.ele.FIRE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
+    print(info)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+    print(dmg)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
     return dmg
 end

--- a/scripts/globals/mobskills/bomb_toss.lua
+++ b/scripts/globals/mobskills/bomb_toss.lua
@@ -14,11 +14,8 @@ end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
-    print(mob:getWeaponDmg())
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg()*3, xi.magic.ele.FIRE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
-    print(info)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    print(dmg)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
     return dmg
 end

--- a/scripts/globals/mobskills/poison_breath.lua
+++ b/scripts/globals/mobskills/poison_breath.lua
@@ -23,7 +23,6 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.1, 1.25, xi.magic.ele.WATER, 200)
-
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)
     return dmg

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -767,7 +767,7 @@ function doMagicWeaponskill(attacker, target, wsID, wsParams, tp, action, primar
         ['type'] = xi.attackType.MAGICAL,
         ['slot'] = xi.slot.MAIN,
         ['weaponType'] = attacker:getWeaponSkillType(xi.slot.MAIN),
-        ['damageType'] = xi.damageType.ELEMENTAL + wsParams.ele
+        ['damageType'] = xi.damageType.ELEMENTAL + wsParams.element
     }
 
     local calcParams =
@@ -819,9 +819,9 @@ function doMagicWeaponskill(attacker, target, wsID, wsParams, tp, action, primar
         dmg = dmg + ((dmg * attacker:getMod(xi.mod.ALL_WSDMG_FIRST_HIT)) / 100) -- Add in our "first hit" WS dmg bonus
 
         -- Calculate magical bonuses and reductions
-        dmg = addBonusesAbility(attacker, wsParams.ele, target, dmg, wsParams)
-        dmg = dmg * applyResistanceAbility(attacker, target, wsParams.ele, wsParams.skill, bonusacc)
-        dmg = target:magicDmgTaken(dmg, wsParams.ele)
+        dmg = addBonusesAbility(attacker, wsParams.element, target, dmg, wsParams)
+        dmg = dmg * applyResistanceAbility(attacker, target, wsID, wsParams)
+        dmg = target:magicDmgTaken(dmg, wsParams.element)
 
         if dmg < 0 then
             calcParams.finalDmg = dmg
@@ -830,7 +830,7 @@ function doMagicWeaponskill(attacker, target, wsID, wsParams, tp, action, primar
             return dmg
         end
 
-        dmg = adjustForTarget(target, dmg, wsParams.ele)
+        dmg = adjustForTarget(target, dmg, wsParams.element)
 
         if dmg > 0 then
             dmg = dmg - target:getMod(xi.mod.PHALANX)

--- a/scripts/globals/weaponskills/aeolian_edge.lua
+++ b/scripts/globals/weaponskills/aeolian_edge.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 2.75 params.ftp200 = 3.50 params.ftp300 = 4
     params.str_wsc = 0.0 params.dex_wsc = 0.28 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.28 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.WIND
-    params.skill = xi.skill.DAGGER
+    params.element = xi.magic.ele.WIND
+    params.skillType = xi.skill.DAGGER
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/blade_chi.lua
+++ b/scripts/globals/weaponskills/blade_chi.lua
@@ -28,8 +28,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
     params.hybridWS = true
-    params.ele = xi.magic.ele.EARTH
-    params.skill = xi.skill.KATANA
+    params.element = xi.magic.ele.EARTH
+    params.skillType = xi.skill.KATANA
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/blade_ei.lua
+++ b/scripts/globals/weaponskills/blade_ei.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.DARK
-    params.skill = xi.skill.KATANA
+    params.element = xi.magic.ele.DARK
+    params.skillType = xi.skill.KATANA
     params.includemab = true
     -- to do ignore shadow and blink https://www.bg-wiki.com/ffxi/Blade:_Ei
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/blade_teki.lua
+++ b/scripts/globals/weaponskills/blade_teki.lua
@@ -26,8 +26,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true
-    params.ele = xi.magic.ele.WATER
-    params.skill = xi.skill.KATANA
+    params.element = xi.magic.ele.WATER
+    params.skillType = xi.skill.KATANA
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/blade_to.lua
+++ b/scripts/globals/weaponskills/blade_to.lua
@@ -26,8 +26,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true
-    params.ele = xi.magic.ele.ICE
-    params.skill = xi.skill.KATANA
+    params.element = xi.magic.ele.ICE
+    params.skillType = xi.skill.KATANA
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/blade_yu.lua
+++ b/scripts/globals/weaponskills/blade_yu.lua
@@ -23,8 +23,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.ftp100 = 2.25 params.ftp200 = 2.25 params.ftp300 = 2.25
     params.str_wsc = 0.0 params.dex_wsc = 0.28 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.28 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     -- http://wiki.ffo.jp/html/20351.html
-    params.ele = xi.magic.ele.WATER
-    params.skill = xi.skill.KATANA
+    params.element = xi.magic.ele.WATER
+    params.skillType = xi.skill.KATANA
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/burning_blade.lua
+++ b/scripts/globals/weaponskills/burning_blade.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.FIRE
-    params.skill = xi.skill.SWORD
+    params.element = xi.magic.ele.FIRE
+    params.skillType = xi.skill.SWORD
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/cataclysm.lua
+++ b/scripts/globals/weaponskills/cataclysm.lua
@@ -26,8 +26,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.DARK
-    params.skill = xi.skill.STAFF
+    params.element = xi.magic.ele.DARK
+    params.skillType = xi.skill.STAFF
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/cloudsplitter.lua
+++ b/scripts/globals/weaponskills/cloudsplitter.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 3.75 params.ftp200 = 5.0 params.ftp300 = 6.0
     params.str_wsc = 0.4 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.4 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.LIGHTNING
-    params.skill = xi.skill.AXE
+    params.element = xi.magic.ele.LIGHTNING
+    params.skillType = xi.skill.AXE
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/cyclone.lua
+++ b/scripts/globals/weaponskills/cyclone.lua
@@ -24,8 +24,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.375 params.ftp300 = 2.875
     params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.25 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.WIND
-    params.skill = xi.skill.DAGGER
+    params.element = xi.magic.ele.WIND
+    params.skillType = xi.skill.DAGGER
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/dark_harvest.lua
+++ b/scripts/globals/weaponskills/dark_harvest.lua
@@ -21,8 +21,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.DARK
-    params.skill = xi.skill.SCYTHE
+    params.element = xi.magic.ele.DARK
+    params.skillType = xi.skill.SCYTHE
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/earth_crusher.lua
+++ b/scripts/globals/weaponskills/earth_crusher.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.3125 params.ftp300 = 3.625
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.EARTH
-    params.skill = xi.skill.STAFF
+    params.element = xi.magic.ele.EARTH
+    params.skillType = xi.skill.STAFF
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/flaming_arrow.lua
+++ b/scripts/globals/weaponskills/flaming_arrow.lua
@@ -28,8 +28,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
     params.hybridWS = true
-    params.ele = xi.magic.ele.FIRE
-    params.skill = xi.skill.ARCHERY
+    params.element = xi.magic.ele.FIRE
+    params.skillType = xi.skill.ARCHERY
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/flash_nova.lua
+++ b/scripts/globals/weaponskills/flash_nova.lua
@@ -26,8 +26,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.LIGHT
-    params.skill = xi.skill.CLUB
+    params.element = xi.magic.ele.LIGHT
+    params.skillType = xi.skill.CLUB
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/freezebite.lua
+++ b/scripts/globals/weaponskills/freezebite.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 3
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.ICE
-    params.skill = xi.skill.GREAT_SWORD
+    params.element = xi.magic.ele.ICE
+    params.skillType = xi.skill.GREAT_SWORD
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/frostbite.lua
+++ b/scripts/globals/weaponskills/frostbite.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.ICE
-    params.skill = xi.skill.GREAT_SWORD
+    params.element = xi.magic.ele.ICE
+    params.skillType = xi.skill.GREAT_SWORD
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/garland_of_bliss.lua
+++ b/scripts/globals/weaponskills/garland_of_bliss.lua
@@ -25,8 +25,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.ftp100 = 2 params.ftp200 = 2 params.ftp300 = 2
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
     params.mnd_wsc = 0.4 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.LIGHT
-    params.skill = xi.skill.STAFF
+    params.element = xi.magic.ele.LIGHT
+    params.skillType = xi.skill.STAFF
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/gust_slash.lua
+++ b/scripts/globals/weaponskills/gust_slash.lua
@@ -23,8 +23,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
     params.str_wsc = 0.0 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.WIND
-    params.skill = xi.skill.DAGGER
+    params.element = xi.magic.ele.WIND
+    params.skillType = xi.skill.DAGGER
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/herculean_slash.lua
+++ b/scripts/globals/weaponskills/herculean_slash.lua
@@ -23,8 +23,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 3.5 params.ftp200 = 3.5 params.ftp300 = 3.5
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.6 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.ICE
-    params.skill = xi.skill.GREAT_SWORD
+    params.element = xi.magic.ele.ICE
+    params.skillType = xi.skill.GREAT_SWORD
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/hot_shot.lua
+++ b/scripts/globals/weaponskills/hot_shot.lua
@@ -28,8 +28,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
     params.hybridWS = true
-    params.ele = xi.magic.ele.FIRE
-    params.skill = xi.skill.MARKSMANSHIP
+    params.element = xi.magic.ele.FIRE
+    params.skillType = xi.skill.MARKSMANSHIP
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/infernal_scythe.lua
+++ b/scripts/globals/weaponskills/infernal_scythe.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 3.5 params.ftp200 = 3.5 params.ftp300 = 3.5
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.DARK
-    params.skill = xi.skill.SCYTHE
+    params.element = xi.magic.ele.DARK
+    params.skillType = xi.skill.SCYTHE
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/leaden_salute.lua
+++ b/scripts/globals/weaponskills/leaden_salute.lua
@@ -24,8 +24,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.ftp100 = 4 params.ftp200 = 4.25 params.ftp300 = 4.75
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0
     params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.DARK
-    params.skill = xi.skill.MARKSMANSHIP
+    params.element = xi.magic.ele.DARK
+    params.skillType = xi.skill.MARKSMANSHIP
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/omniscience.lua
+++ b/scripts/globals/weaponskills/omniscience.lua
@@ -25,8 +25,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.ftp100 = 2 params.ftp200 = 2 params.ftp300 = 2
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
     params.mnd_wsc = 0.3 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.DARK
-    params.skill = xi.skill.STAFF
+    params.element = xi.magic.ele.DARK
+    params.skillType = xi.skill.STAFF
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/primal_rend.lua
+++ b/scripts/globals/weaponskills/primal_rend.lua
@@ -24,8 +24,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.ftp100 = 4 params.ftp200 = 4.25 params.ftp300 = 4.75
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
     params.mnd_wsc = 0.0 params.chr_wsc = 0.3
-    params.ele = xi.magic.ele.LIGHT
-    params.skill = xi.skill.AXE
+    params.element = xi.magic.ele.LIGHT
+    params.skillType = xi.skill.AXE
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/raiden_thrust.lua
+++ b/scripts/globals/weaponskills/raiden_thrust.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 3
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.LIGHTNING
-    params.skill = xi.skill.POLEARM
+    params.element = xi.magic.ele.LIGHTNING
+    params.skillType = xi.skill.POLEARM
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/red_lotus_blade.lua
+++ b/scripts/globals/weaponskills/red_lotus_blade.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.38 params.ftp300 = 3
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.FIRE
-    params.skill = xi.skill.SWORD
+    params.element = xi.magic.ele.FIRE
+    params.skillType = xi.skill.SWORD
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/rock_crusher.lua
+++ b/scripts/globals/weaponskills/rock_crusher.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.EARTH
-    params.skill = xi.skill.STAFF
+    params.element = xi.magic.ele.EARTH
+    params.skillType = xi.skill.STAFF
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/sanguine_blade.lua
+++ b/scripts/globals/weaponskills/sanguine_blade.lua
@@ -35,8 +35,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.5 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.DARK
-    params.skill = xi.skill.SWORD
+    params.element = xi.magic.ele.DARK
+    params.skillType = xi.skill.SWORD
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/seraph_blade.lua
+++ b/scripts/globals/weaponskills/seraph_blade.lua
@@ -23,8 +23,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.5 params.ftp300 = 3
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.LIGHT
-    params.skill = xi.skill.SWORD
+    params.element = xi.magic.ele.LIGHT
+    params.skillType = xi.skill.SWORD
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/seraph_strike.lua
+++ b/scripts/globals/weaponskills/seraph_strike.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 3
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.LIGHT
-    params.skill = xi.skill.CLUB
+    params.element = xi.magic.ele.LIGHT
+    params.skillType = xi.skill.CLUB
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/shadow_of_death.lua
+++ b/scripts/globals/weaponskills/shadow_of_death.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.5 params.ftp300 = 3
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.DARK
-    params.skill = xi.skill.SCYTHE
+    params.element = xi.magic.ele.DARK
+    params.skillType = xi.skill.SCYTHE
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/shining_blade.lua
+++ b/scripts/globals/weaponskills/shining_blade.lua
@@ -23,8 +23,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.2 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.LIGHT
-    params.skill = xi.skill.SWORD
+    params.element = xi.magic.ele.LIGHT
+    params.skillType = xi.skill.SWORD
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/shining_strike.lua
+++ b/scripts/globals/weaponskills/shining_strike.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1 params.ftp200 = 1.75 params.ftp300 = 2.5
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.2 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.LIGHT
-    params.skill = xi.skill.CLUB
+    params.element = xi.magic.ele.LIGHT
+    params.skillType = xi.skill.CLUB
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/starburst.lua
+++ b/scripts/globals/weaponskills/starburst.lua
@@ -24,12 +24,12 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.vit_wsc = 0.0 params.agi_wsc = 0.0
     params.int_wsc = 0.0 params.mnd_wsc = 0.0
     params.chr_wsc = 0.0
-    params.skill = xi.skill.STAFF
+    params.skillType = xi.skill.STAFF
     params.includemab = true
     -- 50/50 shot of being light or dark
-    params.ele = xi.magic.ele.LIGHT
+    params.element = xi.magic.ele.LIGHT
     if math.random() < 0.5 then
-        params.ele = xi.magic.ele.DARK
+        params.element = xi.magic.ele.DARK
     end
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true then

--- a/scripts/globals/weaponskills/sunburst.lua
+++ b/scripts/globals/weaponskills/sunburst.lua
@@ -24,12 +24,12 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.vit_wsc = 0.0 params.agi_wsc = 0.0
     params.int_wsc = 0.0 params.mnd_wsc = 0.4
     params.chr_wsc = 0.0
-    params.skill = xi.skill.STAFF
+    params.skillType = xi.skill.STAFF
     params.includemab = true
     -- 50/50 shot of being light or dark
-    params.ele = xi.magic.ele.LIGHT
+    params.element = xi.magic.ele.LIGHT
     if math.random() < 0.5 then
-        params.ele = xi.magic.ele.DARK
+        params.element = xi.magic.ele.DARK
     end
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true then

--- a/scripts/globals/weaponskills/tachi_goten.lua
+++ b/scripts/globals/weaponskills/tachi_goten.lua
@@ -29,8 +29,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
     params.hybridWS = true
-    params.ele = xi.magic.ele.LIGHTNING
-    params.skill = xi.skill.GREAT_KATANA
+    params.element = xi.magic.ele.LIGHTNING
+    params.skillType = xi.skill.GREAT_KATANA
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/tachi_jinpu.lua
+++ b/scripts/globals/weaponskills/tachi_jinpu.lua
@@ -28,8 +28,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true
     params.includemab = true
-    params.ele = xi.magic.ele.WIND
-    params.skill = xi.skill.GREAT_KATANA
+    params.element = xi.magic.ele.WIND
+    params.skillType = xi.skill.GREAT_KATANA
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1

--- a/scripts/globals/weaponskills/tachi_kagero.lua
+++ b/scripts/globals/weaponskills/tachi_kagero.lua
@@ -29,8 +29,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
     params.hybridWS = true
-    params.ele = xi.magic.ele.FIRE
-    params.skill = xi.skill.GREAT_KATANA
+    params.element = xi.magic.ele.FIRE
+    params.skillType = xi.skill.GREAT_KATANA
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/tachi_koki.lua
+++ b/scripts/globals/weaponskills/tachi_koki.lua
@@ -28,8 +28,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
     params.hybridWS = true
-    params.ele = xi.magic.ele.LIGHT
-    params.skill = xi.skill.GREAT_KATANA
+    params.element = xi.magic.ele.LIGHT
+    params.skillType = xi.skill.GREAT_KATANA
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/thunder_thrust.lua
+++ b/scripts/globals/weaponskills/thunder_thrust.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 1.5 params.ftp200 = 2 params.ftp300 = 2.5
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.LIGHTNING
-    params.skill = xi.skill.POLEARM
+    params.element = xi.magic.ele.LIGHTNING
+    params.skillType = xi.skill.POLEARM
     params.includemab = true
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/trueflight.lua
+++ b/scripts/globals/weaponskills/trueflight.lua
@@ -29,8 +29,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
     params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0
     params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.LIGHT
-    params.skill = xi.skill.MARKSMANSHIP
+    params.element = xi.magic.ele.LIGHT
+    params.skillType = xi.skill.MARKSMANSHIP
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/uriel_blade.lua
+++ b/scripts/globals/weaponskills/uriel_blade.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.ftp100 = 4.5 params.ftp200 = 6 params.ftp300 = 7.5
     params.str_wsc = 0.32 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.32 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.LIGHT
-    params.skill = xi.skill.SWORD
+    params.element = xi.magic.ele.LIGHT
+    params.skillType = xi.skill.SWORD
     params.includemab = true
 
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)

--- a/scripts/globals/weaponskills/vidohunir.lua
+++ b/scripts/globals/weaponskills/vidohunir.lua
@@ -25,8 +25,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.ftp100 = 1.75 params.ftp200 = 1.75 params.ftp300 = 1.75
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3
     params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.DARK
-    params.skill = xi.skill.STAFF
+    params.element = xi.magic.ele.DARK
+    params.skillType = xi.skill.STAFF
     params.includemab = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/wildfire.lua
+++ b/scripts/globals/weaponskills/wildfire.lua
@@ -27,8 +27,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
     params.agi_wsc = 0.6 params.int_wsc = 0.0 params.mnd_wsc = 0.0
     params.chr_wsc = 0.0
-    params.ele = xi.magic.ele.FIRE
-    params.skill = xi.skill.MARKSMANSHIP
+    params.element = xi.magic.ele.FIRE
+    params.skillType = xi.skill.MARKSMANSHIP
     params.includemab = true
 
     -- TODO: needs to give enmity down at varying tp percent's that is treated separately than the gear cap of -50% enmity http://www.bg-wiki.com/bg/Wildfire


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixed calculation of resist multipliers for applyResistanceAbility.
+ Fixed calculation of resists for breath attacks.
+ Fixed mab calculation for magical mob skills.

## Steps to test these changes
+ Printed out all outputs for the following. Checked outputs for resist, damage, damage mults, and final damage.
+ Testing on crawlers with poison breath.
+ Testing on crawlers and goblins with wyvern breath attacks.
+ Testing on crawlers with gust slash.
+ Testing on goblins with bomb toss.

All values appeared normal and no longer default to 0 or their minimum clamp.