### PR TITLE
Fix Magic Accuracy dLvl Multipliers for MEVA | Added a Catch for Nil Skills to Default to C Rank Accuracy Bonus

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -525,8 +525,8 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
     local magicacc = 0
     local magiceva = 0
     local resMod = 0
-    local dLvl = caster:getMainLvl() - target:getMainLvl()
-    local dStatAcc = 0
+    local dLvl = target:getMainLvl() - caster:getMainLvl()
+    local dLvlStatAcc = 0
 
     -- resist everything if real magic shield is active (see effects/magic_shield)
     if target:hasStatusEffect(xi.effect.MAGIC_SHIELD) then
@@ -658,6 +658,7 @@ function getMagicResist(magicHitRate)
         resist = 1.0
     end
 
+    print(resist)
     return resist
 end
 

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -658,7 +658,6 @@ function getMagicResist(magicHitRate)
         resist = 1.0
     end
 
-    print(resist)
     return resist
 end
 

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -526,7 +526,7 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
     local magiceva = 0
     local resMod = 0
     local dLvl = target:getMainLvl() - caster:getMainLvl()
-    local dLvlStatAcc = 0
+    local dStatAcc = 0
 
     -- resist everything if real magic shield is active (see effects/magic_shield)
     if target:hasStatusEffect(xi.effect.MAGIC_SHIELD) then
@@ -599,6 +599,8 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
         magicacc = dStatAcc + utils.getMobSkillLvl(1, caster:getMainLvl())
     elseif caster:isPet() and skillType == nil then
         magicacc = dStatAcc + utils.getMobSkillLvl(3, caster:getMainLvl())
+    else
+        magicacc = utils.getSkillLvl(4, caster:getMainLvl()) + dStatAcc
     end
 
     if element ~= xi.magic.ele.NONE then

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -595,7 +595,7 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     -----------------------------------
     -- Apply level correction.
     -----------------------------------
-    local levelDiff = caster:getMainLvl() - target:getMainLvl()
+    local levelDiff = target:getMainLvl() - caster:getMainLvl()
 
     -----------------------------------
     -- STEP 2: Get target magic evasion


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Changes the order of the subtractive function for determining dLvl to appropriately determine it.
+ Adds a C Level catch for magic accuracy calculations when skill is nil.

## Steps to test these changes
+ Used prints while on a 33 RDM to determine that against Bloodtear that the dLvl for Bloodtear was positive. 
