### PR TITLE
Fix Calculation of Elemental And Dark Seal

### DIFF
--- a/scripts/globals/effects/elemental_seal.lua
+++ b/scripts/globals/effects/elemental_seal.lua
@@ -6,14 +6,12 @@ require("scripts/globals/status")
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
-   target:addMod(xi.mod.MACC, 256)
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.MACC, 256)
 end
 
 return effect_object

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -122,8 +122,12 @@ local function getSpellBonusAcc(caster, target, spell, params)
     if casterJob == xi.job.DRK then
         -- Add MACC for Dark Seal
         if skill == xi.skill.DARK_MAGIC and caster:hasStatusEffect(xi.effect.DARK_SEAL) then
-            magicAccBonus = magicAccBonus + 256
+            magicAccBonus = magicAccBonus + 75
         end
+    end
+
+    if caster:hasStatusEffect(xi.effect.ELEMENTAL_SEAL) then
+        magicAccBonus = magicAccBonus + 75
     end
 
     if casterJob == xi.job.RDM then

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -506,7 +506,11 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
 
     -- Dark Seal
     if casterJob == xi.job.DRK and skillType == xi.skill.DARK_MAGIC and caster:hasStatusEffect(xi.effect.DARK_SEAL) then
-        magicAcc = magicAcc + 256 -- Need citation. 256 seems OP
+        magicAcc = magicAcc + 75
+    end
+
+    if caster:hasStatusEffect(xi.effect.ELEMENTAL_SEAL) then
+        magicAcc = magicAcc + 75
     end
 
     -- Add acc for skillchains


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes the application method of elemental and dark seal.
+ Corrects bonus macc values for both status effects.

## Steps to test these changes
