### PR TITLE
Remove additional stat casing for non-normal mobs

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -135,13 +135,8 @@ namespace mobutils
      *                                                                       *
      ************************************************************************/
 
-    uint16 GetBaseToRank(CMobEntity * PMob, uint8 rank, uint16 lvl)
+    uint16 GetBaseToRank(CMobEntity* PMob, uint8 rank, uint16 lvl)
     {
-        bool isNM = PMob->m_Type & MOBTYPE_NOTORIOUS && !PMob->isInDynamis();
-        bool isEventMob = PMob->m_Type & MOBTYPE_EVENT && !PMob->isInDynamis();
-        bool isBattlefieldMob = PMob->m_Type & MOBTYPE_BATTLEFIELD && !PMob->isInDynamis();
-        bool isDynamisNM = PMob->isInDynamis() && PMob->getMobMod(MOBMOD_CHECK_AS_NM) > 1;
-
         switch (rank)
         {
             case 1:

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -142,46 +142,23 @@ namespace mobutils
         bool isBattlefieldMob = PMob->m_Type & MOBTYPE_BATTLEFIELD && !PMob->isInDynamis();
         bool isDynamisNM = PMob->isInDynamis() && PMob->getMobMod(MOBMOD_CHECK_AS_NM) > 1;
 
-        if (isNM || isEventMob || isBattlefieldMob || isDynamisNM) // NMs, Event, and Battlefield Mobs
+        switch (rank)
         {
-            switch (rank)
-            {
-                case 1:
-                    return (5 + ((lvl - 1) * 64) / 100); // A
-                case 2:
-                    return (4 + ((lvl - 1) * 59) / 100); // B
-                case 3:
-                    return (4 + ((lvl - 1) * 54) / 100); // C
-                case 4:
-                    return (3 + ((lvl - 1) * 47) / 100); // D
-                case 5:
-                    return (3 + ((lvl - 1) * 43) / 100); // E
-                case 6:
-                    return (2 + ((lvl - 1) * 42) / 100); // F
-                case 7:
-                    return (2 + ((lvl - 1) * 39) / 100); // G
-            }
+            case 1:
+                return (5 + ((lvl - 1) * 50) / 100); // A
+            case 2:
+                return (4 + ((lvl - 1) * 45) / 100); // B
+            case 3:
+                return (4 + ((lvl - 1) * 40) / 100); // C
+            case 4:
+                return (3 + ((lvl - 1) * 35) / 100); // D
+            case 5:
+                return (3 + ((lvl - 1) * 30) / 100); // E
+            case 6:
+                return (2 + ((lvl - 1) * 25) / 100); // F
+            case 7:
+                return (2 + ((lvl - 1) * 20) / 100); // G
         }
-        else // Normal Mobs
-        {
-            switch (rank)
-                {
-                    case 1:
-                        return (5 + ((lvl - 1) * 50) / 100); // A
-                    case 2:
-                        return (4 + ((lvl - 1) * 45) / 100); // B
-                    case 3:
-                        return (4 + ((lvl - 1) * 40) / 100); // C
-                    case 4:
-                        return (3 + ((lvl - 1) * 35) / 100); // D
-                    case 5:
-                        return (3 + ((lvl - 1) * 30) / 100); // E
-                    case 6:
-                        return (2 + ((lvl - 1) * 25) / 100); // F
-                    case 7:
-                        return (2 + ((lvl - 1) * 20) / 100); // G
-                }
-            }
 
         return 0;
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Removes additional stat casing originally used to correct damage functions. This is no longer needed after the changes made to magic hit rate, pdif, and other aspect of core gameplay systems.

## Steps to test these changes
+ Not needed as we revert to original code.
