### PR TITLE
Disable Pets Following Across Zonelines

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -507,10 +507,10 @@ void SmallPacket0x00D(map_session_data_t* const PSession, CCharEntity* const PCh
             }
         }
 
-        if (PChar->PPet != nullptr)
-        {
-            PChar->setPetZoningInfo();
-        }
+        // if (PChar->PPet != nullptr)
+        // {
+            // PChar->setPetZoningInfo();
+        // }
 
         PSession->shuttingDown = 1;
         sql->Query("UPDATE char_stats SET zoning = 0 WHERE charid = %u", PChar->id);
@@ -3616,11 +3616,11 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
     TracyZoneScoped;
 
     // handle pets on zone
-    if (PChar->PPet != nullptr)
-    {
-        PChar->setPetZoningInfo();
-        petutils::DespawnPet(PChar);
-    }
+    // if (PChar->PPet != nullptr)
+    // {
+        // PChar->setPetZoningInfo();
+        // petutils::DespawnPet(PChar);
+    // }
 
     uint32 zoneLineID    = data.ref<uint32>(0x04);
     uint8  town          = data.ref<uint8>(0x16);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -507,10 +507,18 @@ void SmallPacket0x00D(map_session_data_t* const PSession, CCharEntity* const PCh
             }
         }
 
-        // if (PChar->PPet != nullptr)
-        // {
-            // PChar->setPetZoningInfo();
-        // }
+        if (PChar->PPet != nullptr)
+        {
+            auto* PPetEntity = dynamic_cast<CPetEntity*>(PChar->PPet);
+            if (PPetEntity->getPetType() == PET_TYPE::WYVERN)
+            {
+                PChar->setPetZoningInfo();
+            }
+            else
+            {
+                PChar->resetPetZoningInfo();
+            }
+        }
 
         PSession->shuttingDown = 1;
         sql->Query("UPDATE char_stats SET zoning = 0 WHERE charid = %u", PChar->id);
@@ -3616,11 +3624,19 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
     TracyZoneScoped;
 
     // handle pets on zone
-    // if (PChar->PPet != nullptr)
-    // {
-        // PChar->setPetZoningInfo();
-        // petutils::DespawnPet(PChar);
-    // }
+    if (PChar->PPet != nullptr)
+    {
+        auto* PPetEntity = dynamic_cast<CPetEntity*>(PChar->PPet);
+        if (PPetEntity->getPetType() == PET_TYPE::WYVERN)
+        {
+            PChar->setPetZoningInfo();
+            petutils::DespawnPet(PChar);
+        }
+        else
+        {
+            PChar->resetPetZoningInfo();
+        }
+    }
 
     uint32 zoneLineID    = data.ref<uint32>(0x04);
     uint8  town          = data.ref<uint8>(0x16);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Disables saving of pets when interacting with a zoneline with the exception of Wyverns.

## Steps to test these changes
+ Tested to see if wyverns followed through zonelines.
+ Tested to ensure players w/o pet can zone.
+ Tested to see if BST jugs followed through zonelines.
+ Tested to see if avatars followed through zonelines.
