### PR TITLE
Add Spell Cast Time Modifier Using Local Var

### DIFF
--- a/scripts/zones/South_Gustaberg/mobs/Stone_Eater.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Stone_Eater.lua
@@ -6,10 +6,6 @@ require("scripts/globals/regimes")
 -----------------------------------
 local entity = {}
 
-entity.onMobEngaged = function(mob, target)
-    mob:setLocalVar("[CastTime]ID_159", 10)
-end
-
 entity.onMobDeath = function(mob, player, isKiller)
     xi.regime.checkRegime(player, mob, 77, 1, xi.regime.type.FIELDS)
 end

--- a/scripts/zones/South_Gustaberg/mobs/Stone_Eater.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Stone_Eater.lua
@@ -6,6 +6,10 @@ require("scripts/globals/regimes")
 -----------------------------------
 local entity = {}
 
+entity.onMobEngaged = function(mob, target)
+    mob:setLocalVar("[CastTime]ID_159", 10)
+end
+
 entity.onMobDeath = function(mob, player, isKiller)
     xi.regime.checkRegime(player, mob, 77, 1, xi.regime.type.FIELDS)
 end

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -66,7 +66,7 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
                                                                         errorMsg == 1 ? MSGBASIC_CANNOT_CAST_SPELL : errorMsg));
     }
 
-    m_castTime = std::chrono::milliseconds(battleutils::CalculateSpellCastTime(m_PEntity, this));
+    m_castTime = std::chrono::milliseconds(battleutils::CalculateSpellCastTime(m_PEntity, this, static_cast<uint16>(m_PSpell->getID())));
     m_startPos = m_PEntity->loc.p;
 
     action_t action;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -6116,7 +6116,7 @@ namespace battleutils
         return found;
     }
 
-    uint32 CalculateSpellCastTime(CBattleEntity* PEntity, CMagicState* PMagicState)
+    uint32 CalculateSpellCastTime(CBattleEntity* PEntity, CMagicState* PMagicState, uint16 spellid)
     {
         CSpell* PSpell = PMagicState->GetSpell();
         if (PSpell == nullptr)
@@ -6130,6 +6130,11 @@ namespace battleutils
         {
             PMagicState->SetInstantCast(true);
             return 0;
+        }
+
+        if (PEntity->GetLocalVar(std::to_string(spellid).c_str()) != 0) // Usage: mob:setLocalVar("spellid", casttimeseconds)
+        {
+            return PEntity->GetLocalVar(std::to_string(spellid).c_str()) * 1000; // Convert to ms
         }
 
         bool   applyArts = true;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -6132,9 +6132,9 @@ namespace battleutils
             return 0;
         }
 
-        if (PEntity->GetLocalVar(std::to_string(spellid).c_str()) != 0) // Usage: mob:setLocalVar("spellid", casttimeseconds)
+        if (PEntity->GetLocalVar(("[CastTime]ID_" + std::to_string(spellid)).c_str()) != 0) // Usage: mob:setLocalVar("[CastTime]ID_spellId", casttimeseconds)
         {
-            return PEntity->GetLocalVar(std::to_string(spellid).c_str()) * 1000; // Convert to ms
+            return PEntity->GetLocalVar(("[CastTime]ID_" + std::to_string(spellid)).c_str()) * 1000; // Convert to ms
         }
 
         bool   applyArts = true;

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -247,7 +247,7 @@ namespace battleutils
     void    AddTraits(CBattleEntity* PEntity, TraitList_t* TraitList, uint8 level);
     bool    HasClaim(CBattleEntity* PEntity, CBattleEntity* PTarget);
 
-    uint32 CalculateSpellCastTime(CBattleEntity*, CMagicState*);
+    uint32 CalculateSpellCastTime(CBattleEntity*, CMagicState*, uint16 spellid);
     uint16 CalculateSpellCost(CBattleEntity*, CSpell*);
     uint32 CalculateSpellRecastTime(CBattleEntity*, CSpell*);
     int16  CalculateSpellTP(CBattleEntity* PEntity, CSpell* PSpell);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Adds the ability to change cast times via a local var.
+ Usage: entity:setLocalVar("[CastTime]ID_spellId", seconds)

## Steps to test these changes
+ Confirmed that spell cast times are modified by setting this var.
