### PR TITLE
Add More Variance to Mob Physical Moves

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -194,6 +194,14 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
 
     hitdamage = hitdamage * dmgmod
 
+    local dmgrandsel = math.random(0, 1) -- Can select either positive or negative.
+    local dmgrand = math.random(0, 10) -- Variance should be 0-10%
+    if dmgrandsel == 0 then
+        hitdamage = hitdamage + (hitdamage * (dmgrand / 100))
+    else
+        hitdamage = hitdamage - (hitdamage * (dmgrand / 100))
+    end
+
     -- Calculating with the known era pdif ratio for weaponskills.
     if mtp000 == nil or mtp150 == nil or mtp300 == nil then -- Nil gate for cMeleeRatio, will default mtp for each level to 1.
         mtp000 = 1.0
@@ -218,13 +226,9 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
     local chance = math.random()
 
     -- first hit has a higher chance to land
-    local firstHitChance = hitrate * 1.5
+    local firstHitChance = hitrate * 1.2
 
-    if tpeffect == xi.mobskills.magicalTpBonus.RANGED then
-        firstHitChance = hitrate * 1.2
-    end
-
-    firstHitChance = utils.clamp(firstHitChance, 35, 95)
+    firstHitChance = utils.clamp(firstHitChance, 25, 95)
 
     if (chance * 100) <= firstHitChance then -- it hit
         local isCrit = math.random() < critRate

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -195,7 +195,7 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
     hitdamage = hitdamage * dmgmod
 
     local dmgrandsel = math.random(0, 1) -- Can select either positive or negative.
-    local dmgrand = math.random(0, 10) -- Variance should be 0-10%
+    local dmgrand = math.random(0, 5) -- Variance should be 0-5%
     if dmgrandsel == 0 then
         hitdamage = hitdamage + (hitdamage * (dmgrand / 100))
     else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Reduced first hit accuracy bonus of mobs to 1.3 instead of 1.5 to reduce the overall hit rate of skills when the player is higher.
+ Reduced the minimum clamp for first hit accuracy bonus on mobs to 25% from 35%.
+ Added in variance for hitdamage for mobs which will range from -5% to 5%.

## Steps to test these changes
+ Tested with prints on single hit moves to see if variance occurred and how much there was.