### PR TITLE
Fix a Crash Related to Null m_PetType

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -510,9 +510,16 @@ void SmallPacket0x00D(map_session_data_t* const PSession, CCharEntity* const PCh
         if (PChar->PPet != nullptr)
         {
             auto* PPetEntity = dynamic_cast<CPetEntity*>(PChar->PPet);
-            if (PPetEntity->getPetType() == PET_TYPE::WYVERN)
+            if (PChar->PPet->objtype != TYPE_MOB)
             {
-                PChar->setPetZoningInfo();
+                if (PPetEntity->getPetType() == PET_TYPE::WYVERN)
+                {
+                    PChar->setPetZoningInfo();
+                }
+                else
+                {
+                    PChar->resetPetZoningInfo();
+                }
             }
             else
             {
@@ -3629,10 +3636,16 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
     if (PChar->PPet != nullptr)
     {
         auto* PPetEntity = dynamic_cast<CPetEntity*>(PChar->PPet);
-        if (PPetEntity->getPetType() == PET_TYPE::WYVERN)
+        if (PChar->PPet->objtype != TYPE_MOB)
         {
-            PChar->setPetZoningInfo();
-            petutils::DespawnPet(PChar);
+            if (PPetEntity->getPetType() == PET_TYPE::WYVERN)
+            {
+                PChar->setPetZoningInfo();
+            }
+            else
+            {
+                PChar->resetPetZoningInfo();
+            }
         }
         else
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where a query for m_PetType was calling a null value when a mob was charmed and a player zoned.

## Steps to test these changes
+ Tested every pet type to ensure there were no crashes, all behaviors were normal.
