### PR TITLE
Adds content tag restrictions to synth recipes

### DIFF
--- a/modules/era/sql/mob_groups_era.sql
+++ b/modules/era/sql/mob_groups_era.sql
@@ -380,7 +380,7 @@ UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Raker_Bee' AND groupi
 -- ------------------------------------------------------------
 
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Bashe' AND groupid='68' AND zoneid='120';
-UPDATE mob_groups SET content_tag='WOTG' WHERE name='Thunderclaw_Thuban' AND groupid='333' AND zoneid='120';
+UPDATE mob_groups SET content_tag='WOTG' WHERE name='Thunderclaw_Thuban' AND groupid='33' AND zoneid='120';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Blighting_Brand' AND groupid='38' AND zoneid='120';
 UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='46' AND zoneid='120';
 UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Verthandi' AND groupid='47' AND zoneid='120';

--- a/modules/era/sql/synth_recipes_era.sql
+++ b/modules/era/sql/synth_recipes_era.sql
@@ -1,0 +1,36 @@
+-- ---------------------------------------------------------------------------
+--  Notes: Adds content tags to prevent synths depending on if content is enabled or not
+-- Format: (`ID`,`Desynth`,`KeyItem`,`Wood`,`Smith`,`Gold`,`Cloth`,`Leather`,`Bone`,`Alchemy`,
+-- `Cook`,`Crystal`,`HQCrystal`,`Ingredient1`,`Ingredient2`,`Ingredient3`,`Ingredient4`,`Ingredient5`,
+-- `Ingredient6`,`Ingredient7`,`Ingredient8`,`Result`,`ResultHQ1`,`ResultHQ2`,`ResultHQ3`,`ResultQty`,
+-- `ResultHQ1Qty`,`ResultHQ2Qty`,`ResultHQ3Qty`,`ResultName`,`ContentTag`)
+------------------------------------------------------------------------------
+
+-- ------------------------------------------------------------
+-- Add content_tag to recipes
+-- ------------------------------------------------------------
+
+LOCK TABLE `synth_recipes` WRITE;
+
+ALTER TABLE `synth_recipes`
+    ADD COLUMN IF NOT EXISTS `ContentTag` varchar(14) DEFAULT NULL AFTER `ResultName`;
+
+-- ------------------------------------------------------------
+-- ToAU Synths
+-- ------------------------------------------------------------
+
+-- ------------------------------------------------------------
+-- WotG Synths
+-- ------------------------------------------------------------
+
+UPDATE synth_recipes SET ContentTag='WOTG' WHERE ResultName='Thalassocrat';
+
+-- ------------------------------------------------------------
+-- Abyssea Synths
+-- ------------------------------------------------------------
+
+-- ------------------------------------------------------------
+-- SoA Synths
+-- ------------------------------------------------------------
+
+UNLOCK TABLES;

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -26,6 +26,8 @@
 #include <cmath>
 #include <cstring>
 
+#include "../lua/luautils.h"
+
 #include "../packets/char_skills.h"
 #include "../packets/char_update.h"
 #include "../packets/inventory_assign.h"
@@ -66,8 +68,8 @@ namespace synthutils
     {
         const char* fmtQuery =
 
-            "SELECT ID, KeyItem, Wood, Smith, Gold, Cloth, Leather, Bone, Alchemy, Cook, \
-            Result, ResultHQ1, ResultHQ2, ResultHQ3, ResultQty, ResultHQ1Qty, ResultHQ2Qty, ResultHQ3Qty, Desynth \
+            "SELECT ID, KeyItem, Wood, Smith, Gold, Cloth, Leather, Bone, Alchemy, Cook, Result, ResultHQ1, \
+            ResultHQ2, ResultHQ3, ResultQty, ResultHQ1Qty, ResultHQ2Qty, ResultHQ3Qty, Desynth, ContentTag \
         FROM synth_recipes \
         WHERE (Crystal = %u OR HQCrystal = %u) \
             AND Ingredient1 = %u \
@@ -101,6 +103,14 @@ namespace synthutils
 
                 uint16 skillValue   = 0;
                 uint16 currentSkill = 0;
+
+                const char* contentTag = (const char*)sql->GetData(19);
+
+                if (!luautils::IsContentEnabled(contentTag))
+                {
+                    PChar->pushPacket(new CSynthMessagePacket(PChar, SYNTH_BADRECIPE));
+                    return false;
+                }
 
                 for (uint8 skillID = SKILL_WOODWORKING; skillID <= SKILL_COOKING; ++skillID) // range for all 8 synth skills
                 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds the ability to restrict synths based on content tags.

Slipping in a bug fix here to prevent a NM from spawning if WOTG isn't enabled.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
