### PR TITLE
Mod Clamps for Underflows and Overflows for int16 Treated as uint16 | Fix Movement Speed Clamping

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1012,6 +1012,11 @@ void CBattleEntity::addModifier(Mod type, int16 amount)
         m_MSNonItemValues.push_back(amount);
         m_modStat[type] = CalculateMSFromSources();
     }
+    else if (type == Mod::DEF || (type >= Mod::STR && type <= Mod::CHR) ||
+             (type >= Mod::ATT && type <= Mod::RACC) || (type >= Mod::MATT && type <= Mod::MEVA))
+    {
+        m_modStat[type] = std::clamp(m_modStat[type] + amount, 0, 65535); // These are all treated as uint16 values.
+    }
     else
     {
         m_modStat[type] += amount;
@@ -1077,7 +1082,7 @@ int16 CBattleEntity::CalculateMSFromSources()
         }
     }
 
-    return (highestItemPositiveValue + totalItemReducedValue) + (highestNonItemPositve + totalNonItemReducedValue);
+    return std::clamp((highestItemPositiveValue + totalItemReducedValue) + (highestNonItemPositve + totalNonItemReducedValue), 0, 255);
 }
 
 void CBattleEntity::addEquipModifiers(std::vector<CModifier>* modList, uint8 itemLevel, uint8 slotid)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Implements a clamp for all mods which are treated like uint16 values. (DEF, ATT, RATT, RACC, ACC, STR, DEX, VIT, etc.)
+ Implements a clamp for Mod::Move to clamp in case we run into an issue with something like a GM moving at 255 with striders on. This will also serve to be a sanity clamp for if movement speed goes below 0 so we do not get speedy speed players.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
