### PR TITLE
Fix damage.lua Interaction with ranged attack types

### DIFF
--- a/scripts/globals/damage.lua
+++ b/scripts/globals/damage.lua
@@ -28,7 +28,7 @@ local dmgMods =
         {mod = xi.mod.UDMGBREATH},
         {mod = xi.mod.DMG},
     },
-    [xi.attackType.MAGICAL] =
+    [xi.attackType.RANGED] =
     {
         {mod = xi.mod.DMGRANGE, min = -0.5, max = 1000},
         {mod = xi.mod.UDMGRANGE},


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes a typo in damage.lua that caused a nil table index.

## Steps to test these changes
