### PR TITLE
Synth Utils Standardization to Era | Add Break Types

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -540,7 +540,7 @@ void SmallPacket0x00D(map_session_data_t* const PSession, CCharEntity* const PCh
         sql->Query("UPDATE char_stats SET zoning = 1 WHERE charid = %u", PChar->id);
         charutils::CheckEquipLogic(PChar, SCRIPT_CHANGEZONE, PChar->getZone());
 
-        if (PChar->CraftContainer->getItemsCount() > 0 && PChar->animation == ANIMATION_SYNTH)
+        if ((PChar->CraftContainer->getItemsCount() > 0 && PChar->animation == ANIMATION_SYNTH) || PChar->GetLocalVar("InSynth") != 0)
         {
             // NOTE:
             // Supposed non-losable items are reportely lost if this condition is met:
@@ -549,7 +549,9 @@ void SmallPacket0x00D(map_session_data_t* const PSession, CCharEntity* const PCh
             // interrupted in some way, such as by being attacked or moving to another area (e.g. ship docking).
 
             ShowWarning("SmallPacket0x00D: %s attempting to zone in the middle of a synth, failing their synth!", PChar->GetName());
+            PChar->CraftContainer->m_failType = 3;
             synthutils::doSynthFail(PChar);
+            PChar->SetLocalVar("InSynth", 0);
         }
     }
 

--- a/src/map/trade_container.cpp
+++ b/src/map/trade_container.cpp
@@ -290,6 +290,7 @@ void CTradeContainer::Clean()
     m_craftType  = 0;
     m_ItemsCount = 0;
     m_exSize     = 0;
+    m_failType   = 0;
 
     m_PItem.clear();
     m_PItem.resize(CONTAINER_SIZE, nullptr);

--- a/src/map/trade_container.h
+++ b/src/map/trade_container.h
@@ -80,6 +80,8 @@ public:
 
     void Clean(); // we clean the container
 
+    uint8 m_failType;
+
 private:
     uint8 m_type;       // Container type (crystal type, store nation, etc.)
     uint8 m_craftType;  // The craft synthesis type (CRAFT_TYPE)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes HQ rates.
+ Fixes success rates.
+ Fixes skillup rates.
+ Fixes fastsynth exploits.
+ Fixes craft cheese.

## Steps to test these changes
+ Tested skillup.
+ Tested break.
+ Tested craft cheese.
+ Everything else was from LB and tested.