### PR TITLE
Fix SATA Application During Weaponskills

### DIFF
--- a/scripts/globals/weaponskills/cyclone.lua
+++ b/scripts/globals/weaponskills/cyclone.lua
@@ -22,7 +22,7 @@ local weaponskill_object = {}
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
 
     local params = {}
-    params.ftp100 = 1 params.ftp200 = 2.375 params.ftp300 = 2.875
+    params.ftp100 = 1 params.ftp200 = 2.50 params.ftp300 = 3
     params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.25 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.element = xi.magic.ele.WIND
     params.skillType = xi.skill.DAGGER

--- a/scripts/globals/weaponskills/viper_bite.lua
+++ b/scripts/globals/weaponskills/viper_bite.lua
@@ -22,7 +22,7 @@ local weaponskill_object = {}
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
 
     local params = {}
-    params.numHits = 1
+    params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixed the application of SA and TA bonuses for THF main during weaponskills. SA and TA bonuses are now applied as part of the base damage rather than only on one hit.
+ Fixed an issue where WSC was not taking into account additional mod level stats. This in turn was only allowing WSC to act on a player's base stat.
+ Fixed how base damage is calculated.
+ Fixed some damage multipliers with Cyclone.
+ Fixed viper bite to have 2 attacks instead of 1.
+ Fixed an issue where by having 2 weapons equipped you will automatically gain an extra hit on your physical weaponskills.

## Steps to test these changes
+ Tested viper bite with and without SA on leveling shrooms in Zitah with decent gear and a sole sushi. SA will make the damage roughly 2x a single SA auto attack (~260 vs 120) as expected. 

closes #384 
