### PR TITLE
Implement Empty Ecosystem Mixin

### DIFF
--- a/documentation/model_ids.txt
+++ b/documentation/model_ids.txt
@@ -1103,40 +1103,40 @@ ID Number    Costume Name
 1103    Memory Recepticle (yellow)
 1104    Memory Recepticle (blue)
 1105    Memory Recepticle (red)
-1106    Wanderer (Dark)
-1107    Wanderer (Lightning)
-1108    Wanderer (Fire)
+1106    Wanderer Animation Sub 1: Dark, Sub 2: Water
+1107    Wanderer Animation Sub 1: Lightning, Sub 2: Earth
+1108    Wanderer Animation Sub 1: Light, Sub 2: Fire
 1109    Skeleton
-1110    Wanderer (Wind)
-1111    Wanderer (Light)
-1112    Weeper (Dark)
-1113    Weeper (No Core)
-1114    Weeper (No Core)
-1115    Weeper (No Core)
-1116    Weeper (No Core)
-1117    Seether (No Elem)
+1110    Wanderer Animation Sub 1: Ice, Sub 2: Wind
+1111    Wanderer (No element)
+1112    Weeper Animation Sub 1: Dark, Sub 2: Water
+1113    Weeper Animation Sub 1: Lightning, Sub 2: Earth
+1114    Weeper Animation Sub 1: Light, Sub 2: Fire
+1115    Weeper Animation Sub 1: Ice, Sub 2: Wind
+1116    Weeper (No element)
+1117    Seether Animation Sub 1: Dark, Sub 2: Water
 1118    Skeleton 3
-1119    Seether (No Elem)
-1120    Seether (No Elem)
-1121    Seether (No Elem)
-1122    Seether (No Elem)
-1123    Thinker (No Elem)
-1124    Thinker (No Elem)
+1119    Seether Animation Sub 1: Lightning, Sub 2: Earth
+1120    Seether Animation Sub 1: Light, Sub 2: Fire
+1121    Seether Animation Sub 1: Ice, Sub 2: Wind
+1122    Seether (No element)
+1123    Thinker Animation Sub 1: Dark, Sub 2: Water
+1124    Thinker Animation Sub 1: Lightning, Sub 2: Earth
 1125    Skeleton 4
-1126    Thinker (No Elem)
-1127    Thinker (No Elem)
-1128    Thinker (No Elem)
-1129    Gorger (No Elem)
-1130    Gorger (No Elem)
-1131    Gorger (No Elem)
-1132    Gorger (No Elem)
-1133    Gorger (No Elem)
-1134    Craver (No Elem)
-1135    Craver (No Elem)
+1126    Thinker Animation Sub 1: Light, Sub 2: Fire
+1127    Thinker Animation Sub 1: Ice, Sub 2: Wind
+1128    Thinker (No element)
+1129    Gorger Animation Sub 1: Dark, Sub 2: Water
+1130    Gorger Animation Sub 1: Lightning, Sub 2: Earth
+1131    Gorger Animation Sub 1: Light, Sub 2: Fire
+1132    Gorger Animation Sub 1: Ice, Sub 2: Wind
+1133    Gorger (No element)
+1134    Craver Animation Sub 1: Dark, Sub 2: Water
+1135    Craver Animation Sub 1: Lightning, Sub 2: Earth
 1136    Skeleton 5
-1137    Craver (No Elem)
-1138    Craver (No Elem)
-1139    Craver (No Elem)
+1137    Craver Animation Sub 1: Light, Sub 2: Fire
+1138    Craver Animation Sub 1: Ice, Sub 2: Wind
+1139    Craver (No element)
 1140    Baby Gorger
 1141    Baby Gorger
 1142    Thinker (No Elem)

--- a/scripts/mixins/families/empty.lua
+++ b/scripts/mixins/families/empty.lua
@@ -1,0 +1,178 @@
+-----------------------------------
+-- Empty mob ecosystem mixin
+-----------------------------------
+require("scripts/globals/mixins")
+require("scripts/globals/status")
+-----------------------------------
+
+g_mixins = g_mixins or {}
+
+local setModel = function(mob, skin)
+    -- Two elements per model
+    local model = 0
+    if skin < 3 then
+        model = 1
+    elseif skin > 2 and skin < 5 then
+        model = 2
+    elseif skin > 4 and skin < 7 then
+        model = 3
+    elseif skin > 6 then
+        model = 4
+    end
+
+    -- Set model depending on mob family
+    if mob:getFamily() == 255 or mob:getFamily() == 499 then -- Wanderer/Stray
+        if model == 4 then
+            model = model + 1
+        end
+        mob:setModelId(1105 + model)
+    elseif mob:getFamily() == 256 then -- Weeper
+        mob:setModelId(1111 + model)
+    elseif mob:getFamily() == 220 then -- Seether
+        if model > 1 then
+            model = model + 1
+        end
+        mob:setModelId(1116 + model)
+    elseif mob:getFamily() == 241 then -- Thinker
+        if model > 2 then
+            model = model + 1
+        end
+        mob:setModelId(1122 + model)
+    elseif mob:getFamily() == 137 or mob:getFamily() == 138 then -- Gorger
+        mob:setModelId(1128 + model)
+    elseif mob:getFamily() == 78 then -- Craver
+        if model > 2 then
+            model = model + 1
+        end
+        mob:setModelId(1133 + model)
+    end
+end
+
+g_mixins.families.empty = function(emptyMob)
+    emptyMob:addListener("SPAWN", "EMPTY_SPAWN", function(mob)
+        -- Dark > Water > Lightning > Earth > Light > Fire > Ice > Wind
+        local skin = math.random(1, 8)
+        mob:setLocalVar("skin", skin)
+
+        -- Set elemental resistances
+        -- Currently bugged, mods cannot be set on spawn through a listener
+        -- if skin == 1 then -- Dark
+        --     mob:setMod(xi.mod.DARK_MEVA, 99)
+        --     mob:setMod(xi.mod.SLEEPRES, 90)
+        --     mob:setMod(xi.mod.LIGHT_MEVA, -27)
+        -- elseif skin == 2 then -- Water
+        --     mob:setMod(xi.mod.FIRE_MEVA, 80)
+        --     mob:setMod(xi.mod.WATER_MEVA, 99)
+        --     mob:setMod(xi.mod.POISONRES, 90)
+        --     mob:setMod(xi.mod.THUNDER_MEVA, -27)
+        -- elseif skin == 3 then -- Lightning
+        --     mob:setMod(xi.mod.WATER_MEVA, 80)
+        --     mob:setMod(xi.mod.POISONRES, 90)
+        --     mob:setMod(xi.mod.THUNDER_MEVA, 99)
+        --     mob:setMod(xi.mod.STUNRES, 90)
+        --     mob:setMod(xi.mod.EARTH_MEVA, -27)
+        -- elseif skin == 4 then -- Earth
+        --     mob:setMod(xi.mod.THUNDER_MEVA, 80)
+        --     mob:setMod(xi.mod.STUNRES, 90)
+        --     mob:setMod(xi.mod.EARTH_MEVA, 99)
+        --     mob:setMod(xi.mod.SLOWRES, 90)
+        --     mob:setMod(xi.mod.WIND_MEVA, -27)
+        -- elseif skin == 5 then -- Light
+        --     mob:setMod(xi.mod.LIGHT_MEVA, 99)
+        --     mob:setMod(xi.mod.LULLABYRES, 90)
+        --     mob:setMod(xi.mod.DARK_MEVA, -27)
+        -- elseif skin == 6 then -- Fire
+        --     mob:setMod(xi.mod.ICE_MEVA, 80)
+        --     mob:setMod(xi.mod.PARALYZERES, 90)
+        --     mob:setMod(xi.mod.BINDRES, 90)
+        --     mob:setMod(xi.mod.FIRE_MEVA, 99)
+        --     mob:setMod(xi.mod.WATER_MEVA, -27)
+        -- elseif skin == 7 then -- Ice
+        --     mob:setMod(xi.mod.WIND_MEVA, 80)
+        --     mob:setMod(xi.mod.GRAVITYRES, 90)
+        --     mob:setMod(xi.mod.SILENCERES, 90)
+        --     mob:setMod(xi.mod.ICE_MEVA, 99)
+        --     mob:setMod(xi.mod.PARALYZERES, 90)
+        --     mob:setMod(xi.mod.BINDRES, 90)
+        --     mob:setMod(xi.mod.FIRE_MEVA, -27)
+        -- else -- Wind
+        --     mob:setMod(xi.mod.EARTH_MEVA, 80)
+        --     mob:setMod(xi.mod.SLOWRES, 90)
+        --     mob:setMod(xi.mod.WIND_MEVA, 99)
+        --     mob:setMod(xi.mod.GRAVITYRES, 90)
+        --     mob:setMod(xi.mod.SILENCERES, 90)
+        --     mob:setMod(xi.mod.ICE_MEVA, -27)
+        -- end
+
+        setModel(mob, skin)
+    end)
+
+    emptyMob:addListener("ROAM_TICK", "EMPTY_ROAM_TICK", function(mob)
+        local skin = mob:getLocalVar("skin")
+        if skin % 2 == 0 and mob:getAnimationSub() ~= 2 then
+            mob:setAnimationSub(2)
+        elseif skin % 2 ~= 0 and mob:getAnimationSub() ~= 1 then
+            mob:setAnimationSub(1)
+        end
+
+        -- Temporary solution until mods on spawn issue is corrected
+        local buffed = mob:getLocalVar("buffed")
+        if skin == 1 and buffed == 0 then -- Dark
+            mob:setMod(xi.mod.DARK_MEVA, 99)
+            mob:setMod(xi.mod.SLEEPRES, 90)
+            mob:setMod(xi.mod.LIGHT_MEVA, -27)
+            mob:setLocalVar("buffed", 1)
+        elseif skin == 2 and buffed == 0 then -- Water
+            mob:setMod(xi.mod.FIRE_MEVA, 80)
+            mob:setMod(xi.mod.WATER_MEVA, 99)
+            mob:setMod(xi.mod.POISONRES, 90)
+            mob:setMod(xi.mod.THUNDER_MEVA, -27)
+            mob:setLocalVar("buffed", 1)
+        elseif skin == 3 and buffed == 0 then -- Lightning
+            mob:setMod(xi.mod.WATER_MEVA, 80)
+            mob:setMod(xi.mod.POISONRES, 90)
+            mob:setMod(xi.mod.THUNDER_MEVA, 99)
+            mob:setMod(xi.mod.STUNRES, 90)
+            mob:setMod(xi.mod.EARTH_MEVA, -27)
+            mob:setLocalVar("buffed", 1)
+        elseif skin == 4 and buffed == 0 then -- Earth
+            mob:setMod(xi.mod.THUNDER_MEVA, 80)
+            mob:setMod(xi.mod.STUNRES, 90)
+            mob:setMod(xi.mod.EARTH_MEVA, 99)
+            mob:setMod(xi.mod.SLOWRES, 90)
+            mob:setMod(xi.mod.WIND_MEVA, -27)
+            mob:setLocalVar("buffed", 1)
+        elseif skin == 5 and buffed == 0 then -- Light
+            mob:setMod(xi.mod.LIGHT_MEVA, 99)
+            mob:setMod(xi.mod.LULLABYRES, 90)
+            mob:setMod(xi.mod.DARK_MEVA, -27)
+            mob:setLocalVar("buffed", 1)
+        elseif skin == 6 and buffed == 0 then -- Fire
+            mob:setMod(xi.mod.ICE_MEVA, 80)
+            mob:setMod(xi.mod.PARALYZERES, 90)
+            mob:setMod(xi.mod.BINDRES, 90)
+            mob:setMod(xi.mod.FIRE_MEVA, 99)
+            mob:setMod(xi.mod.WATER_MEVA, -27)
+            mob:setLocalVar("buffed", 1)
+        elseif skin == 7 and buffed == 0 then -- Ice
+            mob:setMod(xi.mod.WIND_MEVA, 80)
+            mob:setMod(xi.mod.GRAVITYRES, 90)
+            mob:setMod(xi.mod.SILENCERES, 90)
+            mob:setMod(xi.mod.ICE_MEVA, 99)
+            mob:setMod(xi.mod.PARALYZERES, 90)
+            mob:setMod(xi.mod.BINDRES, 90)
+            mob:setMod(xi.mod.FIRE_MEVA, -27)
+            mob:setLocalVar("buffed", 1)
+        elseif buffed == 0 then -- Wind
+            mob:setMod(xi.mod.EARTH_MEVA, 80)
+            mob:setMod(xi.mod.SLOWRES, 90)
+            mob:setMod(xi.mod.WIND_MEVA, 99)
+            mob:setMod(xi.mod.GRAVITYRES, 90)
+            mob:setMod(xi.mod.SILENCERES, 90)
+            mob:setMod(xi.mod.ICE_MEVA, -27)
+            mob:setLocalVar("buffed", 1)
+        end
+    end)
+end
+
+return g_mixins.families.empty

--- a/scripts/zones/Promyvion-Dem/mobs/Gorger.lua
+++ b/scripts/zones/Promyvion-Dem/mobs/Gorger.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Dem
 --  Mob: Gorger
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Dem/mobs/Seether.lua
+++ b/scripts/zones/Promyvion-Dem/mobs/Seether.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Dem
 --  Mob: Seether
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Dem/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Dem/mobs/Stray.lua
@@ -3,6 +3,7 @@
 --   NM: Stray
 -----------------------------------
 require("scripts/globals/promyvion")
+mixins = {require("scripts/mixins/families/empty")}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Dem/mobs/Wanderer.lua
+++ b/scripts/zones/Promyvion-Dem/mobs/Wanderer.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Dem
 --  Mob: Wanderer
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Dem/mobs/Weeper.lua
+++ b/scripts/zones/Promyvion-Dem/mobs/Weeper.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Dem
 --  Mob: Weeper
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Holla/mobs/Seether.lua
+++ b/scripts/zones/Promyvion-Holla/mobs/Seether.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Holla
 --  Mob: Seether
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Holla/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Holla/mobs/Stray.lua
@@ -3,6 +3,7 @@
 --   NM: Stray
 -----------------------------------
 require("scripts/globals/promyvion")
+mixins = {require("scripts/mixins/families/empty")}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Holla/mobs/Thinker.lua
+++ b/scripts/zones/Promyvion-Holla/mobs/Thinker.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Holla
 --  Mob: Thinker
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Holla/mobs/Wanderer.lua
+++ b/scripts/zones/Promyvion-Holla/mobs/Wanderer.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Holla
 --  Mob: Wanderer
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Holla/mobs/Weeper.lua
+++ b/scripts/zones/Promyvion-Holla/mobs/Weeper.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Holla
 --  Mob: Weeper
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Mea/mobs/Craver.lua
+++ b/scripts/zones/Promyvion-Mea/mobs/Craver.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Mea
 --  Mob: Craver
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Mea/mobs/Seether.lua
+++ b/scripts/zones/Promyvion-Mea/mobs/Seether.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Mea
 --  Mob: Seether
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Mea/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Mea/mobs/Stray.lua
@@ -3,6 +3,7 @@
 --   NM: Stray
 -----------------------------------
 require("scripts/globals/promyvion")
+mixins = {require("scripts/mixins/families/empty")}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Mea/mobs/Wanderer.lua
+++ b/scripts/zones/Promyvion-Mea/mobs/Wanderer.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Mea
 --  Mob: Wanderer
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Mea/mobs/Weeper.lua
+++ b/scripts/zones/Promyvion-Mea/mobs/Weeper.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Mea
 --  Mob: Weeper
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Vahzl/mobs/Craver.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Craver.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Vahzl
 --  Mob: Craver
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Vahzl/mobs/Gorger.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Gorger.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Vahzl
 --  Mob: Gorger
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Vahzl/mobs/Seether.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Seether.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Vahzl
 --  Mob: Seether
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Vahzl/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Stray.lua
@@ -3,6 +3,7 @@
 --   NM: Stray
 -----------------------------------
 require("scripts/globals/promyvion")
+mixins = {require("scripts/mixins/families/empty")}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Vahzl/mobs/Thinker.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Thinker.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Vahzl
 --  Mob: Thinker
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Vahzl/mobs/Wanderer.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Wanderer.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Vahzl
 --  Mob: Wanderer
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Promyvion-Vahzl/mobs/Weeper.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Weeper.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion-Vahzl
 --  Mob: Weeper
 -----------------------------------
-mixins = {require("scripts/mixins/families/empty_terroanima")}
+mixins =
+{
+    require("scripts/mixins/families/empty_terroanima"),
+    require("scripts/mixins/families/empty")
+}
 -----------------------------------
 local entity = {}
 


### PR DESCRIPTION
…lements

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

- Adds a mixin to all empty ecosystem mobs. All empty mobs will now spawn with a random element and have the associated resistances according to the element.

## Steps to test these changes
