### PR TITLE
Fixed calculation issue in Avatar Pet Physical BP

### DIFF
--- a/scripts/globals/abilities/pets/camisado.lua
+++ b/scripts/globals/abilities/pets/camisado.lua
@@ -13,12 +13,14 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local damage = pet:getMainLvl() + 2
+    local numhits = 1
+    local accmod = 1
+    local dmgmod = 3
 
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, 2, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
-    damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.DARK)
-    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
-    target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 1, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, xi.mobskills.magicalTpBonus.NO_EFFECT)
+
+    target:takeDamage(damage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, damage)
 
     return damage

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -193,6 +193,7 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
             end
 
             finaldmg = avatarHitDmg(weaponDmg, fSTR, pDif, avatar, target) * dmgmod
+
             numHitsProcessed = 1
         end
 
@@ -211,8 +212,8 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
         end
     end
 
-        finaldmg = finaldmg * (target:getMod(xi.mod.PET_DMG_TAKEN_PHYSICAL) / 100)
     if target:getMod(xi.mod.PET_DMG_TAKEN_PHYSICAL) ~= 0 then
+        finaldmg = finaldmg * (target:getMod(xi.mod.PET_DMG_TAKEN_PHYSICAL) / 100)
     end
 
     finaldmg = xi.damage.applyDamageTaken(target, finaldmg, xi.attackType.PHYSICAL)


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixed error in Pet Avatar Physical BP damage calculation to prevent from being set to zero.

## Steps to test these changes

Call summon and use any physical BP.
