### PR TITLE
Fix Avatar ATK | Add WSC | Rework Camisado | Fix Inaccuracies in Pacts

### DIFF
--- a/scripts/globals/abilities/pets/aerial_blast.lua
+++ b/scripts/globals/abilities/pets/aerial_blast.lua
@@ -21,9 +21,7 @@ end
 ability_object.onPetAbility = function(target, pet, skill, master)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
 
-    local level = pet:getMainLvl()
-    local damage = 48 + level
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 9, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)

--- a/scripts/globals/abilities/pets/aero_ii.lua
+++ b/scripts/globals/abilities/pets/aero_ii.lua
@@ -15,7 +15,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 30
     local dmgmod = 0
 
     if tp < 1500 then
@@ -24,7 +23,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((22/256) * (1500/10)) + ((9/256) * ((tp-1500)/10) + 384/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)

--- a/scripts/globals/abilities/pets/aero_iv.lua
+++ b/scripts/globals/abilities/pets/aero_iv.lua
@@ -15,7 +15,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 90
     local dmgmod = 0
 
     if tp < 1500 then
@@ -24,7 +23,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((29/256) * (1500/10)) + ((14/256) * ((tp-1500)/10)) + (928/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)

--- a/scripts/globals/abilities/pets/axe_kick.lua
+++ b/scripts/globals/abilities/pets/axe_kick.lua
@@ -16,9 +16,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2
+    local wSC = pet:getStat(xi.mod.STR) * 0.30
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/barracuda_dive.lua
+++ b/scripts/globals/abilities/pets/barracuda_dive.lua
@@ -16,9 +16,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2
+    local wSC = pet:getStat(xi.mod.STR) * 0.30
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHINGING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/blizzard_ii.lua
+++ b/scripts/globals/abilities/pets/blizzard_ii.lua
@@ -15,7 +15,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 30
     local dmgmod = 0
 
     if tp < 1500 then
@@ -24,7 +23,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((22/256) * (1500/10)) + ((9/256) * ((tp-1500)/10) + 384/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)

--- a/scripts/globals/abilities/pets/blizzard_iv.lua
+++ b/scripts/globals/abilities/pets/blizzard_iv.lua
@@ -15,7 +15,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 90
     local dmgmod = 0
 
     if tp < 1500 then
@@ -24,7 +23,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((29/256) * (1000/10)) + ((14/256) * ((tp-1000)/10)) + (928/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)

--- a/scripts/globals/abilities/pets/burning_strike.lua
+++ b/scripts/globals/abilities/pets/burning_strike.lua
@@ -17,9 +17,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2.75
+    local wSC = (pet:getStat(xi.mod.STR) * 0.20) + (pet:getStat(xi.mod.INT) * 0.20)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     --get resist multiplier (1x if no resist)
     local resist = xi.mobskills.applyPlayerResistance(pet, -1, target, pet:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), xi.skill.ELEMENTAL_MAGIC, xi.magic.ele.FIRE)
     --get the resisted damage

--- a/scripts/globals/abilities/pets/camisado.lua
+++ b/scripts/globals/abilities/pets/camisado.lua
@@ -13,17 +13,15 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local numhits = 1
-    local accmod = 1
-    local dmgmod = 2
+    local damage = pet:getMainLvl() + 2
 
-    local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
-    target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
-    target:updateEnmityFromDamage(pet, totaldamage)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, 2, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.DARK)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
+    target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
+    target:updateEnmityFromDamage(pet, damage)
 
-    return totaldamage
+    return damage
 end
 
 return ability_object

--- a/scripts/globals/abilities/pets/chaotic_strike.lua
+++ b/scripts/globals/abilities/pets/chaotic_strike.lua
@@ -17,7 +17,9 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 4
     local dmgmodsubsequent = 2
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local wSC = (pet:getStat(xi.mod.STR) * 0.20) + (pet:getStat(xi.mod.INT) * 0.20)
+
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:addStatusEffect(xi.effect.STUN, 1, 0, 2)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)

--- a/scripts/globals/abilities/pets/claw.lua
+++ b/scripts/globals/abilities/pets/claw.lua
@@ -15,9 +15,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2
+    local wSC = (pet:getStat(xi.mod.DEX) * 0.30)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/crescent_fang.lua
+++ b/scripts/globals/abilities/pets/crescent_fang.lua
@@ -16,9 +16,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local accmod = 1
     local dmgmod = 1.5
     local dmgmodsubsequent = 1
+    local wSC = (pet:getStat(xi.mod.STR) * 0.30)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
 
     if (damage.hitslanded > 0) then

--- a/scripts/globals/abilities/pets/diamond_dust.lua
+++ b/scripts/globals/abilities/pets/diamond_dust.lua
@@ -22,9 +22,7 @@ end
 ability_object.onPetAbility = function(target, pet, skill, master)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
 
-    local level = pet:getMainLvl()
-    local damage = 48 + level
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 9, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)

--- a/scripts/globals/abilities/pets/double_punch.lua
+++ b/scripts/globals/abilities/pets/double_punch.lua
@@ -15,11 +15,12 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 2
     local accmod = 1
-    local dmgmod = 2
-    local dmgmodsubsequent = 1
+    local dmgmod = 3
+    local dmgmodsubsequent = 3
+    local wSC = (pet:getStat(xi.mod.STR) * 0.30)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/double_slap.lua
+++ b/scripts/globals/abilities/pets/double_slap.lua
@@ -15,11 +15,12 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 2
     local accmod = 1
-    local dmgmod = 4
-    local dmgmodsubsequent = 3
+    local dmgmod = 3.66
+    local dmgmodsubsequent = 3.66
+    local wSC = (pet:getStat(xi.mod.CHR) * 0.30)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.H2H, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.H2H)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/earthen_fury.lua
+++ b/scripts/globals/abilities/pets/earthen_fury.lua
@@ -22,9 +22,7 @@ end
 ability_object.onPetAbility = function(target, pet, skill, master)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
 
-    local level = pet:getMainLvl()
-    local damage = 48 + level
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 9, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)

--- a/scripts/globals/abilities/pets/eclipse_bite.lua
+++ b/scripts/globals/abilities/pets/eclipse_bite.lua
@@ -17,7 +17,9 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 3
     local dmgmodsubsequent = 3
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local wSC = (pet:getStat(xi.mod.DEX) * 0.30)
+
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASH)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/fire_ii.lua
+++ b/scripts/globals/abilities/pets/fire_ii.lua
@@ -16,8 +16,7 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 30
-    local dmgmod
+    local dmgmod = 0
 
     if tp < 1500 then
         dmgmod = math.floor((22/256) * (tp/10) + (384/256))
@@ -25,7 +24,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((22/256) * (1500/10)) + ((9/256) * ((tp-1500)/10) + 384/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.FIRE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)

--- a/scripts/globals/abilities/pets/fire_iv.lua
+++ b/scripts/globals/abilities/pets/fire_iv.lua
@@ -16,7 +16,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 90
     local dmgmod = 0
 
     if tp < 1500 then
@@ -25,7 +24,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((29/256) * (1500/10)) + ((14/256) * ((tp-1500)/10)) + (928/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.FIRE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)

--- a/scripts/globals/abilities/pets/flaming_crush.lua
+++ b/scripts/globals/abilities/pets/flaming_crush.lua
@@ -14,20 +14,22 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local numhits = 3
+    local numhits = 2
     local accmod = 1
     local dmgmod = 6
     local dmgmodsubsequent = 1
+    local wSC = (pet:getStat(xi.mod.STR) * 0.20) + (pet:getStat(xi.mod.INT) * 0.20)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     --get resist multiplier (1x if no resist)
     local resist = xi.mobskills.applyPlayerResistance(pet, -1, target, pet:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), xi.skill.ELEMENTAL_MAGIC, xi.magic.ele.FIRE)
     --get the resisted damage
-    damage.dmg = damage.dmg*resist
+    local firedamage = (damage.dmg / 2) * resist
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
-    damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, 1)
-    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.FIRE, numhits)
+    firedamage = xi.mobskills.mobAddBonuses(pet, target, firedamage, 1)
+    damage = firedamage + damage.dmg
+    totaldamage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.FIRE, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.FIRE)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/geocrush.lua
+++ b/scripts/globals/abilities/pets/geocrush.lua
@@ -27,7 +27,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         tp = 300
     end
 
-    local damage = 96 + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)

--- a/scripts/globals/abilities/pets/grand_fall.lua
+++ b/scripts/globals/abilities/pets/grand_fall.lua
@@ -27,7 +27,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         tp = 300
     end
 
-    local damage = 96 + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)

--- a/scripts/globals/abilities/pets/heavenly_strike.lua
+++ b/scripts/globals/abilities/pets/heavenly_strike.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Geocrush
+-- Heavenly Strike
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -27,7 +27,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         tp = 300
     end
 
-    local damage = 96 + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)

--- a/scripts/globals/abilities/pets/howling_moon.lua
+++ b/scripts/globals/abilities/pets/howling_moon.lua
@@ -21,9 +21,7 @@ end
 ability_object.onPetAbility = function(target, pet, skill, master)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
 
-    local level = pet:getMainLvl()
-    local damage = 48 + level
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, 9, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.DARK)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)

--- a/scripts/globals/abilities/pets/inferno.lua
+++ b/scripts/globals/abilities/pets/inferno.lua
@@ -21,9 +21,7 @@ end
 ability_object.onPetAbility = function(target, pet, skill, master)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
 
-    local level = pet:getMainLvl()
-    local damage = 48 + level
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 9, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.FIRE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)

--- a/scripts/globals/abilities/pets/judgment_bolt.lua
+++ b/scripts/globals/abilities/pets/judgment_bolt.lua
@@ -21,9 +21,7 @@ end
 ability_object.onPetAbility = function(target, pet, skill, master)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
 
-    local level = pet:getMainLvl()
-    local damage = 48 + level
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 9, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)

--- a/scripts/globals/abilities/pets/megalith_throw.lua
+++ b/scripts/globals/abilities/pets/megalith_throw.lua
@@ -15,9 +15,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2.375
+    local wSC = (pet:getStat(xi.mod.STR) * 0.20) + (pet:getStat(xi.mod.AGI) * 0.20)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/meteor_strike.lua
+++ b/scripts/globals/abilities/pets/meteor_strike.lua
@@ -27,7 +27,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         tp = 300
     end
 
-    local damage = 96 + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage, xi.magic.ele.FIRE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)

--- a/scripts/globals/abilities/pets/meteorite.lua
+++ b/scripts/globals/abilities/pets/meteorite.lua
@@ -15,7 +15,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dint = pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
     local tp = skill:getTP()
-    local damage = 143
     local dmgmod = 0
 
     if tp < 1500 then
@@ -24,7 +23,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((8/256) * (1500/10)) + ((4/256) * ((tp-1500)/10) + 896/256))
     end
 
-    damage = damage + (1.5 * dint)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dint * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHT)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/globals/abilities/pets/moonlit_charge.lua
+++ b/scripts/globals/abilities/pets/moonlit_charge.lua
@@ -16,9 +16,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local accmod = 1
     local dmgmod = 1
     local dmgmodsubsequent = 1
+    local wSC = (pet:getStat(xi.mod.VIT) * 0.30)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:addStatusEffect(xi.effect.BLINDNESS, 20, 0, 30)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)

--- a/scripts/globals/abilities/pets/mountain_buster.lua
+++ b/scripts/globals/abilities/pets/mountain_buster.lua
@@ -14,15 +14,13 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
-    local dmgmod = 7.25
-
-    if skill:getTP() == 3000 then
-        dmgmod = 11.25
-    end
+    local tp = skill:getTP() / 10
+    local dmgmod = (0.133 * tp) + 7.25
+    local wSC = (pet:getStat(xi.mod.VIT) * 0.30)
 
     local dmgmodsubsequent = 1
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/nether_blast.lua
+++ b/scripts/globals/abilities/pets/nether_blast.lua
@@ -17,7 +17,6 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, 5, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.DARK)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.BREATH, xi.damageType.DARK, 1)
-
     target:takeDamage(damage, pet, xi.attackType.BREATH, xi.damageType.DARK)
     target:updateEnmityFromDamage(pet, damage)
 

--- a/scripts/globals/abilities/pets/nether_blast.lua
+++ b/scripts/globals/abilities/pets/nether_blast.lua
@@ -13,13 +13,12 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local level = pet:getMainLvl()
-    local damage = 5 * level + 10
+    local damage = pet:getMainLvl() + 2
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, 5, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.DARK)
-    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.BREATH, xi.damageType.DARK, 1)
 
-    target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
+    target:takeDamage(damage, pet, xi.attackType.BREATH, xi.damageType.DARK)
     target:updateEnmityFromDamage(pet, damage)
 
     return damage

--- a/scripts/globals/abilities/pets/poison_nails.lua
+++ b/scripts/globals/abilities/pets/poison_nails.lua
@@ -15,9 +15,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2
+    local wSC = (pet:getStat(xi.mod.DEX) * 0.30)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
 
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
 

--- a/scripts/globals/abilities/pets/predator_claws.lua
+++ b/scripts/globals/abilities/pets/predator_claws.lua
@@ -17,7 +17,9 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 3.90
     local dmgmodsubsequent = 3.90
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local wSC = (pet:getStat(xi.mod.DEX) * 0.30)
+
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/punch.lua
+++ b/scripts/globals/abilities/pets/punch.lua
@@ -15,10 +15,11 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
-    local dmgmod = 3
+    local dmgmod = 2
+    local wSC = (pet:getStat(xi.mod.STR) * 0.30)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/rock_buster.lua
+++ b/scripts/globals/abilities/pets/rock_buster.lua
@@ -15,9 +15,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2.25
+    local wSC = (pet:getStat(xi.mod.VIT) * 0.30)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
 
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)

--- a/scripts/globals/abilities/pets/rock_throw.lua
+++ b/scripts/globals/abilities/pets/rock_throw.lua
@@ -15,9 +15,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 1
+    local wSC = (pet:getStat(xi.mod.STR) * 0.20) + (pet:getStat(xi.mod.AGI) * 0.20)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
 
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)

--- a/scripts/globals/abilities/pets/rush.lua
+++ b/scripts/globals/abilities/pets/rush.lua
@@ -17,9 +17,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local accmod = 1
     local dmgmod = 5
     local dmgmodsubsequent = 2
+    local wSC = (pet:getStat(xi.mod.STR) * 0.20) + (pet:getStat(xi.mod.DEX) * 0.20)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/searing_light.lua
+++ b/scripts/globals/abilities/pets/searing_light.lua
@@ -21,9 +21,7 @@ end
 ability_object.onPetAbility = function(target, pet, skill, master)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
 
-    local level = pet:getMainLvl()
-    local damage = 26 + level
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHT, 8, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHT)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, 1)

--- a/scripts/globals/abilities/pets/shock_strike.lua
+++ b/scripts/globals/abilities/pets/shock_strike.lua
@@ -16,9 +16,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2
+    local wSC = (pet:getStat(xi.mod.STR) * 0.20) + (pet:getStat(xi.mod.INT) * 0.20)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:addStatusEffect(xi.effect.STUN, 1, 0, 2)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)

--- a/scripts/globals/abilities/pets/spinning_dive.lua
+++ b/scripts/globals/abilities/pets/spinning_dive.lua
@@ -16,9 +16,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 7
+    local wSC = (pet:getStat(xi.mod.STR) * 0.30)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/stone_ii.lua
+++ b/scripts/globals/abilities/pets/stone_ii.lua
@@ -15,7 +15,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 30
     local dmgmod = 0
 
     if tp < 1500 then
@@ -24,7 +23,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((22/256) * (1500/10)) + ((9/256) * ((tp-1500)/10) + 384/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)

--- a/scripts/globals/abilities/pets/stone_iv.lua
+++ b/scripts/globals/abilities/pets/stone_iv.lua
@@ -15,7 +15,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 90
     local dmgmod = 0
 
     if tp < 1500 then
@@ -24,7 +23,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((29/256) * (1500/10)) + ((14/256) * ((tp-1500)/10)) + (928/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)

--- a/scripts/globals/abilities/pets/tail_whip.lua
+++ b/scripts/globals/abilities/pets/tail_whip.lua
@@ -16,9 +16,10 @@ ability_object.onPetAbility = function(target, pet, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 3
+    local wSC = (pet:getStat(xi.mod.VIT) * 0.30)
 
     local totaldamage = 0
-    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3, wSC)
     totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
 
     local duration = 120

--- a/scripts/globals/abilities/pets/thunder_ii.lua
+++ b/scripts/globals/abilities/pets/thunder_ii.lua
@@ -15,7 +15,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 30
     local dmgmod = 0
 
     if tp < 1500 then
@@ -24,7 +23,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((22/256) * (1500/10)) + ((9/256) * ((tp-1500)/10) + 384/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)

--- a/scripts/globals/abilities/pets/thunder_iv.lua
+++ b/scripts/globals/abilities/pets/thunder_iv.lua
@@ -15,7 +15,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 90
     local dmgmod = 0
 
     if tp < 1500 then
@@ -24,7 +23,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((29/256) * (1500/10)) + ((14/256) * ((tp-1500)/10)) + (928/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)

--- a/scripts/globals/abilities/pets/thunderspark.lua
+++ b/scripts/globals/abilities/pets/thunderspark.lua
@@ -16,7 +16,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 90
     local dmgmod = 0
 
     if tp < 1500 then
@@ -25,7 +24,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((21/256) * (1500/10)) + ((5/256) * ((tp-1500)/10) + 640/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)

--- a/scripts/globals/abilities/pets/thunderstorm.lua
+++ b/scripts/globals/abilities/pets/thunderstorm.lua
@@ -28,7 +28,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         tp = 300
     end
 
-    local damage = 96 + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)

--- a/scripts/globals/abilities/pets/tidal_wave.lua
+++ b/scripts/globals/abilities/pets/tidal_wave.lua
@@ -21,9 +21,7 @@ end
 ability_object.onPetAbility = function(target, pet, skill, master)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
 
-    local level = pet:getMainLvl()
-    local damage = 48 + level
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 9, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)

--- a/scripts/globals/abilities/pets/water_ii.lua
+++ b/scripts/globals/abilities/pets/water_ii.lua
@@ -15,7 +15,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 30
     local dmgmod = 0
 
     if tp < 1500 then
@@ -24,7 +23,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((22/256) * (1500/10)) + ((9/256) * ((tp-1500)/10) + 384/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)

--- a/scripts/globals/abilities/pets/water_iv.lua
+++ b/scripts/globals/abilities/pets/water_iv.lua
@@ -15,7 +15,6 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
-    local damage = 90
     local dmgmod = 0
 
     if tp < 1500 then

--- a/scripts/globals/abilities/pets/water_iv.lua
+++ b/scripts/globals/abilities/pets/water_iv.lua
@@ -24,7 +24,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         dmgmod = math.floor(((29/256) * (1500/10)) + ((14/256) * ((tp-1500)/10)) + (928/256))
     end
 
-    damage = damage + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)

--- a/scripts/globals/abilities/pets/wind_blade.lua
+++ b/scripts/globals/abilities/pets/wind_blade.lua
@@ -29,7 +29,7 @@ ability_object.onPetAbility = function(target, pet, skill)
         tp = 300
     end
 
-    local damage = 96 + (dINT * 1.5)
+    local damage = pet:getMainLvl() + 2 + (0.30 * pet:getStat(xi.mod.INT)) + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -335,11 +335,11 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
         end
     end
 
-    -- get resistence
-    local params = {diff = (mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT)), skillType = nil, bonus = bonusMacc, element = element, effect = nil}
-    resist = applyResistanceEffect(mob, target, nil, params) -- Uses magic.lua resistance calcs as this moves to a global use case.
+    if skill:getID() ~= 1910 then -- Nether Blast Should Ignore Resist
+        -- get resistence
+        local params = {diff = (mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT)), skillType = nil, bonus = bonusMacc, element = element, effect = nil}
+        resist = applyResistanceEffect(mob, target, nil, params) -- Uses magic.lua resistance calcs as this moves to a global use case.
 
-    if skill:getID() ~= 610 or skill:getID() ~= 1910 then -- Nether Blast Should Ignore Resist
         finaldmg = finaldmg * resist
     end
 

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -339,7 +339,9 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
     local params = {diff = (mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT)), skillType = nil, bonus = bonusMacc, element = element, effect = nil}
     resist = applyResistanceEffect(mob, target, nil, params) -- Uses magic.lua resistance calcs as this moves to a global use case.
 
-    finaldmg = finaldmg * resist
+    if skill:getID() ~= 610 or skill:getID() ~= 1910 then -- Nether Blast Should Ignore Resist
+        finaldmg = finaldmg * resist
+    end
 
     returninfo.dmg = finaldmg
 

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -84,8 +84,12 @@ xi.summon.getSummoningSkillOverCap = function(avatar)
     return math.max(summoningSkill - maxSkill, 0)
 end
 
-xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, accmod, dmgmod, dmgmodsubsequent, tpeffect, mtp100, mtp200, mtp300)
+xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, accmod, dmgmod, dmgmodsubsequent, tpeffect, mtp100, mtp200, mtp300, wSC)
     local returninfo = {}
+
+    if wSC == nil then
+        wSC = 0
+    end
 
     -- I have never read a limit on accuracy bonus from summoning skill which can currently go far past 200 over cap
     -- current retail is over +250 skill so I am removing the cap, my SMN is at 695 total skill
@@ -176,6 +180,7 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
         critRate = utils.clamp(critRate, minCritRate, maxCritRate)
 
         local weaponDmg = avatar:getWeaponDmg()
+        weaponDmg = weaponDmg + wSC
 
         local fSTR = getAvatarFSTR(weaponDmg, avatar:getStat(xi.mod.STR), target:getStat(xi.mod.VIT))
 

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1601,23 +1601,22 @@ namespace petutils
             uint16 weaponDamage = 1 + mLvl;
             if (PetID == PETID_CARBUNCLE || PetID == PETID_CAIT_SITH)
             {
-                weaponDamage = static_cast<uint16>(floor(PPet->GetMLevel() * 0.74f));
+                weaponDamage = floor(weaponDamage * 0.74);
             }
 
             ((CItemWeapon*)PPet->m_Weapons[SLOT_MAIN])->setDamage(weaponDamage);
 
-            // Set B+ weapon skill (assumed capped for level derp)
-            // attack is madly high for avatars (roughly x2)
+            // Set B weapon skill which is consistent with every other mob
             if (PetID == PETID_FENRIR)
             {
-                PPet->setModifier(Mod::ATT, 2.6 * battleutils::GetMaxSkill(SKILL_CLUB, JOB_WHM, PPet->GetMLevel())); // Fenrir has been proven to have an additional 30% ATK
+                PPet->setModifier(Mod::ATT, 1.3 * battleutils::GetMaxSkill(SKILL_SWORD, JOB_WAR, PPet->GetMLevel())); // Fenrir has been proven to have an additional 30% ATK
             }
             else
             {
-                PPet->setModifier(Mod::ATT, 2 * battleutils::GetMaxSkill(SKILL_CLUB, JOB_WHM, PPet->GetMLevel()));
+                PPet->setModifier(Mod::ATT, battleutils::GetMaxSkill(SKILL_SWORD, JOB_WAR, PPet->GetMLevel()));
             }
 
-            PPet->setModifier(Mod::ACC, battleutils::GetMaxSkill(SKILL_CLUB, JOB_WHM, PPet->GetMLevel()));
+            PPet->setModifier(Mod::ACC, battleutils::GetMaxSkill(SKILL_SWORD, JOB_WAR, PPet->GetMLevel()));
             // Set E evasion and def
             PPet->setModifier(Mod::EVA, battleutils::GetMaxSkill(SKILL_THROWING, JOB_WHM, PPet->GetMLevel()));
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixed nether blast's damage calculation to calculate as breath damage. (Supported by the link in my other PR.)
+ Added resist nullification to nether blast (it didn't have it before).
+ Changed camisado to be a magical blood pact instead of a physical. (Supported by the link in my other PR.)
+ Added WSC calcs to all blood pacts.
+ Removed the 2x ATK bonus avatars were getting. (Idk what this even was, but its gone now so no more 200+ dmg Ifrit punches.)
+ Changed Avatar ATK calc to use B skill instead of B+, accuracy now B instead of B+.

## Steps to test these changes
+ Tested w/ new WSC calcs and the values seem much more accurate for all BPs.
+ Tested and found that white damage is now reasonable and not insane like previous iterations. (Ifrit's dmg at 75 went from 200+ -> ~76 dmg.
+ Tested nether blast and it works as expected.
+ Tested camisado and it works as expected.