### PR TITLE
Rework Current Digging System | Pull Xaver-Red Work + LB Chocobo Digging

### DIFF
--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -14,6 +14,13 @@ require("scripts/missions/amk/helpers")
 xi = xi or {}
 xi.chocoboDig = xi.chocoboDig or {}
 
+local DIG_RATE = xi.settings.main.DIG_RATE
+local DIG_FATIGUE = xi.settings.main.DIG_FATIGUE
+local DIG_ZONE_LIMIT = xi.settings.main.DIG_ZONE_LIMIT
+local DIG_GRANT_BURROW = xi.settings.main.DIG_GRANT_BURROW
+local DIG_GRANT_BORE = xi.settings.DIG_GRANT_BORE
+local DIG_DISTANCE_REQ = xi.settings.DIG_DISTANCE_REQ
+
 local digReq =
 {
     NONE     = 0,
@@ -21,6 +28,8 @@ local digReq =
     BORE     = 2,
     MODIFIER = 4,
     NIGHT    = 8,
+    WEATHER  = 16,
+    ORE      = 32,
 }
 
 local crystalMap =
@@ -72,8 +81,8 @@ local digInfo =
         {  699,  76, digReq.NONE    },
         { 4447,  38, digReq.NONE    },
         {  695,  45, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         { 4100,  59, digReq.BURROW  },
         { 4101,  59, digReq.BURROW  },
         {  690,  15, digReq.BORE    },
@@ -87,6 +96,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.BIBIKI_BAY] = -- 4
     {
         {  847,  70, digReq.NONE    },
@@ -99,8 +109,8 @@ local digInfo =
         {17397, 110, digReq.NONE    },
         {  641, 130, digReq.NONE    },
         {  885,  30, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  845, 150, digReq.BURROW  },
         {  843,  10, digReq.BURROW  },
         {  844,  90, digReq.BURROW  },
@@ -120,6 +130,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.WAJAOM_WOODLANDS] = -- 51
     {
         {  646,   3, digReq.NONE    },
@@ -131,8 +142,8 @@ local digInfo =
         { 2164,  17, digReq.NONE    },
         { 2213, 152, digReq.NONE    },
         {  838,   4, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  688, 137, digReq.BURROW  },
         {  690,  10, digReq.BURROW  },
         { 1446,   1, digReq.BURROW  },
@@ -153,6 +164,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.BHAFLAU_THICKETS] = -- 52
     {
         {  770,  50, digReq.NONE    },
@@ -164,8 +176,8 @@ local digInfo =
         {  703,  69, digReq.NONE    },
         { 2213, 135, digReq.NONE    },
         {  838,  21, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  688, 144, digReq.BURROW  },
         {  702,  14, digReq.BURROW  },
         {  690,  23, digReq.BURROW  },
@@ -186,6 +198,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.WEST_RONFAURE] = -- 100
     {
         { 4504, 120, digReq.NONE    },
@@ -198,8 +211,8 @@ local digInfo =
         {  639,  10, digReq.NONE    },
         {  694,  63, digReq.NONE    },
         {  918,  12, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         { 4545,   5, digReq.BURROW  },
         {  636,  63, digReq.BURROW  },
         {  617,  63, digReq.BORE    },
@@ -210,6 +223,7 @@ local digInfo =
         { 4532,  12, digReq.MODIFIER},
         {  573,  23, digReq.NIGHT   },
     },
+
     [xi.zone.EAST_RONFAURE] = -- 101
     {
         { 4504, 224, digReq.NONE    },
@@ -222,8 +236,8 @@ local digInfo =
         {  694,  10, digReq.NONE    },
         { 4386,  11, digReq.NONE    },
         {  918,  10, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         { 4545,  12, digReq.BURROW  },
         {  636,  29, digReq.BURROW  },
         {  617,  12, digReq.BORE    },
@@ -234,6 +248,7 @@ local digInfo =
         { 4532,  11, digReq.MODIFIER},
         {  574,  37, digReq.NIGHT   },
     },
+
     [xi.zone.LA_THEINE_PLATEAU] = -- 102
     {
         {  688, 153, digReq.NONE    },
@@ -246,8 +261,8 @@ local digInfo =
         {  694,  40, digReq.NONE    },
         {  622,  28, digReq.NONE    },
         {  700,   3, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         { 4545,  34, digReq.BURROW  },
         {  636,  20, digReq.BURROW  },
         {  616,   8, digReq.BURROW  },
@@ -261,6 +276,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 1237,  12, digReq.MODIFIER},
     },
+
     [xi.zone.VALKURM_DUNES] = -- 103
     {
         {  770,   1, digReq.NONE    },
@@ -274,8 +290,8 @@ local digInfo =
         { 4484,  32, digReq.NONE    },
         {17397,  21, digReq.NONE    },
         {  885,  10, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  845, 125, digReq.BURROW  },
         {  843,  10, digReq.BURROW  },
         {  844,  40, digReq.BURROW  },
@@ -293,6 +309,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.JUGNER_FOREST] = -- 104
     {
         { 4504, 152, digReq.NONE    },
@@ -305,8 +322,8 @@ local digInfo =
         {  699,  76, digReq.NONE    },
         { 4447,  38, digReq.NONE    },
         {  695,  45, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  690,  15, digReq.BORE    },
         { 1446,   8, digReq.BORE    },
         {  702,  23, digReq.BORE    },
@@ -318,6 +335,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.BATALLIA_DOWNS] = -- 105
     {
         {  847,  69, digReq.NONE    },
@@ -330,8 +348,8 @@ local digInfo =
         {  774,  26, digReq.NONE    },
         {  106,  69, digReq.NONE    },
         { 4449,   3, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  656, 106, digReq.BURROW  },
         {  748,   8, digReq.BURROW  },
         {  749,  30, digReq.BURROW  },
@@ -345,6 +363,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.NORTH_GUSTABERG] = -- 106
     {
         {  880, 226, digReq.NONE    },
@@ -358,8 +377,8 @@ local digInfo =
         {  749,  63, digReq.NONE    },
         {  644,  60, digReq.NONE    },
         {  645,   3, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         { 4545, 150, digReq.BURROW  },
         {  636,  50, digReq.BURROW  },
         {  617, 100, digReq.BORE    },
@@ -370,6 +389,7 @@ local digInfo =
         { 4532,  12, digReq.MODIFIER},
         { 1236,   3, digReq.NIGHT   },
     },
+
     [xi.zone.SOUTH_GUSTABERG] = -- 107
     {
         {17296, 252, digReq.NONE    },
@@ -381,8 +401,8 @@ local digInfo =
         {  749,  32, digReq.NONE    },
         {  847,  23, digReq.NONE    },
         {  644,   5, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         { 4545,   5, digReq.BURROW  },
         {  636,  63, digReq.BURROW  },
         {  617,  63, digReq.BORE    },
@@ -393,6 +413,7 @@ local digInfo =
         { 4532,  12, digReq.MODIFIER},
         {  575,  14, digReq.NIGHT   },
     },
+
     [xi.zone.KONSCHTAT_HIGHLANDS] = -- 108
     {
         {  847,  13, digReq.NONE    },
@@ -406,8 +427,8 @@ local digInfo =
         {  844,  14, digReq.NONE    },
         {  868,  45, digReq.NONE    },
         {  642,  71, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  845,  28, digReq.BORE    },
         {  842,  27, digReq.BORE    },
         {  843,  23, digReq.BORE    },
@@ -419,6 +440,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.PASHHOW_MARSHLANDS] = -- 109
     {
         {  846, 216, digReq.NONE    },
@@ -431,8 +453,8 @@ local digInfo =
         {  749,  18, digReq.NONE    },
         {  703,   6, digReq.NONE    },
         {  885,   9, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         { 2364, 120, digReq.BURROW  },
         { 2235,  42, digReq.BURROW  },
         { 1237,  24, digReq.BURROW  },
@@ -443,6 +465,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.ROLANBERRY_FIELDS] = -- 110
     {
         { 4450,  30, digReq.NONE    },
@@ -457,8 +480,8 @@ local digInfo =
         { 4448,  15, digReq.NONE    },
         {  638,  82, digReq.NONE    },
         {  106,  37, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  656, 200, digReq.BURROW  },
         {  750, 100, digReq.BURROW  },
         { 4375,  60, digReq.BORE    },
@@ -471,6 +494,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.EASTERN_ALTEPA_DESERT] = -- 114
     {
         {  880, 167, digReq.NONE    },
@@ -481,8 +505,8 @@ local digInfo =
         {  942,   4, digReq.NONE    },
         {  738,  12, digReq.NONE    },
         {  866,  36, digReq.NONE    },
-        {  642,  58, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
+        {  642,  58, digReq.NONE     },
+        { 4096, 100, digReq.WEATHER }, -- all crystals
         {  574,  33, digReq.BURROW  },
         {  575,  74, digReq.BURROW  },
         {  572,  59, digReq.BURROW  },
@@ -501,6 +525,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.WEST_SARUTABARUTA] = -- 115
     {
         {  689, 205, digReq.NONE    },
@@ -514,8 +539,8 @@ local digInfo =
         {  834,  50, digReq.NONE    },
         {  701,  50, digReq.NONE    },
         {  702,   3, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  617,  50, digReq.BORE    },
         { 4570,  10, digReq.MODIFIER},
         { 4487,  11, digReq.MODIFIER},
@@ -524,6 +549,7 @@ local digInfo =
         { 4532,  12, digReq.MODIFIER},
         { 1237,  10, digReq.NIGHT   },
     },
+
     [xi.zone.EAST_SARUTABARUTA] = -- 116
     {
         {  689, 132, digReq.NONE    },
@@ -537,8 +563,8 @@ local digInfo =
         {  772,  50, digReq.NONE    },
         {  701,  50, digReq.NONE    },
         {  702,   3, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         { 4545, 200, digReq.BURROW  },
         {  636,  50, digReq.BURROW  },
         { 5235,  10, digReq.BURROW  },
@@ -550,6 +576,7 @@ local digInfo =
         { 4532,  12, digReq.MODIFIER},
         {  572, 100, digReq.NIGHT   },
     },
+
     [xi.zone.TAHRONGI_CANYON] = -- 117
     {
         {  880, 118, digReq.NONE    },
@@ -563,8 +590,8 @@ local digInfo =
         {  641, 100, digReq.NONE    },
         {  841,  45, digReq.NONE    },
         {  843,   4, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  656, 148, digReq.BURROW  },
         {  749,  25, digReq.BURROW  },
         {  751,   1, digReq.BURROW  },
@@ -582,6 +609,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.BUBURIMU_PENINSULA] = -- 118
     {
         {  847,  45, digReq.NONE    },
@@ -594,8 +622,8 @@ local digInfo =
         {17397,  66, digReq.NONE    },
         {  641, 134, digReq.NONE    },
         {  885,  12, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  845, 125, digReq.BURROW  },
         {  843,   1, digReq.BURROW  },
         {  844,  64, digReq.BURROW  },
@@ -615,6 +643,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.MERIPHATAUD_MOUNTAINS] = -- 119
     {
         {  646,   4, digReq.NONE    },
@@ -627,8 +656,8 @@ local digInfo =
         {  869, 100, digReq.NONE    },
         {17296, 162, digReq.NONE    },
         {  771,  21, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  678,   5, digReq.BURROW  },
         {  645,   9, digReq.BURROW  },
         {  737,   5, digReq.BURROW  },
@@ -647,6 +676,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.SAUROMUGUE_CHAMPAIGN] = -- 120
     {
         {  845,   8, digReq.NONE    },
@@ -661,8 +691,8 @@ local digInfo =
         {17296, 168, digReq.NONE    },
         {  106,  32, digReq.NONE    },
         {  773,  50, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  656,  95, digReq.BURROW  },
         {  749,  26, digReq.BURROW  },
         {  751,  33, digReq.BURROW  },
@@ -681,6 +711,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.THE_SANCTUARY_OF_ZITAH] = -- 121
     {
         {  688, 117, digReq.NONE    },
@@ -693,8 +724,8 @@ local digInfo =
         {  773,  33, digReq.NONE    },
         { 4386,   9, digReq.NONE    },
         {  703,   7, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
-        { 1255,  10, digReq.NONE    }, -- all ores
+        { 4096, 100, digReq.WEATHER }, -- all crystals
+        { 1255,  10, digReq.ORE     }, -- all ores
         {  656, 117, digReq.BURROW  },
         {  750, 133, digReq.BURROW  },
         {  749, 117, digReq.BURROW  },
@@ -709,6 +740,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.YUHTUNGA_JUNGLE] = -- 123
     {
         {  880, 185, digReq.NONE    },
@@ -722,7 +754,7 @@ local digInfo =
         {  703,   9, digReq.NONE    },
         { 4448,   7, digReq.NONE    },
         {  720,   3, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
+        { 4096, 100, digReq.WEATHER }, -- all crystals
         { 4374,  17, digReq.BURROW  },
         { 4373,  41, digReq.BURROW  },
         { 4375,  15, digReq.BURROW  },
@@ -739,6 +771,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.YHOATOR_JUNGLE] = -- 124
     {
         {  880, 282, digReq.NONE    },
@@ -748,9 +781,9 @@ local digInfo =
         {  702,  41, digReq.NONE    },
         {  700,  44, digReq.NONE    },
         { 4450,  47, digReq.NONE    },
-        {  703,  26, digReq.NONE    },
+        {  703,  26, digReq.NONE    }, 
         { 4449,  12, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
+        { 4096, 100, digReq.WEATHER }, -- all crystals
         { 4374,  17, digReq.BURROW  },
         { 4373,  41, digReq.BURROW  },
         { 4375,  15, digReq.BURROW  },
@@ -767,6 +800,7 @@ local digInfo =
         { 1188,  10, digReq.MODIFIER},
         { 4532,  12, digReq.MODIFIER},
     },
+
     [xi.zone.WESTERN_ALTEPA_DESERT] = -- 125
     {
         {  880, 224, digReq.NONE    },
@@ -780,7 +814,7 @@ local digInfo =
         {  642,  58, digReq.NONE    },
         {  864,  22, digReq.NONE    },
         {  843,   4, digReq.NONE    },
-        { 4096, 100, digReq.NONE    }, -- all crystals
+        { 4096, 100, digReq.WEATHER }, -- all crystals
         {  845, 122, digReq.BURROW  },
         {  844,  71, digReq.BURROW  },
         { 1845,  33, digReq.BURROW  },
@@ -801,86 +835,175 @@ local digInfo =
     },
 }
 
--- Check if player can dig. Returns boolean.
+local function updatePlayerDigCount(player, increment)
+    if increment == 0 then
+        player:setCharVar('[DIG]DigCount', 0)
+    else
+        player:setCharVar('[DIG]DigCount', player:getCharVar('[DIG]DigCount') + increment)
+    end
+
+    player:setCharVar('[DIG]LastDigTime', os.time())
+end
+
 local function canDig(player)
-    -- NOTE:
-    -- Players are able to dig even when fatigued or when zone is empty of items.
-    -- It just means they wont dig up anything nor will they be able to skill up.
+    local digCount                 = player:getCharVar('[DIG]DigCount')
+    local lastDigTime              = player:getCharVar('[DIG]LastDigTime')
+    local lastDigX                 = player:getCharVar('[DIG]LastDigX')
+    local lastDigY                 = player:getCharVar('[DIG]LastDigY')
+    local lastDigZ                 = player:getCharVar('[DIG]LastDigZ')
+    local posTable                 = player:getPos()
+    local currX           = math.floor(posTable.x)
+    local currY           = math.floor(posTable.y)
+    local currZ           = math.floor(posTable.z)
+    local distanceSquared = (lastDigX - currX) * (lastDigX - currX) + (lastDigY - currY) * (lastDigY - currY) + (lastDigZ - currZ) * (lastDigZ - currZ)
+    local zoneItemsDug             = GetServerVariable('[DIG]ZONE'..player:getZoneID()..'_ITEMS')
+    local zoneInTime               = player:getLocalVar('ZoneInTime')
+    local currentTime     = os.time()
+    local skillRank                = player:getSkillRank(xi.skill.DIG)
+     -- personal dig caps
+    local digCap          = DIG_FATIGUE + (skillRank * 10)
+    -- base delay -5 for each rank
+    local digDelay        = 16 - (skillRank * 5)
+    local areaDigDelay    = 60 - (skillRank * 5)
 
-    -- Check: Gysahl green in main inventory.
     if player:hasItem(4545, 0) then
-        local zoneInTime   = player:getLocalVar('ZoneInTime')
-        local lastDigTime  = player:getCharVar('[DIG]LastDigTime')
-        local skillRank    = player:getSkillRank(xi.skill.DIG)
-        local digDelay     = utils.clamp(16 - (skillRank * 5), 4, 16) -- Base delay -5 for each rank. Minimun 4 seconds.
-        local areaDigDelay = 60 - (skillRank * 5)
-        local currentTime  = os.time()
+        -- Minimum delay to cover the animation time
 
-        -- Check: Delays.
+        local prevMidnight = getMidnight() - 86400
+
+        -- Last dig was before today, so reset player fatigue
+        if lastDigTime < prevMidnight then
+            updatePlayerDigCount(player, 0)
+            digCount = 0
+        end
+
+        -- neither player nor zone have reached their dig limit
         if
-            (zoneInTime + areaDigDelay) <= currentTime and -- Initial delay on Zone-in.
-            (lastDigTime + digDelay) <= currentTime        -- Delay in between digs.
+            (digCount < digCap and zoneItemsDug < DIG_ZONE_LIMIT)
         then
-            return true
+            -- pesky delays
+            if
+                (zoneInTime + areaDigDelay) <= currentTime and
+                (lastDigTime + digDelay) <= currentTime and
+                distanceSquared > DIG_DISTANCE_REQ
+            then
+                player:setCharVar('[DIG]LastDigX', currX)
+                player:setCharVar('[DIG]LastDigY', currY)
+                player:setCharVar('[DIG]LastDigZ', currZ)
+                player:delItem(4545, 1)
+
+                return true
+            end
         end
     end
 
     return false
 end
 
--- Calculate skill up.
+--[[
+per wiki, avg. digs needed per rank
+taken from wiki, took the average of top/bottom
+and then x12 to convert from "stacks" to singles
+
+Amateur    1650 (chopped the 50 so we dont have to math.floor later)
+Recruit    3600
+Initiate    6000
+Novice         9000
+Apprentice    12600
+Journeyman  16200
+Craftsman    21000
+Artisan    27000
+Adept         33000
+Veteran    39000
+Expert         ---- 
+]]
+
 local function calculateSkillUp(player)
-    local skillRank     = player:getSkillRank(xi.skill.DIG)
-    local realSkill     = player:getCharSkillLevel(xi.skill.DIG)
-    local skillUpChance = 20 * skillRank + 20
+    local skillRank  = player:getSkillRank(xi.skill.DIG)
+    local maxSkill   = utils.clamp((skillRank + 1) * 100, 0, 1000) -- if im at 0 i max at 100, if im at 1 i max at 200
+    local realSkill  = player:getCharSkillLevel(xi.skill.DIG)
 
-    if math.random(1, skillUpChance) == 1 then
-        player:setSkillLevel(xi.skill.DIG, realSkill + 1)
+    local digsTable = -- Era Dig Table
+    {
+        [0] = { 1600},
+        [1] = { 3600},
+        [2] = { 6000},
+        [3] = { 9000},
+        [4] = {12600},
+        [5] = {16200},
+        [6] = {21000},
+        [7] = {27000},
+        [8] = {33000},
+        [9] = {39000},
+    }
 
-        -- Increment rank once player hits 10.0, 20.0, .. 100.0
-        if (realSkill + 1) >= (skillRank * 100) + 100 then
-            player:setSkillRank(xi.skill.DIG, skillRank + 1)
+    -- local digsTable = -- Limit Break Dig Table
+	-- {
+        -- [0] = { 2000},
+        -- [1] = { 2500},
+        -- [2] = { 3300},
+        -- [3] = { 5000},
+        -- [4] = {10000},
+        -- [5] = {11100},
+        -- [6] = {12500},
+        -- [7] = {14300},
+        -- [8] = {16700},
+        -- [9] = {20000},
+	-- }
+
+    if math.random(1, math.floor(digsTable[skillRank][1] / 100)) == 1 then
+	    if realSkill < 1000 then -- Safety check.
+            player:setSkillLevel(xi.skill.DIG, realSkill + 1)
+
+            -- Digging does not have test items, so increment rank once player hits 10.0, 20.0, .. 100.0
+            if (realSkill + 1) >= (skillRank * 100) + 100 then
+               player:setSkillRank(xi.skill.DIG, skillRank + 1)
+            end
         end
     end
 end
 
--- Calculate item dug.
 local function getChocoboDiggingItem(player)
-    local allItems      = digInfo[player:getZoneID()]
-    local burrowAbility = (xi.settings.DIG_GRANT_BURROW == 1) and 1 or 0
-    local boreAbility   = (xi.settings.DIG_GRANT_BORE == 1) and 1 or 0
-    local modifier      = player:getMod(xi.mod.EGGHELM)
-    local totd          = VanadielTOTD()
+    local allItems        = digInfo[player:getZoneID()]
+    local burrowAbility = (DIG_GRANT_BURROW == 1) and 1 or 0
+    local boreAbility   = (DIG_GRANT_BORE == 1) and 1 or 0
+    local modifier               = player:getMod(xi.mod.EGGHELM)
+    local totd                   = VanadielTOTD()
     -- Zone Weather
-    local weather       = player:getZone():getWeather()
+    local zone                   = player:getZone()
+    local weather                = zone:getWeather()
     -- Waxing 7% - 24%
-    local moon          = VanadielMoonPhase()
-    local moonDirection = VanadielMoonDirection()
-    local DigRank       = player:getSkillRank(xi.skill.DIG)
+    local moon                   = VanadielMoonPhase()
+    local moonDirection          = VanadielMoonDirection()
+    local DigRank                = player:getSkillRank(xi.skill.DIG)
     -- Filter allItems to possibleItems and sum weights
-    local possibleItems = {}
-    local sum = 0
+    local possibleItems          = {}
+    local itemWeight             = 0
+    local sum                    = 0
 
     -- Generate a table with items the player can actually dig up based on weather, time, moon, skills, etc...
     for i = 1, #allItems do
-        local item = allItems[i]
+        local item    = allItems[i]
         local itemReq = item[3]
+
         if
             (itemReq == digReq.NONE) or
             (itemReq == digReq.BURROW and burrowAbility == 1) or
             (itemReq == digReq.BORE and boreAbility == 1) or
             (itemReq == digReq.MODIFIER and modifier == 1) or
-            (itemReq == digReq.NIGHT and totd == xi.time.NIGHT)
+            (itemReq == digReq.NIGHT and totd == xi.time.NIGHT) or
+            (itemReq == digReq.WEATHER and weather > xi.weather.FOG) or
+            (itemReq == digReq.ORE and weather >= xi.weather.FOG and moonDirection == 2 and moon >= 7 and moon <= 24 and DigRank >= 6)
         then
             -- skill up weight variation and ore moon variation
             itemWeight = item[2]
 
             if DigRank > 0 then
                 if itemWeight >= 150 then
-                    itemWeight = itemWeight * (0.95^DigRank)
+                    itemWeight = itemWeight * (0.95^DigRank) 
                 elseif itemWeight >= 125 then
                     itemWeight = itemWeight * (0.97^DigRank)
-                elseif itemWeight >= 100 then
+                elseif itemWeight >= 100 then     
                     itemWeight = itemWeight * (0.99^DigRank)
                 elseif itemWeight >= 50 then
                     itemWeight = itemWeight * (1.03^DigRank)
@@ -908,19 +1031,19 @@ local function getChocoboDiggingItem(player)
 
     -- Pick weighted result.
     local itemId = 0
-    local pick = math.random(sum)
-    sum = 0
+    local pick   = math.random(math.floor(sum))
+    sum          = 0
 
     for i = 1, #possibleItems do
-        itemWeight = possibleItems[i][2]
+        local itemWeight = possibleItems[i][2]
 
-        -- Skill-up weight variation and ore moon variation.
+        -- skill up weight variation and ore moon variation
         if DigRank > 0 then
             if itemWeight >= 150 then
-                itemWeight = itemWeight * (0.95^DigRank)
+                itemWeight = itemWeight * (0.95^DigRank) 
             elseif itemWeight >= 125 then
                 itemWeight = itemWeight * (0.97^DigRank)
-            elseif itemWeight >= 100 then
+            elseif itemWeight >= 100 then     
                 itemWeight = itemWeight * (0.99^DigRank)
             elseif itemWeight >= 50 then
                 itemWeight = itemWeight * (1.03^DigRank)
@@ -951,17 +1074,9 @@ local function getChocoboDiggingItem(player)
 
     -- Item is a crystal or ore
     if itemId == 4096 then
-        if weather >= xi.weather.HOT_SPELL then
-            itemId = crystalMap[weather]
-        else
-            itemId = 0
-        end
+        itemId = crystalMap[weather]
     elseif itemId == 1255 then
-        if weather >= xi.weather.CLOUDS and moon >= 10 and moon <= 40 and player:getSkillRank(xi.skill.DIG) >= 7 then
-            itemId = oreMap[VanadielDayOfTheWeek()]
-        else
-            itemId = 0
-        end
+        itemId = oreMap[VanadielDayOfTheWeek()]
     end
 
     return itemId
@@ -969,49 +1084,71 @@ end
 
 -- Main function.
 xi.chocoboDig.start = function(player, precheck)
-    -- Make sure the player can dig before going any further.
-    if not canDig(player) then
-        return
-    end
+    local zoneId      = player:getZoneID()
+    local text        = zones[zoneId].text
+    local skillRank   = player:getSkillRank(xi.skill.DIG)
+    local lastDigTime = player:getCharVar('[DIG]LastDigTime')
 
-    -- Handle AMK07 first thing.
-    local zoneId = player:getZoneID()
-    local text   = zones[zoneId].text
+    -- make sure the player can dig before going any further
+    -- (and also cause i need a return before core can go any further with this)
+    if canDig(player) == true then
+        local roll         = math.random(0, 100)
+        local moon                  = VanadielMoonPhase()
+        local moonmodifier          = 1
+        local skillmodifier = 0.5 + (skillRank / 20) -- 50% at amateur, 55% at recruit, 60% at initiate, and so on, to 100% at exper
 
-    if
-        xi.settings.ENABLE_AMK == 1 and
-        player:getCurrentMission(xi.mission.log_id.AMK) == xi.mission.id.amk.SHOCK_ARRANT_ABUSE_OF_AUTHORITY and
-        xi.amk.helpers.chocoboDig(player, zoneId, text)
-    then
-        player:setCharVar('[DIG]LastDigTime', os.time())
-
-        return
-    end
-
-    -- Handle player fatigue and zone dig limit automatic fails.
-    local lastDigTime  = player:getCharVar('[DIG]LastDigTime')
-    local digCount     = player:getCharVar('[DIG]DigCount')
-    local zoneItemsDug = GetServerVariable('[DIG]ZONE'..player:getZoneID()..'_ITEMS')
+        if moon < 50 then
+            moon = 100 - moon -- This converts moon phase percent to a number that represents how FAR the moon phase is from 50
+        end
+      
+        moonmodifier = 1 - (100 - moon) / 100 -- the more the moon phase is from 50, the closer we get to 100% on this modifier.
 
     if lastDigTime < (getMidnight() - 86400) then
         player:setCharVar('[DIG]DigCount', 0) -- Reset player dig count/fatigue.
         digCount = 0
     end
 
-    if
-        (digCount >= xi.settings.DIG_FATIGUE and xi.settings.DIG_FATIGUE > 0) or
-        (zoneItemsDug >= xi.settings.DIG_ZONE_LIMIT and xi.settings.DIG_ZONE_LIMIT > 0)
-    then
-        player:setCharVar('[DIG]LastDigTime', os.time())
-        player:messageText(player, text.FIND_NOTHING)
+        -- dig chance failure
+        if roll > (DIG_RATE * moonmodifier * skillmodifier) then -- base digging rate is 85% and it is multiplied by the moon and skill modifiers
+            player:messageText(player, text.FIND_NOTHING)
+            player:setCharVar('[DIG]LastDigTime', os.time())
+        -- dig chance success
+        else
+            local itemId = getChocoboDiggingItem(player)
+            local zonedug = '[DIG]ZONE'..player:getZoneID()..'_ITEMS'
+            local zoneDugCurrent  = GetServerVariable(zonedug)
+            -- success!
+            if itemId ~= 0 then
+                -- make sure we have enough room for the item
+                if player:addItem(itemId) then
+                    player:messageSpecial(text.ITEM_OBTAINED, itemId)
+                    SetServerVariable(zonedug, zoneDugCurrent + 1)
+                    updatePlayerDigCount(player, 1)
+                else
+                    player:messageSpecial(text.DIG_THROW_AWAY, itemId)
+                    updatePlayerDigCount(player, 1)
+                end
+
+                player:triggerRoeEvent(xi.roe.triggers.chocoboDigSuccess)
+
+            -- got a crystal ore, but lacked weather or skill to dig it up
+            else
+                player:messageText(player, text.FIND_NOTHING, false)
+                player:setCharVar('[DIG]LastDigTime', os.time())
+            end
+        end
+
+		if skillRank < 10 then -- Safety check. Let's not try to skill-up if at max skill.
+            calculateSkillUp(player)
+        end
 
         return true
     end
 
     -- We can perform an actual dig.
-    local skillRank     = player:getSkillRank(xi.skill.DIG)
+    local skillRank             = player:getSkillRank(xi.skill.DIG)
     local skillModifier = 0.5 + (skillRank / 20) -- 0.5 at "Amateur", 0.55 at "Recruit", 0.6 at "Initiate", and so on, to 1 at "Expert".
-    local itemId        = getChocoboDiggingItem(player)
+    local itemId       = getChocoboDiggingItem(player)
 
     -- Moon work
     local moon = VanadielMoonPhase()
@@ -1028,7 +1165,6 @@ xi.chocoboDig.start = function(player, precheck)
         itemId == 0
     then
         player:messageText(player, text.FIND_NOTHING)
-
     -- Dig success.
     else
         -- Make sure we have enough room for the item.
@@ -1048,8 +1184,6 @@ xi.chocoboDig.start = function(player, precheck)
         end
 
         player:triggerRoeEvent(xi.roe.triggers.chocoboDigSuccess)
-
-        -- TODO: Learn abilities from chocobo raising.
     end
 
     player:setCharVar('[DIG]LastDigTime', os.time())

--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -864,6 +864,7 @@ local function canDig(player)
     -- base delay -5 for each rank
     local digDelay        = 16 - (skillRank * 5)
     local areaDigDelay    = 60 - (skillRank * 5)
+    digDelay = utils.clamp(digDelay, 4, 16)
 
     if player:hasItem(4545, 0) then
         -- Minimum delay to cover the animation time
@@ -936,7 +937,7 @@ local function calculateSkillUp(player)
     }
 
     -- local digsTable = -- Limit Break Dig Table
-	-- {
+    -- {
         -- [0] = { 2000},
         -- [1] = { 2500},
         -- [2] = { 3300},
@@ -947,10 +948,10 @@ local function calculateSkillUp(player)
         -- [7] = {14300},
         -- [8] = {16700},
         -- [9] = {20000},
-	-- }
+    -- }
 
     if math.random(1, math.floor(digsTable[skillRank][1] / 100)) == 1 then
-	    if realSkill < 1000 then -- Safety check.
+        if realSkill < 1000 then -- Safety check.
             player:setSkillLevel(xi.skill.DIG, realSkill + 1)
 
             -- Digging does not have test items, so increment rank once player hits 10.0, 20.0, .. 100.0
@@ -1090,12 +1091,12 @@ xi.chocoboDig.start = function(player, precheck)
     -- make sure the player can dig before going any further
     -- (and also cause i need a return before core can go any further with this)
     if canDig(player) == true then
-        local roll         = math.random(0, 100)
-        local moon                  = VanadielMoonPhase()
-        local moonmodifier          = 1
-        local skillmodifier = 0.5 + (skillRank / 20) -- 50% at amateur, 55% at recruit, 60% at initiate, and so on, to 100% at exper
-        local zonedug       = '[DIG]ZONE'..player:getZoneID()..'_ITEMS'
-        local zoneDugCurrent        = GetServerVariable(zonedug)
+    local roll         = math.random(0, 100)
+    local moon                  = VanadielMoonPhase()
+    local moonmodifier          = 1
+    local skillmodifier = 0.5 + (skillRank / 20) -- 50% at amateur, 55% at recruit, 60% at initiate, and so on, to 100% at exper
+    local zonedug       = '[DIG]ZONE'..player:getZoneID()..'_ITEMS'
+    local zoneDugCurrent        = GetServerVariable(zonedug)
 
         if moon < 50 then
             moon = 100 - moon -- This converts moon phase percent to a number that represents how FAR the moon phase is from 50
@@ -1146,7 +1147,7 @@ xi.chocoboDig.start = function(player, precheck)
             end
         end
 
-		if skillRank < 10 then -- Safety check. Let's not try to skill-up if at max skill.
+        if skillRank < 10 then -- Safety check. Let's not try to skill-up if at max skill.
             calculateSkillUp(player)
         end
 

--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -781,7 +781,7 @@ local digInfo =
         {  702,  41, digReq.NONE    },
         {  700,  44, digReq.NONE    },
         { 4450,  47, digReq.NONE    },
-        {  703,  26, digReq.NONE    }, 
+        {  703,  26, digReq.NONE    },
         { 4449,  12, digReq.NONE    },
         { 4096, 100, digReq.WEATHER }, -- all crystals
         { 4374,  17, digReq.BURROW  },
@@ -856,7 +856,6 @@ local function canDig(player)
     local currY           = math.floor(posTable.y)
     local currZ           = math.floor(posTable.z)
     local distanceSquared = (lastDigX - currX) * (lastDigX - currX) + (lastDigY - currY) * (lastDigY - currY) + (lastDigZ - currZ) * (lastDigZ - currZ)
-    local zoneItemsDug             = GetServerVariable('[DIG]ZONE'..player:getZoneID()..'_ITEMS')
     local zoneInTime               = player:getLocalVar('ZoneInTime')
     local currentTime     = os.time()
     local skillRank                = player:getSkillRank(xi.skill.DIG)
@@ -915,12 +914,11 @@ Craftsman    21000
 Artisan    27000
 Adept         33000
 Veteran    39000
-Expert         ---- 
+Expert         ----
 ]]
 
 local function calculateSkillUp(player)
     local skillRank  = player:getSkillRank(xi.skill.DIG)
-    local maxSkill   = utils.clamp((skillRank + 1) * 100, 0, 1000) -- if im at 0 i max at 100, if im at 1 i max at 200
     local realSkill  = player:getCharSkillLevel(xi.skill.DIG)
 
     local digsTable = -- Era Dig Table
@@ -1000,10 +998,10 @@ local function getChocoboDiggingItem(player)
 
             if DigRank > 0 then
                 if itemWeight >= 150 then
-                    itemWeight = itemWeight * (0.95^DigRank) 
+                    itemWeight = itemWeight * (0.95^DigRank)
                 elseif itemWeight >= 125 then
                     itemWeight = itemWeight * (0.97^DigRank)
-                elseif itemWeight >= 100 then     
+                elseif itemWeight >= 100 then
                     itemWeight = itemWeight * (0.99^DigRank)
                 elseif itemWeight >= 50 then
                     itemWeight = itemWeight * (1.03^DigRank)
@@ -1035,15 +1033,15 @@ local function getChocoboDiggingItem(player)
     sum          = 0
 
     for i = 1, #possibleItems do
-        local itemWeight = possibleItems[i][2]
+        itemWeight = possibleItems[i][2]
 
         -- skill up weight variation and ore moon variation
         if DigRank > 0 then
             if itemWeight >= 150 then
-                itemWeight = itemWeight * (0.95^DigRank) 
+                itemWeight = itemWeight * (0.95^DigRank)
             elseif itemWeight >= 125 then
                 itemWeight = itemWeight * (0.97^DigRank)
-            elseif itemWeight >= 100 then     
+            elseif itemWeight >= 100 then
                 itemWeight = itemWeight * (0.99^DigRank)
             elseif itemWeight >= 50 then
                 itemWeight = itemWeight * (1.03^DigRank)
@@ -1096,18 +1094,17 @@ xi.chocoboDig.start = function(player, precheck)
         local moon                  = VanadielMoonPhase()
         local moonmodifier          = 1
         local skillmodifier = 0.5 + (skillRank / 20) -- 50% at amateur, 55% at recruit, 60% at initiate, and so on, to 100% at exper
-        local zonedug = '[DIG]ZONE'..player:getZoneID()..'_ITEMS'
+        local zonedug       = '[DIG]ZONE'..player:getZoneID()..'_ITEMS'
         local zoneDugCurrent        = GetServerVariable(zonedug)
 
         if moon < 50 then
             moon = 100 - moon -- This converts moon phase percent to a number that represents how FAR the moon phase is from 50
         end
-      
+
         moonmodifier = 1 - (100 - moon) / 100 -- the more the moon phase is from 50, the closer we get to 100% on this modifier.
 
         if lastDigTime < (getMidnight() - 86400) then
             player:setCharVar('[DIG]DigCount', 0) -- Reset player dig count/fatigue.
-            digCount = 0
         end
 
         if zoneDugCurrent + 1 > DIG_ZONE_LIMIT then

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1726,13 +1726,14 @@ xi.mod =
     PET_DMG_TAKEN_PHYSICAL        = 1154, -- Percent increase/decrease in pet physical damage taken for the target.
     PET_DMG_TAKEN_MAGICAL         = 1155, -- Percent increase/decrease in pet magical damage taken for the target.
     PET_DMG_TAKEN_BREATH          = 1156, -- Percent increase/decrease in pet breath damage taken for the target.
+    DIG_BYPASS_FATIGUE            = 1157, -- Chocobo digging modifier found in "Blue Race Silks". Modifier works as a direct percent. Used in Chocobo_Digging.lua
 
     -- IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN src/map/modifier.h ASWELL!
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
     -- For Next ID, see modifier.h
-    -- Spares start at: 1157
+    -- Spares start at: 1158
 }
 
 xi.latent =

--- a/scripts/zones/Batallia_Downs/Zone.lua
+++ b/scripts/zones/Batallia_Downs/Zone.lua
@@ -73,6 +73,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE105_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
     if player:hasStatusEffect(xi.effect.FULL_SPEED_AHEAD) then
         xi.fsa.onRegionEnter(player, region:GetRegionID())

--- a/scripts/zones/Bhaflau_Thickets/Zone.lua
+++ b/scripts/zones/Bhaflau_Thickets/Zone.lua
@@ -37,6 +37,10 @@ zone_object.afterZoneIn = function(player)
     player:entityVisualPacket("2pb1")
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE52_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Bibiki_Bay/Zone.lua
+++ b/scripts/zones/Bibiki_Bay/Zone.lua
@@ -37,6 +37,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE4_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
     xi.manaclipper.aboard(player, region:GetRegionID(), true)
 end

--- a/scripts/zones/Buburimu_Peninsula/Zone.lua
+++ b/scripts/zones/Buburimu_Peninsula/Zone.lua
@@ -56,6 +56,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE118_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Buburimu_Peninsula/Zone.lua
+++ b/scripts/zones/Buburimu_Peninsula/Zone.lua
@@ -49,7 +49,7 @@ end
 zone_object.onZoneOut = function(player)
     if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
         player:delStatusEffect(xi.effect.BATTLEFIELD)
-	end
+    end
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)

--- a/scripts/zones/Carpenters_Landing/Zone.lua
+++ b/scripts/zones/Carpenters_Landing/Zone.lua
@@ -43,6 +43,10 @@ zone_object.onGameHour = function(zone)
     end
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE2_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/East_Ronfaure/Zone.lua
+++ b/scripts/zones/East_Ronfaure/Zone.lua
@@ -36,6 +36,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE101_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/East_Sarutabaruta/Zone.lua
+++ b/scripts/zones/East_Sarutabaruta/Zone.lua
@@ -41,6 +41,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE116_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Eastern_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/Zone.lua
@@ -56,7 +56,7 @@ end
 zone_object.onZoneOut = function(player)
     if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
         player:delStatusEffect(xi.effect.BATTLEFIELD)
-	end
+    end
 end
 
 zone_object.onGameDay = function()

--- a/scripts/zones/Eastern_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/Zone.lua
@@ -59,6 +59,10 @@ zone_object.onZoneOut = function(player)
 	end
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE114_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Jugner_Forest/Zone.lua
+++ b/scripts/zones/Jugner_Forest/Zone.lua
@@ -65,6 +65,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE104_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function( player, region)
     if region:GetRegionID() == 1 and player:getCharVar("UnderOathCS") == 7 then -- Quest: Under Oath - PLD AF3
         player:startEvent(14)

--- a/scripts/zones/Konschtat_Highlands/Zone.lua
+++ b/scripts/zones/Konschtat_Highlands/Zone.lua
@@ -43,6 +43,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE108_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function( player, region)
 end
 

--- a/scripts/zones/La_Theine_Plateau/Zone.lua
+++ b/scripts/zones/La_Theine_Plateau/Zone.lua
@@ -46,6 +46,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE102_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Meriphataud_Mountains/Zone.lua
+++ b/scripts/zones/Meriphataud_Mountains/Zone.lua
@@ -48,7 +48,7 @@ end
 zone_object.onZoneOut = function(player)
     if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
         player:delStatusEffect(xi.effect.BATTLEFIELD)
-	end
+    end
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)

--- a/scripts/zones/Meriphataud_Mountains/Zone.lua
+++ b/scripts/zones/Meriphataud_Mountains/Zone.lua
@@ -55,6 +55,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE119_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/North_Gustaberg/Zone.lua
+++ b/scripts/zones/North_Gustaberg/Zone.lua
@@ -35,7 +35,7 @@ end
 zone_object.onZoneOut = function(player)
     if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
         player:delStatusEffect(xi.effect.BATTLEFIELD)
-	end
+    end
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)

--- a/scripts/zones/North_Gustaberg/Zone.lua
+++ b/scripts/zones/North_Gustaberg/Zone.lua
@@ -42,6 +42,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE106_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Pashhow_Marshlands/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands/Zone.lua
@@ -52,6 +52,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE109_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Pashhow_Marshlands/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands/Zone.lua
@@ -45,7 +45,7 @@ end
 zone_object.onZoneOut = function(player)
     if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
         player:delStatusEffect(xi.effect.BATTLEFIELD)
-	end
+    end
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)

--- a/scripts/zones/Rolanberry_Fields/Zone.lua
+++ b/scripts/zones/Rolanberry_Fields/Zone.lua
@@ -50,6 +50,10 @@ zone_object.onGameHour = function(zone)
     end
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE110_ITEMS", 0)
+end
+
 zone_object.onEventUpdate = function(player, csid, option)
     if csid == 2 then
         quests.rainbow.onEventUpdate(player)

--- a/scripts/zones/Sauromugue_Champaign/Zone.lua
+++ b/scripts/zones/Sauromugue_Champaign/Zone.lua
@@ -48,6 +48,9 @@ zone_object.onGameDay = function(zone)
     end
 
     GetNPCByID(ID.npc.QM2 + math.random(0, 5)):setLocalVar('Quest[2][70]Option', 1) -- Determine which QM is active today for THF AF2
+
+    -- Chocobo digging
+    SetServerVariable("[DIG]ZONE120_ITEMS", 0)
 end
 
 zone_object.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/South_Gustaberg/Zone.lua
+++ b/scripts/zones/South_Gustaberg/Zone.lua
@@ -33,6 +33,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE107_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Tahrongi_Canyon/Zone.lua
+++ b/scripts/zones/Tahrongi_Canyon/Zone.lua
@@ -47,6 +47,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE117_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
@@ -50,6 +50,10 @@ zone_object.onZoneOut = function(player)
 	end
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE121_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
@@ -47,7 +47,7 @@ end
 zone_object.onZoneOut = function(player)
     if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
         player:delStatusEffect(xi.effect.BATTLEFIELD)
-	end
+    end
 end
 
 zone_object.onGameDay = function()

--- a/scripts/zones/Valkurm_Dunes/Zone.lua
+++ b/scripts/zones/Valkurm_Dunes/Zone.lua
@@ -64,6 +64,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE103_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Valkurm_Dunes/Zone.lua
+++ b/scripts/zones/Valkurm_Dunes/Zone.lua
@@ -57,7 +57,7 @@ end
 zone_object.onZoneOut = function(player)
     if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
         player:delStatusEffect(xi.effect.BATTLEFIELD)
-	end
+    end
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)

--- a/scripts/zones/Wajaom_Woodlands/Zone.lua
+++ b/scripts/zones/Wajaom_Woodlands/Zone.lua
@@ -32,6 +32,10 @@ zone_object.onZoneIn = function(player, prevZone)
     return cs
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE51_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/West_Ronfaure/Zone.lua
+++ b/scripts/zones/West_Ronfaure/Zone.lua
@@ -34,7 +34,7 @@ end
 zone_object.onZoneOut = function(player)
     if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
         player:delStatusEffect(xi.effect.BATTLEFIELD)
-	end
+    end
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)

--- a/scripts/zones/West_Ronfaure/Zone.lua
+++ b/scripts/zones/West_Ronfaure/Zone.lua
@@ -41,6 +41,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE100_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/West_Sarutabaruta/Zone.lua
+++ b/scripts/zones/West_Sarutabaruta/Zone.lua
@@ -50,6 +50,10 @@ zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
+zone_object.onGameDay = function()
+    SetServerVariable("[DIG]ZONE115_ITEMS", 0)
+end
+
 zone_object.onRegionEnter = function( player, region)
 end
 

--- a/scripts/zones/West_Sarutabaruta/Zone.lua
+++ b/scripts/zones/West_Sarutabaruta/Zone.lua
@@ -43,7 +43,7 @@ end
 zone_object.onZoneOut = function(player)
     if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
         player:delStatusEffect(xi.effect.BATTLEFIELD)
-	end
+    end
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)

--- a/scripts/zones/Western_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Western_Altepa_Desert/Zone.lua
@@ -27,6 +27,9 @@ end
 
 zone_object.onGameDay = function()
     xi.bmt.updatePeddlestox(xi.zone.WESTERN_ALTEPA_DESERT, ID.npc.PEDDLESTOX)
+
+    -- Chocobo Digging.
+    SetServerVariable("[DIG]ZONE125_ITEMS", 0)
 end
 
 zone_object.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -43,6 +43,9 @@ end
 
 zone_object.onGameDay = function()
     xi.bmt.updatePeddlestox(xi.zone.YHOATOR_JUNGLE, ID.npc.PEDDLESTOX)
+
+    -- Chocobo Digging.
+    SetServerVariable("[DIG]ZONE124_ITEMS", 0)
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)

--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -77,7 +77,7 @@ end
 zone_object.onZoneOut = function(player)
     if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
         player:delStatusEffect(xi.effect.BATTLEFIELD)
-	end
+    end
 end
 
 zone_object.onEventUpdate = function( player, csid, option)

--- a/scripts/zones/Yuhtunga_Jungle/Zone.lua
+++ b/scripts/zones/Yuhtunga_Jungle/Zone.lua
@@ -32,6 +32,9 @@ end
 
 zone_object.onGameDay = function()
     xi.bmt.updatePeddlestox(xi.zone.YUHTUNGA_JUNGLE, ID.npc.PEDDLESTOX)
+
+    -- Chocobo Digging.
+    SetServerVariable("[DIG]ZONE105_ITEMS", 0)
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -206,7 +206,7 @@ xi.settings.main =
     DIG_ZONE_LIMIT               = 120,  -- Set max amount of items that can be dug from a specific zone every Vana'Diel Day. Set to 0 to disable.
     DIG_GRANT_BURROW             = 0,
     DIG_GRANT_BORE               = 0,
-    DIG_DISTANCE_REQ             = 1, -- Sets the distance squared in yalms of how far a player has to move.
+    DIG_DISTANCE_REQ             = 0, -- Sets the distance squared in yalms of how far a player has to move.
 
     -- MISC
     RIVERNE_PORTERS              = 120,  -- Time in seconds that Unstable Displacements in Cape Riverne stay open after trading a scale.

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -130,8 +130,6 @@ xi.settings.main =
     EXCAVATION_RATE         = 50, -- % chance to recieve an item from excavation.  Set between 0 and 100.
     LOGGING_RATE            = 50, -- % chance to recieve an item from logging.  Set between 0 and 100.
     MINING_RATE             = 50, -- % chance to recieve an item from mining.  Set between 0 and 100.
-    DIGGING_RATE            = 85, -- % chance to receive an item from chocbo digging during favorable weather.  Set between 0 and 100.
-
     HEALING_TP_CHANGE       = -100, -- Change in TP for each healing tick. Default is -100
 
     -- SE implemented coffer/chest illusion time in order to prevent coffer farming. No-one in the same area can open a chest or coffer for loot (gil, gems & items)
@@ -202,6 +200,13 @@ xi.settings.main =
     -- Please visit scripts/globals/events/login_campaign.lua for assigning the correct campaign dates.
     ENABLE_LOGIN_CAMPAIGN = 0,
 
+    -- Chocobo digging
+    DIG_RATE                     = 85, -- % chance to receive an item from chocbo digging during favorable weather.  Set between 0 and 100.
+    DIG_FATIGUE                  = 100,  -- Set max amount of items a player can dig every 24 hours. Set to 0 to disable.
+    DIG_ZONE_LIMIT               = 120,  -- Set max amount of items that can be dug from a specific zone every Vana'Diel Day. Set to 0 to disable.
+    DIG_GRANT_BURROW             = 0,
+    DIG_GRANT_BORE               = 0,
+
     -- MISC
     RIVERNE_PORTERS              = 120,  -- Time in seconds that Unstable Displacements in Cape Riverne stay open after trading a scale.
     LANTERNS_STAY_LIT            = 1200, -- time in seconds that lanterns in the Den of Rancor stay lit.
@@ -210,10 +215,6 @@ xi.settings.main =
     BYPASS_EXP_RING_ONE_PER_WEEK = 0,    -- Set to 1 to bypass the limit of one ring per Conquest Tally Week.
     NUMBER_OF_DM_EARRINGS        = 1,    -- Number of earrings players can simultaneously own from Divine Might before scripts start blocking them (Default: 1)
     HOMEPOINT_TELEPORT           = 0,    -- Enables the homepoint teleport system
-    DIG_ABUNDANCE_BONUS          = 0,    -- Increase chance of digging up an item (450  = item digup chance +45)
-    DIG_FATIGUE                  = 1,    -- Set to 0 to disable Dig Fatigue
-    DIG_GRANT_BURROW             = 0,    -- Set to 1 to grant burrow ability
-    DIG_GRANT_BORE               = 0,    -- Set to 1 to grant bore ability
     ENM_COOLDOWN                 = 120,  -- Number of hours before a player can obtain same KI for ENMs (default: 5 days)
     FORCE_SPAWN_QM_RESET_TIME    = 300,  -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.
     GOBBIE_BOX_MIN_AGE           = 45,   -- Minimum character age in days before a character can sign up for Gobbie Mystery Box

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -206,6 +206,7 @@ xi.settings.main =
     DIG_ZONE_LIMIT               = 120,  -- Set max amount of items that can be dug from a specific zone every Vana'Diel Day. Set to 0 to disable.
     DIG_GRANT_BURROW             = 0,
     DIG_GRANT_BORE               = 0,
+    DIG_DISTANCE_REQ             = 1, -- Sets the distance squared in yalms of how far a player has to move.
 
     -- MISC
     RIVERNE_PORTERS              = 120,  -- Time in seconds that Unstable Displacements in Cape Riverne stay open after trading a scale.

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -905,6 +905,7 @@ enum class Mod
     PET_DMG_TAKEN_PHYSICAL = 1154, // Percent increase/decrease in pet physical damage taken for the target.
     PET_DMG_TAKEN_MAGICAL  = 1155, // Percent increase/decrease in pet physical damage taken for the target.
     PET_DMG_TAKEN_BREATH   = 1156, // Percent increase/decrease in pet physical damage taken for the target.
+    DIG_BYPASS_FATIGUE     = 1157, // Chocobo digging modifier found in "Blue Race Silks". Modifier works as a direct percent. Used in Chocobo_Digging.lua
 
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/globals/status.lua ASWELL!
 
@@ -922,7 +923,7 @@ enum class Mod
     // 888
     // 936
     //
-    // SPARE = 1157, and onward
+    // SPARE = 1158, and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1037,7 +1037,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                     charutils::UpdateItem(PChar, LOC_INVENTORY, slotID, -1);
 
                     PChar->pushPacket(new CInventoryFinishPacket());
-                    PChar->pushPacket(new CChocoboDiggingPacket(PChar));
+                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChocoboDiggingPacket(PChar));
 
                     // dig is possible
                     luautils::OnChocoboDig(PChar, false);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Cherry-pick all work from Xaver-Red and LB.
+ Audit all work done in the original PR.
+ Added some additional settings enums for further customization to the system.
+ Some formatting changes.
+ Removed duplicate code which proc'd multiple dig messages and item rolls sometimes bypassing the zone pool depletion.

## Steps to test these changes
+ Tested zone pool depletion.
+ Tested player fatigue.
+ Tested item rates.