### PR TITLE
Pipe Caster Pointer in Magic.lua | Limit Nuke Wall to Only NMs

### DIFF
--- a/scripts/globals/spells/black/bind.lua
+++ b/scripts/globals/spells/black/bind.lua
@@ -29,7 +29,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/bindga.lua
+++ b/scripts/globals/spells/black/bindga.lua
@@ -31,7 +31,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if (resist >= 0.5) then --Do it!
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/blind.lua
+++ b/scripts/globals/spells/black/blind.lua
@@ -35,7 +35,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/blind_ii.lua
+++ b/scripts/globals/spells/black/blind_ii.lua
@@ -36,7 +36,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/blindga.lua
+++ b/scripts/globals/spells/black/blindga.lua
@@ -39,7 +39,7 @@ spell_object.onSpellCast = function(caster, target, spell)
 
     if (duration >= 60) then --Do it!
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/break.lua
+++ b/scripts/globals/spells/black/break.lua
@@ -28,7 +28,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/breakga.lua
+++ b/scripts/globals/spells/black/breakga.lua
@@ -28,7 +28,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/curse.lua
+++ b/scripts/globals/spells/black/curse.lua
@@ -29,7 +29,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     duration = duration * applyResistanceEffect(caster, target, spell, params)
 
     if (duration >= 150) then --Do it!
-        duration = calculateBuildDuration(target, duration, params.effect)
+        duration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/graviga.lua
+++ b/scripts/globals/spells/black/graviga.lua
@@ -28,7 +28,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     duration = duration * applyResistanceEffect(caster, target, spell, params)
 
     if (duration >= 30) then --Do it!
-        duration = calculateBuildDuration(target, duration, params.effect)
+        duration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/gravity.lua
+++ b/scripts/globals/spells/black/gravity.lua
@@ -30,7 +30,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/gravity_ii.lua
+++ b/scripts/globals/spells/black/gravity_ii.lua
@@ -30,7 +30,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poison.lua
+++ b/scripts/globals/spells/black/poison.lua
@@ -33,7 +33,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poison_ii.lua
+++ b/scripts/globals/spells/black/poison_ii.lua
@@ -33,7 +33,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poison_iii.lua
+++ b/scripts/globals/spells/black/poison_iii.lua
@@ -29,7 +29,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poisonga.lua
+++ b/scripts/globals/spells/black/poisonga.lua
@@ -33,7 +33,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poisonga_ii.lua
+++ b/scripts/globals/spells/black/poisonga_ii.lua
@@ -33,7 +33,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poisonga_iii.lua
+++ b/scripts/globals/spells/black/poisonga_iii.lua
@@ -41,7 +41,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if (resist == 1 or resist == 0.5) then -- effect taken
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/sleep.lua
+++ b/scripts/globals/spells/black/sleep.lua
@@ -26,7 +26,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/sleep_ii.lua
+++ b/scripts/globals/spells/black/sleep_ii.lua
@@ -26,7 +26,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/sleepga.lua
+++ b/scripts/globals/spells/black/sleepga.lua
@@ -37,7 +37,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/sleepga_ii.lua
+++ b/scripts/globals/spells/black/sleepga_ii.lua
@@ -26,7 +26,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/stun.lua
+++ b/scripts/globals/spells/black/stun.lua
@@ -34,7 +34,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     else
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/virus.lua
+++ b/scripts/globals/spells/black/virus.lua
@@ -28,7 +28,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if (resist >= 0.5) then -- effect taken
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/songs/battlefield_elegy.lua
+++ b/scripts/globals/spells/songs/battlefield_elegy.lua
@@ -51,7 +51,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         -- Ensure the reduction is capped at 50%
         power = utils.clamp(power, 0, 5000)
 
-        duration = calculateBuildDuration(target, duration, params.effect)
+        duration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/songs/carnage_elegy.lua
+++ b/scripts/globals/spells/songs/carnage_elegy.lua
@@ -51,7 +51,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         -- Ensure the reduction is capped at 50%
         power = utils.clamp(power, 0, 5000)
 
-        duration = calculateBuildDuration(target, duration, params.effect)
+        duration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/songs/foe_lullaby.lua
+++ b/scripts/globals/spells/songs/foe_lullaby.lua
@@ -38,7 +38,7 @@ spell_object.onSpellCast = function(caster, target, spell)
 
         duration = duration * resm
 
-        duration = calculateBuildDuration(target, duration, params.effect)
+        duration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/songs/foe_lullaby_ii.lua
+++ b/scripts/globals/spells/songs/foe_lullaby_ii.lua
@@ -38,7 +38,7 @@ spell_object.onSpellCast = function(caster, target, spell)
 
         duration = duration * resm
 
-        duration = calculateBuildDuration(target, duration, params.effect)
+        duration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/songs/horde_lullaby.lua
+++ b/scripts/globals/spells/songs/horde_lullaby.lua
@@ -38,7 +38,7 @@ spell_object.onSpellCast = function(caster, target, spell)
 
         duration = duration * resm
 
-        duration = calculateBuildDuration(target, duration, params.effect)
+        duration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/songs/horde_lullaby_ii.lua
+++ b/scripts/globals/spells/songs/horde_lullaby_ii.lua
@@ -38,7 +38,7 @@ spell_object.onSpellCast = function(caster, target, spell)
 
         duration = duration * resm
 
-        duration = calculateBuildDuration(target, duration, params.effect)
+        duration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/songs/maidens_virelai.lua
+++ b/scripts/globals/spells/songs/maidens_virelai.lua
@@ -40,7 +40,7 @@ spell_object.onSpellCast = function(caster, target, spell)
 
         duration = duration * resist
 
-        duration = calculateBuildDuration(target, duration, params.effect)
+        duration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/songs/massacre_elegy.lua
+++ b/scripts/globals/spells/songs/massacre_elegy.lua
@@ -47,7 +47,7 @@ spell_object.onSpellCast = function(caster, target, spell)
 
         duration = duration * resm
 
-        duration = calculateBuildDuration(target, duration, params.effect)
+        duration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if duration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/paralyga.lua
+++ b/scripts/globals/spells/white/paralyga.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         if (resist >= 0.5) then --there are no quarter or less hits, if target resists more than .5 spell is resisted completely
             local resduration = duration * resist
 
-            resduration = calculateBuildDuration(target, duration, params.effect)
+            resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
             if resduration == 0 then
                 spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/paralyze.lua
+++ b/scripts/globals/spells/white/paralyze.lua
@@ -33,7 +33,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- There are no quarter or less hits, if target resists more than .5 spell is resisted completely
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/paralyze_ii.lua
+++ b/scripts/globals/spells/white/paralyze_ii.lua
@@ -33,7 +33,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/silence.lua
+++ b/scripts/globals/spells/white/silence.lua
@@ -27,7 +27,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/silencega.lua
+++ b/scripts/globals/spells/white/silencega.lua
@@ -37,7 +37,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if (resist >= 0.5) then --Do it!
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/slow.lua
+++ b/scripts/globals/spells/white/slow.lua
@@ -34,7 +34,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/slow_ii.lua
+++ b/scripts/globals/spells/white/slow_ii.lua
@@ -33,7 +33,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/slowga.lua
+++ b/scripts/globals/spells/white/slowga.lua
@@ -32,7 +32,7 @@ spell_object.onSpellCast = function(caster, target, spell)
 
     if resist >= 0.5 then -- Do it!
         local resduration = duration * resist
-        resduration = calculateBuildDuration(target, duration, params.effect)
+        resduration = calculateBuildDuration(target, duration, params.effect, caster)
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
         elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, 1) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Adds pointer piping for caster in tryBuildResistance() for future implementations if necessary.
+ Pipes all spell luas that calculateBuildDuration() to allow for caster passthrough.
+ Limits nuke wall to NMs.
## Steps to test these changes

