### PR TITLE
Add Pet Dmg Multipliers For Targets With a Mod

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -271,6 +271,10 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
         skill:setMsg(xi.msg.basic.SKILL_MISS)
     end
 
+    if target:getMod(xi.mod.PET_DMG_TAKEN_PHYSICAL) ~= 0 then
+        finaldmg = finaldmg + (finaldmg * (target:getMod(xi.mod.PET_DMG_TAKEN_PHYSICAL) / 100))
+    end
+
     returninfo.dmg = finaldmg
     returninfo.hitslanded = hitslanded
 
@@ -341,6 +345,10 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
         resist = applyResistanceEffect(mob, target, nil, params) -- Uses magic.lua resistance calcs as this moves to a global use case.
 
         finaldmg = finaldmg * resist
+    end
+
+    if target:getMod(xi.mod.PET_DMG_TAKEN_MAGICAL) ~= 0 then
+        finaldmg = finaldmg + (finaldmg * (target:getMod(xi.mod.PET_DMG_TAKEN_MAGICAL) / 100))
     end
 
     returninfo.dmg = finaldmg
@@ -470,6 +478,10 @@ xi.mobskills.mobBreathMove = function(mob, target, percent, base, element, cap)
     end
 
     damage = utils.clamp(damage, 1, cap)
+
+    if target:getMod(xi.mod.PET_DMG_TAKEN_BREATH) ~= 0 then
+        damage = damage + (damage * (target:getMod(xi.mod.PET_DMG_TAKEN_BREATH) / 100))
+    end
 
     local liement = target:checkLiementAbsorb(xi.damageType.ELEMENTAL + element) -- check for Liement.
     if liement < 0 then -- skip BDT/DT etc for Liement if we absorb.

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1707,28 +1707,32 @@ xi.mod =
     GEOMANCY_MP_NO_DEPLETE = 1037, -- Percent chance for Geomancy to cost 0 MP (GEO AF3 Sets)
 
     -- Permenant Resistance Build Modifiers
-    SLEEPRESBUILD                 = 1138,
-    POISONRESBUILD                = 1139,
-    PARALYZERESBUILD              = 1140,
-    BLINDRESBUILD                 = 1141,
-    SILENCERESBUILD               = 1142,
-    VIRUSRESBUILD                 = 1143,
-    PETRIFYRESBUILD               = 1144,
-    BINDRESBUILD                  = 1145,
-    CURSERESBUILD                 = 1146,
-    GRAVITYRESBUILD               = 1147,
-    SLOWRESBUILD                  = 1148,
-    STUNRESBUILD                  = 1149,
-    CHARMRESBUILD                 = 1150,
-    AMNESIARESBUILD               = 1151,
-    LULLABYRESBUILD               = 1152,
-    DEATHRESBUILD                 = 1153,
+    SLEEPRESBUILD                 = 1138, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    POISONRESBUILD                = 1139, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    PARALYZERESBUILD              = 1140, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    BLINDRESBUILD                 = 1141, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    SILENCERESBUILD               = 1142, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    VIRUSRESBUILD                 = 1143, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    PETRIFYRESBUILD               = 1144, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    BINDRESBUILD                  = 1145, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    CURSERESBUILD                 = 1146, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    GRAVITYRESBUILD               = 1147, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    SLOWRESBUILD                  = 1148, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    STUNRESBUILD                  = 1149, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    CHARMRESBUILD                 = 1150, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    AMNESIARESBUILD               = 1151, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    LULLABYRESBUILD               = 1152, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    DEATHRESBUILD                 = 1153, -- Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    PET_DMG_TAKEN_PHYSICAL        = 1154, -- Percent increase/decrease in pet physical damage taken for the target.
+    PET_DMG_TAKEN_MAGICAL         = 1155, -- Percent increase/decrease in pet magical damage taken for the target.
+    PET_DMG_TAKEN_BREATH          = 1156, -- Percent increase/decrease in pet breath damage taken for the target.
 
     -- IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN src/map/modifier.h ASWELL!
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
     -- For Next ID, see modifier.h
+    -- Spares start at: 1157
 }
 
 xi.latent =

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -536,6 +536,12 @@ void CAttack::ProcessDamage(bool isCritical)
         SetAttackType(PHYSICAL_ATTACK_TYPE::SAMBA);
     }
 
+    if (m_attacker->objtype == TYPE_PET && m_attacker->GetBattleTarget() != nullptr && m_attacker->GetBattleTarget()->getMod(Mod::PET_DMG_TAKEN_PHYSICAL) != 0)
+    {
+        int32 dmgMult = m_attacker->GetBattleTarget()->getMod(Mod::PET_DMG_TAKEN_PHYSICAL) / 100;
+        m_damage += m_damage * dmgMult;
+    }
+
     // Get damage multipliers.
     m_damage =
         attackutils::CheckForDamageMultiplier((CCharEntity*)m_attacker, dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[slot]), m_damage, m_attackType, slot);

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -886,22 +886,25 @@ enum class Mod
     GEOMANCY_MP_NO_DEPLETE = 1037, // Percent chance for Geomancy to cost 0 MP (GEO AF3 Sets)
 
     // Permenant Resistance Build Modifiers
-    SLEEPRESBUILD    = 1138,
-    POISONRESBUILD   = 1139,
-    PARALYZERESBUILD = 1140,
-    BLINDRESBUILD    = 1141,
-    SILENCERESBUILD  = 1142,
-    VIRUSRESBUILD    = 1143,
-    PETRIFYRESBUILD  = 1144,
-    BINDRESBUILD     = 1145,
-    CURSERESBUILD    = 1146,
-    GRAVITYRESBUILD  = 1147,
-    SLOWRESBUILD     = 1148,
-    STUNRESBUILD     = 1149,
-    CHARMRESBUILD    = 1150,
-    AMNESIARESBUILD  = 1151,
-    LULLABYRESBUILD  = 1152,
-    DEATHRESBUILD    = 1153,
+    SLEEPRESBUILD                 = 1138, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    POISONRESBUILD                = 1139, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    PARALYZERESBUILD              = 1140, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    BLINDRESBUILD                 = 1141, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    SILENCERESBUILD               = 1142, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    VIRUSRESBUILD                 = 1143, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    PETRIFYRESBUILD               = 1144, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    BINDRESBUILD                  = 1145, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    CURSERESBUILD                 = 1146, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    GRAVITYRESBUILD               = 1147, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    SLOWRESBUILD                  = 1148, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    STUNRESBUILD                  = 1149, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    CHARMRESBUILD                 = 1150, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    AMNESIARESBUILD               = 1151, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    LULLABYRESBUILD               = 1152, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    DEATHRESBUILD                 = 1153, // Used to create a resbuild for the appropriate effect. Will decrease overall duration of effect. (Out of 1000)
+    PET_DMG_TAKEN_PHYSICAL        = 1154, // Perc ent increase/decrease in pet physical damage taken for the target.
+    PET_DMG_TAKEN_MAGICAL         = 1155, // Percent increase/decrease in pet physical damage taken for the target.
+    PET_DMG_TAKEN_BREATH          = 1156, // Percent increase/decrease in pet physical damage taken for the target.
 
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/globals/status.lua ASWELL!
 
@@ -919,7 +922,7 @@ enum class Mod
     // 888
     // 936
     //
-    // SPARE = 1045, and onward
+    // SPARE = 1157, and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [ ] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Added 3 new mods to increase damage of pets for Physical, Magical, and Breath by a percentage.
+ Added physical mod to physical mobskills and auto attack damage.
+ Added magical mod to magical mobskills.
+ Added breath mod to breath mobskills.

## Steps to test these changes

