### PR TITLE
Implement Save and Load of Previously Equipped Sets During Job Change

### DIFF
--- a/sql/char_equip_saved.sql
+++ b/sql/char_equip_saved.sql
@@ -1,0 +1,27 @@
+
+SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
+-- ----------------------------
+-- Table structure for char_equip_saved
+-- ----------------------------
+DROP TABLE IF EXISTS `char_equip_saved`;
+CREATE TABLE IF NOT EXISTS `char_equip_saved` (
+  `charid` int(10) unsigned NOT NULL,
+  `jobid` tinyint(2) unsigned NOT NULL,
+  `main` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `sub` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ranged` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ammo` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `head` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `body` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `hands` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `legs` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `feet` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `neck` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `waist` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ear1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ear2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ring1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ring2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `back` smallint(5) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`charid`, `jobid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 AVG_ROW_LENGTH=20;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6828,6 +6828,7 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
             JOBTYPE prevjob = PChar->GetMJob();
             PChar->resetPetZoningInfo();
 
+            charutils::SaveJobChangeGear(PChar);
             charutils::RemoveAllEquipment(PChar);
             PChar->SetMJob(mjob);
             PChar->SetMLevel(PChar->jobs.job[PChar->GetMJob()]);
@@ -6895,6 +6896,7 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
         PChar->PRecastContainer->ChangeJob();
         charutils::BuildingCharAbilityTable(PChar);
         charutils::BuildingCharWeaponSkills(PChar);
+        charutils::LoadJobChangeGear(PChar);
 
         PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE | EFFECTFLAG_ROLL | EFFECTFLAG_ON_JOBCHANGE);
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2340,6 +2340,108 @@ namespace charutils
         }
     }
 
+    void SaveJobChangeGear(CCharEntity* PChar)
+    {
+        if (PChar == nullptr)
+        {
+            return;
+        }
+
+        const char* Query = "REPLACE INTO char_equip_saved SET \
+                                    charid = %u, \
+                                    jobid = %u, \
+                                    main = %u, \
+                                    sub = %u, \
+                                    ranged = %u, \
+                                    ammo = %u, \
+                                    head = %u, \
+                                    body = %u, \
+                                    hands = %u, \
+                                    legs = %u, \
+                                    feet = %u, \
+                                    neck = %u, \
+                                    waist = %u, \
+                                    ear1 = %u, \
+                                    ear2 = %u, \
+                                    ring1 = %u, \
+                                    ring2 = %u, \
+                                    back = %u;";
+
+        uint16 main   = (PChar->getEquip(SLOT_MAIN) != nullptr) ? PChar->getEquip(SLOT_MAIN)->getID() : 0;
+        uint16 sub    = (PChar->getEquip(SLOT_SUB) != nullptr) ? PChar->getEquip(SLOT_SUB)->getID() : 0;
+        uint16 ranged = (PChar->getEquip(SLOT_RANGED) != nullptr) ? PChar->getEquip(SLOT_RANGED)->getID() : 0;
+        uint16 ammo   = (PChar->getEquip(SLOT_AMMO) != nullptr) ? PChar->getEquip(SLOT_AMMO)->getID() : 0;
+        uint16 head   = (PChar->getEquip(SLOT_HEAD) != nullptr) ? PChar->getEquip(SLOT_HEAD)->getID() : 0;
+        uint16 body   = (PChar->getEquip(SLOT_BODY) != nullptr) ? PChar->getEquip(SLOT_BODY)->getID() : 0;
+        uint16 hands  = (PChar->getEquip(SLOT_HANDS) != nullptr) ? PChar->getEquip(SLOT_HANDS)->getID() : 0;
+        uint16 legs   = (PChar->getEquip(SLOT_LEGS) != nullptr) ? PChar->getEquip(SLOT_LEGS)->getID() : 0;
+        uint16 feet   = (PChar->getEquip(SLOT_FEET) != nullptr) ? PChar->getEquip(SLOT_FEET)->getID() : 0;
+        uint16 neck   = (PChar->getEquip(SLOT_NECK) != nullptr) ? PChar->getEquip(SLOT_NECK)->getID() : 0;
+        uint16 waist  = (PChar->getEquip(SLOT_WAIST) != nullptr) ? PChar->getEquip(SLOT_WAIST)->getID() : 0;
+        uint16 ear1   = (PChar->getEquip(SLOT_EAR1) != nullptr) ? PChar->getEquip(SLOT_EAR1)->getID() : 0;
+        uint16 ear2   = (PChar->getEquip(SLOT_EAR2) != nullptr) ? PChar->getEquip(SLOT_EAR2)->getID() : 0;
+        uint16 ring1  = (PChar->getEquip(SLOT_RING1) != nullptr) ? PChar->getEquip(SLOT_RING1)->getID() : 0;
+        uint16 ring2  = (PChar->getEquip(SLOT_RING2) != nullptr) ? PChar->getEquip(SLOT_RING2)->getID() : 0;
+        uint16 back   = (PChar->getEquip(SLOT_BACK) != nullptr) ? PChar->getEquip(SLOT_BACK)->getID() : 0;
+
+        sql->Query(Query, PChar->id, PChar->GetMJob(), main, sub, ranged, ammo,
+                   head, body, hands, legs, feet, neck, waist, ear1, ear2, ring1,
+                   +ring2, back);
+
+        return;
+    }
+
+    void LoadJobChangeGear(CCharEntity* PChar)
+    {
+        if (PChar == nullptr)
+        {
+            return;
+        }
+
+        const char* Query = "SELECT main, sub, ranged, ammo, head, body, hands, legs, feet, neck, waist, ear1, ear2, ring1, ring2, back FROM char_equip_saved AS equip WHERE charid = %u AND jobid = %u;";
+
+        if (sql->Query(Query, PChar->id, PChar->GetMJob()) == SQL_SUCCESS && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
+        {
+            for (uint8 i = 0; i < SLOT_LINK1; i++)
+            {
+                if (sql->GetUIntData(i) > 0)
+                {
+                    for (int x = 0; x < CONTAINER_ID::MAX_CONTAINER_ID; x++)
+                    {
+                        bool found = false;
+                        if (x == LOC_INVENTORY || (x > LOC_MOGLOCKER && x < LOC_RECYCLEBIN))
+                        {
+                            for (uint8 slot = 0; slot < PChar->getStorage(x)->GetSize(); slot++)
+                            {
+                                CItem* PItem = PChar->getStorage(x)->GetItem(slot);
+                                if (PItem != nullptr && PItem->getID() == sql->GetUIntData(i))
+                                {
+                                    auto* PEquip   = static_cast<CItemEquipment*>(PItem);
+                                    auto  prevSlot = static_cast<SLOTTYPE>(std::clamp(i - 1, 0, MAX_SLOTTYPE - 1));
+                                    auto  nextSlot = static_cast<SLOTTYPE>(std::clamp(i - 1, 0, MAX_SLOTTYPE - 1));
+
+                                    if (PEquip != nullptr && PEquip != PChar->getEquip(static_cast<SLOTTYPE>(i)) && PEquip != PChar->getEquip(prevSlot) && PEquip != PChar->getEquip(nextSlot))
+                                    {
+                                        found = true;
+                                        charutils::EquipItem(PChar, PItem->getSlotID(), i, static_cast<CONTAINER_ID>(x));
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (found)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return;
+    }
+
     void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 containerID)
     {
         if (PChar == nullptr || PChar->getStorage(containerID) == nullptr)

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -116,6 +116,8 @@ namespace charutils
     void   DropItem(CCharEntity* PChar, uint8 container, uint8 slotID, int32 quantity, uint16 ItemID);
     void   CheckValidEquipment(CCharEntity* PChar);
     void   CheckEquipLogic(CCharEntity* PChar, SCRIPTTYPE ScriptType, uint32 param);
+    void   SaveJobChangeGear(CCharEntity* PChar);
+    void   LoadJobChangeGear(CCharEntity* PChar);
     void   EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 containerID);
     void   UnequipItem(CCharEntity* PChar, uint8 equipSlotID,
                        bool update = true); // call with update == false to prevent calls to UpdateHealth() - used for correct handling of stats on armor swaps

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -64,6 +64,7 @@ player_data = [
     'char_blacklist.sql',
     'char_effects.sql',
     'char_equip.sql',
+    'char_equip_saved.sql',
     'char_exp.sql',
     'char_history.sql',
     'char_inventory.sql',


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Implements a system to save and load the last equipped items for a job after a job change.
+ This does work properly with dual wield and same item id accessories.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/81

## Steps to test these changes
+ Tested equipping items in non-equippable inventories.
+ Tested equipping items from multiple inventories.
+ Tested equipping 2 of the same item in both one inventory and seperated.
+ Tested equipping of a deleted item.
+ Tested equipping of an item that moves inventories. 
