### PR TITLE
Fix an issue where charm % could be negative

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4932,11 +4932,8 @@ namespace battleutils
         charmChance *= (1.f + levelRatio);
 
         float chrRatio = ((PCharmer->CHR() - PTarget->CHR())) / 100.f;
-        if (chrRatio == 0.f)
-        {
-            chrRatio = 1 / 100.f;
-        }
 
+        chrRatio = std::clamp(chrRatio, (1 / 100.f), chrRatio); // Clamp so we can't have -charmChance
         charmChance *= (1.f * (chrRatio * 5.83));
 
         // Retail doesn't take light/apollo into account for Gauge


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where charm % could go negative. This clamps the dStat at 1 which will still allow for a very low success rate when dCHR is below 0.

## Steps to test these changes

