### PR TITLE
Switch roamFlag.EVENT for roamFlag.SCRIPTED | Fix Dynamis Crash | Fix Refill Statues Not Dying

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -1511,7 +1511,7 @@ end
 --------------------------------------------
 
 xi.dynamis.mobOnRoam = function(mob) -- Handle pathing.
-    if mob:getRoamFlags() == xi.roamFlag.EVENT then
+    if mob:getRoamFlags() == xi.roamFlag.SCRIPTED then
         local zoneID = mob:getZoneID()
         local mobIndex = mob:getLocalVar(string.format("MobIndex_%s", mob:getID()))
         for _, index in pairs(xi.dynamis.mobList[zoneID].patrolPaths) do
@@ -1730,7 +1730,7 @@ end
 xi.dynamis.setStatueStats = function(mob, mobIndex)
     local zoneID = mob:getZoneID()
     local eyes = xi.dynamis.mobList[zoneID][mobIndex].eyes
-    mob:setRoamFlags(xi.roamFlag.EVENT)
+    mob:setRoamFlags(xi.roamFlag.SCRIPTED)
     mob:setMobType(xi.mobskills.mobType.BATTLEFIELD)
     mob:addStatusEffect(xi.effect.BATTLEFIELD, 1, 0, 0, true)
     mob:setMobMod(xi.mobMod.CHECK_AS_NM, 2)

--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -502,7 +502,7 @@ xi.dynamis.nonStandardDynamicSpawn = function(mobIndex, oMob, forceLink, zoneID,
         {
             ["onMobSpawn"] = {function(mob) xi.dynamis.setStatueStats(mob, mobIndex) end},
             ["onMobEngaged"] = {function(mob, target) xi.dynamis.parentOnEngaged(mob, target) end},
-            ["onMobFight"] = {function(mob) xi.dynamis.statueOnFight(mob) end},
+            ["onMobFight"] = {function(mob, target) xi.dynamis.statueOnFight(mob, target) end},
             ["onMobRoam"] = {function(mob) xi.dynamis.mobOnRoam(mob) end},
             ["mixins"] = { }
         },
@@ -1886,25 +1886,25 @@ xi.dynamis.statueOnFight = function(mob, target)
                 mob:delStatusEffect(xi.effect.REGEN)
                 mob:setHP(1)
             end
-            mob:setUntargetable(true)
-            mob:SetMagicCastingEnabled(false)
-            mob:SetAutoAttackEnabled(false)
-            mob:SetMobAbilityEnabled(false)
-            mob:addStatusEffect(xi.effect.STUN, 1, 0, 5)
-            mob:timer(1000, function(mob) -- Allows stun to tick
-                if mob:hasStatusEffect(xi.effect.STUN) then
+            if mob:getLocalVar("reset") ~= 1 then
+                mob:setLocalVar("reset", 1)
+                mob:addStatusEffect(xi.effect.STUN, 1, 0, 5)
+                mob:setUntargetable(true)
+                mob:SetMagicCastingEnabled(false)
+                mob:SetAutoAttackEnabled(false)
+                mob:SetMobAbilityEnabled(false)
+
+                mob:timer(1000, function(mob) -- Allows stun to tick
+                    mob:setTP(0)
+                    mob:SetMobAbilityEnabled(true)
                     mob:delStatusEffectSilent(xi.effect.STUN) -- Remove stun so we can do skill.
-                end
-                if mob:getAnimationSub() == 2 then
-                    mob:setTP(0)
-                    mob:SetMobAbilityEnabled(true)
-                    mob:useMobAbility(1124) -- Use Recover HP
-                elseif mob:getAnimationSub() == 3 then
-                    mob:setTP(0)
-                    mob:SetMobAbilityEnabled(true)
-                    mob:useMobAbility(1125) -- Use Recover MP
-                end
-            end)
+                    if mob:getAnimationSub() == 2 then
+                        mob:useMobAbility(1124) -- Use Recover HP
+                    elseif mob:getAnimationSub() == 3 then
+                        mob:useMobAbility(1125) -- Use Recover MP
+                    end
+                end)
+            end
         end
     end
 end

--- a/modules/era/lua_dynamis/mobs/era_beaucedine_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_beaucedine_mobs.lua
@@ -11,7 +11,7 @@ xi.dynamis = xi.dynamis or {}
 xi.dynamis.onSpawnAngra = function(mob)
     xi.dynamis.setMegaBossStats(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 25)
-    mob:setRoamFlags(xi.roamFlag.EVENT)
+    mob:setRoamFlags(xi.roamFlag.SCRIPTED)
     xi.mix.jobSpecial.config(mob, {
         between = 300,
         specials =

--- a/modules/era/lua_dynamis/mobs/era_qufim_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_qufim_mobs.lua
@@ -9,7 +9,7 @@ xi = xi or {}
 xi.dynamis = xi.dynamis or {}
 
 xi.dynamis.onSpawnAntaeus = function(mob)
-    mob:setRoamFlags(xi.roamFlag.EVENT)
+    mob:setRoamFlags(xi.roamFlag.SCRIPTED)
     xi.dynamis.setMegaBossStats(mob)
     -- Set Removable Mods
     xi.dynamis.buffsAntaeus =

--- a/modules/era/lua_dynamis/mobs/era_xarcabard_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_xarcabard_mobs.lua
@@ -54,7 +54,7 @@ end
 
 xi.dynamis.onSpawnDynaLord = function(mob)
     local zone = mob:getZone()
-    mob:setRoamFlags(xi.roamFlag.EVENT)
+    mob:setRoamFlags(xi.roamFlag.SCRIPTED)
     xi.dynamis.setMegaBossStats(mob)
     mob:setMod(xi.mod.SLEEPRES, 100)
     mob:setMod(xi.mod.BINDRES, 100)
@@ -85,7 +85,7 @@ end
 xi.dynamis.onSpawnYing = function(mob)
     local zone = mob:getZone()
     local mainLord = zone:getLocalVar("179")
-    mob:setRoamFlags(xi.roamFlag.EVENT)
+    mob:setRoamFlags(xi.roamFlag.SCRIPTED)
     xi.dynamis.setNMStats(mob)
     if mainLord ~= 0 then
         local dynaLord = GetMobByID(mainLord)
@@ -100,7 +100,7 @@ end
 xi.dynamis.onSpawnYang = function(mob)
     local zone = mob:getZone()
     local mainLord = zone:getLocalVar("179")
-    mob:setRoamFlags(xi.roamFlag.EVENT)
+    mob:setRoamFlags(xi.roamFlag.SCRIPTED)
     xi.dynamis.setNMStats(mob)
     if mainLord ~= 0 then
         local dynaLord = GetMobByID(mainLord)
@@ -370,7 +370,7 @@ xi.dynamis.animatedInfo =
     --     ["Spells"] =
     --     {
     --         [spell1] = {chance, xi.effect.EFFECT},
-    --         [spell2] = {chance, xi.effect.EFFECT}, 
+    --         [spell2] = {chance, xi.effect.EFFECT},
     --     },
     -- },
     -- xi.effect.KO is used for if the spell is not enhancing.
@@ -535,7 +535,7 @@ xi.dynamis.animatedInfo =
 }
 
 xi.dynamis.onSpawnAnimated = function(mob)
-    mob:setRoamFlags(xi.roamFlag.EVENT)
+    mob:setRoamFlags(xi.roamFlag.SCRIPTED)
     xi.dynamis.setAnimatedWeaponStats(mob)
 end
 
@@ -572,7 +572,7 @@ xi.dynamis.onFightAnimated = function(mob, target)
 end
 
 xi.dynamis.onSpawnSatellite = function(mob)
-    mob:setRoamFlags(xi.roamFlag.EVENT)
+    mob:setRoamFlags(xi.roamFlag.SCRIPTED)
     xi.dynamis.setNMStats(mob)
     mob:setAnimationSub(math.random(5,6))
 end

--- a/scripts/globals/mobskills/astral_flow_pet.lua
+++ b/scripts/globals/mobskills/astral_flow_pet.lua
@@ -46,16 +46,17 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
 
     -- Find proper pet skill
     local petFamily = pet:getFamily()
+    local modelId   = pet:getModelId()
     local skillId = 0
 
-    if     petFamily == 34 or petFamily == 379 then skillId = 919 -- carbuncle searing light
-    elseif petFamily == 36 or petFamily == 381 then skillId = 839 -- fenrir    howling moon
-    elseif petFamily == 37 or petFamily == 382 then skillId = 916 -- garuda    aerial blast
-    elseif petFamily == 38 or petFamily == 383 then skillId = 913 -- ifrit     inferno
-    elseif petFamily == 40 or petFamily == 384 then skillId = 915 -- leviathan tidal wave
-    elseif petFamily == 43 or petFamily == 386 then skillId = 918 -- ramuh     judgment bolt
-    elseif petFamily == 44 or petFamily == 387 then skillId = 917 -- shiva     diamond dust
-    elseif petFamily == 45 or petFamily == 388 then skillId = 914 -- titan     earthen fury
+    if     petFamily == 34 or petFamily == 379 or modelId == 791 then skillId = 919 -- carbuncle searing light
+    elseif petFamily == 36 or petFamily == 381 or modelId == 792 then skillId = 839 -- fenrir    howling moon
+    elseif petFamily == 37 or petFamily == 382 or modelId == 793 then skillId = 916 -- garuda    aerial blast
+    elseif petFamily == 38 or petFamily == 383 or modelId == 794 then skillId = 913 -- ifrit     inferno
+    elseif petFamily == 40 or petFamily == 384 or modelId == 795 then skillId = 915 -- leviathan tidal wave
+    elseif petFamily == 43 or petFamily == 386 or modelId == 796 then skillId = 918 -- ramuh     judgment bolt
+    elseif petFamily == 44 or petFamily == 387 or modelId == 797 then skillId = 917 -- shiva     diamond dust
+    elseif petFamily == 45 or petFamily == 388 or modelId == 798 then skillId = 914 -- titan     earthen fury
     else
         printf("[astral_flow_pet] received unexpected pet family %i. Defaulted skill to Searing Light.", petFamily)
         skillId = 919 -- searing light

--- a/scripts/zones/Boneyard_Gully/mobs/Tuchulcha.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Tuchulcha.lua
@@ -15,7 +15,7 @@ entity.onMobSpawn = function(mob)
 
     -- Used with HPP to keep track of the number of Sandpits
     mob:setLocalVar("Sandpits", 0)
-    mob:setRoamFlags(xi.roamFlag.EVENT)
+    mob:setRoamFlags(xi.roamFlag.SCRIPTED)
 end
 
 -- Reset restHP when re-engaging after a sandpit

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1362,6 +1362,11 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
                 PEntity->PPet->PMaster = PEntity->PPet;
             }
 
+            if (PEntity->PMaster != nullptr)
+            {
+                PEntity->PMaster->PPet = PEntity->PMaster;
+            }
+
             for (auto PMobIt : m_mobList)
             {
                 CMobEntity* PCurrentMob = (CMobEntity*)PMobIt.second;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Changes all instances of xi.roamFlag.EVENT to xi.roamFlag.SCRIPTED to avoid Lua errors.
+ Fixes a dynamic mob crash error if you kill a dynamic pet before the master.
+ Fixes an issue where dynamis statues which performed refill skills did not perform skills and die after.

## Steps to test these changes

