### PR TITLE
Paralysis Should Stop Abilities, Items, and RAs From Execution

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1402,6 +1402,13 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
     TracyZoneScoped;
     auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
 
+    if (battleutils::IsParalyzed(this))
+    {
+        // display paralyzed
+        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_IS_PARALYZED));
+        return;
+    }
+
     int32 damage      = 0;
     int32 totalDamage = 0;
 
@@ -1789,6 +1796,14 @@ void CCharEntity::OnItemFinish(CItemState& state, action_t& action)
     TracyZoneScoped;
     auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
     auto* PItem   = state.GetItem();
+
+    if (battleutils::IsParalyzed(this))
+    {
+        // display paralyzed
+        // TODO: Make paralyze eat the item or charge when proced.
+        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_IS_PARALYZED));
+        return;
+    }
 
     // TODO: I'm sure this is supposed to be in the action packet... (animation, message)
     if (PItem->getAoE())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Ensured abilities can be interrupted with paralyze. TODO: Make ability go into recast.
+ Made it possible for items to be interrupted with paralyze. TODO: Make paralyze eat the item or charge.
+ Made it possible for RAs to be interrupted with paralyze. (Working as intended.)

## Steps to test these changes
+ Attempted to use an ability with paralyze, it stopped execution.
+ Attempted to use an item with paralyze, it stopped the execution.
+ Attempted to use a RA with paralyze, it started the animation then stopped the execution.
