### PR TITLE
Add Mob Mod that allows for mobs who need to spawn from Alcoves

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -2528,6 +2528,7 @@ xi.mobMod =
     DRAW_IN_MAXIMUM_REACH     = 103, -- Players further than this range (yalms) will be unaffected by the draw-in. default (0) is whole zone
     DRAW_IN_IGNORE_STATIONARY = 104, -- Stationary mobs draw-in the moment they cannot attack you anymore (out of range). put this mobmod on stationary mobs that have draw-in but use ranged attacks instead of melee attacks so that they will ignore this behavior (i.e. KSNM99 Wyrm or ToAU Mission Alexander)
     ATTRACT_FAMILY_NM         = 105, -- NMs within the same family will link onto this mob (used on Sabotenders for Cactrot Rapido)
+    LEDGE_AGGRO               = 106, -- Used to increase vertical aggro range
 }
 
 -----------------------------------

--- a/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
@@ -9,6 +9,10 @@ require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.LEDGE_AGGRO, 1)
+end
+
 entity.onMobDeath = function(mob, player, isKiller)
     xi.regime.checkRegime(player, mob, 143, 2, xi.regime.type.FIELDS)
     xi.regime.checkRegime(player, mob, 144, 1, xi.regime.type.FIELDS)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -249,7 +249,7 @@ bool CMobController::CanDetectTarget(CBattleEntity* PTarget, bool forceSight)
 
     float verticalDistance = abs(PMob->loc.p.y - PTarget->loc.p.y);
 
-    if (PMob->m_Family != 6 && verticalDistance > 8.0f)
+    if ((PMob->m_Family != 6 || PMob->getMobMod(LEDGE_AGGRO) != 0) && verticalDistance > 8.0f)
     {
         return false;
     }
@@ -274,6 +274,10 @@ bool CMobController::CanDetectTarget(CBattleEntity* PTarget, bool forceSight)
 
     if (detectSight && !hasInvisible && currentDistance < PMob->getMobMod(MOBMOD_SIGHT_RANGE) && facing(PMob->loc.p, PTarget->loc.p, 64))
     {
+        if (PMob->getMobMod(LEDGE_AGGRO) != 0)
+        {
+            return true;
+        }
         return CanSeePoint(PTarget->loc.p);
     }
 

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -108,6 +108,7 @@ enum MOBMODIFIER : int
     MOBMOD_DRAW_IN_MAXIMUM_REACH     = 103, // players further than this range (yalms) will be unaffected by the draw-in. default (0) is whole zone
     MOBMOD_DRAW_IN_IGNORE_STATIONARY = 104, // stationary mobs draw-in the moment they cannot attack you anymore (out of range). put this mobmod on stationary mobs that have draw-in but use ranged attacks instead of melee attacks so that they will ignore this behavior (i.e. KSNM99 Wyrm or ToAU Mission Alexander)
     MOBMOD_ATTRACT_FAMILY_NM         = 105, // NMs within the same family will link onto this mob (used on Sabotenders for Cactrot Rapido)
+    LEDGE_AGGRO                      = 106, // Used to increase vertical aggro range
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Adds a mobMod that ignores small cliffs in Y so that mobs in alcoves can aggro players

## Steps to test these changes

Run in front of groundskeepers in sky who are in alcoves
