### PR TITLE
Add Nil Checks For Resist Rate Calcs | Fix Magical Weaponskill Resist Rate Application

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -53,9 +53,12 @@ local hardCap = 120 --guesstimated
 -----------------------------------
 -- affinities that strengthen/weaken the index element
 local function AffinityBonusDmg(caster, ele)
-
-    local affinity = caster:getMod(strongAffinityDmg[ele])
-    local bonus = 1.00 + affinity * 0.05 -- 5% per level of affinity
+    local affinity = 0
+    local bonus = 0
+    if strongAffinityDmg[ele] ~= nil then
+        affinity = caster:getMod(strongAffinityDmg[ele])
+        bonus = 1.00 + affinity * 0.05 -- 5% per level of affinity
+    end
     return bonus
 end
 
@@ -1013,7 +1016,7 @@ function addBonusesAbility(caster, ele, target, dmg, params)
     local dayWeatherBonus = 1.00
     local weather = caster:getWeather()
 
-    if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
+    if elementalObi[ele] ~= nil and (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
         if weather == xi.magic.singleWeatherStrong[ele] then
             if caster:getMod(xi.mod.IRIDESCENCE) >= 1 then
                 dayWeatherBonus = dayWeatherBonus + 0.10
@@ -1052,6 +1055,7 @@ function addBonusesAbility(caster, ele, target, dmg, params)
     local mab = 1
     local mdefBarBonus = 0
     if
+        ele ~= nil and
         ele >= xi.magic.element.FIRE and
         ele <= xi.magic.element.WATER and
         target:hasStatusEffect(xi.magic.barSpell[ele])
@@ -1077,7 +1081,7 @@ end
 -- get elemental damage reduction
 function getElementalDamageReduction(target, element)
     local defense = 1
-    if element > 0 then
+    if element ~= nil and element > 0 then
         defense = 1 - (target:getMod(xi.magic.specificDmgTakenMod[element]) / 10000)
         return utils.clamp(defense, 0.0, 2.0)
     end

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -380,7 +380,8 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, f
                 -- Calculate magical bonuses and reductions
                 local magicdmg = addBonusesAbility(attacker, wsParams.ele, target, finaldmg, wsParams)
 
-                magicdmg = magicdmg * applyResistanceAbility(attacker, target, wsParams.ele, wsParams.skill, calcParams.bonusAcc)
+                wsParams.bonus = calcParams.bonusAcc
+                magicdmg = magicdmg * applyResistanceAbility(attacker, target, wsParams.ele, wsParams)
                 magicdmg = target:magicDmgTaken(magicdmg, wsParams.ele)
 
                 if magicdmg > 0 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Added nil checks for elements related to usage of weaponskills without the appropriate affinity bonuses.
+ Fixed an issue where improper calc params were being passed to the magic resist formula for magical weaponskills.

## Steps to test these changes
+ Traced errors via debug log and fixed all nil element checks.
+ Confirmed that all known weaponskills with the issue (primarily from katana category weaponskills) did not experience any errors while testing.
