### PR TITLE
Add MAGIC_INTERRUPTED State Listener

### DIFF
--- a/documentation/AI_Events.txt
+++ b/documentation/AI_Events.txt
@@ -43,3 +43,4 @@ MAGIC_START - Entity, Spell, action
 MAGIC_USE - Entity, Target, Spell, action
 MAGIC_STATE_EXIT - Entity, Spell
 MAGIC_TAKE - Target, Entity, Spell, ?action?
+MAGIC_INTERRUPTED - Entity, Target, Spell, action

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -140,6 +140,7 @@ bool CMagicState::Update(time_point tick)
         if (m_interrupted)
         {
             m_PEntity->OnCastInterrupted(*this, action, msg);
+            m_PEntity->PAI->EventHandler.triggerListener("MAGIC_INTERRUPTED", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), CLuaSpell(m_PSpell.get()), &action);
         }
         else
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Adds a state listener for MAGIC_INTERRUPTED.

## Steps to test these changes
+ Tested on a stone eater and was successfully able to proc after interrupting it via stun, auto attacks, and other forms of interruption. 
NOTE: This will trigger if the interrupt was due to paralyze.
