### PR TITLE
Fix pDIF Calcs | Add Guard to pDIF | Fix Parry, Guard, and Block Usage | Fix Skill Hit Rate

### DIFF
--- a/scripts/globals/abilities/violent_flourish.lua
+++ b/scripts/globals/abilities/violent_flourish.lua
@@ -62,7 +62,7 @@ ability_object.onUseAbility = function(player, target, ability, action)
     end
 
     local base = weaponDamage + fstr
-    local cratio, _ = cMeleeRatio(player, target, params, 0, 0)
+    local cratio, _ = cMeleeRatio(player, target, params, 0, 0, xi.slot.MAIN)
     local isSneakValid = player:hasStatusEffect(xi.effect.SNEAK_ATTACK)
     if (isSneakValid and not player:isBehind(target)) then
         isSneakValid = false

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -69,11 +69,14 @@ local function getAvatarFSTR(weaponDmg, avatarStr, targetVit)
     return math.max(-min, fSTR)
 end
 
-local function avatarHitDmg(weaponDmg, fSTR, pDif)
+local function avatarHitDmg(weaponDmg, fSTR, pDif, attacker, target)
     -- https://www.bg-wiki.com/bg/Physical_Damage
     -- Physical Damage = Base Damage * pDIF
     -- where Base Damange is defined as Weapon Damage + fSTR
-    return (weaponDmg + fSTR) * pDif
+    local dmg = (weaponDmg + fSTR) * pDif
+
+    dmg = handleBlock(attacker, target, dmg)
+    return dmg
 end
 
 xi.summon.getSummoningSkillOverCap = function(avatar)
@@ -91,23 +94,12 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
         wSC = 0
     end
 
-    -- I have never read a limit on accuracy bonus from summoning skill which can currently go far past 200 over cap
-    -- current retail is over +250 skill so I am removing the cap, my SMN is at 695 total skill
-    local acc = avatar:getACC() + xi.summon.getSummoningSkillOverCap(avatar)
-    local eva = target:getEVA()
-
-    -- Level correction does not happen in Adoulin zones, Legion, or zones in Escha/Reisenjima
-    -- https://www.bg-wiki.com/bg/PDIF#Level_Correction_Function_.28cRatio.29
-    local zoneId = avatar:getZone():getID()
-
-    local shouldApplyLevelCorrection = (zoneId < 256) and zoneId ~= 183
-
     -- https://forum.square-enix.com/ffxi/threads/45365?p=534537#post534537
     -- https://www.bg-wiki.com/bg/Hit_Rate
     -- https://www.bluegartr.com/threads/114636-Monster-Avatar-Pet-damage
     -- As of December 10th 2015 pet hit rate caps at 99% (familiars, wyverns, avatars and automatons)
     -- increased from 95%
-    local maxHitRate = 0.99
+    local maxHitRate = 0.95
     local minHitRate = 0.2
 
     -- Hit Rate (%) = 75 + floor( (Accuracy - Evasion)/2 ) + 2*(dLVL)
@@ -115,30 +107,14 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
     -- bonuses cap at level diff of 38 based on this testing:
     -- https://www.bluegartr.com/threads/114636-Monster-Avatar-Pet-damage
     -- If there are penalties they seem to be applied differently similarly to monsters.
-    local baseHitRate = 75
+    local baseHitRate = getHitRate(avatar, target, 0, xi.summon.getSummoningSkillOverCap(avatar))
     -- First hit gets a +100 ACC bonus which translates to +50 hit
-    local firstHitAccBonus = 50
-    local hitrateFirst = 0
-    local hitrateSubsequent = 0
-    -- Max level diff is 38
-    local levelDiff = math.min(avatar:getMainLvl() - target:getMainLvl(), 38)
-    -- Only bonuses are applied for avatar level correction
-    local levelCorrection = 0
-    if shouldApplyLevelCorrection then
-        if levelDiff > 0 then
-            levelCorrection = math.max((levelDiff*2), 0)
-        end
-    end
-    -- Delta acc / 2 for hit rate
-    local dAcc = math.floor((acc - eva)/2)
+    local firstHitAccBonus = 0.5
 
     -- Normal hits computed first
-    hitrateSubsequent = baseHitRate + dAcc + levelCorrection
+    local hitrateSubsequent = baseHitRate
     -- First hit gets bonus hit rate
     hitrateFirst = hitrateSubsequent + firstHitAccBonus
-
-    hitrateSubsequent = hitrateSubsequent / 100
-    hitrateFirst = hitrateFirst / 100
 
     hitrateSubsequent = utils.clamp(hitrateSubsequent, minHitRate, maxHitRate)
     hitrateFirst = utils.clamp(hitrateFirst, minHitRate, maxHitRate)
@@ -149,13 +125,20 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
     local numHitsProcessed = 1
     local finaldmg = 0
 
-    if math.random() < hitrateFirst then
+    local missChance = math.random()
+
+    missChance = handleParry(avatar, target, missChance, false)
+
+    if missChance < hitrateFirst then
         firstHitLanded = true
         numHitsLanded = numHitsLanded + 1
     end
 
     while numHitsProcessed < numberofhits do
-        if math.random() < hitrateSubsequent then
+        missChance = math.random()
+        missChance = handleParry(avatar, target, missChance, false)
+
+        if missChance < hitrateSubsequent then
             numHitsLanded = numHitsLanded + 1
         end
         numHitsProcessed = numHitsProcessed + 1
@@ -190,8 +173,10 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
             mtp200 = 1.0
             mtp300 = 1.0
         end
+
+        local tp = avatar:getTP()
         local params = {atk100 = mtp100, atk200 = mtp200, atk300 = mtp300,}
-        local pDifTable = cMeleeRatio(avatar, target, params, 0, avatar:getTP())
+        local pDifTable = cMeleeRatio(avatar, target, params, 0, tp, xi.slot.MAIN)
         local pDif = pDifTable[1]
         local pDifCrit = pDifTable[2]
 
@@ -206,18 +191,21 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
                 pDif = pDifCrit
             end
 
-            finaldmg = avatarHitDmg(weaponDmg, fSTR, pDif) * dmgmod
+            finaldmg = avatarHitDmg(weaponDmg, fSTR, pDif, avatar, target) * dmgmod
             numHitsProcessed = 1
         end
 
         while numHitsProcessed < numHitsLanded do
-        local isCrit = math.random() < critRate
+            local isCrit = math.random() < critRate
+            pDifTable = cMeleeRatio(avatar, target, params, 0, tp, xi.slot.MAIN)
+            pDif = pDifTable[1]
+            pDifCrit = pDifTable[2]
 
             if isCrit then
                 pDif = pDifCrit
             end
 
-            finaldmg = finaldmg + (avatarHitDmg(weaponDmg, fSTR, pDif) * dmgmodsubsequent)
+            finaldmg = finaldmg + (avatarHitDmg(weaponDmg, fSTR, pDif, avatar, target) * dmgmodsubsequent)
             numHitsProcessed = numHitsProcessed + 1
         end
     end

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -217,128 +217,21 @@ end
 
 local function cRangedRatio(attacker, defender, params, ignoredDef, tp)
     local atkmulti = fTP(tp, params.atk100, params.atk200, params.atk300)
-    local cratio = attacker:getRATT() / (defender:getStat(xi.mod.DEF) - ignoredDef)
 
-    local levelCorrection = 0
-    if attacker:getMainLvl() < defender:getMainLvl() then
-        levelCorrection = 0.025 * (defender:getMainLvl() - attacker:getMainLvl())
+    if ignoredDef == nil then
+        ignoredDef = 0
     end
 
-    cratio = cratio - levelCorrection
-    cratio = cratio * atkmulti
+    local pdif = attacker:getRangedPDIF(defender, false, atkmulti, ignoredDef)
+    local pdifcrit = attacker:getRangedPDIF(defender, true, atkmulti, ignoredDef)
 
-    if cratio > 3 - levelCorrection then
-        if attacker:hasStatusEffect(xi.effect.FLASHY_SHOT) then
-            levelCorrection = 0
-        else
-            levelCorrection = (defender:getMainLvl() - attacker:getMainLvl()) * 0.025
-        end
-    end
-
-    cratio = utils.clamp(cratio, 0, 3)
-
-    -- max
-    local pdifmax = 0
-
-    if cratio < 0.9 then
-        pdifmax = cratio * (10 / 9)
-    elseif cratio < 1.1 then
-        pdifmax = 1
-    else
-        pdifmax = cratio
-    end
-
-    -- min
-    local pdifmin = 0
-
-    if cratio < 0.9 then
-        pdifmin = cratio
-    elseif cratio < 1.1 then
-        pdifmin = 1
-    else
-        pdifmin = (cratio * (20 / 19)) - (3 / 19)
-    end
-
-    -- Bernoulli distribution, applied for cRatio < 0.5 and 0.75 < cRatio < 1.25
-    -- Other cRatio values are uniformly distributed
-    -- https://www.bluegartr.com/threads/108161-pDif-and-damage?p=5308205&viewfull=1#post5308205
-    local u = math.max(0.0, math.min(0.333, 1.3 * (2.0 - math.abs(cratio - 1)) - 1.96))
-
-    local bernoulli = false
-
-    if (math.random() < u) then
-        bernoulli = true
-    end
-
-    if (bernoulli) then
-        local roundedRatio = math.floor(cratio + 0.5) -- equivalent to rounding
-        pdifmin = roundedRatio
-        pdifmax = roundedRatio
-    end
-
-    local pdif = {}
-    pdif[1] = pdifmin
-    pdif[2] = pdifmax
-
-    local pdifcrit = {}
-
-    pdifmin = pdifmin * 1.25
-    pdifmax = pdifmax * 1.25
-
-    pdifcrit[1] = pdifmin
-    pdifcrit[2] = pdifmax
-
-    return pdif, pdifcrit
+    return {pdif, pdifcrit}
 end
 
 local function getRangedHitRate(attacker, target, capHitRate, bonus)
-    local acc = attacker:getRACC()
-    local eva = target:getEVA()
+    local hitrate = attacker:getCRangedHitRate(target) / 100
 
-    if bonus == nil then
-        bonus = 0
-    end
-
-    if (target:hasStatusEffect(xi.effect.YONIN) and target:isFacing(attacker, 23)) then -- Yonin evasion boost if defender is facing attacker
-        bonus = bonus - target:getStatusEffect(xi.effect.YONIN):getPower()
-    end
-
-    if attacker:hasTrait(76) and attacker:isBehind(target, 23) then --TRAIT_AMBUSH
-        bonus = bonus + attacker:getMerit(xi.merit.AMBUSH)
-    end
-
-    acc = acc + bonus
-
-    if attacker:getMainLvl() > target:getMainLvl() then -- acc bonus!
-        acc = acc + ((attacker:getMainLvl() - target:getMainLvl()) * 4)
-    elseif attacker:getMainLvl() < target:getMainLvl() then -- acc penalty :(
-        acc = acc - ((target:getMainLvl() - attacker:getMainLvl()) * 4)
-    end
-
-    local hitdiff = 0
-    local hitrate = 75
-
-    if acc > eva then
-        hitdiff = (acc - eva) / 2
-    end
-
-    if eva > acc then
-        hitdiff = ((-1) * (eva - acc)) / 2
-    end
-
-    hitrate = hitrate + hitdiff
-    hitrate = hitrate / 100
-
-    -- Applying hitrate caps
-    if capHitRate then -- this isn't capped for when acc varies with tp, as more penalties are due
-        if hitrate > 0.95 then
-            hitrate = 0.95
-        end
-
-        if hitrate < 0.2 then
-            hitrate = 0.2
-        end
-    end
+    hitrate = utils.clamp(hitrate, 0.2, 0.95)
 
     return hitrate
 end
@@ -347,14 +240,28 @@ end
 local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, firstHitAccBonus)
     local criticalHit = false
     local finaldmg = 0
+    local pdif = 0
+    local pdifCrit = 0
+    local ratio = { }
     -- local pdif = 0 Reminder for Future Implementation!
 
+    if calcParams.pdif == nil or calcParams.pdifCrit == nil then
+        ratio = cMeleeRatio(attacker, target, wsParams, calcParams.ignoredDef, calcParams.tp, xi.slot.MAIN)
+        pdif = ratio[1]
+        pdifCrit =  ratio[2]
+    else
+        pdif = calcParams.pdif
+        pdifCrit = calcParams.pdifCrit
+    end
+
     if firstHitAccBonus ~= nil and firstHitAccBonus == true then
-        calcParams.hitRate = calcParams.hitRate + 50 -- First hit gets a +100 ACC bonus which translates to +50 hit
+        calcParams.hitRate = calcParams.hitRate + 0.5 -- First hit gets a +100 ACC bonus which translates to +50 hit
         utils.clamp(calcParams.hitRate, 0.20, 0.95) -- Clamping to expected values.
     end
 
     local missChance = math.random()
+
+    missChance = handleParry(attacker, target, missChance, calcParams.guaranteedHit)
 
     if (missChance <= calcParams.hitRate or-- See if we hit the target
         calcParams.guaranteedHit or
@@ -369,12 +276,14 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, f
 
             if criticalHit then
                 calcParams.criticalHit = true
-                calcParams.pdif = generatePdif(calcParams.ccritratio[1], calcParams.ccritratio[2], true)
+                calcParams.pdif = pdifCrit
             else
-                calcParams.pdif = generatePdif(calcParams.cratio[1], calcParams.cratio[2], true)
+                calcParams.pdif = pdif
             end
 
             finaldmg = dmg * calcParams.pdif
+
+            finaldmg = handleBlock(attacker, target, finaldmg)
 
             -- Duplicate the first hit with an added magical component for hybrid WSes
             if calcParams.hybridHit then
@@ -546,15 +455,18 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
 
     -- Have to calculate added bonus for SA/TA here since it is done outside of the fTP multiplier
     if attacker:getMainJob() == xi.job.THF then
+        local ratio = cMeleeRatio(attacker, target, nil, 0, tp, xi.slot.MAIN)
+        local pdif = ratio[1]
+        local pdifCrit = ratio[2]
         -- Add DEX/AGI bonus to first hit if THF main and valid Sneak/Trick Attack
         if calcParams.sneakApplicable then
             finaldmg = finaldmg +
-                        (attacker:getStat(xi.mod.DEX) * (1 + attacker:getMod(xi.mod.SNEAK_ATK_DEX)/100) * calcParams.pdif) *
+                        (attacker:getStat(xi.mod.DEX) * (1 + attacker:getMod(xi.mod.SNEAK_ATK_DEX)/100) * pdifCrit) *
                         ((100+(attacker:getMod(xi.mod.AUGMENTS_SA)))/100)
         end
         if calcParams.trickApplicable then
             finaldmg = finaldmg +
-                        (attacker:getStat(xi.mod.AGI) * (1 + attacker:getMod(xi.mod.TRICK_ATK_AGI)/100) * calcParams.pdif) *
+                        (attacker:getStat(xi.mod.AGI) * (1 + attacker:getMod(xi.mod.TRICK_ATK_AGI)/100) * pdif) *
                         ((100+(attacker:getMod(xi.mod.AUGMENTS_TA)))/100)
         end
     end
@@ -638,7 +550,6 @@ function doPhysicalWeaponskill(attacker, target, wsID, wsParams, tp, action, pri
     if wsParams.ignoresDef ~= nil and wsParams.ignoresDef == true then
         ignoredDef = calculatedIgnoredDef(tp, target:getStat(xi.mod.DEF), wsParams.ignored100, wsParams.ignored200, wsParams.ignored300)
     end
-    local cratio, ccritratio = cMeleeRatio(attacker, target, wsParams, ignoredDef, tp)
 
     -- Set up conditions and wsParams used for calculating weaponskill damage
     local gorgetBeltFTP, gorgetBeltAcc = handleWSGorgetBelt(attacker)
@@ -655,8 +566,6 @@ function doPhysicalWeaponskill(attacker, target, wsID, wsParams, tp, action, pri
     calcParams.attackInfo = attack
     calcParams.weaponDamage = getMeleeDmg(attacker, attack.weaponType, wsParams.kick)
     calcParams.fSTR = fSTR(attacker:getStat(xi.mod.STR), target:getStat(xi.mod.VIT), attacker:getWeaponDmgRank())
-    calcParams.cratio = cratio
-    calcParams.ccritratio = ccritratio
     calcParams.accStat = attacker:getACC()
     calcParams.melee = true
     calcParams.mustMiss = target:hasStatusEffect(xi.effect.PERFECT_DODGE) or
@@ -665,6 +574,8 @@ function doPhysicalWeaponskill(attacker, target, wsID, wsParams, tp, action, pri
                                  (attacker:isBehind(target) or attacker:hasStatusEffect(xi.effect.HIDE) or
                                  target:hasStatusEffect(xi.effect.DOUBT))
     calcParams.taChar = taChar
+    calcParams.ignoredDef = ignoredDef
+    calcParams.tp = tp
     calcParams.trickApplicable = calcParams.taChar ~= nil
     calcParams.assassinApplicable = calcParams.trickApplicable and attacker:hasTrait(68)
     calcParams.guaranteedHit = calcParams.sneakApplicable or calcParams.trickApplicable
@@ -708,7 +619,9 @@ end
         ignoredDef = calculatedIgnoredDef(tp, target:getStat(xi.mod.DEF), wsParams.ignored100, wsParams.ignored200, wsParams.ignored300)
     end
 
-    local cratio, ccritratio = cRangedRatio(attacker, target, wsParams, ignoredDef, tp)
+    local ratio = cRangedRatio(attacker, target, wsParams, ignoredDef, tp)
+    local pdif = ratio[1]
+    local pdifCrit = ratio[2]
 
     -- Set up conditions and params used for calculating weaponskill damage
     local gorgetBeltFTP, gorgetBeltAcc = handleWSGorgetBelt(attacker)
@@ -726,8 +639,8 @@ end
         weaponDamage = {attacker:getRangedDmg()},
         skillType = attacker:getWeaponSkillType(xi.slot.RANGED),
         fSTR = fSTR2(attacker:getStat(xi.mod.STR), target:getStat(xi.mod.VIT), attacker:getRangedDmgRank()),
-        cratio = cratio,
-        ccritratio = ccritratio,
+        pdif = pdif,
+        pdifCrit = pdifCrit,
         accStat = attacker:getRACC(),
         melee = false,
         mustMiss = false,
@@ -946,63 +859,21 @@ function getHitRate(attacker, target, capHitRate, bonus)
         attacker:addMod(xi.mod.ACC, 20 + flourisheffect:getSubPower())
     end
 
-    local acc = attacker:getACC()
-    local eva = target:getEVA()
+    if bonus ~= nil or bonus == 0 then
+        attacker:addMod(xi.mod.ACC, bonus)
+    end
+
+    local hitrate = utils.clamp((attacker:getCHitRate(target) / 100), 0.2, 0.95)
 
     if flourisheffect ~= nil and flourisheffect:getPower() > 1 then
         attacker:delMod(xi.mod.ACC, 20 + flourisheffect:getSubPower())
     end
 
-    if bonus == nil then
-        bonus = 0
+    if bonus ~= nil or bonus == 0 then
+        attacker:delMod(xi.mod.ACC, bonus)
     end
 
-    if attacker:hasStatusEffect(xi.effect.INNIN) and attacker:isBehind(target, 23) then -- Innin acc boost if attacker is behind target
-        bonus = bonus + attacker:getStatusEffect(xi.effect.INNIN):getPower()
-    end
-
-    if target:hasStatusEffect(xi.effect.YONIN) and attacker:isFacing(target, 23) then -- Yonin evasion boost if attacker is facing target
-        bonus = bonus - target:getStatusEffect(xi.effect.YONIN):getPower()
-    end
-
-    if attacker:hasTrait(76) and attacker:isBehind(target, 23) then --TRAIT_AMBUSH
-        bonus = bonus + attacker:getMerit(xi.merit.AMBUSH)
-    end
-
-    acc = acc + bonus
-
-    if attacker:getMainLvl() > target:getMainLvl() then              -- Accuracy Bonus
-        acc = acc + ((attacker:getMainLvl()-target:getMainLvl())*4)
-    elseif (attacker:getMainLvl() < target:getMainLvl()) then        -- Accuracy Penalty
-        acc = acc - ((target:getMainLvl()-attacker:getMainLvl())*4)
-    end
-
-    local hitdiff = 0
-    local hitrate = 75
-
-    if acc > eva then
-        hitdiff = (acc - eva) / 2
-    end
-
-    if eva > acc then
-        hitdiff = ((-1) * (eva-acc)) / 2
-    end
-
-    hitrate = hitrate + hitdiff
-    hitrate = hitrate / 100
-
-    -- Applying hitrate caps
-    if capHitRate then -- this isn't capped for when acc varies with tp, as more penalties are due
-        if hitrate > 0.95 then
-            hitrate = 0.95
-        end
-
-        if hitrate < 0.2 then
-            hitrate = 0.2
-        end
-    end
-
-    return hitrate
+    return hitrate / 100
 end
 
 function fTP(tp, ftp1, ftp2, ftp3)
@@ -1047,8 +918,9 @@ function calculatedIgnoredDef(tp, def, ignore1, ignore2, ignore3)
 end
 
 -- Given the raw ratio value (atk/def) and levels, returns the cRatio (min then max)
-function cMeleeRatio(attacker, defender, params, ignoredDef, tp)
+function cMeleeRatio(attacker, defender, params, ignoredDef, tp, slot)
     local flourisheffect = attacker:getStatusEffect(xi.effect.BUILDING_FLOURISH)
+    local isGuarded = false
 
     if flourisheffect ~= nil and flourisheffect:getPower() > 1 then
         attacker:addMod(xi.mod.ATTP, 25 + flourisheffect:getSubPower() / 2)
@@ -1062,115 +934,51 @@ function cMeleeRatio(attacker, defender, params, ignoredDef, tp)
         atkmulti = fTP(tp, params.atk100, params.atk200, params.atk300)
     end
 
-    local cratio = (attacker:getStat(xi.mod.ATT) * atkmulti) / (defender:getStat(xi.mod.DEF) - ignoredDef)
+    if ignoredDef == nil then
+        ignoredDef = 0
+    end
 
-    cratio = utils.clamp(cratio, 0, 2.25)
+    if slot == nil then
+        slot = xi.slot.MAIN
+    end
+
+    if defender:getMainJob() == xi.job.MNK then
+        if defender:getGuardRate(attacker) > math.random(100) then
+            isGuarded = true
+        end
+    end
+
+    local pdif = attacker:getPDIF(defender, false, atkmulti, slot, ignoredDef, isGuarded)
+    local pdifcrit = attacker:getPDIF(defender, true, atkmulti, slot, ignoredDef, isGuarded)
 
     if flourisheffect ~= nil and flourisheffect:getPower() > 1 then
         attacker:delMod(xi.mod.ATTP, 25 + flourisheffect:getSubPower() / 2)
     end
 
-    local levelCorrection = 0
+    return {pdif, pdifcrit}
+end
 
-    if attacker:getMainLvl() < defender:getMainLvl() then
-        levelCorrection = 0.05 * (defender:getMainLvl() - attacker:getMainLvl())
+function handleBlock(attacker, target, finaldmg)
+    if (target:getBlockRate(attacker) > math.random(100) and target:isFacing(attacker) and target:getSystem() == xi.eco.BEASTMEN and target:getMainJob() == xi.job.PLD) then
+        finaldmg = math.floor(finaldmg * 0.5)
+    elseif (target:getBlockRate(attacker) > math.random(100) and target:isFacing(attacker) and target:isPC() and (target:getEquippedItem(xi.slot.SUB):getSkillType() == xi.skill.SHIELD)) then
+        local absorb = 100
+        absorb = utils.clamp(absorb - target:getShieldAbsorptionRate(), 0, 100)
+        absorb = absorb + target:getMod(xi.mod.SHIELD_DEF_BONUS)
+        finaldmg = math.floor(finaldmg * (absorb / 100))
     end
 
-    cratio = cratio - levelCorrection
+    return finaldmg
+end
 
-    if cratio < 0 then
-        cratio = 0
+function handleParry(attacker, target, missChance, guaranteedHit)
+    if (target:isFacing(attacker) and (target:getParryRate(attacker) >= math.random(100)) and target:getMainJob() ~= xi.job.MNK and not guaranteedHit) then -- Try parry, if so miss.
+        if (target:getSystem() == xi.eco.BEASTMEN or target:isPC()) then
+            missChance = 1
+        end
     end
 
-    local pdifmin = 0
-    local pdifmax = 0
-
-    -- max
-    if cratio < 0.5 then
-        pdifmax = cratio + 0.5
-    elseif cratio < 0.7 then
-        pdifmax = 1
-    elseif cratio < 1.2 then
-        pdifmax = cratio + 0.3
-    elseif cratio < 1.5 then
-        pdifmax = cratio * 0.25 + cratio
-    elseif cratio < 2.625 then
-        pdifmax = cratio + 0.375
-    else
-        pdifmax = 3
-    end
-
-    -- min
-    if cratio < 0.38 then
-        pdifmin = 0
-    elseif cratio < 1.25 then
-        pdifmin = cratio * 1176 / 1024 - 448 / 1024
-    elseif cratio < 1.51 then
-        pdifmin = 1
-    elseif cratio < 2.44 then
-        pdifmin = cratio * 1176 / 1024 - 775 / 1024
-    else
-        pdifmin = cratio - 0.375
-    end
-
-    local pdif = {}
-    pdif[1] = pdifmin
-    pdif[2] = pdifmax
-
-    local pdifcrit = {}
-    cratio = cratio + 1
-    cratio = utils.clamp(cratio, 0, 3)
-
-    if cratio < 0.5 then
-        pdifmax = cratio + 0.5
-    elseif cratio < 0.7 then
-        pdifmax = 1
-    elseif cratio < 1.2 then
-        pdifmax = cratio + 0.3
-    elseif cratio < 1.5 then
-        pdifmax = cratio * 0.25 + cratio
-    elseif cratio < 2.625 then
-        pdifmax = cratio + 0.375
-    else
-        pdifmax = 3
-    end
-
-    -- min
-    if cratio < 0.38 then
-        pdifmin = 0
-    elseif cratio < 1.25 then
-        pdifmin = cratio * 1176 / 1024 - 448 / 1024
-    elseif cratio < 1.51 then
-        pdifmin = 1
-    elseif cratio < 2.44 then
-        pdifmin = cratio * 1176 / 1024 - 775 / 1024
-    else
-        pdifmin = cratio - 0.375
-    end
-
-    -- Bernoulli distribution, applied for cRatio < 0.5 and 0.75 < cRatio < 1.25
-    -- Other cRatio values are uniformly distributed
-    -- https://www.bluegartr.com/threads/108161-pDif-and-damage?p=5308205&viewfull=1#post5308205
-    local u = math.max(0.0, math.min(0.333, 1.3 * (2.0 - math.abs(cratio - 1)) - 1.96))
-
-    local bernoulli = false
-
-    if (math.random() < u) then
-        bernoulli = true
-    end
-
-    if (bernoulli) then
-        local roundedRatio = math.floor(cratio + 0.5) -- equivalent to rounding
-        pdifmin = roundedRatio
-        pdifmax = roundedRatio
-    end
-
-    local critbonus = attacker:getMod(xi.mod.CRIT_DMG_INCREASE) - defender:getMod(xi.mod.CRIT_DEF_BONUS)
-    critbonus = utils.clamp(critbonus, 0, 100)
-    pdifcrit[1] = pdifmin * (100 + critbonus) / 100
-    pdifcrit[2] = pdifmax * (100 + critbonus) / 100
-
-    return pdif, pdifcrit
+    return missChance
 end
 
 -- Returns fSTR based on range and divisor
@@ -1230,16 +1038,6 @@ function fSTR2(atk_str, def_vit, weapon_rank)
     fSTR2 = utils.clamp(fSTR2, lower_cap, (weapon_rank + 8) * 2)
 
     return fSTR2
-end
-
-function generatePdif (cratiomin, cratiomax, melee)
-    local pdif = math.random(cratiomin * 1000, cratiomax * 1000) / 1000
-
-    if melee then
-        pdif = pdif * (math.random(100, 105) / 100)
-    end
-
-    return pdif
 end
 
 function getStepAnimation(skill)

--- a/scripts/globals/weaponskills/sidewinder.lua
+++ b/scripts/globals/weaponskills/sidewinder.lua
@@ -24,7 +24,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.acc100 = 0.5 params.acc200= 0.8 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/slug_shot.lua
+++ b/scripts/globals/weaponskills/slug_shot.lua
@@ -25,7 +25,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
+    params.acc100 = 0.5 params.acc200= 0.8 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -89,13 +89,13 @@ bool CAttack::IsCritical() const
  *  Sets the critical flag.                                             *
  *                                                                      *
  ************************************************************************/
-void CAttack::SetCritical(bool value, uint16 slot)
+void CAttack::SetCritical(bool value, uint16 slot, bool isGuarded)
 {
     m_isCritical = value;
 
     if (m_attackType == PHYSICAL_ATTACK_TYPE::DAKEN)
     {
-        m_damageRatio = battleutils::GetRangedDamageRatio(m_attacker, m_victim, m_isCritical);
+        m_damageRatio = battleutils::GetRangedDamageRatio(m_attacker, m_victim, m_isCritical, 0);
     }
     else
     {
@@ -108,7 +108,7 @@ void CAttack::SetCritical(bool value, uint16 slot)
             }
         }
 
-        m_damageRatio = battleutils::GetDamageRatio(m_attacker, m_victim, m_isCritical, attBonus, slot);
+        m_damageRatio = battleutils::GetDamageRatio(m_attacker, m_victim, m_isCritical, attBonus, slot, 0, isGuarded);
     }
 }
 
@@ -425,9 +425,11 @@ bool CAttack::CheckCounter()
         seiganChance = std::clamp<uint16>(seiganChance, 0, 100);
         seiganChance /= 4;
     }
-    if ((xirand::GetRandomNumber(100) < std::clamp<uint16>(m_victim->getMod(Mod::COUNTER) + meritCounter, 0, 80) ||
-         xirand::GetRandomNumber(100) < seiganChance) &&
-        facing(m_victim->loc.p, m_attacker->loc.p, 64) && xirand::GetRandomNumber(100) < battleutils::GetHitRate(m_victim, m_attacker))
+    // clang-format off
+    if (((xirand::GetRandomNumber(100) < std::clamp<uint16>(m_victim->getMod(Mod::COUNTER) + meritCounter, 0, 80)) ||
+        (xirand::GetRandomNumber(100) < std::clamp<uint16>(seiganChance, 0, 80))) &&
+            (facing(m_victim->loc.p, m_attacker->loc.p, 64) && (xirand::GetRandomNumber(100) < battleutils::GetHitRate(m_victim, m_attacker))))
+    // clang-format on
     {
         m_isCountered = true;
         m_isCritical  = (xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(m_victim, m_attacker, false));
@@ -469,7 +471,7 @@ bool CAttack::CheckCover()
  *  Processes the damage for this swing.                                    *
  *                                                                      *
  ************************************************************************/
-void CAttack::ProcessDamage(bool isCritical)
+void CAttack::ProcessDamage(bool isCritical, bool isGuarded)
 {
     // Sneak attack.
     if (m_attacker->GetMJob() == JOB_THF && m_isFirstSwing && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK) &&
@@ -501,19 +503,19 @@ void CAttack::ProcessDamage(bool isCritical)
     {
         m_naturalH2hDamage = (int32)(m_attacker->GetSkill(SKILL_HAND_TO_HAND) * 0.11f) + 3;
         m_baseDamage       = m_attacker->GetMainWeaponDmg();
-        m_damage           = (uint32)(((m_baseDamage + m_naturalH2hDamage + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_MAIN)));
+        m_damage           = (uint32)(((m_baseDamage + m_naturalH2hDamage + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_MAIN, 0, isGuarded)));
     }
     else if (slot == SLOT_MAIN)
     {
-        m_damage = (uint32)(((m_attacker->GetMainWeaponDmg() + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_MAIN)));
+        m_damage = (uint32)(((m_attacker->GetMainWeaponDmg() + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_MAIN, 0, isGuarded)));
     }
     else if (slot == SLOT_SUB)
     {
-        m_damage = (uint32)(((m_attacker->GetSubWeaponDmg() + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_SUB)));
+        m_damage = (uint32)(((m_attacker->GetSubWeaponDmg() + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_SUB, 0, isGuarded)));
     }
     else if (slot == SLOT_AMMO || slot == SLOT_RANGED)
     {
-        m_damage = (uint32)((m_attacker->GetRangedWeaponDmg() + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_AMMO));
+        m_damage = (uint32)((m_attacker->GetRangedWeaponDmg() + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_AMMO, 0, isGuarded));
     }
 
     // Apply "Double Attack" damage and "Triple Attack" damage mods

--- a/src/map/attack.h
+++ b/src/map/attack.h
@@ -69,31 +69,31 @@ class CAttack
 public:
     CAttack(CBattleEntity* attacker, CBattleEntity* defender, PHYSICAL_ATTACK_TYPE type, PHYSICAL_ATTACK_DIRECTION direction, CAttackRound* attackRound);
 
-    uint16                    GetAnimationID();                     // Returns the animation ID.
-    PHYSICAL_ATTACK_TYPE      GetAttackType();                      // Returns the attack type (Double, Triple, Zanshin ect).
-    PHYSICAL_ATTACK_DIRECTION GetAttackDirection();                 // Returns the attack direction.
-    uint8                     GetWeaponSlot();                      // Returns the attacking slot.
-    uint8                     GetHitRate();                         // Returns the hitrate for this swing.
-    int32                     GetDamage() const;                    // Returns the damage for this attack.
-    void                      SetDamage(int32);                     // Sets the damage for this attack.
-    bool                      IsCritical() const;                   // Returns the isCritical flag.
-    void                      SetCritical(bool, uint16 slot);       // Sets the isCritical flag;
-    bool                      IsFirstSwing() const;                 // Returns the isFirstSwing flag.
-    void                      SetAsFirstSwing(bool isFirst = true); // Sets this attack as the first swing.
-    float                     GetDamageRatio() const;               // Gets the damage ratio.
-    void                      SetGuarded(bool);                     // Sets the isGuarded flag.
-    bool                      IsGuarded();                          // Sets the isGuarded flag. Also alters the damage ratio accordingly.
-    bool                      IsEvaded() const;                     // Gets the evaded flag.
-    void                      SetEvaded(bool value);                // Sets the evaded flag.
-    bool                      IsBlocked() const;                    // Returns the blocked flag.
+    uint16                    GetAnimationID();                               // Returns the animation ID.
+    PHYSICAL_ATTACK_TYPE      GetAttackType();                                // Returns the attack type (Double, Triple, Zanshin ect).
+    PHYSICAL_ATTACK_DIRECTION GetAttackDirection();                           // Returns the attack direction.
+    uint8                     GetWeaponSlot();                                // Returns the attacking slot.
+    uint8                     GetHitRate();                                   // Returns the hitrate for this swing.
+    int32                     GetDamage() const;                              // Returns the damage for this attack.
+    void                      SetDamage(int32);                               // Sets the damage for this attack.
+    bool                      IsCritical() const;                             // Returns the isCritical flag.
+    void                      SetCritical(bool, uint16 slot, bool isGuarded); // Sets the isCritical flag;
+    bool                      IsFirstSwing() const;                           // Returns the isFirstSwing flag.
+    void                      SetAsFirstSwing(bool isFirst = true);           // Sets this attack as the first swing.
+    float                     GetDamageRatio() const;                         // Gets the damage ratio.
+    void                      SetGuarded(bool);                               // Sets the isGuarded flag.
+    bool                      IsGuarded();                                    // Sets the isGuarded flag. Also alters the damage ratio accordingly.
+    bool                      IsEvaded() const;                               // Gets the evaded flag.
+    void                      SetEvaded(bool value);                          // Sets the evaded flag.
+    bool                      IsBlocked() const;                              // Returns the blocked flag.
     bool                      IsParried();
     bool                      IsAnticipated() const;
     bool                      CheckAnticipated();
     bool                      IsCountered() const;
     bool                      CheckCounter();
-    bool                      IsCovered() const;              // Returns the covered flag.
-    bool                      CheckCover();                   // Sets the covered flag and returns it.
-    void                      ProcessDamage(bool isCritical); // Processes the damage for this swing.
+    bool                      IsCovered() const;                              // Returns the covered flag.
+    bool                      CheckCover();                                   // Sets the covered flag and returns it.
+    void                      ProcessDamage(bool isCritical, bool isGuarded); // Processes the damage for this swing.
 
     void SetAttackType(PHYSICAL_ATTACK_TYPE type); // Sets the attack type.
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1841,7 +1841,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                             csJpAtkBonus = 1 + ((static_cast<float>(targetDex) / 100) * csJpModifier);
                         }
 
-                        float DamageRatio = battleutils::GetDamageRatio(PTarget, this, attack.IsCritical(), csJpAtkBonus, SLOT_MAIN);
+                        float DamageRatio = battleutils::GetDamageRatio(PTarget, this, attack.IsCritical(), csJpAtkBonus, SLOT_MAIN, 0, attack.IsGuarded());
                         auto  damage      = (int32)((PTarget->GetMainWeaponDmg() + naturalh2hDMG + battleutils::GetFSTR(PTarget, this, SLOT_MAIN)) * DamageRatio);
 
                         actionTarget.spikesParam =
@@ -1864,7 +1864,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
             else
             {
                 // Set this attack's critical flag.
-                attack.SetCritical(xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(this, PTarget, !attack.IsFirstSwing()), SLOT_MAIN);
+                attack.SetCritical(xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(this, PTarget, !attack.IsFirstSwing()), SLOT_MAIN, attack.IsGuarded());
 
                 actionTarget.reaction = REACTION::HIT;
 
@@ -1906,7 +1906,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 }
 
                 // Process damage.
-                attack.ProcessDamage(attack.IsCritical());
+                attack.ProcessDamage(attack.IsCritical(), attack.IsGuarded());
 
                 // Try shield block
                 if (attack.IsBlocked())

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1576,7 +1576,7 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
             else
             {
                 bool  isCritical = xirand::GetRandomNumber(100) < battleutils::GetRangedCritHitRate(this, PTarget);
-                float pdif       = battleutils::GetRangedDamageRatio(this, PTarget, isCritical);
+                float pdif       = battleutils::GetRangedDamageRatio(this, PTarget, isCritical, 0);
 
                 if (isCritical)
                 {

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -289,7 +289,7 @@ void CTrustEntity::OnRangedAttack(CRangeState& state, action_t& action)
             else
             {
                 bool  isCritical = xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(this, PTarget, true);
-                float pdif       = battleutils::GetRangedDamageRatio(this, PTarget, isCritical);
+                float pdif       = battleutils::GetRangedDamageRatio(this, PTarget, isCritical, 0);
 
                 if (isCritical)
                 {

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11502,13 +11502,148 @@ int CLuaBaseEntity::getMeleeHitDamage(CLuaBaseEntity* PLuaBaseEntity, sol::objec
 
     if (xirand::GetRandomNumber(100) < hitrate)
     {
-        float DamageRatio = battleutils::GetDamageRatio(PAttacker, PDefender, false, 0.f, SLOT_MAIN);
+        float DamageRatio = battleutils::GetDamageRatio(PAttacker, PDefender, false, 0.f, SLOT_MAIN, 0, false);
         int   damage      = (uint16)((PAttacker->GetMainWeaponDmg() + battleutils::GetFSTR(PAttacker, PDefender, SLOT_MAIN)) * DamageRatio);
 
         return damage;
     }
 
     return -1;
+}
+
+/************************************************************************
+ *  Function: getPDIF()
+ *  Purpose : Return pdif values.
+ *  Example : attacker:getPDIF(defender, isCritical, bonusAttackPercent, xi.slot.MAIN, ignoredDef, isGuarded)
+ *  Notes   : Battleutils calculates via GetDamageRatio
+ ************************************************************************/
+
+float CLuaBaseEntity::getPDIF(CLuaBaseEntity* PLuaBaseEntity, bool isCritical, float bonusAttPercent, uint16 slot, uint16 ignoredDef, bool isGuarded)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    CBattleEntity* PAttacker = static_cast<CBattleEntity*>(m_PBaseEntity);
+    CBattleEntity* PDefender = static_cast<CBattleEntity*>(PLuaBaseEntity->GetBaseEntity());
+
+    return battleutils::GetDamageRatio(PAttacker, PDefender, isCritical, bonusAttPercent, slot, ignoredDef, isGuarded);
+}
+
+/************************************************************************
+ *  Function: getRangedPDIF()
+ *  Purpose : Return pdif values.
+ *  Example : attacker:getRangedPDIF(defender, isCritical, bonusAttackPercent, xi.slot.MAIN, ignoredDef)
+ *  Notes   : Battleutils calculates via GetRangedDamageRatio
+ ************************************************************************/
+
+float CLuaBaseEntity::getRangedPDIF(CLuaBaseEntity* PLuaBaseEntity, bool isCritical, uint16 ignoredDef)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    CBattleEntity* PAttacker = static_cast<CBattleEntity*>(m_PBaseEntity);
+    CBattleEntity* PDefender = static_cast<CBattleEntity*>(PLuaBaseEntity->GetBaseEntity());
+
+    return battleutils::GetRangedDamageRatio(PAttacker, PDefender, isCritical, ignoredDef);
+}
+
+/************************************************************************
+ *  Function: getGuardRate()
+ *  Purpose : Return guard rate.
+ *  Example : defender:getGuardRate(attacker)
+ *  Notes   : Battleutils calculates via GetGuardRate
+ ************************************************************************/
+
+uint8 CLuaBaseEntity::getGuardRate(CLuaBaseEntity* PLuaBaseEntity)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    CBattleEntity* PDefender = static_cast<CBattleEntity*>(m_PBaseEntity);
+    CBattleEntity* PAttacker = static_cast<CBattleEntity*>(PLuaBaseEntity->GetBaseEntity());
+
+    return battleutils::GetGuardRate(PAttacker, PDefender);
+}
+
+/************************************************************************
+ *  Function: getBlockRate()
+ *  Purpose : Return block rate.
+ *  Example : defender:getBlockRate(attacker)
+ *  Notes   : Battleutils calculates via GetBlockRate
+ ************************************************************************/
+
+uint8 CLuaBaseEntity::getBlockRate(CLuaBaseEntity* PLuaBaseEntity)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    CBattleEntity* PDefender = static_cast<CBattleEntity*>(m_PBaseEntity);
+    CBattleEntity* PAttacker = static_cast<CBattleEntity*>(PLuaBaseEntity->GetBaseEntity());
+
+    return battleutils::GetBlockRate(PAttacker, PDefender);
+}
+
+/************************************************************************
+ *  Function: getParryRate()
+ *  Purpose : Return block rate.
+ *  Example : defender:getParryRate(attacker)
+ *  Notes   : Battleutils calculates via GetParryRate
+ ************************************************************************/
+
+uint8 CLuaBaseEntity::getParryRate(CLuaBaseEntity* PLuaBaseEntity)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    CBattleEntity* PDefender = static_cast<CBattleEntity*>(m_PBaseEntity);
+    CBattleEntity* PAttacker = static_cast<CBattleEntity*>(PLuaBaseEntity->GetBaseEntity());
+
+    return battleutils::GetParryRate(PAttacker, PDefender);
+}
+
+/************************************************************************
+ *  Function: getCHitRate()
+ *  Purpose : Return hit rate.
+ *  Example : attacker:getCHitRate(defender)
+ *  Notes   : Battleutils calculates via GetHitRate
+ ************************************************************************/
+
+uint8 CLuaBaseEntity::getCHitRate(CLuaBaseEntity* PLuaBaseEntity)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    CBattleEntity* PAttacker = static_cast<CBattleEntity*>(m_PBaseEntity);
+    CBattleEntity* PDefender = static_cast<CBattleEntity*>(PLuaBaseEntity->GetBaseEntity());
+
+    return battleutils::GetHitRate(PAttacker, PDefender, 1);
+}
+
+/************************************************************************
+ *  Function: getCRangedHitRate()
+ *  Purpose : Return ranged hit rate.
+ *  Example : attacker:getCRagnedHitRate(defender)
+ *  Notes   : Battleutils calculates via GetRangedHitRate
+ ************************************************************************/
+
+uint8 CLuaBaseEntity::getCRangedHitRate(CLuaBaseEntity* PLuaBaseEntity)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    CBattleEntity* PAttacker = static_cast<CBattleEntity*>(m_PBaseEntity);
+    CBattleEntity* PDefender = static_cast<CBattleEntity*>(PLuaBaseEntity->GetBaseEntity());
+
+    return battleutils::GetRangedHitRate(PAttacker, PDefender, false);
+}
+
+/************************************************************************
+ *  Function: getShieldAbsorptionRate()
+ *  Purpose : Return absorbtion rate.
+ *  Example : target:getShieldAbsorbtionRate()
+ *  Notes   : CItem calculates the amount to absorb.
+ ************************************************************************/
+
+uint8 CLuaBaseEntity::getShieldAbsorptionRate()
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+
+    CBattleEntity* PDefender = static_cast<CBattleEntity*>(m_PBaseEntity);
+
+    return PDefender->m_Weapons[SLOT_SUB]->getShieldAbsorption();
 }
 
 /************************************************************************
@@ -15048,6 +15183,14 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("isWeaponTwoHanded", CLuaBaseEntity::isWeaponTwoHanded);
     SOL_REGISTER("getMeleeHitDamage", CLuaBaseEntity::getMeleeHitDamage);
+    SOL_REGISTER("getPDIF", CLuaBaseEntity::getPDIF);
+    SOL_REGISTER("getRangedPDIF", CLuaBaseEntity::getRangedPDIF);
+    SOL_REGISTER("getGuardRate", CLuaBaseEntity::getGuardRate);
+    SOL_REGISTER("getBlockRate", CLuaBaseEntity::getBlockRate);
+    SOL_REGISTER("getParryRate", CLuaBaseEntity::getParryRate);
+    SOL_REGISTER("getCHitRate", CLuaBaseEntity::getCHitRate);
+    SOL_REGISTER("getCRangedHitRate", CLuaBaseEntity::getCRangedHitRate);
+    SOL_REGISTER("getShieldAbsorptionRate", CLuaBaseEntity::getShieldAbsorptionRate);
     SOL_REGISTER("getWeaponDmg", CLuaBaseEntity::getWeaponDmg);
     SOL_REGISTER("getWeaponDmgRank", CLuaBaseEntity::getWeaponDmgRank);
     SOL_REGISTER("getOffhandDmg", CLuaBaseEntity::getOffhandDmg);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -648,14 +648,22 @@ public:
     void  handleAfflatusMiseryDamage(double damage);
 
     bool   isWeaponTwoHanded();
-    int    getMeleeHitDamage(CLuaBaseEntity* PLuaBaseEntity, sol::object const& arg1); // gets the damage of a single hit vs the specified mob
-    uint16 getWeaponDmg();                                                             // gets the current equipped weapons' DMG rating
-    uint16 getWeaponDmgRank();                                                         // gets the current equipped weapons' DMG rating for Rank calc
-    uint16 getOffhandDmg();                                                            // gets the current equipped offhand's DMG rating (used in WS calcs)
-    uint16 getOffhandDmgRank();                                                        // gets the current equipped offhand's DMG rating for Rank calc
-    uint16 getRangedDmg();                                                             // Get ranged weapon DMG rating
-    uint16 getRangedDmgRank();                                                         // Get ranged weapond DMG rating used for calculating rank
-    uint16 getAmmoDmg();                                                               // Get ammo DMG rating
+    int    getMeleeHitDamage(CLuaBaseEntity* PLuaBaseEntity, sol::object const& arg1);                                                      // gets the damage of a single hit vs the specified mob
+    float  getPDIF(CLuaBaseEntity* PLuaBaseEntity, bool isCritical, float bonusAttPercent, uint16 slot, uint16 ignoredDef, bool isGuarded); // Gets PDIF for an attack.
+    float  getRangedPDIF(CLuaBaseEntity* PLuaBaseEntity, bool isCritical, uint16 ignoredDef);                                               // Gets PDIF for an attack.
+    uint8  getGuardRate(CLuaBaseEntity* PLuaBaseEntity);                                                                                    // Returns the guard rate for an attack.
+    uint8  getBlockRate(CLuaBaseEntity* PLuaBaseEntity);                                                                                    // Returns the block rate for an attack.
+    uint8  getParryRate(CLuaBaseEntity* PLuaBaseEntity);                                                                                    // Returns the parry rate for an attack.
+    uint8  getCHitRate(CLuaBaseEntity* PLuaBaseEntity);                                                                                     // Returns the hit rate for an attack.
+    uint8  getCRangedHitRate(CLuaBaseEntity* PLuaBaseEntity);                                                                               // Returns the ranged hit rate for an attack.
+    uint8  getShieldAbsorptionRate();                                                                                                       // Returns the shield absorption for an attack.
+    uint16 getWeaponDmg();                                                                                                                  // gets the current equipped weapons' DMG rating
+    uint16 getWeaponDmgRank();                                                                                                              // gets the current equipped weapons' DMG rating for Rank calc
+    uint16 getOffhandDmg();                                                                                                                 // gets the current equipped offhand's DMG rating (used in WS calcs)
+    uint16 getOffhandDmgRank();                                                                                                             // gets the current equipped offhand's DMG rating for Rank calc
+    uint16 getRangedDmg();                                                                                                                  // Get ranged weapon DMG rating
+    uint16 getRangedDmgRank();                                                                                                              // Get ranged weapond DMG rating used for calculating rank
+    uint16 getAmmoDmg();                                                                                                                    // Get ammo DMG rating
 
     void removeAmmo();
 

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -151,7 +151,7 @@ namespace battleutils
     uint8 GetBlockRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8 GetParryRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8 GetGuardRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
-    float GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, float bonusAttPercent, uint16 slot);
+    float GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, float bonusAttPercent, uint16 slot, uint16 ignoredDef, bool isGuarded);
     float GetRangedDistanceCorrection(CBattleEntity* PBattleEntity, float distance);
 
     int32 TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, PHYSICAL_ATTACK_TYPE physicalAttackType, int32 damage, bool isBlocked,
@@ -164,7 +164,7 @@ namespace battleutils
     int32 TakeSwipeLungeDamage(CBattleEntity* PDefender, CCharEntity* PAttacker, int32 damage, ATTACK_TYPE attackType, DAMAGE_TYPE damageType);
 
     bool  TryInterruptSpell(CBattleEntity* PAttacker, CBattleEntity* PDefender, CSpell* PSpell);
-    float GetRangedDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical);
+    float GetRangedDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, uint16 ignoredDef);
     void  HandleRangedAdditionalEffect(CCharEntity* PAttacker, CBattleEntity* PDefender, apAction_t* Action);
     int32 CalculateSpikeDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, actionTarget_t* Action, uint16 damageTaken);
     bool  HandleSpikesDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, actionTarget_t* Action, int32 damage);

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -513,6 +513,7 @@ namespace mobutils
         PMob->addModifier(Mod::EVA, GetEvasion(PMob));
         PMob->addModifier(Mod::ATT, GetBase(PMob, PMob->attRank));
         PMob->addModifier(Mod::ACC, GetBase(PMob, PMob->accRank));
+        PMob->addModifier(Mod::PARRY, GetBase(PMob, 3));
 
         // natural magic evasion
         PMob->addModifier(Mod::MEVA, GetMagicEvasion(PMob));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where parry rate was too high.
+ Fixes an issue where guard rate was too high.
+ Fixes an issue where guard was not being calculated in damage ratio mitigation.
+ Adds a sanity clamp to Seigan counter rate.
+ Changes all weaponskills, mobskills, and avatar BPs which are physical or ranged to use the C++ implementation of pdif.
+ Changes all weaponskills, mobskills, and avatar BPs which are physical or ranged to use the C++ implementation of hit rate.
+ Changes all weaponskills, mobskills, and avatar BPs which are physical or ranged to use the C++ implementation of block rate.
+ Changes all weaponskills, mobskills, and avatar BPs which are physical or ranged to use the C++ implementation of guard rate.
+ Changes all weaponskills, mobskills, and avatar BPs which are physical or ranged to use the C++ implementation of parry rate.
+ Adds the ability to parry for both players and mobs when taking a weaponskill, mobskill, or avatar physical bloodpact.
+ Adds the ability to guard for both players and mobs when taking a weaponskill, mobskill, or avatar physical bloodpact.
+ Adds the ability to block for both players and mobs when taking a weaponskill, mobskill, or avatar physical bloodpact.
+ Fixes the accuracy mod for sidewinder and slug shot. Known good value for acc100 is 0.5 for both, acc200 and acc300 were conservative guesses based on that information.
+ Multihit physical moves now calculate pdif for every hit.
+ Multihit physical moves now calculate hit rate for every hit.
+ Parry, block, and guard are applied to every hit of a multihit physical move independently.
+ Piped the ability to add wSC to mobskills.

Note: The ability to parry, guard, or block are exclusive to melee weaponskills, mobskills, and physical bloodpacts. Ranged skills will still subvert these.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
+ Tested player multihit and single hit.
+ Tested avatar multihit and single hit.
+ Tested mob multihit and single hit.