### PR TITLE
Removed Ruinous Omen from Darkness Named battlefield

### DIFF
--- a/scripts/zones/The_Shrouded_Maw/bcnms/darkness_named.lua
+++ b/scripts/zones/The_Shrouded_Maw/bcnms/darkness_named.lua
@@ -19,6 +19,7 @@ battlefield_object.onBattlefieldInitialise = function(battlefield)
     local tile = ID.npc.DARKNESS_NAMED_TILE_OFFSET + (inst - 1) * 8
     for i = tile, tile + 7 do
         GetNPCByID(i):setAnimation(xi.anim.CLOSE_DOOR)
+        GetNPCByID(i):setLocalVar("Dropped", xi.anim.CLOSE_DOOR)
     end
 end
 

--- a/scripts/zones/The_Shrouded_Maw/bcnms/waking_dreams.lua
+++ b/scripts/zones/The_Shrouded_Maw/bcnms/waking_dreams.lua
@@ -20,6 +20,7 @@ battlefield_object.onBattlefieldInitialise = function(battlefield)
     local tile = ID.npc.DARKNESS_NAMED_TILE_OFFSET + (inst - 1) * 8
     for i = tile, tile + 7 do
         GetNPCByID(i):setAnimation(xi.anim.CLOSE_DOOR)
+        GetNPCByID(i):setLocalVar("Dropped", xi.anim.CLOSE_DOOR)
     end
 end
 

--- a/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
@@ -28,6 +28,14 @@ entity.onMobSpawn = function(mob)
         mob:addMod(xi.mod.ATTP, -15)
         mob:addMod(xi.mod.DEFP, -15)
         mob:addMod(xi.mod.MDEF, -40)
+    else
+    -- If this is Diabolos Prime, give him Ruinous Omen
+        xi.mix.jobSpecial.config(mob, {
+            specials =
+            {
+                {id = 1911, hpp = math.random(30,55)}, -- uses Ruinous Omen once while near 50% HPP.
+            },
+        })
     end
 
     -- Tile Drop Trigger:  Max HPP = 76%, Min HPP = 20%, Gap = 56%, Half = 28%
@@ -42,19 +50,12 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar("Area", area)
     mob:setMobMod(xi.mobMod.DRAW_IN, 1)
 
-    -- Add the Ruinous Omen special ability
-    xi.mix.jobSpecial.config(mob, {
-        specials =
-        {
-            {id = 1911, hpp = math.random(30,55)}, -- uses Ruinous Omen once while near 50% HPP.
-        },
-    })
 end
 
 entity.onMobFight = function(mob, target)
     local area = mob:getLocalVar("Area") - 1
     local trigger = mob:getLocalVar("TileTriggerHPP")
-    
+
     local tileDrops =
         {   -- {Animation Area 1, Animation Area 2, Animation Area 3}
             {"byc8", "bya8", "byb8"},
@@ -81,8 +82,8 @@ entity.onMobFight = function(mob, target)
                 SendEntityVisualPacket(tileId, animationSet[area + 1], 4)     -- Animation for floor dropping
                 SendEntityVisualPacket(tileId, "s123", 4)          -- Tile dropping sound
 
-                tile:timer(2750, function(tile)                 -- 2.7s second delay (ish)
-                    tile:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)       -- Floor opens
+                tile:timer(2750, function(t)                 -- 2.7s second delay (ish)
+                    t:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)       -- Floor opens
                 end)
             end
         end


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Removes Ruinous Omen from Diabolos for the Darkness Named fight only.

## Steps to test these changes

