### PR TITLE
Fix Issues with Astral Flow and Call Wyvern for Mobs Outside of Dynamis

### DIFF
--- a/modules/era/lua_dynamis/mobskills/era_pet_skills.lua
+++ b/modules/era/lua_dynamis/mobskills/era_pet_skills.lua
@@ -6,6 +6,7 @@
 ---------------------------------------------
 require("scripts/globals/dynamis")
 require("modules/module_utils")
+require("scripts/globals/mobskills/astral_flow")
 ---------------------------------------------
 local m = Module:new("era_pet_skills")
 
@@ -52,8 +53,8 @@ m:addOverride("xi.globals.mobskills.astral_flow.onMobWeaponSkill", function(targ
             xi.dynamis.spawnDynamicPet(target, mob, xi.job.SMN)
         end
     else
-        if avatarOffsets[mobID] then
-            avatar = mobID + avatarOffsets[mobID]
+        if xi.astralflow.avatarOffsets[mobID] then
+            avatar = mobID + xi.astralflow.avatarOffsets[mobID]
         else
             avatar = mobID + 2 -- default offset
         end

--- a/modules/era/lua_dynamis/mobskills/era_pet_skills.lua
+++ b/modules/era/lua_dynamis/mobskills/era_pet_skills.lua
@@ -10,13 +10,13 @@ require("modules/module_utils")
 local m = Module:new("era_pet_skills")
 
 m:addOverride("xi.globals.mobskills.call_wyvern.onMobWeaponSkill", function(target, mob, skill)
-    local mobName = xi.dynamis.mobList[mob:getZoneID()][mob:getZone():getLocalVar((string.format("MobIndex_%s", mob:getID())))].info[2]
     if mob:getLocalVar("CALL_WYVERN") == 1 then
         skill:setMsg(xi.msg.basic.NONE)
         return 0
     end
 
     if mob:isInDynamis() then
+        local mobName = xi.dynamis.mobList[mob:getZoneID()][mob:getZone():getLocalVar((string.format("MobIndex_%s", mob:getID())))].info[2]
         if mobName == "Apocalyptic Beast" then
             for i = 5, 1, -1 do
                 xi.dynamis.spawnDynamicPet(target, mob, xi.job.DRG)
@@ -38,7 +38,6 @@ m:addOverride("xi.globals.mobskills.astral_flow.onMobWeaponSkill", function(targ
     skill:setMsg(xi.msg.basic.USES)
     local mobID = mob:getID()
     local avatar = 0
-    local mobName = xi.dynamis.mobList[mob:getZoneID()][mob:getZone():getLocalVar((string.format("MobIndex_%s", mob:getID())))].info[2]
 
     if mob:getLocalVar("ASTRAL_FLOW") == 1 then
         skill:setMsg(xi.msg.basic.NONE)
@@ -46,6 +45,7 @@ m:addOverride("xi.globals.mobskills.astral_flow.onMobWeaponSkill", function(targ
     end
 
     if mob:isInDynamis() then
+        local mobName = xi.dynamis.mobList[mob:getZoneID()][mob:getZone():getLocalVar((string.format("MobIndex_%s", mob:getID())))].info[2]
         if mobName == "Apocalyptic Beast" then
             xi.dynamis.spawnDynamicPet(target, mob, xi.job.SMN)
         elseif mobName == "Dagourmarche" then

--- a/scripts/globals/mobskills/astral_flow.lua
+++ b/scripts/globals/mobskills/astral_flow.lua
@@ -7,7 +7,9 @@ require("scripts/globals/msg")
 -----------------------------------
 local mobskill_object = {}
 
-local avatarOffsets =
+xi = xi or {}
+xi.astralflow = xi.astralflow or {}
+xi.astralflow.avatarOffsets =
 {
     [17444883] = 3, -- Vermilion-eared Noberry
     [17453078] = 3, -- Duke Dantalian
@@ -25,8 +27,8 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local mobID = mob:getID()
     local avatar = 0
 
-    if avatarOffsets[mobID] then
-        avatar = mobID + avatarOffsets[mobID]
+    if xi.astralflow.avatarOffsets[mobID] then
+        avatar = mobID + xi.astralflow.avatarOffsets[mobID]
     else
         avatar = mobID + 2 -- default offset
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Moved mobName declaration into the check for isInDyanmis()  so that we do not try to index a nil value when the mob is not in dynamis.

## Steps to test these changes
