### PR TITLE
Some COP fixes

### DIFF
--- a/scripts/zones/PsoXja/mobs/Nunyunuwi.lua
+++ b/scripts/zones/PsoXja/mobs/Nunyunuwi.lua
@@ -4,6 +4,10 @@
 -----------------------------------
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.REGEN, 150)
+end
+
 entity.onMobDeath = function(mob, player, isKiller)
 end
 

--- a/scripts/zones/Sacrarium/mobs/Keremet.lua
+++ b/scripts/zones/Sacrarium/mobs/Keremet.lua
@@ -20,6 +20,11 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
+    for i = mob:getID() + 1, mob:getID() + 12 do
+        if GetMobByID(i):isAlive() then
+            GetMobByID(i):setHP(0)
+        end
+    end
 end
 
 entity.onMobDespawn = function(mob)


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Evidence:
Personal captures
https://ffxiclopedia.fandom.com/wiki/Nunyunuwi

The following were achieved using personal captures. 
While fighting Nunyunuwi, player would deal roughly 130 dmg per tick. Nunyunuwi would almost immediately recover to full HP afterwards.
After killing Keremet without first killing the adds, they were all killed upon Keremet's death.

- Gave NM Nunyunuwi a potent regen of 150.
- Keremet's adds now die along with him if they are alive.
