### PR TITLE
Fix MB Damage Mult w/ EEM | Fix AOE MBs

### DIFF
--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -674,7 +674,7 @@ xi.spells.damage.calculateIfMagicBurst = function(caster, target, spell, spellEl
     local magicBurst         = 1 -- The variable we want to calculate
     local _, skillchainCount = FormMagicBurst(spellElement, target) -- External function. Not present in magic.lua.
 
-    if skillchainCount > 0 then
+    if skillchainCount > 0 and target:hasStatusEffect(xi.effect.SKILLCHAIN) then
         magicBurst = 1.25 + (0.1 * skillchainCount) -- Here we add SDT DAMAGE bonus for magic bursts aswell, once SDT is implemented. https://www.bg-wiki.com/ffxi/Resist#SDT_and_Magic_Bursting
     end
 
@@ -682,7 +682,8 @@ xi.spells.damage.calculateIfMagicBurst = function(caster, target, spell, spellEl
 end
 
 xi.spells.damage.calculateIfMagicBurstBonus = function(caster, target, spell, spellId, spellElement) -- Calculates the bonus damage applied to the spell.
-    local magicBurstBonus        = 1.0 -- The variable we want to calculate
+    local magicBurstBonus        = 1.0
+    local resTierBonus           = 0.0
     local modBurst               = 1.0
     local ancientMagicBurstBonus = 0
     local _, skillchainCount     = FormMagicBurst(spellElement, target) -- External function. Not present in magic.lua.
@@ -720,7 +721,6 @@ xi.spells.damage.calculateIfMagicBurstBonus = function(caster, target, spell, sp
     -- Magic Burst Damage II is found in other gear and BLM job traits pertain to this one OR to a third, separate one. neither has known cap
 
     if skillchainCount > 0 then
-        magicBurstBonus = modBurst -- + modBurstTrait once investigated. Probably needs to be divided by 100
         if target:getObjType() == xi.objType.MOB then
             local resTier = target:getLocalVar("[MagicBurst]Resist_Tier")
             local resTierBonusLookup =
@@ -735,9 +735,11 @@ xi.spells.damage.calculateIfMagicBurstBonus = function(caster, target, spell, sp
                 [0.50] = 0.05,
             }
             if resTierBonusLookup[resTier] ~= nil then
-                magicBurstBonus = magicBurstBonus + (magicBurstBonus * resTierBonusLookup[resTier])
+                resTierBonus = resTierBonusLookup[resTier]
             end
         end
+
+        magicBurstBonus = resTierBonus + modBurst
     end
 
     return magicBurstBonus
@@ -1017,8 +1019,12 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     finalDamage = math.floor(finalDamage * magianAffinity)
     finalDamage = math.floor(finalDamage * sdt)
     finalDamage = math.floor(finalDamage * resist)
-    finalDamage = math.floor(finalDamage * magicBurst)
-    finalDamage = math.floor(finalDamage * magicBurstBonus)
+
+    if target:hasStatusEffect(xi.effect.SKILLCHAIN) then -- Gated since this is recalculated for each target.
+        finalDamage = math.floor(finalDamage * magicBurst)
+        finalDamage = math.floor(finalDamage * magicBurstBonus)
+    end
+
     finalDamage = math.floor(finalDamage * dayAndWeather)
     finalDamage = math.floor(finalDamage * magicBonusDiff)
     finalDamage = math.floor(finalDamage * targetMagicDamageAdjustment)
@@ -1066,7 +1072,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
         end
 
         -- Add "Magic Burst!" message
-        if magicBurst > 1 then
+        if target:hasStatusEffect(xi.effect.SKILLCHAIN) then -- Gated as this is run per target.
             spell:setMsg(spell:getMagicBurstMessage())
             caster:triggerRoeEvent(xi.roe.triggers.magicBurst)
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where when EEM was factored into MB calculations damage would be roughly 2x even on nearly full resists.
+ Removes additional addition of a potentially higher value and instead simply adds the resist tier addition rather than multiplicatively using it. 
+ Fixes magic burst bonuses being applied to all targets if the target had triggered a burst bonus.

TODO: Messaging is still weird, but would require a cache propagation multiple times per AOE spell or further dissection of the message code for magic bursts and how they should be handled.

## Steps to test these changes
+ Tested with dynamis statues and their children, confirmed even though the magic burst message is there, that the damage is not.
+ Confirmed much lower numbers with EEM included in the MB
