### PR TITLE
Fix Dynamic Entity Pet Nullptr Issues | Fix Dynamis Engaged Script Multiple Execution

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1353,8 +1353,15 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
 
         PMob->PAI->Tick(tick);
 
-        if (PMob->status == STATUS_TYPE::DISAPPEAR && PMob->m_bReleaseTargIDOnDeath)
+        auto PEntity = static_cast<CBattleEntity*>(PMob); // Battle Entity Cast for Pet Checks
+
+        if (PMob->status == STATUS_TYPE::DISAPPEAR && PMob->m_bReleaseTargIDOnDeath) // Only Affects Dynamic Mobs
         {
+            if (PEntity->PPet != nullptr) // If I have a pet when I despawn, I need to replace my entity on the pet with the pet's entity. (This pseudo-detaches the pet)
+            {
+                PEntity->PPet->PMaster = PEntity->PPet;
+            }
+
             for (auto PMobIt : m_mobList)
             {
                 CMobEntity* PCurrentMob = (CMobEntity*)PMobIt.second;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where the deletion of a dynamic entity was causing a nullptr lookup throughout the pet state. We are now setting the PMaster to the PPet entity as it pseudo-detaches the pet from the master and will suffice long enough for it to not crash the server.
+ Fixes an issue where multiple engaged scripts triggered each time the mob was engaged rather than only the first time.

## Steps to test these changes
+ Tested this fix on SMN (which just despawns), DRG (which stays up and operates normally), and BST (which stays up and operates normally). 
+ Ensured mobs could only run their spawner script once.
