### PR TITLE
Fix FTP Calcs for Ability WS Calcs

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -1000,6 +1000,10 @@ function getHitRate(attacker, target, capHitRate, bonus)
 end
 
 function fTP(tp, ftp1, ftp2, ftp3)
+    if (tp < 1000) then
+        tp = 1000
+    end
+
     if tp >= 1000 and tp < 2000 then
         return ftp1 + ( ((ftp2 - ftp1) / 1000) * (tp - 1000) )
     elseif tp >= 2000 and tp <= 3000 then
@@ -1016,6 +1020,7 @@ local function fTPMob(tp, ftp1, ftp2, ftp3)
     if (tp < 1000) then
         tp = 1000
     end
+
     if (tp >= 1000 and tp < 1500) then
         return ftp1 + ( ((ftp2-ftp1)/500) * (tp-1000))
     elseif (tp >= 1500 and tp <= 3000) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where abilities that use a weaponskill calculation for damage were using a non 1000->3000 fTP modifier. Defaulted to 1000 if weaponskill TP < 1000 to ensure we at minimum hit .ftp100 in the params table.

## Steps to test these changes
+ Tested eagle eye shot repeatedly to ensure that no fTP error occurred. This will not affect normal weaponskills since they cannot initialize before 1000 TP.
