### PR TITLE
Add Crash Persistence to Guild Shop Quantities

### DIFF
--- a/src/map/utils/guildutils.cpp
+++ b/src/map/utils/guildutils.cpp
@@ -138,6 +138,9 @@ namespace guildutils
                 {
                     PItem->setQuantity(PItem->getQuantity() + PItem->getDailyIncrease());
                 }
+
+                const char* fmtQuery = "UPDATE guild_shops SET initial_quantity = %u WHERE itemid = %u AND guildid = %u";
+                sql->Query(fmtQuery, PItem->getQuantity(), PItem->getID(), PGuildShop->GetID());
             }
         }
         ShowDebug("UpdateGuildsStock is finished");


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Adds crash persistence to guild item quantities by overwriting the initial_quantity field in guild_shops every vanamidnight.
+ NOTE: Quantities will still reset post a maintenance where dbs are updated.

## Steps to test these changes
+ Bought out an item from the smithing guild in North San'dOria then waited until vanamidnight, checked intitial_quantity in the db which showed the appropriate amount, then crashed map, logged in and proceeded to ensure I could buy the full qty.