### PR TITLE
Fix CHR Ratio for Charm Chance | Fix Tame Usage

### DIFF
--- a/scripts/globals/abilities/tame.lua
+++ b/scripts/globals/abilities/tame.lua
@@ -27,7 +27,7 @@ ability_object.onUseAbility = function(player, target, ability)
         return 0
     end
 
-    local params = {diff = (player:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)), skillType = xi.skill.NONE, bonus = 0, effect = xi.effect.NONE, element = xi.magic.element.NONE}
+    local params = {diff = (player:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)), skillType = nil, bonus = 0, effect = xi.effect.NONE, element = xi.magic.element.NONE}
     local resist = applyResistanceAbility(player, target, ability:getID(), params)
 
     if resist <= 0.25 then

--- a/scripts/globals/abilities/tame.lua
+++ b/scripts/globals/abilities/tame.lua
@@ -26,7 +26,10 @@ ability_object.onUseAbility = function(player, target, ability)
         target:addEnmity(player, 1, 0)
         return 0
     end
-    local resist = applyResistanceAbility(player, target, xi.magic.ele.NONE, xi.skill.NONE, player:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+
+    local params = {diff = (player:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)), skillType = xi.skill.NONE, bonus = 0, effect = xi.effect.NONE, element = xi.magic.element.NONE}
+    local resist = applyResistanceAbility(player, target, ability:getID(), params)
+    print(resist)
     if resist <= 0.25 then
         ability:setMsg(xi.msg.basic.JA_MISS_2)
         target:addEnmity(player, 1, 0)

--- a/scripts/globals/abilities/tame.lua
+++ b/scripts/globals/abilities/tame.lua
@@ -29,7 +29,7 @@ ability_object.onUseAbility = function(player, target, ability)
 
     local params = {diff = (player:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)), skillType = xi.skill.NONE, bonus = 0, effect = xi.effect.NONE, element = xi.magic.element.NONE}
     local resist = applyResistanceAbility(player, target, ability:getID(), params)
-    print(resist)
+
     if resist <= 0.25 then
         ability:setMsg(xi.msg.basic.JA_MISS_2)
         target:addEnmity(player, 1, 0)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4926,12 +4926,13 @@ namespace battleutils
             charmerBSTlevel = charmerLvl;
         }
 
-        // FIXME: Level and CHR ratios are complete guesses
+        // Based on https://www.bluegartr.com/threads/57288-Charm-and-Magic-Accuracy where charm rate hit 25% w/ 11 dStat
+        // Result on EP mob at 75 MJob w/ 67 BST + 11 dCHR should be 25% according to gauge messages.
         const float levelRatio = (charmerBSTlevel - targetLvl) / 100.f;
         charmChance *= (1.f + levelRatio);
 
-        const float chrRatio = (PCharmer->CHR() - PTarget->CHR()) / 100.f;
-        charmChance *= (1.f + chrRatio);
+        float chrRatio = ((PCharmer->CHR() - PTarget->CHR())) / 100.f;
+        charmChance *= (1.f * (chrRatio * 2.47));
 
         // Retail doesn't take light/apollo into account for Gauge
         if (includeCharmAffinityAndChanceMods)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes CHR ratio modifier for charm chance to meet the parameters outlined here: https://www.bluegartr.com/threads/57288-Charm-and-Magic-Accuracy
+ // Result on EP mob at 75 MJob w/ 67 BST + 11 dCHR should be 25% according to gauge messages.
+ Fixed an issue where the resist rate for Tame was erroring out and causing the ability to fail closed.

## Steps to test these changes
+ Ensured under the above circumstances that the charm rate was 25%.
+ Ensured the player is able to reasonably tame monsters.
