### PR TITLE
Remove Gysahl Greens deletion from lua as it  is handled in packet

### DIFF
--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -887,7 +887,6 @@ local function canDig(player)
                 player:setCharVar('[DIG]LastDigX', currX)
                 player:setCharVar('[DIG]LastDigY', currY)
                 player:setCharVar('[DIG]LastDigZ', currZ)
-                player:delItem(4545, 1)
 
                 return true
             end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Removes the Gysahl Greens delete from the lua as the item removal is already handled in the [packet system](https://github.com/AirSkyBoat/AirSkyBoat/blob/01c392e0c83ff7581b6d89e2bd6554b53dd0b3d1/src/map/packet_system.cpp#L1052).

## Steps to test these changes

Dig, you should only lose 1 green now. 