### PR TITLE
Adds functionality to miasmas on the path up Parradamo Tor

### DIFF
--- a/scripts/zones/Attohwa_Chasm/IDs.lua
+++ b/scripts/zones/Attohwa_Chasm/IDs.lua
@@ -51,6 +51,13 @@ zones[xi.zone.ATTOHWA_CHASM] =
         MIASMA_OFFSET   = 16806304, -- _071 in npc_list
         GASPONIA_OFFSET = 16806327, -- _07n in npc_list
         ALASTOR_QM      = 16806296, -- qm_feeler_antlion in npc_list
+        PARRA_MIASMA    =
+        {
+            16806320,
+            16806321,
+            16806322,
+            16806323,
+        },
         EXCAVATION =
         {
             16806369,

--- a/scripts/zones/Attohwa_Chasm/Zone.lua
+++ b/scripts/zones/Attohwa_Chasm/Zone.lua
@@ -40,6 +40,12 @@ zone_object.onInitialize = function(zone)
     zone:registerRegion(29, -238, 5, -118, 0, 0, 0)
     zone:registerRegion(30, -385.349, 5, -173.973, 0, 0, 0)
 
+    -- Parradamo Tor miasma walls
+    GetNPCByID(ID.npc.PARRA_MIASMA[1]):addPeriodicTrigger(0, 3, 0)
+    GetNPCByID(ID.npc.PARRA_MIASMA[2]):addPeriodicTrigger(0, 3, 0)
+    GetNPCByID(ID.npc.PARRA_MIASMA[3]):addPeriodicTrigger(0, 3, 0)
+    GetNPCByID(ID.npc.PARRA_MIASMA[4]):addPeriodicTrigger(0, 3, 0)
+
     UpdateNMSpawnPoint(ID.mob.TIAMAT)
     GetMobByID(ID.mob.TIAMAT):setRespawnTime(math.random(86400, 259200))
 

--- a/scripts/zones/Attohwa_Chasm/npcs/_07h.lua
+++ b/scripts/zones/Attohwa_Chasm/npcs/_07h.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Area: Attohwa Chasm
+--  NPC: Miasma
+-----------------------------------
+require("scripts/globals/status")
+-----------------------------------
+local entity = {}
+
+entity.onTimeTrigger = function(npc, triggerID)
+    local timer = npc:getLocalVar("timer")
+
+    if npc:getAnimation() == 8 and os.time() >= timer then
+        npc:setAnimation(9)
+        npc:setLocalVar("timer", os.time() + math.random(30,40))
+    elseif npc:getAnimation() == 9 and os.time() >= timer then
+        npc:setAnimation(8)
+        npc:setLocalVar("timer", os.time() + math.random(14,16))
+    end
+end
+
+return entity

--- a/scripts/zones/Attohwa_Chasm/npcs/_07i.lua
+++ b/scripts/zones/Attohwa_Chasm/npcs/_07i.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Area: Attohwa Chasm
+--  NPC: Miasma
+-----------------------------------
+require("scripts/globals/status")
+-----------------------------------
+local entity = {}
+
+entity.onTimeTrigger = function(npc, triggerID)
+    local timer = npc:getLocalVar("timer")
+
+    if npc:getAnimation() == 8 and os.time() >= timer then
+        npc:setAnimation(9)
+        npc:setLocalVar("timer", os.time() + math.random(30,40))
+    elseif npc:getAnimation() == 9 and os.time() >= timer then
+        npc:setAnimation(8)
+        npc:setLocalVar("timer", os.time() + math.random(14,16))
+    end
+end
+
+return entity

--- a/scripts/zones/Attohwa_Chasm/npcs/_07j.lua
+++ b/scripts/zones/Attohwa_Chasm/npcs/_07j.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Area: Attohwa Chasm
+--  NPC: Miasma
+-----------------------------------
+require("scripts/globals/status")
+-----------------------------------
+local entity = {}
+
+entity.onTimeTrigger = function(npc, triggerID)
+    local timer = npc:getLocalVar("timer")
+
+    if npc:getAnimation() == 8 and os.time() >= timer then
+        npc:setAnimation(9)
+        npc:setLocalVar("timer", os.time() + math.random(30,40))
+    elseif npc:getAnimation() == 9 and os.time() >= timer then
+        npc:setAnimation(8)
+        npc:setLocalVar("timer", os.time() + math.random(14,16))
+    end
+end
+
+return entity

--- a/scripts/zones/Attohwa_Chasm/npcs/_07k.lua
+++ b/scripts/zones/Attohwa_Chasm/npcs/_07k.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Area: Attohwa Chasm
+--  NPC: Miasma
+-----------------------------------
+require("scripts/globals/status")
+-----------------------------------
+local entity = {}
+
+entity.onTimeTrigger = function(npc, triggerID)
+    local timer = npc:getLocalVar("timer")
+
+    if npc:getAnimation() == 8 and os.time() >= timer then
+        npc:setAnimation(9)
+        npc:setLocalVar("timer", os.time() + math.random(30,40))
+    elseif npc:getAnimation() == 9 and os.time() >= timer then
+        npc:setAnimation(8)
+        npc:setLocalVar("timer", os.time() + math.random(14,16))
+    end
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

- Adds functionality to the miasmas on the path up Parradamo Tor in Attohwa Chasm.
- Time intervals for the miasmas was collected myself by standing at the miasmas on retail and using a stopwatch.
😈 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
