### PR TITLE
Uragnite mixin adjustments

### DIFF
--- a/scripts/zones/Manaclipper/mobs/uragnite.lua
+++ b/scripts/zones/Manaclipper/mobs/uragnite.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Manaclipper
+--  Mob: Uragnite
+-----------------------------------
+mixins = {require("scripts/mixins/families/uragnite")}
+-----------------------------------
+local entity = {}
+
+entity.onMobDeath = function(mob, player, isKiller)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adjustments to the Uragnite mixin:

- They will now always use venom shell when forced into their shell with damage.
- Uragnites are forced into their shell by doing a certain % of their HP of damage rather than being a random chance
- They now also can go into and out of their shell on a timer, even when roaming.

All adjustments are from my own time spent poking uragnites on retail.
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
