### PR TITLE
Add Enmity on Attack Misses

### DIFF
--- a/scripts/commands/getenmity.lua
+++ b/scripts/commands/getenmity.lua
@@ -24,5 +24,5 @@ function onTrigger(player)
         return
     end
 
-    player:PrintToPlayer(string.format("Your enmity against %s is ... CE = %u ... VE = %u", targ:getName(), targ:getCE(player), targ:getVE(player)))
+    player:PrintToPlayer(string.format("your enmity against %s is ... CE = %u ... VE = %u ... TH = %u", targ:getName(), targ:getCE(player), targ:getVE(player), targ:getTHlevel()))
 end

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -34,6 +34,7 @@
 #include "../ai/states/weaponskill_state.h"
 #include "../attack.h"
 #include "../attackround.h"
+#include "../enmity_container.h"
 #include "../items/item_weapon.h"
 #include "../job_points.h"
 #include "../lua/luautils.h"
@@ -2085,9 +2086,16 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                         charutils::TrySkillUP((CCharEntity*)PTarget, SKILL_PARRY, GetMLevel());
                     }
                 }
+
                 if (!attack.IsCountered() && !attack.IsParried())
                 {
                     charutils::TrySkillUP((CCharEntity*)PTarget, SKILL_EVASION, GetMLevel());
+                }
+
+                if (PTarget->objtype == TYPE_MOB && this->objtype == TYPE_PC)
+                {
+                    // 1 ce for a missed attack for TH application
+                    ((CMobEntity*)PTarget)->PEnmityContainer->UpdateEnmity(this, 1, 0);
                 }
             }
         }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -61,6 +61,7 @@
 #include "../battlefield.h"
 #include "../char_recast_container.h"
 #include "../conquest_system.h"
+#include "../enmity_container.h"
 #include "../item_container.h"
 #include "../items/item_furnishing.h"
 #include "../items/item_usable.h"
@@ -86,6 +87,7 @@
 #include "../weapon_skill.h"
 #include "automatonentity.h"
 #include "charentity.h"
+#include "mobentity.h"
 #include "trustentity.h"
 
 CCharEntity::CCharEntity()
@@ -1763,6 +1765,11 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
         }
 
         StatusEffectContainer->DelStatusEffect(EFFECT_SANGE);
+    }
+    else if (!hitOccured && PTarget->objtype == TYPE_MOB)
+    {
+        // 1 ce for a missed attack for TH application
+        ((CMobEntity*)PTarget)->PEnmityContainer->UpdateEnmity((CBattleEntity*)this, 1, 0);
     }
 
     battleutils::ClaimMob(PTarget, this);


### PR DESCRIPTION
Co-Authored-By: lbegnaud <lbegnaud@radersolutions.com>

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds 1 Enmity on RA/ATT misses to ensure no claimshield and TH shenanigans

## Steps to test these changes

Attack / Miss on a mob and !checkenmity to view TH and other things
