### PR TITLE
Added function and ability for static mob lookups

### DIFF
--- a/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
@@ -18,8 +18,8 @@ local entity = {}
 -- Note: Diabolos Prime fight drops all tiles at once.
 
 entity.onMobSpawn = function(mob)
-    local dBase = ID.mob.DIABOLOS_OFFSET
-    local dPrimeBase = dBase + 27
+    local dBase = GetStaticMobID('diabolos_cop')
+    local dPrimeBase = GetStaticMobID('diabolos_prime')
 
     -- Only add these for the CoP Diabolos NOT Prime
     if mob:getID() >= dBase and mob:getID() <= dBase + 14 then  -- three possible instances of Diabolos

--- a/sql/static_mobs.sql
+++ b/sql/static_mobs.sql
@@ -1,0 +1,22 @@
+-- ---------------------------------------------------------------------------
+-- Create table of static lookup entities
+-- Any LUA file that requires a direct reference to a mob ID
+--  can create an entry in this table.  Rather than scour through each LUA file
+--  you can create a static table here and update IDs all in one location instead
+-- ---------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `static_mobs`;
+
+CREATE TABLE `static_mobs` (
+    `static_name`       varchar(24)     NOT NULL,
+    `mobid`             int(10)         NOT NULL,
+    PRIMARY KEY (`static_name`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+LOCK TABLES `static_mobs` WRITE;
+
+INSERT INTO `static_mobs` VALUES 
+    ('diabolos_cop',                16818177),
+    ('diabolos_prime',              16818204);
+
+UNLOCK TABLES;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -182,6 +182,7 @@ namespace luautils
         lua.set_function("GetCachedInstanceScript", &luautils::GetCachedInstanceScript);
         lua.set_function("GetItemIDByName", &luautils::GetItemIDByName);
         lua.set_function("SendLuaFuncStringToZone", &luautils::SendLuaFuncStringToZone);
+        lua.set_function("GetStaticMobID", &luautils::GetStaticMobID);
 
         // This binding specifically exists to forcefully crash the server.
         // clang-format off
@@ -4936,6 +4937,23 @@ namespace luautils
         {
             // 0xFFFF is gil, so we will always return a value less than that as a warning
             id = 0xFFFF - sql->NumRows() + 1;
+        }
+
+        return id;
+    }
+
+    uint32 GetStaticMobID(std::string const& name)
+    {
+        uint32      id    = 0;
+        const char* Query = "SELECT mobid FROM static_mobs WHERE static_name = '%s';";
+        int32       ret   = sql->Query(Query, name);
+
+        if (ret != SQL_ERROR && sql->NumRows() == 1) // Found a single result
+        {
+            while (sql->NextRow() == SQL_SUCCESS)
+            {
+                id = sql->GetIntData(0);
+            }
         }
 
         return id;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -332,8 +332,9 @@ namespace luautils
     bool HasCustomMenuContext(CCharEntity* PChar);
     void HandleCustomMenu(CCharEntity* PChar, std::string selection);
 
-    // Retrive the first itemId that matches a name
-    uint16 GetItemIDByName(std::string const& name);
+    uint16 GetItemIDByName(std::string const& name);  // Retrieve the first itemId that matches a name
+    uint32 GetStaticMobID(std::string const& name);  // Get a mob ID from the static table
+
 }; // namespace luautils
 
 #endif // _LUAUTILS_H -


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds functionality for a static table lookup of mob IDs that certain scripts rely on.  Rather than hardcoding various lua scripts with a mob's ID, contributors can put all lookups in a single table and search by name.

Added function in luautils.cpp/.h called GetStaticMobID that takes the name of a static entry (as seen in the new sql file) and returns the associated 

## Steps to test these changes

1. Add rows to the newly added sql/static_mobs.sql file
2. Where lua files use a hard-coded ID, replace with GetStaticMobID('associative name').
3. Update the database using dbtool.py

Changed IDs on Diabolos (zones/The_Shrouded_Maw/mobs/diabolos.lua) as an example.
