### PR TITLE
Revert Viper Bite | Fix Double Bonus WS | Fix SATA Again | Fix Mob Meikyo Shisui | Fix Paralysis Item Guard

### DIFF
--- a/scripts/globals/weaponskills/viper_bite.lua
+++ b/scripts/globals/weaponskills/viper_bite.lua
@@ -22,7 +22,7 @@ local weaponskill_object = {}
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
 
     local params = {}
-    params.numHits = 2
+    params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -84,7 +84,12 @@ CMobSkill* CMobSkillState::GetSkill()
 
 void CMobSkillState::SpendCost()
 {
-    if (!m_PSkill->isTpFreeSkill())
+    if (m_PEntity->StatusEffectContainer->HasStatusEffect({ EFFECT_SEKKANOKI, EFFECT_MEIKYO_SHISUI }))
+    {
+        m_spentTP            = 1000;
+        m_PEntity->health.tp = (m_PEntity->health.tp > 1000 ? m_PEntity->health.tp - 1000 : 0);
+    }
+    else if (!m_PSkill->isTpFreeSkill())
     {
         m_spentTP            = m_PEntity->health.tp;
         m_PEntity->health.tp = 0;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -36,6 +36,7 @@
 #include "../packets/event.h"
 #include "../packets/event_string.h"
 #include "../packets/inventory_finish.h"
+#include "../packets/inventory_item.h"
 #include "../packets/key_items.h"
 #include "../packets/lock_on.h"
 #include "../packets/menu_raisetractor.h"
@@ -2038,7 +2039,10 @@ void CCharEntity::OnItemFinish(CItemState& state, action_t& action)
 
     if ((isParalyzed && scrollProtection && isScroll && itemLoss) || (isParalyzed && !itemLoss)) // Become paralyzed and stop executing.
     {
-        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_IS_PARALYZED));
+        this->loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_IS_PARALYZED));
+        PItem->setSubType(ITEM_UNLOCKED);
+        this->pushPacket(new CInventoryItemPacket(PItem, PItem->getLocationID(), PItem->getSlotID()));
+        this->pushPacket(new CInventoryFinishPacket());
         return;
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where wSC was applied with 2x the bonus stat.
+ Fixes Viper Bite to be single hit again.
+ Fixes SATA application to be the first hit and appropriately give stat bonuses.
+ Fixes an issue with mobs which use Meikyo Shisui not being able to tp multiple times in a row. Added Sekkanoki for good measure the same as players.
+ Fixes an issue while item guard or scroll guard is enabled that the item would be stuck in a locked state until a zone.

closes #289
closes #301

## Steps to test these changes
+ Lots and lots of testing to test things and do testy test test things for tests.
