### PR TITLE
Change Base Weapon Damage Calcs for Mobs | Add Distance Correction

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -488,6 +488,17 @@ void CAttack::ProcessDamage(bool isCritical)
     }
 
     SLOTTYPE slot = (SLOTTYPE)GetWeaponSlot();
+
+    if (m_attacker->objtype == TYPE_MOB)
+    {
+        auto* PMob    = static_cast<CBaseEntity*>(m_attacker);
+        auto* PTarget = static_cast<CBaseEntity*>(m_victim);
+        if (distance(PMob->loc.p, PTarget->loc.p) > 2)
+        {
+            slot = SLOT_RANGED;
+        }
+    }
+
     if (m_attackRound->IsH2H())
     {
         m_naturalH2hDamage = (int32)(m_attacker->GetSkill(SKILL_HAND_TO_HAND) * 0.11f) + 3;
@@ -502,7 +513,7 @@ void CAttack::ProcessDamage(bool isCritical)
     {
         m_damage = (uint32)(((m_attacker->GetSubWeaponDmg() + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_SUB)));
     }
-    else if (slot == SLOT_AMMO)
+    else if (slot == SLOT_AMMO || slot == SLOT_RANGED)
     {
         m_damage = (uint32)((m_attacker->GetRangedWeaponDmg() + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_AMMO));
     }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -43,6 +43,7 @@
 #include "../roe.h"
 #include "../status_effect_container.h"
 #include "../utils/battleutils.h"
+#include "../utils/mobutils.h"
 #include "../utils/petutils.h"
 #include "../utils/puppetutils.h"
 #include "../weapon_skill.h"
@@ -400,6 +401,13 @@ uint16 CBattleEntity::GetRangedWeaponDmg()
 {
     TracyZoneScoped;
     uint16 dmg = 0;
+
+    if (objtype == TYPE_MOB)
+    {
+        auto* PMob = static_cast<CMobEntity*>(this);
+        return (mobutils::GetWeaponDamage(PMob, SLOT_RANGED) + getMod(Mod::RANGED_DMG_RATING)) * battleutils::GetRangedDistanceCorrection(this, distance(this->loc.p, this->GetBattleTarget()->loc.p));
+    }
+
     if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_RANGED]))
     {
         if ((weapon->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -51,22 +51,18 @@ namespace mobutils
      *                                                                       *
      ************************************************************************/
 
-    uint16 GetWeaponDamage(CMobEntity* PMob)
+    uint16 GetWeaponDamage(CMobEntity* PMob, uint16 slot)
     {
         uint16 lvl   = PMob->GetMLevel();
         uint8  bonus = 0;
 
-        if (lvl >= 75)
+        if (slot == SLOT_RANGED)
         {
-            bonus = 3;
+            bonus = 5;
         }
-        else if (lvl >= 60)
+        else
         {
             bonus = 2;
-        }
-        else if (lvl >= 50)
-        {
-            bonus = 1;
         }
 
         uint16 damage = lvl + bonus;
@@ -380,7 +376,8 @@ namespace mobutils
             PMob->health.mp = PMob->GetMaxMP();
         }
 
-        ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDamage(GetWeaponDamage(PMob));
+        ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDamage(GetWeaponDamage(PMob, SLOT_MAIN));
+        ((CItemWeapon*)PMob->m_Weapons[SLOT_RANGED])->setDamage(GetWeaponDamage(PMob, SLOT_RANGED));
 
         // reduce weapon delay of MNK
         if (PMob->GetMJob() == JOB_MNK)
@@ -803,7 +800,8 @@ namespace mobutils
 
         // boost dynamis mobs weapon damage
         PMob->setMobMod(MOBMOD_WEAPON_BONUS, 135);
-        ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDamage(GetWeaponDamage(PMob));
+        ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDamage(GetWeaponDamage(PMob, SLOT_MAIN));
+        ((CItemWeapon*)PMob->m_Weapons[SLOT_RANGED])->setDamage(GetWeaponDamage(PMob, SLOT_RANGED));
 
         // job resist traits are much more powerful in dynamis
         // according to wiki

--- a/src/map/utils/mobutils.h
+++ b/src/map/utils/mobutils.h
@@ -65,7 +65,7 @@ namespace mobutils
     void SetupNMMob(CMobEntity* PMob);
     void SetupPetSkills(CMobEntity* PMob);
 
-    uint16 GetWeaponDamage(CMobEntity* PMob);
+    uint16 GetWeaponDamage(CMobEntity* PMob, uint16 slot);
     uint16 GetMagicEvasion(CMobEntity* PMob);
     uint16 GetEvasion(CMobEntity* PMob);
     uint16 GetBase(CMobEntity* PMob, uint8 rank);

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -415,7 +415,7 @@ namespace trustutils
         LoadTrustStatsAndSkills(PTrust);
 
         // Use Mob formulas to work out base "weapon" damage, but scale down to reasonable values.
-        auto mobStyleDamage   = static_cast<float>(mobutils::GetWeaponDamage(PTrust));
+        auto mobStyleDamage   = static_cast<float>(mobutils::GetWeaponDamage(PTrust, SLOT_MAIN));
         auto baseDamage       = mobStyleDamage * 0.5f;
         auto damageMultiplier = static_cast<float>(trustData->cmbDmgMult) / 100.0f;
         auto adjustedDamage   = baseDamage * damageMultiplier;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Changes bonus for mob melee damage calcs to be globally 2.
+ Changes bonus for mob ranged damage calcs to be 5.
+ Adds distance correction to mob ranged attacks.

## Steps to test these changes
