### PR TITLE
Bst gear sync fixes

### DIFF
--- a/scripts/globals/abilities/call_beast.lua
+++ b/scripts/globals/abilities/call_beast.lua
@@ -18,6 +18,38 @@ ability_object.onAbilityCheck = function(player, target, ability)
     elseif not player:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA, 0
     else
+        local playerLevel = player:getMainLvl();
+        local petId = player:getWeaponSubSkillType(xi.slot.AMMO)
+        local petLevels = {}
+        petLevels[21] = 23 -- SHEEP FAMILIAR
+        petLevels[22] = 23 -- HARE FAMILIAR
+        petLevels[23] = 23 -- CRAB FAMILIAR
+        petLevels[24] = 23 -- COURIER CARRIE
+        petLevels[25] = 23 -- HOMUNCULUS
+        petLevels[26] = 28 -- FLYTRAP FAMILIAR
+        petLevels[27] = 28 -- TIGER FAMILIAR
+        petLevels[28] = 28 -- FLOWERPOT BILL
+        petLevels[29] = 33 -- EFT FAMILIAR
+        petLevels[30] = 33 -- LIZARD FAMILIAR
+        petLevels[31] = 33 -- MAYFLY FAMILIAR
+        petLevels[32] = 33 -- FUNGUAR FAMILIAR
+        petLevels[33] = 38 -- BEETLE FAMILIAR
+        petLevels[34] = 38 -- ANTLION FAMILIAR
+        petLevels[35] = 43 -- MITE FAMILIAR
+        petLevels[36] = 43 -- LULLABY MELODIA
+        petLevels[37] = 43 -- KEENEARED STEFFI,
+        petLevels[38] = 51 -- FLOWERPOT BEN
+        petLevels[39] = 51 -- SABER SIRAVARDE
+        petLevels[40] = 53 -- COLDBLOOD COMO
+        petLevels[41] = 53 -- SHELLBUSTER OROB
+        petLevels[42] = 53 -- VORACIOUS AUDREY
+        petLevels[43] = 58 -- AMBUSHER ALLIE
+        petLevels[44] = 63 -- LIFEDRINKER LARS
+        petLevels[45] = 63 -- PANZER GALAHAD,
+        petLevels[46] = 63 -- CHOPSUEY CHUCKY
+        petLevels[47] = 75 -- AMIGO SABOTENDER
+
+        if playerLevel < petLevels[petId] then return xi.msg.basic.NO_JUG_PET_ITEM, 0 end
         return 0, 0
     end
 end

--- a/scripts/globals/abilities/reward.lua
+++ b/scripts/globals/abilities/reward.lua
@@ -21,6 +21,18 @@ ability_object.onAbilityCheck = function(player, target, ability)
     else
         local id = player:getEquipID(xi.slot.AMMO)
         if (id >= 17016 and id <= 17023) then
+            local playerLevel = player:getMainLvl();
+            local itemLevels = {}
+            itemLevels[17016] = 12 -- Alpha
+            itemLevels[17017] = 24 -- Beta
+            itemLevels[17018] = 36 -- Gamma
+            itemLevels[17019] = 48 -- Delta
+            itemLevels[17020] = 60 -- Epsilon
+            itemLevels[17021] = 72 -- Zeta
+            itemLevels[17022] = 84 -- Eta
+            itemLevels[17023] = 96 -- Theta
+
+            if playerLevel < itemLevels[id] then return xi.msg.basic.MUST_HAVE_FOOD, 0 end
             return 0, 0
         else
             return xi.msg.basic.MUST_HAVE_FOOD, 0

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1918,8 +1918,8 @@ namespace petutils
             CCharEntity* PChar = (CCharEntity*)PMaster;
             highestLvl += PChar->PMeritPoints->GetMeritValue(MERIT_BEAST_AFFINITY, PChar);
 
-            // And cap it to the master's level or weapon ilvl, whichever is greater
-            auto capLevel = std::max(PMaster->GetMLevel(), PMaster->m_Weapons[SLOT_MAIN]->getILvl());
+            // And cap it to the master's level
+            auto capLevel = PMaster->GetMLevel();
             if (highestLvl > capLevel)
             {
                 highestLvl = capLevel;

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1918,8 +1918,17 @@ namespace petutils
             CCharEntity* PChar = (CCharEntity*)PMaster;
             highestLvl += PChar->PMeritPoints->GetMeritValue(MERIT_BEAST_AFFINITY, PChar);
 
-            // And cap it to the master's level
-            auto capLevel = PMaster->GetMLevel();
+            // And cap it to the master's level or their item's level if the player is level 99
+            auto capLevel = 0;
+            if ((lua["xi"]["settings"]["main"]["MAX_LEVEL"].get<uint8>() >= 99) && (PMaster->GetMLevel() >= 99))
+            {
+                capLevel = std::max(PMaster->GetMLevel(), PMaster->m_Weapons[SLOT_MAIN]->getILvl());
+            }
+            else
+            {
+                capLevel = PMaster->GetMLevel();
+            }
+
             if (highestLvl > capLevel)
             {
                 highestLvl = capLevel;

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1920,7 +1920,7 @@ namespace petutils
 
             // And cap it to the master's level or their item's level if the player is level 99
             auto capLevel = 0;
-            if ((lua["xi"]["settings"]["main"]["MAX_LEVEL"].get<uint8>() >= 99) && (PMaster->GetMLevel() >= 99))
+            if ((lua["xi"]["settings"]["main"]["MAX_LEVEL"].get<uint16>() >= 99) && (PMaster->GetMLevel() >= 99))
             {
                 capLevel = std::max(PMaster->GetMLevel(), PMaster->m_Weapons[SLOT_MAIN]->getILvl());
             }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

* Prevents high level Pet Food and Jugs from being used while synced below their level.
* Fixes a bug in the Jug level logic that caused low level BSTs to summon high level Jugs when sync'd

## Steps to test these changes

* Sync down and try to use high level pet food and jugs
* Sync down and use a low level jug with a high level weapon equipped, use !getstats on the pet to confirm it is low level
