### PR TITLE
Fix Charm for BST Main | Add Piping for CHARMRES

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4870,9 +4870,9 @@ namespace battleutils
             }
         }
 
-        uint8 charmerLvl = PCharmer->GetMLevel();
-        uint8 targetLvl  = PTarget->GetMLevel();
-        uint16 charmres  = PTarget->getMod(Mod::CHARMRES) / 100.f;
+        uint8  charmerLvl = PCharmer->GetMLevel();
+        uint8  targetLvl  = PTarget->GetMLevel();
+        uint16 charmres   = PTarget->getMod(Mod::CHARMRES) / 100.f;
 
         // printf("Charmer = %s, Lvl. %u\n", PCharmer->name.c_str(), charmerLvl);
         // printf("Target = %s, Lvl. %u\n", PTarget->name.c_str(), targetLvl);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4872,6 +4872,7 @@ namespace battleutils
 
         uint8 charmerLvl = PCharmer->GetMLevel();
         uint8 targetLvl  = PTarget->GetMLevel();
+        uint16 charmres  = PTarget->getMod(Mod::CHARMRES) / 100.f;
 
         // printf("Charmer = %s, Lvl. %u\n", PCharmer->name.c_str(), charmerLvl);
         // printf("Target = %s, Lvl. %u\n", PTarget->name.c_str(), targetLvl);
@@ -4928,11 +4929,17 @@ namespace battleutils
 
         // Based on https://www.bluegartr.com/threads/57288-Charm-and-Magic-Accuracy where charm rate hit 50% w/ 11 dStat
         // Result on EP mob at 75 MJob w/ 67 BST + 11 dCHR should be 50% according to gauge messages.
-        const float levelRatio = (charmerBSTlevel - targetLvl) / 100.f;
+        float levelRatio = (charmerBSTlevel - targetLvl) / 100.f;
         charmChance *= (1.f + levelRatio);
+
+        if (PCharmer->GetMJob() == JOB_BST)
+        {
+            charmChance *= 1.1f;
+        }
 
         float chrRatio = ((PCharmer->CHR() - PTarget->CHR())) / 100.f;
         charmChance *= (1.f * (chrRatio * 5.83));
+        charmChance *= 1 - charmres;
 
         // Retail doesn't take light/apollo into account for Gauge
         if (includeCharmAffinityAndChanceMods)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Removed secondary dLvl step down from the original values.
+ Adjusted the mult for BST main dLvl to be accurate to darters (level 75) with 90 CHR on the player. (https://ffxiclopedia.fandom.com/wiki/Beastmaster_Charm_Guide).
+ Added piping for CHARMRES to properly be accounted for in gauge and chance.

## Steps to test these changes
+ Tested on level 75 darters, was able to get the final charm rate to 76.72% with the methods described in the guide.
