### PR TITLE
Fixed bad power in Rage script

### DIFF
--- a/scripts/globals/mobskills/rage.lua
+++ b/scripts/globals/mobskills/rage.lua
@@ -19,9 +19,9 @@ end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local duration = 60
-
+    local power = 25
     local typeEffect = xi.effect.BERSERK
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 1, 0, duration))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
     return typeEffect
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes a bad power value in the mobskill Rage script.

## Steps to test these changes

Use /checkparam on a Sheep jug pet before and after using Rage.
