### PR TITLE
Build Extra Checks for Important Pointers and Values

### DIFF
--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -678,6 +678,12 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
     auto expression  = false;
     auto latentFound = true;
 
+    if (m_POwner == nullptr)
+    {
+        ShowWarning("m_POwner was a nullptr, stopping case steps");
+        return false;
+    }
+
     // find the latent type from the enum and find the expression to tests againts
     switch (latentEffect.GetConditionsID())
     {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -270,14 +270,17 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
         char session_key[20 * 2 + 1];
         bin2hex(session_key, (uint8*)PSession->blowfish.key, 20);
 
-        uint16 destination = PChar->loc.destination;
+        uint16 destination = MAX_ZONEID + 1; // Forces the function to fail closed
 
-        if (destination >= MAX_ZONEID)
+        if (PChar != nullptr)
         {
-            // TODO: work out how to drop player in moghouse that exits them to the zone they were in before this happened, like we used to.
-            ShowWarning("packet_system::SmallPacket0x00A player tried to enter zone out of range: %d", destination);
-            ShowWarning("packet_system::SmallPacket0x00A dumping player `%s` to homepoint!", PChar->GetName());
-            charutils::HomePoint(PChar);
+            destination = PChar->loc.destination; // Only sets destination if PChar isn't nullptr
+        }
+
+        if (destination >= MAX_ZONEID) // Fails to putting player back to it's previous zone
+        {
+            ShowWarning("packet_system::SmallPacket0x00A GetZone Bad Args for IncreaseZoneCounter, MITIGATING: Sending %s to loc.prevzone.", PChar->GetName());
+            destination = PChar->loc.prevzone;
         }
 
         zoneutils::GetZone(destination)->IncreaseZoneCounter(PChar);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1530,7 +1530,7 @@ namespace battleutils
         // get ratio (not capped for RAs)
         float ratio = (float)rAttack / (float)PDefender->DEF();
 
-        ratio = std::clamp<float>(ratio, 0, 3);
+        ratio        = std::clamp<float>(ratio, 0, 3);
         float cRatio = ratio;
 
         // level correct (0.025 not 0.05 like for melee)
@@ -2753,7 +2753,7 @@ namespace battleutils
         // Using 2013 model since it is the most up-to-date and tested version of the one used in 75 era
         // https://www.bg-wiki.com/index.php?title=PDIF&oldid=268066
         // Note that only player autoattacks use this function, weaponskill pDIF is calculated in scripts/global/weaponskills.lua
-        float ratio  = (static_cast<float>(attack)) / (static_cast<float>(defense));
+        float ratio    = (static_cast<float>(attack)) / (static_cast<float>(defense));
         float ratioCap = 2.25f;
 
         ratio = std::clamp<float>(ratio, 0, ratioCap);
@@ -2887,7 +2887,7 @@ namespace battleutils
         }
         else if (wRatio < 2.625f)
         {
-            upperLimit = wRatio + 0.375f;
+            upperLimit = std::min(wRatio + 0.375f, maxRatio);
         }
         else
         {
@@ -2912,7 +2912,7 @@ namespace battleutils
         }
         else
         {
-            lowerLimit = wRatio - 0.375f;
+            lowerLimit = std::min(wRatio - 0.375f, maxRatio);
         }
 
         float pDIF = 0.0f;
@@ -2920,13 +2920,14 @@ namespace battleutils
         // Bernoulli distribution, applied for cRatio < 0.5 and 0.75 < cRatio < 1.25
         // Other cRatio values are uniformly distributed
         // https://www.bluegartr.com/threads/108161-pDif-and-damage?p=5308205&viewfull=1#post5308205
-        float U = std::max<float>(0.0, std::min<float>(0.333, 1.3 * (2.0 - std::abs(wRatio - 1)) - 1.96));
-        bool bernoulli = xirand::GetRandomNumber(0.0f, 1.0f) < U ? true : false;
+        float U         = std::max<float>(0.0, std::min<float>(0.333, 1.3 * (2.0 - std::abs(wRatio - 1)) - 1.96));
+        bool  bernoulli = xirand::GetRandomNumber(0.0f, 1.0f) < U ? true : false;
 
         if (bernoulli)
         {
             pDIF = std::round(wRatio);
-        } else
+        }
+        else
         {
             pDIF = xirand::GetRandomNumber(lowerLimit, upperLimit);
         }
@@ -5784,7 +5785,7 @@ namespace battleutils
         // Move the target a little higher, just in case
         nearEntity.y -= 1.0f;
 
-        bool  success        = false;
+        bool success = false;
         // float drawInDistance = (float)(PMob->getMobMod(MOBMOD_DRAW_IN) > 1 ? PMob->getMobMod(MOBMOD_DRAW_IN) : PMob->GetMeleeRange() * 2);
 
         // if (std::chrono::time_point_cast<std::chrono::seconds>(server_clock::now()).time_since_epoch().count() - PMob->GetLocalVar("DrawInTime") < 2)
@@ -6905,9 +6906,9 @@ namespace battleutils
             RMainSub  = ((CItemWeapon*)PRangedSlot)->getSubSkillType();
         }
 
-        bool LongBowCurve  = (RMainType == 25 && RMainSub == 9); // Longbows Only
+        bool LongBowCurve  = (RMainType == 25 && RMainSub == 9);                                         // Longbows Only
         bool CrossBowCurve = ((RMainType == 25 && RMainSub == 0) || (RMainType == 26 && RMainSub == 0)); // Crossbows and Shortbows
-        bool GunCurve      = (RMainType == 26 && RMainSub == 1); // Guns Only
+        bool GunCurve      = (RMainType == 26 && RMainSub == 1);                                         // Guns Only
 
         if (LongBowCurve)
         {
@@ -6942,7 +6943,6 @@ namespace battleutils
                 return 1.00f + ((-1.10f * distance) / 100);
 
             return 0.86f; // Default to >20' Curve w/ 86% Cap
-
         }
         else if (GunCurve)
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Add a nullptr check to latent instantiation for the case of a player being in zone transit while the weather proc occurs.
+ Add an additional check to zone destination as well as set zone destination to prevZone when this occurs.

## Steps to test these changes
+ Able to zone just fine.
+ Confirmed that weather latents can still proc.
+ Unable to test nullptr issues as this is aimed to fix clustering problems likely with how each of these functions are handled with ZMQ.
