### PR TITLE
Fix UDMGMAGIC Mod Application in damage_spell.lua

### DIFF
--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -872,6 +872,9 @@ xi.spells.damage.calculateTMDA = function(caster, target, damageType)
 
     targetMagicDamageAdjustment = 1 + utils.clamp(combinedDamageTaken + magicDamageTakenII, -0.5, 0.125)  -- "Magic Damage Taken II" bypasses the regular cap, but combined cap is -87.5%
 
+    local uncappedMagicDamageTaken = target:getMod(xi.mod.UDMGMAGIC) / 10000   -- Mod is base 10000
+    targetMagicDamageAdjustment = targetMagicDamageAdjustment + uncappedMagicDamageTaken
+
     return targetMagicDamageAdjustment
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where UDMGMAGIC was not accounted for in damage_spell.lua

## Steps to test these changes

