### PR TITLE
Summoner Kiting

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -617,6 +617,18 @@ void CMobController::DoCombatTick(time_point tick)
     PMob->PAI->EventHandler.triggerListener("COMBAT_TICK", CLuaBaseEntity(PMob));
     luautils::OnMobFight(PMob, PTarget);
 
+    // handle pet behaviour on the targets behalf (faster than in ai_pet_dummy)
+    // Avatars defend masters by attacking mobs if the avatar isn't attacking anything currently (bodyguard behaviour)
+    //
+    // This change allows pets to auto-engage mobs to allow summoner kiting without the mob having to swing at the player.
+    if (PTarget->PPet != nullptr && PTarget->PPet->GetBattleTargetID() == 0)
+    {
+        if (PTarget->PPet->objtype == TYPE_PET && ((CPetEntity*)PTarget->PPet)->getPetType() == PET_TYPE::AVATAR)
+        {
+            petutils::AttackTarget(PTarget, PMob);
+        }
+    }
+
     // Try to spellcast (this is done first so things like Chainspell spam is prioritised over TP moves etc.
     if (IsSpecialSkillReady(currentDistance) && TrySpecialSkill())
     {


### PR DESCRIPTION
Allows summoner's to kite and have pets auto-engage a mob that is chasing them.   This is retail like behavior.

https://www.ffxiah.com/forum/topic/4553/smn-kitingand-you/

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Allows summoner's to kite and have pets auto-engage a mob that is chasing them.   This is retail like behavior.

https://www.ffxiah.com/forum/topic/4553/smn-kitingand-you/

## Steps to test these changes

1. Tested on local ASB.  
2. 

1. Engage pet onto a mob
2. Run away.
3. Release pet, and resummon pet.  
4. Watch as the pet starts running to the mob that is chasing after yourself.

<!-- Clear and detailed steps to test your changes here -->
