### PR TITLE
Airship fixes

### DIFF
--- a/scripts/zones/Bastok-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/Bastok-Jeuno_Airship/Zone.lua
@@ -32,8 +32,13 @@ zone_object.onEventFinish = function(player, csid, option)
     if (csid == 100) then
         local prevzone = player:getPreviousZone()
         if (prevzone == xi.zone.PORT_JEUNO) then
-            player:setPos(0, 0, 0, 0, 236)
+            player:setPos(-75, 2.39, -34.83, 0, 236)
         elseif (prevzone == xi.zone.PORT_BASTOK) then
+            player:setPos(-47.69, 12, -109.88, 0, 246)
+        else
+            --fix for black screen if prevzone is not getting set correctly
+            --or the player logged out during the airship, and the pos_prevzone was set TO the airship
+            --set to Port Jeuno position 0,0,0
             player:setPos(0, 0, 0, 0, 246)
         end
     end

--- a/scripts/zones/Kazham-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/Kazham-Jeuno_Airship/Zone.lua
@@ -32,9 +32,14 @@ zone_object.onEventFinish = function(player, csid, option)
     if (csid == 10) then
         local prevzone = player:getPreviousZone()
         if (prevzone == xi.zone.KAZHAM) then
-            player:setPos(0, 0, 0, 0, 246)
+            player:setPos(-26.30, 12, 109.13, 0, 246)
         elseif (prevzone == xi.zone.PORT_JEUNO) then
             player:setPos(0, 0, 0, 0, 250)
+        else
+            --fix for black screen if prevzone is not getting set correctly
+            --or the player logged out during the airship, and the pos_prevzone was set TO the airship
+            --set to Port Jeuno position 0,0,0
+            player:setPos(0, 0, 0, 0, 246)
         end
     end
 end

--- a/scripts/zones/San_dOria-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/San_dOria-Jeuno_Airship/Zone.lua
@@ -32,8 +32,13 @@ zone_object.onEventFinish = function(player, csid, option)
     if (csid == 100) then
         local prevzone = player:getPreviousZone()
         if (prevzone == xi.zone.PORT_JEUNO) then
-            player:setPos(0, 0, 0, 0, 232)
+            player:setPos(-20, -2, 44.26, 0, 232)
         elseif (prevzone == xi.zone.PORT_SAN_DORIA) then
+            player:setPos(-90.63, 12, 107.17, 0, 246)
+        else
+            --fix for black screen if prevzone is not getting set correctly
+            --or the player logged out during the airship, and the pos_prevzone was set TO the airship
+            --set to Port Jeuno position 0,0,0
             player:setPos(0, 0, 0, 0, 246)
         end
     end

--- a/scripts/zones/Windurst-Jeuno_Airship/Zone.lua
+++ b/scripts/zones/Windurst-Jeuno_Airship/Zone.lua
@@ -32,8 +32,13 @@ zone_object.onEventFinish = function(player, csid, option)
     if csid == 100 then
         local prevzone = player:getPreviousZone()
         if prevzone == xi.zone.PORT_JEUNO then
-            player:setPos(0, 0, 0, 0, 240)
+            player:setPos(213.72, -6.1312, 90.11, 0, 240)
         elseif prevzone == xi.zone.PORT_WINDURST then
+            player:setPos(16.24, 12, -108.07, 0, 246)
+        else
+            --fix for black screen if prevzone is not getting set correctly
+            --or the player logged out during the airship, and the pos_prevzone was set TO the airship
+            --set to Port Jeuno position 0,0,0
             player:setPos(0, 0, 0, 0, 246)
         end
     end

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6248,9 +6248,18 @@ namespace charutils
                                 "boundary = %u "
                                 "WHERE charid = %u;";
 
-            sql->Query(Query, PChar->loc.destination,
-                       (PChar->m_moghouseID || PChar->loc.destination == PChar->getZone()) ? PChar->getZone() : PChar->loc.prevzone, PChar->loc.p.rotation,
-                       PChar->loc.p.x, PChar->loc.p.y, PChar->loc.p.z, PChar->m_moghouseID, PChar->loc.boundary, PChar->id);
+            // Fix so that pos_prevzone is correctly saved into the database
+
+            sql->Query(Query,
+                       PChar->loc.destination,
+                       (PChar->m_moghouseID || PChar->loc.destination != PChar->getZone()) ? PChar->getZone() : PChar->loc.prevzone,
+                       PChar->loc.p.rotation,
+                       PChar->loc.p.x,
+                       PChar->loc.p.y,
+                       PChar->loc.p.z,
+                       PChar->m_moghouseID,
+                       PChar->loc.boundary,
+                       PChar->id);
         }
         else
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
1. Fix to blacksreen on logout/login on airship - will now boot you out in Port Jeuno if pos_prevzone is set to the airship zone you are on.
2. Fixed correct positions to boot out of.
3. Edge case bandaid for when pos_prevzone is unknown for some reason to boot you out to Port Jeuno instead of hanging on blackscreen
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1. Ride all of the airships to and from Jeuno.
