### PR TITLE
Fix Issues With Status Weaponskills

### DIFF
--- a/scripts/globals/weaponskills/armor_break.lua
+++ b/scripts/globals/weaponskills/armor_break.lua
@@ -37,7 +37,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false) then
-        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
+        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
     end
 

--- a/scripts/globals/weaponskills/blade_kamu.lua
+++ b/scripts/globals/weaponskills/blade_kamu.lua
@@ -45,7 +45,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.ACCURACY_DOWN) then
-            local duration = tp / 1000 * 60 * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, 0)
+            local duration = tp / 1000 * 60 * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, ((player:getMainLvl() / 7.5) * (tp / 1000)))
             target:addStatusEffect(xi.effect.ACCURACY_DOWN, 10, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/blade_metsu.lua
+++ b/scripts/globals/weaponskills/blade_metsu.lua
@@ -43,7 +43,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.PARALYSIS) then
-            local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
+            local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
             target:addStatusEffect(xi.effect.PARALYSIS, 10, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/blade_retsu.lua
+++ b/scripts/globals/weaponskills/blade_retsu.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if (damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false) then
-        local duration = (tp/1000 * 30) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
+        local duration = (tp/1000 * 30) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         -- paralyze proc based on lvl difference
         local power = 30 + (player:getMainLvl() - target:getMainLvl())*3
         if (power > 35) then

--- a/scripts/globals/weaponskills/blade_yu.lua
+++ b/scripts/globals/weaponskills/blade_yu.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.POISON) == false) then
-        local duration = (75 + (tp/1000 * 15)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0)
+        local duration = (75 + (tp/1000 * 15)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.POISON, 10, 0, duration)
     end
     return tpHits, extraHits, false, damage

--- a/scripts/globals/weaponskills/bora_axe.lua
+++ b/scripts/globals/weaponskills/bora_axe.lua
@@ -37,9 +37,9 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0) > math.random() * 150
+    local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000))) > math.random() * 150
     if (damage > 0 and target:hasStatusEffect(xi.effect.BIND) == false and chance) then
-        local duration = 20 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
+        local duration = 20 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.BIND, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/brainshaker.lua
+++ b/scripts/globals/weaponskills/brainshaker.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false) then
-        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
+        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/exenterator.lua
+++ b/scripts/globals/weaponskills/exenterator.lua
@@ -39,7 +39,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.ACCURACY_DOWN) == false) then
-        local duration = (45 + (tp/1000 * 45)) * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, 0)
+        local duration = (45 + (tp/1000 * 45)) * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/full_break.lua
+++ b/scripts/globals/weaponskills/full_break.lua
@@ -36,16 +36,16 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     if (damage > 0) then
         local duration = (tp/1000 * 30) + 60
         if (target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false) then
-            target:addStatusEffect(xi.effect.DEFENSE_DOWN, 12.5, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0))
+            target:addStatusEffect(xi.effect.DEFENSE_DOWN, 12.5, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000))))
         end
         if (target:hasStatusEffect(xi.effect.ATTACK_DOWN) == false) then
-            target:addStatusEffect(xi.effect.ATTACK_DOWN, 12.5, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0))
+            target:addStatusEffect(xi.effect.ATTACK_DOWN, 12.5, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, ((player:getMainLvl() / 7.5) * (tp / 1000))))
         end
         if (target:hasStatusEffect(xi.effect.EVASION_DOWN) == false) then
-            target:addStatusEffect(xi.effect.EVASION_DOWN, 20, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0))
+            target:addStatusEffect(xi.effect.EVASION_DOWN, 20, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000))))
         end
         if (target:hasStatusEffect(xi.effect.ACCURACY_DOWN) == false) then
-            target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, 0))
+            target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, ((player:getMainLvl() / 7.5) * (tp / 1000))))
         end
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/garland_of_bliss.lua
+++ b/scripts/globals/weaponskills/garland_of_bliss.lua
@@ -40,7 +40,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.DEFENSE_DOWN) then
-            local duration = (30 + tp / 1000 * 30) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
+            local duration = (30 + tp / 1000 * 30) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
             target:addStatusEffect(xi.effect.DEFENSE_DOWN, 12.5, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/gate_of_tartarus.lua
+++ b/scripts/globals/weaponskills/gate_of_tartarus.lua
@@ -41,7 +41,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
-            local duration = tp / 1000 * 3 * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0)
+            local duration = tp / 1000 * 3 * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, ((player:getMainLvl() / 7.5) * (tp / 1000)))
             target:addStatusEffect(xi.effect.ATTACK_DOWN, 20, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/glory_slash.lua
+++ b/scripts/globals/weaponskills/glory_slash.lua
@@ -31,7 +31,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false) then
-        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
+        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end
 

--- a/scripts/globals/weaponskills/guillotine.lua
+++ b/scripts/globals/weaponskills/guillotine.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.SILENCE) == false) then
-        local duration = (30 + (tp/1000 * 30)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
+        local duration = (30 + (tp/1000 * 30)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.SILENCE, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/herculean_slash.lua
+++ b/scripts/globals/weaponskills/herculean_slash.lua
@@ -34,7 +34,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false) then
-        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
+        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.PARALYSIS, 30, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/leg_sweep.lua
+++ b/scripts/globals/weaponskills/leg_sweep.lua
@@ -37,7 +37,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0) > math.random() * 150
     if (damage > 0 and chance) then
         if (target:hasStatusEffect(xi.effect.STUN) == false) then
-            local duration = 4 * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
+            local duration = 4 * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, ((player:getMainLvl() / 7.5) * (tp / 1000)))
             target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/metatron_torment.lua
+++ b/scripts/globals/weaponskills/metatron_torment.lua
@@ -43,7 +43,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if damage > 0 then
-        local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
+        local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 19, 0, duration)
     end
 

--- a/scripts/globals/weaponskills/numbing_shot.lua
+++ b/scripts/globals/weaponskills/numbing_shot.lua
@@ -34,7 +34,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false) then
-        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
+        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.PARALYSIS, 30, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/onslaught.lua
+++ b/scripts/globals/weaponskills/onslaught.lua
@@ -41,7 +41,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.ACCURACY_DOWN) then
-            local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, 0)
+            local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, ((player:getMainLvl() / 7.5) * (tp / 1000)))
             target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/pyrrhic_kleos.lua
+++ b/scripts/globals/weaponskills/pyrrhic_kleos.lua
@@ -44,7 +44,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
-            local duration = tp / 1000 * 60 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
+            local duration = tp / 1000 * 60 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
             target:addStatusEffect(xi.effect.EVASION_DOWN, 10, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/randgrith.lua
+++ b/scripts/globals/weaponskills/randgrith.lua
@@ -39,7 +39,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
-            local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
+            local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
             target:addStatusEffect(xi.effect.EVASION_DOWN, 32, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/shadowstitch.lua
+++ b/scripts/globals/weaponskills/shadowstitch.lua
@@ -37,7 +37,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     if (damage > 0) then
         local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0) > math.random() * 150
         if (target:hasStatusEffect(xi.effect.BIND) == false and chance) then
-            local duration = (5 + (tp/1000 * 5)) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
+            local duration = (5 + (tp/1000 * 5)) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
             target:addStatusEffect(xi.effect.BIND, 1, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/shell_crusher.lua
+++ b/scripts/globals/weaponskills/shell_crusher.lua
@@ -36,7 +36,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false) then
-        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
+        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/shield_break.lua
+++ b/scripts/globals/weaponskills/shield_break.lua
@@ -38,7 +38,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.EVASION_DOWN) == false) then
-        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
+        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.EVASION_DOWN, 40, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/shockwave.lua
+++ b/scripts/globals/weaponskills/shockwave.lua
@@ -29,7 +29,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.SLEEP_I) == false) then
-        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, 0)
+        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.SLEEP_I, 1, 0, duration)
     end
 

--- a/scripts/globals/weaponskills/shoulder_tackle.lua
+++ b/scripts/globals/weaponskills/shoulder_tackle.lua
@@ -34,7 +34,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     end
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false) then
-        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
+        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/smash_axe.lua
+++ b/scripts/globals/weaponskills/smash_axe.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false) then
-        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
+        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/tachi_ageha.lua
+++ b/scripts/globals/weaponskills/tachi_ageha.lua
@@ -38,7 +38,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false) then
-        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
+        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/tachi_kasha.lua
+++ b/scripts/globals/weaponskills/tachi_kasha.lua
@@ -40,7 +40,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false) then
-        local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
+        local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.PARALYSIS, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/tachi_yukikaze.lua
+++ b/scripts/globals/weaponskills/tachi_yukikaze.lua
@@ -38,7 +38,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.BLINDNESS) == false) then
-        local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, 0)
+        local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.BLINDNESS, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/ukkos_fury.lua
+++ b/scripts/globals/weaponskills/ukkos_fury.lua
@@ -44,7 +44,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.SLOW) then
-            local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, 0)
+            local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, ((player:getMainLvl() / 7.5) * (tp / 1000)))
             target:addStatusEffect(xi.effect.SLOW, 1500, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/viper_bite.lua
+++ b/scripts/globals/weaponskills/viper_bite.lua
@@ -37,7 +37,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.POISON) == false) then
-        local duration = (30 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0)
+        local duration = (30 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.POISON, 3, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/weapon_break.lua
+++ b/scripts/globals/weaponskills/weapon_break.lua
@@ -38,7 +38,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.ATTACK_DOWN) == false) then
-        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0)
+        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, ((player:getMainLvl() / 7.5) * (tp / 1000)))
         target:addStatusEffect(xi.effect.ATTACK_DOWN, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Added a bonus accuracy formula for status effects applied by weaponskills based on player level * tp threshold. (Maxes out at +30 MACC at 75)

## Steps to test these changes
+ Tested Blade: Retsu at multiple level ranges and noticed that minimum durations generally were around 5s with maximum at the full duration. Generally the values stayed near the 1/4th resist mark for each level range.
