### PR TITLE
Fix Error With Pointing to DB Loaded Levels on Jugs

### DIFF
--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -481,8 +481,8 @@ namespace petutils
 
         float growth = 1.0;
         uint8 lvl    = PMob->GetMLevel();
-        uint8 lvlmax = PMob->m_maxLevel;
-        uint8 lvlmin = PMob->m_minLevel;
+        uint8 lvlmax = petStats->maxLevel;
+        uint8 lvlmin = petStats->minLevel;
 
         // give hp boost every 10 levels after 25
         // special boosts at 25 and 50


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where the level was being inappropriately called from the entity rather than the pet table (petStats) which actually held the values.

## Steps to test these changes
+ Used a print to determine that the appropriate level was being pulled.
