### PR TITLE
Change !pos to include rot in print

### DIFF
--- a/scripts/commands/pos.lua
+++ b/scripts/commands/pos.lua
@@ -68,7 +68,7 @@ function onTrigger(player, arg1, arg2, arg3, arg4, arg5)
 
     -- report or move position
     if (x == nil or y == nil or z == nil) then
-        player:PrintToPlayer(string.format("%s's position: X %.4f  Y %.4f  Z %.4f", targ:getName(), targ:getXPos(), targ:getYPos(), targ:getZPos() ))
+        player:PrintToPlayer(string.format("%s's position: X %.4f  Y %.4f  Z %.4f Rot %.4f", targ:getName(), targ:getXPos(), targ:getYPos(), targ:getZPos(), targ:getRotPos() ))
     else
         if (zoneId == nil) then
             zoneId = targ:getZoneID()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Adds a rot print to !pos.

## Steps to test these changes

