### PR TITLE
Fix Dynamic SMN AF | Fix Dyna Mob Groups | Fix Engaged Spawning

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis.lua
@@ -88,10 +88,10 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
     {
         text = -- text for table lookup
         {
-            INFORMATION_RECORDED = 11734, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
-            ANOTHER_GROUP = 11733, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
-            UNABLE_TO_CONNECT = 11731, -- Unable to connect.≺Prompt≻
-            CONNECTING_WITH_THE_SERVER = 11730, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
+            INFORMATION_RECORDED = 11731, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
+            ANOTHER_GROUP = 11736, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
+            UNABLE_TO_CONNECT = 11734, -- Unable to connect.≺Prompt≻
+            CONNECTING_WITH_THE_SERVER = 11733, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
         },
     },
 
@@ -99,10 +99,10 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
     {
         text = -- text for table lookup
         {
-            INFORMATION_RECORDED = 7878, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
-            ANOTHER_GROUP = 7877, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
-            UNABLE_TO_CONNECT = 7876, -- Unable to connect.≺Prompt≻
-            CONNECTING_WITH_THE_SERVER = 7874, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
+            INFORMATION_RECORDED = 7881, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
+            ANOTHER_GROUP = 7880, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
+            UNABLE_TO_CONNECT = 7878, -- Unable to connect.≺Prompt≻
+            CONNECTING_WITH_THE_SERVER = 7877, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
         },
     },
 
@@ -110,10 +110,10 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
     {
         text = -- text for table lookup
         {
-            INFORMATION_RECORDED = 7903, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
-            ANOTHER_GROUP = 7902, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
-            UNABLE_TO_CONNECT = 7900, -- Unable to connect.≺Prompt≻
-            CONNECTING_WITH_THE_SERVER = 7899, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
+            INFORMATION_RECORDED = 7906, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
+            ANOTHER_GROUP = 7905, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
+            UNABLE_TO_CONNECT = 7903, -- Unable to connect.≺Prompt≻
+            CONNECTING_WITH_THE_SERVER = 7902, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
         },
     },
 
@@ -121,10 +121,10 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
     {
         text = -- text for table lookup
         {
-            INFORMATION_RECORDED = 7861, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
-            ANOTHER_GROUP = 7860, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
-            UNABLE_TO_CONNECT = 7858, -- Unable to connect.≺Prompt≻
-            CONNECTING_WITH_THE_SERVER = 7867, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
+            INFORMATION_RECORDED = 7864, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
+            ANOTHER_GROUP = 7863, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
+            UNABLE_TO_CONNECT = 7861, -- Unable to connect.≺Prompt≻
+            CONNECTING_WITH_THE_SERVER = 7860, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
         },
     },
 
@@ -132,10 +132,10 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
     {
         text = -- text for table lookup
         {
-            INFORMATION_RECORDED = 11232, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
-            ANOTHER_GROUP = 11231, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
-            UNABLE_TO_CONNECT = 11229, -- Unable to connect.≺Prompt≻
-            CONNECTING_WITH_THE_SERVER = 11228, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
+            INFORMATION_RECORDED = 11235, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
+            ANOTHER_GROUP = 11234, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
+            UNABLE_TO_CONNECT = 11232, -- Unable to connect.≺Prompt≻
+            CONNECTING_WITH_THE_SERVER = 11231, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
         },
     },
 
@@ -143,50 +143,50 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
     {
         text = -- text for table lookup
         {
-            INFORMATION_RECORDED = 7423, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
-            ANOTHER_GROUP = 7422, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
-            UNABLE_TO_CONNECT = 7420, -- Unable to connect.≺Prompt≻
-            CONNECTING_WITH_THE_SERVER = 7419, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
+            INFORMATION_RECORDED = 7426, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
+            ANOTHER_GROUP = 7425, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
+            UNABLE_TO_CONNECT = 7423, -- Unable to connect.≺Prompt≻
+            CONNECTING_WITH_THE_SERVER = 7422, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
         },
     },
     [xi.zone.TAVNAZIAN_SAFEHOLD] = -- zoneID for array lookup
     {
         text = -- text for table lookup
         {
-            INFORMATION_RECORDED = 11832, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
-            ANOTHER_GROUP = 11831, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
-            UNABLE_TO_CONNECT = 11829, -- Unable to connect.≺Prompt≻
-            CONNECTING_WITH_THE_SERVER = 11828, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
+            INFORMATION_RECORDED = 11835, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
+            ANOTHER_GROUP = 11834, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
+            UNABLE_TO_CONNECT = 11832, -- Unable to connect.≺Prompt≻
+            CONNECTING_WITH_THE_SERVER = 11831, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
         },
     },
     [xi.zone.VALKURM_DUNES] = -- zoneID for array lookup
     {
         text = -- text for table lookup
         {
-            INFORMATION_RECORDED = 7877, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
-            ANOTHER_GROUP = 7876, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
-            UNABLE_TO_CONNECT = 7874, -- Unable to connect.≺Prompt≻
-            CONNECTING_WITH_THE_SERVER = 7873, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
+            INFORMATION_RECORDED = 7880, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
+            ANOTHER_GROUP = 7879, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
+            UNABLE_TO_CONNECT = 7877, -- Unable to connect.≺Prompt≻
+            CONNECTING_WITH_THE_SERVER = 7876, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
         },
     },
     [xi.zone.WINDURST_WALLS] = -- zoneID for array lookup
     {
         text = -- text for table lookup
         {
-            INFORMATION_RECORDED = 9092, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
-            ANOTHER_GROUP = 9091, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
-            UNABLE_TO_CONNECT = 9089, -- Unable to connect.≺Prompt≻
-            CONNECTING_WITH_THE_SERVER = 9088, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
+            INFORMATION_RECORDED = 9095, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
+            ANOTHER_GROUP = 9094, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
+            UNABLE_TO_CONNECT = 9092, -- Unable to connect.≺Prompt≻
+            CONNECTING_WITH_THE_SERVER = 9091, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
         },
     },
     [xi.zone.XARCABARD] = -- zoneID for array lookup
     {
         text = -- text for table lookup
         {
-            INFORMATION_RECORDED = 7858, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
-            ANOTHER_GROUP = 7857, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
-            UNABLE_TO_CONNECT = 7855, -- Unable to connect.≺Prompt≻
-            CONNECTING_WITH_THE_SERVER = 7854, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
+            INFORMATION_RECORDED = 7861, -- The time and destination for your foray into Dynamis has been recorded on your <itemID>.
+            ANOTHER_GROUP = 7860, -- Another group of player characters is currently occupying Dynamis - ≺Multiple Choice (Parameter 0)≻[Dummy/San d'Oria/Bastok/Windurst/Jeuno/Beaucedine/Xarcabard/Valkurm/Buburimu/Qufim/Tavnazia].≺Prompt≻
+            UNABLE_TO_CONNECT = 7858, -- Unable to connect.≺Prompt≻
+            CONNECTING_WITH_THE_SERVER = 7857, -- Connecting with server. Please wait.≺Possible Special Code: 00≻
         },
     },
     --------------------------------------------

--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -501,7 +501,7 @@ xi.dynamis.nonStandardDynamicSpawn = function(mobIndex, oMob, forceLink, zoneID,
         ["Statue"] =
         {
             ["onMobSpawn"] = {function(mob) xi.dynamis.setStatueStats(mob, mobIndex) end},
-            ["onMobEngaged"] = {function(mob, target) xi.dynamis.parentOnEngaged(mob, target) end},
+            ["onMobEngaged"] = {function(mob, target) end},
             ["onMobFight"] = {function(mob, target) xi.dynamis.statueOnFight(mob, target) end},
             ["onMobRoam"] = {function(mob) xi.dynamis.mobOnRoam(mob) end},
             ["mixins"] = { }
@@ -509,7 +509,7 @@ xi.dynamis.nonStandardDynamicSpawn = function(mobIndex, oMob, forceLink, zoneID,
         ["Nightmare"] =
         {
             ["onMobSpawn"] = {function(mob) xi.dynamis.setMobStats(mob) mob:setRoamFlags(xi.roamFlag.NONE) end},
-            ["onMobEngaged"] = {function(mob, target) xi.dynamis.parentOnEngaged(mob, target) end},
+            ["onMobEngaged"] = {function(mob, target) end},
             ["onMobFight"] = {function(mob) end},
             ["onMobRoam"] = {function(mob) end},
             ["mixins"] = { }
@@ -620,45 +620,45 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         ["Slinkix Trufflesniff"] = {"S.Trufflesniff", 155, 134, 176, 0, 5013, "Beastmen"}, -- Slin (RNG)
         ["Swypestix Tigershins"] = {"S.Tigershins", 145, 134, 176, 7, 5013, "Beastmen"}, -- Swyp (NIN)
         ["Tocktix Thinlids"] = {"T.Thinlids", 150, 134, 176, 5, 5013, "Beastmen"}, -- Tock (DRK)
-        ["Whistix Toadthroat"] = {"W.Toadthroat", 34, 188, 176, 6, 5013, "Beastmen"}, -- Whis (BRD)
+        ["Whistix Toadthroat"] = {"W.Toadthroat", 154, 134, 176, 6, 5013, "Beastmen"}, -- Whis (BRD)
         -- Dynamis - Buburimu
-        ["Gosspix Blabberlips"] = {"G.Blabberlips", 144, 134,2667, 5013, "Beastmen"}, -- Goss (RDM)
-        ["Shamblix Rottenheart"] = {"S.Rottenheart", 150, 134,2667, 5, 5013, "Beastmen"}, -- Sham (DRK)
-        ["Woodnix Shrillwhistle"] = {"W.Shrillwhistle", 151, 134, 2667, 0, 5013, "Beastmen"}, -- Wood (BST)
+        ["Gosspix Blabberlips"] = {"G.Blabberlips", 24, 40,2667, 5013, "Beastmen"}, -- Goss (RDM)
+        ["Shamblix Rottenheart"] = {"S.Rottenheart", 16, 40,2667, 5, 5013, "Beastmen"}, -- Sham (DRK)
+        ["Woodnix Shrillwhistle"] = {"W.Shrillwhistle", 6, 40, 2667, 0, 5013, "Beastmen"}, -- Wood (BST)
         -- Dynamis - Jeuno
-        ["Bandrix Rockjaw"] = {"B.Rockjaw", 146, 134, 143, 0, 5013, "Beastmen"}, -- Band (THF)
-        ["Buffrix Eargone"] = {"B.Eargone", 148, 134, 143, 4, 5013, "Beastmen"}, -- Buff (PLD)
-        ["Clocktix Longnail"] = {"C.Longnail", 150, 134, 143, 5, 5013, "Beastmen"}, -- Cloc (DRK)
-        ["Elixmix Hooknose"] = {"E.Hooknose", 142, 134, 143, 1, 5013, "Beastmen"}, -- Elix (WHM)
-        ["Gabblox Magpietongue"] = {"G.Magpietongue", 144, 134, 143, 3, 5013, "Beastmen"}, -- Gabb (RDM)
-        ["Hermitrix Toothrot"] = {"H.Toothrot", 143, 134, 143, 5000, 5013, "Beastmen"}, -- Herm (BLM)
+        ["Bandrix Rockjaw"] = {"B.Rockjaw", 32, 188, 143, 0, 5013, "Beastmen"}, -- Band (THF)
+        ["Buffrix Eargone"] = {"B.Eargone", 33, 188, 143, 4, 5013, "Beastmen"}, -- Buff (PLD)
+        ["Clocktix Longnail"] = {"C.Longnail", 51, 188, 143, 5, 5013, "Beastmen"}, -- Cloc (DRK)
+        ["Elixmix Hooknose"] = {"E.Hooknose", 31, 188, 143, 1, 5013, "Beastmen"}, -- Elix (WHM)
+        ["Gabblox Magpietongue"] = {"G.Magpietongue", 11, 188, 143, 3, 5013, "Beastmen"}, -- Gabb (RDM)
+        ["Hermitrix Toothrot"] = {"H.Toothrot", 27, 188, 143, 5000, 5013, "Beastmen"}, -- Herm (BLM)
         ["Humnox Drumbelly"] = {"H.Drumbelly", 34, 188, 143, 6, 5013, "Beastmen"}, -- Humn (BRD)
-        ["Lurklox Dhalmelneck"] = {"L.Dhalmelneck", 155, 134, 143, 0, 5013, "Beastmen"}, -- Lurk (RNG)
-        ["Morgmox Moldnoggin"] = {"M.Moldnoggin", 153, 134, 143, 0, 5013, "Beastmen"}, -- Morg (SMN)
-        ["Sparkspox Sweatbrow"] = {"S.Sweatbrow", 136, 134, 143, 0, 5013, "Beastmen"}, -- Spar (WAR)
-        ["Ticktox Beadeyes"] = {"T.Beadeyes", 150, 134, 143, 5, 5013, "Beastmen"}, -- Tick (DRK)
-        ["Trailblix Goatmug"] = {"T.Goatmug", 151, 134, 143, 0, 5013, "Beastmen"}, -- Trai (BST)
-        ["Tufflix Loglimbs"] = {"T.Loglimbs", 148, 134, 143, 4, 5013, "Beastmen"}, -- Tuff (PLD)
-        ["Wyrmwix Snakespecs"] = {"W.Snakespecs", 149, 134, 143, 0, 5013, "Beastmen"}, -- Snak (DRG)
-        ["Karashix Swollenskull"] = {"K.Swollenskull", 156, 134, 143, 0, 5013, "Beastmen"}, -- Kara (SAM)
-        ["Kikklix Longlegs"] = {"K.Longlegs", 139, 134, 143, 0, 5013, "Beastmen"}, -- Kikk (MNK)
-        ["Rutrix Hamgams"] = {"R.Hamgams", 151, 134, 143, 0, 5013, "Beastmen"}, -- Rutr (BST)
-        ["Snypestix Eaglebeak"] = {"S.Eaglebeak", 145, 134, 143, 7, 5013, "Beastmen"}, -- Snyp (NIN)
-        ["Mortilox Wartpaws"] = {"M.Wartpaws", 153, 134, 143, 0, 5013, "Beastmen"}, -- Mort (SMN)
-        ["Jabkix Pigeonpecs"] = {"J.Pigeonpecs", 139, 134, 143, 0, 5013, "Beastmen"}, -- Jabk (MNK)
-        ["Smeltix Thickhide"] = {"S.Thickhide", 136, 134, 143, 0, 5013, "Beastmen"}, -- Smel (WAR)
-        ["Wasabix Callusdigit"] = {"W.Callusdigit", 156, 134, 143, 0, 5013, "Beastmen"}, -- Wasa (SAM)
-        ["Anvilix Sootwrists"] = {"A.Sootwrists", 136, 134, 143, 0, 5013, "Beastmen"}, -- Anvi (WAR)
-        ["Blazox Boneybod"] = {"B.Boneybod", 151, 134, 143, 0, 5013, "Beastmen"}, -- Blaz (BST)
-        ["Bootrix Jaggedelbow"] = {"B.Jaggedelbow", 139, 134, 143, 0, 5013, "Beastmen"}, -- Boot (MNK)
-        ["Distilix Stickytoes"] = {"D.Stickytoes", 142, 134, 143, 1, 5013, "Beastmen"}, -- Dist (WHM)
-        ["Eremix Snottynostril"] = {"E.Snottynostril", 143, 134, 143, 5000, 5013, "Beastmen"}, -- Erem (BLM)
-        ["Jabbrox Grannyguise"] = {"J.Grannyguise", 144, 134, 143, 3, 5013, "Beastmen"}, -- Jabb (RDM)
-        ["Mobpix Mucousmouth"] = {"M.Mucousmouth", 146, 134, 143, 0, 5013, "Beastmen"}, -- Mobp (THF)
-        ["Prowlox Barrelbelly"] = {"P.Barrelbelly", 155, 134, 143, 0, 5013, "Beastmen"}, -- Prow (RNG)
-        ["Scruffix Shaggychest"] = {"S.Shaggychest", 148, 134, 143, 4, 5013, "Beastmen"}, -- Scru (PLD)
-        ["Slystix Megapeepers"] = {"S.Megapeepers", 145, 134, 143, 7, 5013, "Beastmen"}, -- Slys (NIN)
-        ["Tymexox Ninefingers"] = {"T.Ninefingers", 150, 134, 143, 5, 5013, "Beastmen"}, -- Tyme (DRK)
+        ["Lurklox Dhalmelneck"] = {"L.Dhalmelneck", 36, 188, 143, 0, 5013, "Beastmen"}, -- Lurk (RNG)
+        ["Morgmox Moldnoggin"] = {"M.Moldnoggin", 29, 188, 143, 0, 5013, "Beastmen"}, -- Morg (SMN)
+        ["Sparkspox Sweatbrow"] = {"S.Sweatbrow", 30, 188, 143, 0, 5013, "Beastmen"}, -- Spar (WAR)
+        ["Ticktox Beadeyes"] = {"T.Beadeyes", 35, 188, 143, 5, 5013, "Beastmen"}, -- Tick (DRK)
+        ["Trailblix Goatmug"] = {"T.Goatmug", 37, 188, 143, 0, 5013, "Beastmen"}, -- Trai (BST)
+        ["Tufflix Loglimbs"] = {"T.Loglimbs", 21, 188, 143, 4, 5013, "Beastmen"}, -- Tuff (PLD)
+        ["Wyrmwix Snakespecs"] = {"W.Snakespecs", 28, 188, 143, 0, 5013, "Beastmen"}, -- Snak (DRG)
+        ["Karashix Swollenskull"] = {"K.Swollenskull", 39, 188, 143, 0, 5013, "Beastmen"}, -- Kara (SAM)
+        ["Kikklix Longlegs"] = {"K.Longlegs", 38, 188, 143, 0, 5013, "Beastmen"}, -- Kikk (MNK)
+        ["Rutrix Hamgams"] = {"R.Hamgams", 40, 188, 143, 0, 5013, "Beastmen"}, -- Rutr (BST)
+        ["Snypestix Eaglebeak"] = {"S.Eaglebeak", 41, 188, 143, 7, 5013, "Beastmen"}, -- Snyp (NIN)
+        ["Mortilox Wartpaws"] = {"M.Wartpaws", 52, 188, 143, 0, 5013, "Beastmen"}, -- Mort (SMN)
+        ["Jabkix Pigeonpecs"] = {"J.Pigeonpecs", 24, 188, 143, 0, 5013, "Beastmen"}, -- Jabk (MNK)
+        ["Smeltix Thickhide"] = {"S.Thickhide", 23, 188, 143, 0, 5013, "Beastmen"}, -- Smel (WAR)
+        ["Wasabix Callusdigit"] = {"W.Callusdigit", 25, 188, 143, 0, 5013, "Beastmen"}, -- Wasa (SAM)
+        ["Anvilix Sootwrists"] = {"A.Sootwrists", 42, 188, 143, 0, 5013, "Beastmen"}, -- Anvi (WAR)
+        ["Blazox Boneybod"] = {"B.Boneybod", 49, 188, 143, 0, 5013, "Beastmen"}, -- Blaz (BST)
+        ["Bootrix Jaggedelbow"] = {"B.Jaggedelbow", 43, 188, 143, 0, 5013, "Beastmen"}, -- Boot (MNK)
+        ["Distilix Stickytoes"] = {"D.Stickytoes", 45, 188, 143, 1, 5013, "Beastmen"}, -- Dist (WHM)
+        ["Eremix Snottynostril"] = {"E.Snottynostril", 46, 188, 143, 5000, 5013, "Beastmen"}, -- Erem (BLM)
+        ["Jabbrox Grannyguise"] = {"J.Grannyguise", 47, 188, 143, 3, 5013, "Beastmen"}, -- Jabb (RDM)
+        ["Mobpix Mucousmouth"] = {"M.Mucousmouth", 44, 188, 143, 0, 5013, "Beastmen"}, -- Mobp (THF)
+        ["Prowlox Barrelbelly"] = {"P.Barrelbelly", 50, 188, 143, 0, 5013, "Beastmen"}, -- Prow (RNG)
+        ["Scruffix Shaggychest"] = {"S.Shaggychest", 48, 188, 143, 4, 5013, "Beastmen"}, -- Scru (PLD)
+        ["Slystix Megapeepers"] = {"S.Megapeepers", 53, 188, 143, 7, 5013, "Beastmen"}, -- Slys (NIN)
+        ["Tymexox Ninefingers"] = {"T.Ninefingers", 54, 188, 143, 5, 5013, "Beastmen"}, -- Tyme (DRK)
         -- Orc
         -- Dynamis - Beaucedine
         ["Cobraclaw Buchzvotch"] = {"C.Buchzvotch", 65, 134, 493, 0, 5012, "Beastmen"}, -- CBuc (MNK)
@@ -677,16 +677,16 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         ["Ultrasonic Zeknajak"] = {"U.Zeknajak", 87, 134, 493, 6, 5012, "Beastmen"}, -- UZek (BRD)
         ["Wraithdancer Gidbnod"] = {"W.Gidbnod", 63, 134, 493, 1, 5012, "Beastmen"}, -- WGid (WHM)
         -- Dynamis Buburimu
-        ["Elvaansticker Bxafraff"] = {"E.Bxafraff", 88, 134, 760, 0, 5012, "Beastmen"}, -- Elva (DRG)
-        ["Flamecaller Zoeqdoq"] = {"F.Zoeqdoq", 84, 134, 760, 5000, 5012, "Beastmen"}, -- Flam (BLM)
-        ["Hamfist Gukhbuk"] = {"H.Gukhbuk", 65, 134, 760, 0, 5012, "Beastmen"}, -- Hamf (MNK)
-        ["Lyncean Juvgneg"] = {"L.Juvgneg", 82, 134, 760, 0, 5012, "Beastmen"}, -- Lync (RNG)
+        ["Elvaansticker Bxafraff"] = {"E.Bxafraff", 35, 40, 760, 0, 5012, "Beastmen"}, -- Elva (DRG)
+        ["Flamecaller Zoeqdoq"] = {"F.Zoeqdoq", 34, 40, 760, 5000, 5012, "Beastmen"}, -- Flam (BLM)
+        ["Hamfist Gukhbuk"] = {"H.Gukhbuk", 46, 40, 760, 0, 5012, "Beastmen"}, -- Hamf (MNK)
+        ["Lyncean Juwgneg"] = {"L.Juvgneg", 47, 40, 760, 0, 5012, "Beastmen"}, -- Lync (RNG)
         -- Dynamis - San d'Oria
-        ["Wyrmgnasher Bjakdek"] = {"W.Bjakdek", 88, 134, 237, 0, 5012, "Beastmen"}, -- WyrB (DRG)
-        ["Reapertongue Gadgquok"] = {"R.Gadgquok", 73, 134, 237, 0, 5012, "Beastmen"}, -- ReaG (SMN)
-        ["Voidstreaker Butchnotch"] = {"V.Butchnotch", 63, 134, 237, 7, 5012, "Beastmen"}, -- VoiB (NIN)
-        ["Battlechoir Gitchfotch"] = {"B.Gitchfotch", 87, 134, 237, 6, 5012, "Beastmen"}, -- BatG (BRD)
-        ["Soulsender Fugbrag"] = {"S.Fugbrag", 87, 134, 237, 6, 5012, "Beastmen"}, -- SouF (BRD)
+        ["Wyrmgnasher Bjakdek"] = {"W.Bjakdek", 25, 185, 237, 0, 5012, "Beastmen"}, -- WyrB (DRG)
+        ["Reapertongue Gadgquok"] = {"R.Gadgquok", 23, 185, 237, 0, 5012, "Beastmen"}, -- ReaG (SMN)
+        ["Voidstreaker Butchnotch"] = {"V.Butchnotch", 26, 185, 237, 7, 5012, "Beastmen"}, -- VoiB (NIN)
+        ["Battlechoir Gitchfotch"] = {"B.Gitchfotch", 2, 185, 237, 6, 5012, "Beastmen"}, -- BatG (BRD)
+        ["Soulsender Fugbrag"] = {"S.Fugbrag", 3, 185, 237, 6, 5012, "Beastmen"}, -- SouF (BRD)
         -- Quadav
         -- Dynamis - Beaucedine
         ["Be'Zhe Keeprazer"] = {"B.Keeprazer", 53, 134, 261, 0, 5011, "Beastmen"}, -- BeZh (SMN)
@@ -705,10 +705,10 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         ["So'Zho Metalbender"] = {"S.Metalbender", 46, 134, 261, 0, 5011, "Beastmen"}, -- SoZh (MNK)
         ["Ta'Hyu Gallanthunter"] = {"T.Gallanthunter", 40, 134, 261, 5, 5011, "Beastmen"}, -- TaHy (DRK)
         -- Dynamis Buburimu
-        ["Gi'Bhe Flesheater"] = {"G.Flesheater", 39, 134, 2901, 1, 5011, "Beastmen"}, -- GiBh (WHM)
-        ["Qu'Pho Bloodspiller"] = {"Q.Bloodspiller", 24, 134, 2901, 0, 5011, "Beastmen"}, -- QuPh (WAR)
-        ["Te'Zha Ironclad"] = {"T.Ironclad", 47, 134, 2901, 4, 5011, "Beastmen"}, -- TeZh (PLD)
-        ["Va'Rhu Bodysnatcher"] = {"V.Bodysnatcher", 37, 134, 2901, 0, 5011, "Beastmen"}, -- VaRh (THF)
+        ["Gi'Bhe Flesheater"] = {"G.Flesheater", 57, 40, 2901, 1, 5011, "Beastmen"}, -- GiBh (WHM)
+        ["Qu'Pho Bloodspiller"] = {"Q.Bloodspiller", 56, 40, 2901, 0, 5011, "Beastmen"}, -- QuPh (WAR)
+        ["Te'Zha Ironclad"] = {"T.Ironclad", 69, 40, 2901, 4, 5011, "Beastmen"}, -- TeZh (PLD)
+        ["Va'Rhu Bodysnatcher"] = {"V.Bodysnatcher", 68, 40, 2901, 0, 5011, "Beastmen"}, -- VaRh (THF)
         -- Dynamis - Bastok (Done)
         ["Aa'Nyu Dismantler"] = {"A.Dismantler", 40, 134, 2907, 5, 5011, "Beastmen"}, -- AaNy (DRK)
         ["Gu'Nhi Noondozer"] = {"G.Noondozer", 53, 134, 2907, 0, 5011, "Beastmen"}, -- GuNh (SMN)
@@ -739,17 +739,17 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         ["Xaa Chau the Roctalon"] = {"X.Roctalon", 97, 134, 265, 0, 5014, "Beastmen"}, -- XaaC (MNK)
         ["Xhoo Fuza the Sublime"] = {"X.Sublime", 119, 134, 265, 6, 5014, "Beastmen"}, -- Xhoo (BRD)
         -- Dynamis - Buburimu
-        ["Baa Dava the Bibliopage"] = {"B.Bibliopage", 91, 317, 2085, 0, 5014, "Beastmen"}, -- BaaD (SMN)
+        ["Baa Dava the Bibliopage"] = {"B.Bibliopage", 24, 187, 2085, 0, 5014, "Beastmen"}, -- BaaD (SMN)
         ["Doo Peku the Fleetfoot"] = {"D.Fleetfoot", 115, 134, 2085, 7, 5014, "Beastmen"}, -- DooP (NIN)
         ["Koo Rahi the Levinblade"] = {"K.Levinblade", 121, 134, 2085, 0, 5014, "Beastmen"}, -- KooR (SAM)
         ["Ree Nata the Melomanic"] = {"R.Melomanic", 119, 134, 2085, 6, 5014, "Beastmen"}, -- ReeN (BRD)
         -- Dynamis - Windurst
-        ["Xoo Kaza the Solemn"] = {"X.Solemn", 106, 134, 1560, 5000, 5014, "Beastmen"}, -- XooK (BLM)
-        ["Haa Pevi the Stentorian"] = {"H.Stentorian", 91, 317, 1560, 0, 5014, "Beastmen"}, -- HaaP (SMN)
-        ["Wuu Qoho the Razorclaw"] = {"W.Razorclaw", 97, 134, 1560, 0, 5014, "Beastmen"}, -- WuuQ (MNK)
-        ["Loo Hepe the Eyepiercer"] = {"L.Eyepiercer", 107, 134, 1560, 3, 5014, "Beastmen"}, -- LooH (RDM)
-        ["Muu Febi the Steadfast"] = {"Muu.Steadfast", 113, 134, 1560, 4, 5014, "Beastmen"}, -- MuuF (PLD)
-        ["Maa Febi the Steadfast"] = {"Maa.Steadfast", 113, 134, 1560, 4, 5014, "Beastmen"}, -- MaaF (PLD)
+        ["Xoo Kaza the Solemn"] = {"X.Solemn", 27, 187, 1560, 5000, 5014, "Beastmen"}, -- XooK (BLM)
+        ["Haa Pevi the Stentorian"] = {"H.Stentorian", 24, 187, 1560, 0, 5014, "Beastmen"}, -- HaaP (SMN)
+        ["Wuu Qoho the Razorclaw"] = {"W.Razorclaw", 26, 187, 1560, 0, 5014, "Beastmen"}, -- WuuQ (MNK)
+        ["Loo Hepe the Eyepiercer"] = {"L.Eyepiercer", 25, 187, 1560, 3, 5014, "Beastmen"}, -- LooH (RDM)
+        ["Muu Febi the Steadfast"] = {"Muu.Steadfast", 3, 187, 1560, 4, 5014, "Beastmen"}, -- MuuF (PLD)
+        ["Maa Febi the Steadfast"] = {"Maa.Steadfast", 2, 187, 1560, 4, 5014, "Beastmen"}, -- MaaF (PLD)
         -- Kindred
         -- Dynamis - Xarcabard
         ["Count Zaebos"] = {"C.Zaebos", 51, 135, 521, 0, 358, "Beastmen"}, -- Zaeb (WAR)
@@ -866,7 +866,7 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         ["Beastmen"] =
         {
             ["onMobSpawn"] = {function(mob) xi.dynamis.setNMStats(mob) end},
-            ["onMobEngaged"] = {function(mob, target) xi.dynamis.parentOnEngaged(mob, target) xi.dynamis.mobOnEngaged(mob, target) end},
+            ["onMobEngaged"] = {function(mob, target) xi.dynamis.mobOnEngaged(mob, target) end},
             ["onMobFight"] = {function(mob) end},
             ["onMobRoam"] = {function(mob) end},
             ["onMobMagicPrepare"] = {function(mob, target, spellId) end},
@@ -878,7 +878,7 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         ["Statue Megaboss"] =
         {
             ["onMobSpawn"] = {function(mob) xi.dynamis.setMegaBossStats(mob) end},
-            ["onMobEngaged"] = {function(mob, target)  xi.dynamis.parentOnEngaged(mob, target) end},
+            ["onMobEngaged"] = {function(mob, target)  end},
             ["onMobFight"] = {function(mob) end},
             ["onMobRoam"] = {function(mob) end},
             ["onMobMagicPrepare"] = {function(mob, target, spellId) end},
@@ -890,7 +890,7 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         ["Angra Mainyu"] =
         {
             ["onMobSpawn"] = {function(mob) xi.dynamis.onSpawnAngra(mob) end},
-            ["onMobEngaged"] = {function(mob, target)  xi.dynamis.parentOnEngaged(mob, target) end},
+            ["onMobEngaged"] = {function(mob, target) end},
             ["onMobFight"] = {function(mob, target) xi.dynamis.onFightAngra(mob, target) end},
             ["onMobRoam"] = {function(mob) xi.dynamis.onRoamAngra(mob) end},
             ["onMobMagicPrepare"] = {function(mob, target, spellId) xi.dynamis.onMagicPrepAngra(mob) end},
@@ -914,7 +914,7 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         ["Goublefaupe"] =
         {
             ["onMobSpawn"] = {function(mob) xi.dynamis.onSpawnGouble(mob) end},
-            ["onMobEngaged"] = {function(mob, target)  xi.dynamis.parentOnEngaged(mob, target) end},
+            ["onMobEngaged"] = {function(mob, target) end},
             ["onMobFight"] = {function(mob, target) end},
             ["onMobRoam"] = {function(mob) end},
             ["onMobMagicPrepare"] = {function(mob, target, spellId) end},
@@ -926,7 +926,7 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         ["Mildaunegeux"] =
         {
             ["onMobSpawn"] = {function(mob) xi.dynamis.onSpawnMildaun(mob) end},
-            ["onMobEngaged"] = {function(mob, target)  xi.dynamis.parentOnEngaged(mob, target) end},
+            ["onMobEngaged"] = {function(mob, target) end},
             ["onMobFight"] = {function(mob, target) end},
             ["onMobRoam"] = {function(mob) end},
             ["onMobMagicPrepare"] = {function(mob, target, spellId) end},
@@ -938,7 +938,7 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         ["Quiebitiel"] =
         {
             ["onMobSpawn"] = {function(mob) xi.dynamis.onSpawnQuieb(mob) end},
-            ["onMobEngaged"] = {function(mob, target)  xi.dynamis.parentOnEngaged(mob, target) end},
+            ["onMobEngaged"] = {function(mob, target) end},
             ["onMobFight"] = {function(mob, target) end},
             ["onMobRoam"] = {function(mob) end},
             ["onMobMagicPrepare"] = {function(mob, target, spellId) end},
@@ -950,7 +950,7 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         ["Velosareon"] =
         {
             ["onMobSpawn"] = {function(mob) xi.dynamis.onSpawnVelosar(mob) end},
-            ["onMobEngaged"] = {function(mob, target)  xi.dynamis.parentOnEngaged(mob, target) end},
+            ["onMobEngaged"] = {function(mob, target) end},
             ["onMobFight"] = {function(mob, target) end},
             ["onMobRoam"] = {function(mob) end},
             ["onMobMagicPrepare"] = {function(mob, target, spellId) end},
@@ -1279,10 +1279,10 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
             },
             [360] = -- Yagudo Family
             {
-                [false] = {"V. Crow", 117, 135, 0, 52, 55}, -- Normal Yagudo BST (VCro)
+                [false] = {"V. Crow", 100, 134, 0, 52, 55}, -- Normal Yagudo BST (VCro)
                 [true] = -- Yagudo NM
                 {
-                    ["Soo Jopo the Fiendking"] = {"V. Crow", 117, 135, 0, 52, 55}, -- NM Yagudo BST (VCro)
+                    ["Soo Jopo the Fiendking"] = {"V. Crow", 100, 134, 0, 52, 55}, -- NM Yagudo BST (VCro)
                 },
             },
         },
@@ -1717,6 +1717,14 @@ xi.dynamis.setNMStats = function(mob)
     mob:setTrueDetection(true)
     mob:setMobMod(xi.mobMod.CHECK_AS_NM, 2)
 
+    mob:addListener('TAKE_DAMAGE', 'DYNA_DMG_TAKE', function(mobArg, amount, attacker, attackType, damageType)
+        xi.dynamis.parentOnEngaged(mobArg, attacker)
+    end)
+
+    mob:addListener('ENGAGE', 'DYNA_ENGAGE', function(mobArg, target)
+        xi.dynamis.parentOnEngaged(mobArg, target)
+    end)
+
     if job == xi.job.NIN then
         local params = { }
         params.specials = { }
@@ -1743,6 +1751,14 @@ xi.dynamis.setStatueStats = function(mob, mobIndex)
     mob:setMobMod(xi.mobMod.CHECK_AS_NM, 2)
     mob:setSpeed(20)
 
+    mob:addListener('TAKE_DAMAGE', 'DYNA_DMG_TAKE', function(mobArg, amount, attacker, attackType, damageType)
+        xi.dynamis.parentOnEngaged(mobArg, attacker)
+    end)
+
+    mob:addListener('ENGAGE', 'DYNA_ENGAGE', function(mobArg, target)
+        xi.dynamis.parentOnEngaged(mobArg, target)
+    end)
+
     if mob:getFamily() >= 92 and mob:getFamily() <= 95 then -- If statue
         if eyes ~= nil then
             mob:setLocalVar("eyeColor", eyes) -- Set Eyes if need be
@@ -1764,6 +1780,14 @@ xi.dynamis.setMegaBossStats = function(mob)
     mob:setMobLevel(88)
     mob:setMod(xi.mod.STR, -10)
     mob:setTrueDetection(true)
+
+    mob:addListener('TAKE_DAMAGE', 'DYNA_DMG_TAKE', function(mobArg, amount, attacker, attackType, damageType)
+        xi.dynamis.parentOnEngaged(mobArg, attacker)
+    end)
+
+    mob:addListener('ENGAGE', 'DYNA_ENGAGE', function(mobArg, target)
+        xi.dynamis.parentOnEngaged(mobArg, target)
+    end)
 end
 
 xi.dynamis.setPetStats = function(mob)
@@ -1792,6 +1816,14 @@ xi.dynamis.setAnimatedWeaponStats = function(mob)
     mob:setMod(xi.mod.LULLABYRES, 100)
     mob:setMod(xi.mod.SLEEPRES, 100)
     mob:setMobMod(xi.mobMod.CHECK_AS_NM, 2)
+
+    mob:addListener('TAKE_DAMAGE', 'DYNA_DMG_TAKE', function(mobArg, amount, attacker, attackType, damageType)
+        xi.dynamis.parentOnEngaged(mobArg, attacker)
+    end)
+
+    mob:addListener('ENGAGE', 'DYNA_ENGAGE', function(mobArg, target)
+        xi.dynamis.parentOnEngaged(mobArg, target)
+    end)
 end
 
 xi.dynamis.teleport = function(mob, hideDuration)

--- a/modules/era/lua_dynamis/mobs/era_qufim_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_qufim_mobs.lua
@@ -50,10 +50,17 @@ xi.dynamis.onSpawnAntaeus = function(mob)
     mob:addMod(xi.mod.GRAVITYRES, 40)
     mob:addMod(xi.mod.BINDRES, 40)
     mob:addMod(xi.mod.REGAIN, 50)
+
+    mob:addListener('TAKE_DAMAGE', 'DYNA_DMG_TAKE', function(mobArg, amount, attacker, attackType, damageType)
+        xi.dynamis.parentOnEngaged(mobArg, attacker)
+    end)
+
+    mob:addListener('ENGAGE', 'DYNA_ENGAGE', function(mobArg, target)
+        xi.dynamis.parentOnEngaged(mobArg, target)
+    end)
 end
 
 xi.dynamis.onEngagedAntaeus = function(mob, target)
-    xi.dynamis.parentOnEngaged(mob, target)
 end
 
 xi.dynamis.onFightAntaeus = function(mob, target)

--- a/modules/era/lua_dynamis/mobs/era_valkurm_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_valkurm_mobs.lua
@@ -96,7 +96,6 @@ xi.dynamis.onEngagedCirrate = function(mob, target)
     local zoneID = mob:getZoneID()
     local flytrapKills = checkFlytrapKills(mob)
     local morbolKills = checkMorbolKills(mob)
-    xi.dynamis.parentOnEngaged(mob, target)
     if flytrapKills < 3 and morbolKills == 0 then
         xi.dynamis.nmDynamicSpawn(289, 24, true, zoneID, target, mob)
         xi.dynamis.nmDynamicSpawn(290, 24, true, zoneID, target, mob)

--- a/modules/era/lua_dynamis/mobs/era_xarcabard_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_xarcabard_mobs.lua
@@ -15,9 +15,9 @@ xi.dynamis = xi.dynamis or {}
 -----------------------------------
 --    Dynamis Lord, Ying, Yang   --
 -----------------------------------
-local lordText = 7281
-local yingText = 7289
-local yangText = 7290
+local lordText = 7284
+local yingText = 7301
+local yangText = 7302
 local busy = {xi.act.MOBABILITY_FINISH, xi.act.MOBABILITY_START, xi.act.MOBABILITY_USING, xi.act.MAGIC_CASTING, xi.act.MAGIC_START, xi.act.MAGIC_FINISH}
 local specials =
 {
@@ -540,7 +540,6 @@ xi.dynamis.onSpawnAnimated = function(mob)
 end
 
 xi.dynamis.onEngagedAnimated = function(mob, target)
-    xi.dynamis.parentOnEngaged(mob, target)
     mob:setLocalVar("castTime", os.time() + math.random(0, 3))
     mob:setLocalVar("changeTime", os.time() + math.random(20, 30))
 end

--- a/scripts/globals/mobskills/astral_flow_pet.lua
+++ b/scripts/globals/mobskills/astral_flow_pet.lua
@@ -49,14 +49,22 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local modelId   = pet:getModelId()
     local skillId = 0
 
-    if     petFamily == 34 or petFamily == 379 or modelId == 791 then skillId = 919 -- carbuncle searing light
-    elseif petFamily == 36 or petFamily == 381 or modelId == 792 then skillId = 839 -- fenrir    howling moon
-    elseif petFamily == 37 or petFamily == 382 or modelId == 793 then skillId = 916 -- garuda    aerial blast
-    elseif petFamily == 38 or petFamily == 383 or modelId == 794 then skillId = 913 -- ifrit     inferno
-    elseif petFamily == 40 or petFamily == 384 or modelId == 795 then skillId = 915 -- leviathan tidal wave
-    elseif petFamily == 43 or petFamily == 386 or modelId == 796 then skillId = 918 -- ramuh     judgment bolt
-    elseif petFamily == 44 or petFamily == 387 or modelId == 797 then skillId = 917 -- shiva     diamond dust
-    elseif petFamily == 45 or petFamily == 388 or modelId == 798 then skillId = 914 -- titan     earthen fury
+    if     petFamily == 45 or petFamily == 388 or modelId == 798 then
+        skillId = 914 -- titan     earthen fury
+    elseif petFamily == 44 or petFamily == 387 or modelId == 797 then
+        skillId = 917 -- shiva     diamond dust
+    elseif petFamily == 43 or petFamily == 386 or modelId == 796 then
+        skillId = 918 -- ramuh     judgment bolt
+    elseif petFamily == 40 or petFamily == 384 or modelId == 795 then
+        skillId = 915 -- leviathan tidal wave
+    elseif petFamily == 38 or petFamily == 383 or modelId == 794 then
+        skillId = 913 -- ifrit     inferno
+    elseif petFamily == 37 or petFamily == 382 or modelId == 793 then
+        skillId = 916 -- garuda    aerial blast
+    elseif petFamily == 36 or petFamily == 381 or modelId == 792 then
+        skillId = 839 -- fenrir    howling moon
+    elseif petFamily == 34 or petFamily == 379 or modelId == 791 then
+        skillId = 919 -- carbuncle searing light
     else
         printf("[astral_flow_pet] received unexpected pet family %i. Defaulted skill to Searing Light.", petFamily)
         skillId = 919 -- searing light


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes ID shifts in starting zones.
+ Fixes ID shifts in Dynamis - Xarcabard.
+ Fixes dynamic SMN astral flow selection.
+ Fixes mismatches in multiple spawning groups.
+ Converts parentOnEngaged to be based on a TAKE_DAMAGE and ENGAGE listener so we can have statues spawn mobs if they die in one shot. 

## Steps to test these changes

