### PR TITLE
Mobskill FTP | Weaponskill Fixes | Magic Cleanup | Misc Fixes

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -232,7 +232,7 @@ local function calculateMagicBurst(caster, spell, target, params)
         elseif skillchainCount == 2 then -- three weaponskills
             skillchainburst = 1.45
         elseif skillchainCount == 3 then -- four weaponskills
-             skillchainburst = 1.55
+            skillchainburst = 1.55
         elseif skillchainCount == 4 then -- five weaponskills
             skillchainburst = 1.65
         elseif skillchainCount == 5 then -- six weaponskills
@@ -564,6 +564,21 @@ function applyResistanceAddEffect(player, target, element, bonus)
     return getMagicResist(p, target, element)
 end
 
+function applyResistanceAddEffectWS(player, target, element, bonus)
+    local p = getMagicHitRate(player, target, 0, element, 0, bonus)
+    local resist = getMagicResist(p, target, element)
+
+    if resist < 0.5 then
+        resist = 0
+    elseif resist < 1 then
+        resist = 0.5
+    else
+        resist = 1
+    end
+
+    return resist
+end
+
 function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc, dStat)
     local magicacc = 0
     local magiceva = 0
@@ -604,7 +619,7 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
         skillType == xi.skill.SINGING or skillType == xi.skill.STRING_INSTRUMENT or
         skillType == xi.skill.HEALING_MAGIC or skillType == xi.skill.BLUE_MAGIC or
         skillType == xi.skill.DARK_MAGIC or skillType == xi.skill.NINJUTSU
-        then -- Max 10 dStat before squash.
+    then -- Max 10 dStat before squash.
         if dStat > 10 then -- >10 dStat should be suashed.
             local bonusDStat = dStat - 10
             dStatAcc = 10 + (bonusDStat / 2)
@@ -615,14 +630,21 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
         dStatAcc = dStat
     end
 
-    if skillType ~= xi.skill.SINGING and skillType ~= nil then -- If not a bard song
+    if
+        skillType ~= nil and
+        skillType > xi.skill.STAFF and
+        (skillType > xi.skill.WIND_INSTRUMENT or skillType < xi.skill.SINGING)
+    then -- If not a bard song
         if caster:isPC() then
             local gearBonus = caster:getMod(xi.mod.MACC) + caster:getILvlMacc()
             magicacc = caster:getSkillLevel(skillType) + gearBonus + dStatAcc
         else
             magicacc = utils.getSkillLvl(1, caster:getMainLvl()) + dStatAcc
         end
-    elseif skillType ~= nil then -- If a bard song
+    elseif
+        skillType ~= nil and
+        (skillType >= xi.skill.SINGING and skillType <= xi.skill.WIND_INSTRUMENT)
+    then -- If a bard song
         if caster:isPC() then
             local secondarySkill = 0
             local gearBonus = caster:getMod(xi.mod.MACC) + caster:getILvlMacc()
@@ -639,10 +661,12 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
         else
             magicacc = utils.getSkillLvl(1, caster:getMainLvl()) + dStatAcc
         end
+    elseif caster:isPC() and skillType <= xi.skill.STAFF then
+        magicacc = dStatAcc + caster:getSkillLevel(caster:getEquippedItem(xi.slot.MAIN):getSkillType())
     elseif caster:isMob() and skillType == nil then
         magicacc = dStatAcc + utils.getMobSkillLvl(1, caster:getMainLvl())
     elseif caster:isPet() and skillType == nil then
-        magicacc = dStatAcc + utils.getMobSkillLvl(3, caster:getMainLvl())
+        magicacc = dStatAcc + utils.getMobSkillLvl(1, caster:getMainLvl())
     else
         magicacc = utils.getSkillLvl(4, caster:getMainLvl()) + dStatAcc
     end
@@ -685,7 +709,7 @@ function getMagicResist(magicHitRate, target, element)
         local sortEvaMult = { 1.50, 1.30, 1.15, 1.00, 0.85, 0.70, 0.60, 0.50, 0.40, 0.30, 0.25, 0.20, 0.15, 0.10, 0.05 }
 
         for _, tier in pairs(sortEvaMult) do -- Finds the highest tier for the resist.
-            if evaMult > tier then
+            if evaMult >= tier then
                 evaMult = tier
                 break
             end
@@ -926,10 +950,10 @@ function finalMagicNonSpellAdjustments(caster, target, ele, dmg)
 end
 
 function adjustForTarget(target, dmg, ele)
-    if dmg > 0 and math.random(0, 99) < target:getMod(xi.magic.absorbMod[ele]) then
+    if dmg > 0 and xi.magic.absorbMod[ele] and math.random(0, 99) < target:getMod(xi.magic.absorbMod[ele]) then
         return -dmg
     end
-    if math.random(0, 99) < target:getMod(nullMod[ele]) then
+    if nullMod[ele] and math.random(0, 99) < target:getMod(nullMod[ele]) then
         return 0
     end
     --Moved non element specific absorb and null mod checks to core

--- a/scripts/globals/mobskills/acid_mist.lua
+++ b/scripts/globals/mobskills/acid_mist.lua
@@ -20,7 +20,14 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration)
 
     local dmgmod = 1
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3.2, xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
+    local ftp = 2
+    if mob:getTP() >= 2000 then
+        ftp = 2.5
+    elseif mob:getTP() == 3000 then
+        ftp = 3
+    end
+
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * ftp, xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WATER)
     return dmg

--- a/scripts/globals/mobskills/brain_drain.lua
+++ b/scripts/globals/mobskills/brain_drain.lua
@@ -17,6 +17,12 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 2
+    if mob:getTP() >= 2000 then
+        dmgmod = 2.5
+    elseif mob:getTP() == 3000 then
+        dmgmod = 3
+    end
+
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, info.hitslanded)
 

--- a/scripts/globals/mobskills/cursed_sphere.lua
+++ b/scripts/globals/mobskills/cursed_sphere.lua
@@ -18,7 +18,15 @@ end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg()*2.6, xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local ftp = 2
+
+    if mob:getTP() >= 2000 then
+        ftp = 3
+    elseif mob:getTP() == 3000 then
+        ftp = 4
+    end
+
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * ftp, xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WATER)
     return dmg

--- a/scripts/globals/mobskills/eyes_on_me.lua
+++ b/scripts/globals/mobskills/eyes_on_me.lua
@@ -15,7 +15,11 @@ mobskill_object.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = mob:getWeaponDmg() * 4
+    local dmgmod = mob:getWeaponDmg() * 5
+
+    if mob:getZoneID() == bit.bor(xi.zone.TEMENOS, xi.zone.APOLLYON) then
+        dmgmod = mob:getWeaponDmg() * 7
+    end
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.SPECIAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 

--- a/scripts/globals/mobskills/hurricane_wing.lua
+++ b/scripts/globals/mobskills/hurricane_wing.lua
@@ -29,6 +29,10 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 60, 0, 30)
 
     local dmgmod = 4
+    if mob:getName() == "Nidhogg" then
+        dmgmod = 5
+    end
+
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg(), xi.magic.ele.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WIND)

--- a/scripts/globals/mobskills/maelstrom.lua
+++ b/scripts/globals/mobskills/maelstrom.lua
@@ -19,7 +19,7 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120)
 
     local dmgmod = 1
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3.5, xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WATER)
     return dmg

--- a/scripts/globals/mobskills/thunderbolt.lua
+++ b/scripts/globals/mobskills/thunderbolt.lua
@@ -24,7 +24,7 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, duration)
 
     local dmgmod = 1
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg()*2, xi.magic.ele.THUNDER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 1.5, xi.magic.ele.THUNDER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.LIGHTNING)
     return dmg

--- a/scripts/globals/mobskills/venom.lua
+++ b/scripts/globals/mobskills/venom.lua
@@ -24,7 +24,7 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
 
     local dmgmod = 1
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg()*1.5, xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg(), xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WATER)
     return dmg

--- a/scripts/globals/mobskills/whirlwind.lua
+++ b/scripts/globals/mobskills/whirlwind.lua
@@ -20,7 +20,7 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120)
 
     local dmgmod = 1
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4, xi.magic.ele.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.magic.ele.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WIND)
     return dmg

--- a/scripts/globals/mobskills/wing_cutter.lua
+++ b/scripts/globals/mobskills/wing_cutter.lua
@@ -14,7 +14,15 @@ end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.magic.ele.WIND, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
+
+    local ftp = 2
+    if mob:getTP() >= 2000 then
+        ftp = 2.5
+    elseif mob:getTP() == 3000 then
+        ftp = 3
+    end
+
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * ftp, xi.magic.ele.WIND, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WIND)
     return dmg

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -206,24 +206,14 @@ entity.onMobSpawn = function(mob)
                 pet:addMod(xi.mod.ATTP, 5 * diff)
                 pet:setHP(pet:getMaxHP())
                 player:messageBasic(xi.msg.basic.STATUS_INCREASED, 0, 0, pet)
-                master:addMod(xi.mod.ATTP, 4 * diff)
-                master:addMod(xi.mod.DEFP, 4 * diff)
-                master:addMod(xi.mod.HASTE_ABILITY, 200 * diff)
             end
             pet:setLocalVar("wyvern_exp", prev_exp + exp)
-            pet:setLocalVar("level_Ups", pet:getLocalVar("level_Ups") + diff)
         end
     end)
 end
 
 entity.onMobDeath = function(mob, player)
     local master = mob:getMaster()
-    local numLvls = mob:getLocalVar("level_Ups")
-    if numLvls ~= 0 then
-        master:delMod(xi.mod.ATTP, 4 * numLvls)
-        master:delMod(xi.mod.DEFP, 4 * numLvls)
-        master:delMod(xi.mod.HASTE_ABILITY, 200 * numLvls)
-    end
     master:removeListener("PET_WYVERN_WS")
     master:removeListener("PET_WYVERN_MAGIC")
     master:removeListener("PET_WYVERN_ENGAGE")

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -32,7 +32,7 @@ xi.magic.singleWeatherWeak   = { xi.weather.RAIN,              xi.weather.HOT_SP
 xi.magic.doubleWeatherWeak   = { xi.weather.SQUALL,            xi.weather.HEAT_WAVE,        xi.weather.BLIZZARDS,          xi.weather.GALES,              xi.weather.SAND_STORM,             xi.weather.THUNDERSTORMS,       xi.weather.DARKNESS,        xi.weather.STELLAR_GLARE  }
 xi.magic.resistMod           = { xi.mod.FIRE_MEVA,             xi.mod.ICE_MEVA,             xi.mod.WIND_MEVA,              xi.mod.EARTH_MEVA,             xi.mod.THUNDER_MEVA,               xi.mod.WATER_MEVA,              xi.mod.LIGHT_MEVA,          xi.mod.DARK_MEVA          }
 xi.magic.specificDmgTakenMod = { xi.mod.FIRE_SDT,              xi.mod.ICE_SDT,              xi.mod.WIND_SDT,               xi.mod.EARTH_SDT,              xi.mod.THUNDER_SDT,                xi.mod.WATER_SDT,               xi.mod.LIGHT_SDT,           xi.mod.DARK_SDT           }
-xi.magic.eleEvaMult          = { xi.mod.FIRE_EEM,              xi.mod.ICE_EEM,              xi.mod.WIND_EEM,               xi.mod.EARTH_EEM,              xi.mod.THUNDER_EEM,                xi.mod.WATER_EEM,               xi.mod.LIGHT_EEM,           xi.mod.DARK_EEM}
+xi.magic.eleEvaMult          = { xi.mod.FIRE_EEM,              xi.mod.ICE_EEM,              xi.mod.WIND_EEM,               xi.mod.EARTH_EEM,              xi.mod.THUNDER_EEM,                xi.mod.WATER_EEM,               xi.mod.LIGHT_EEM,           xi.mod.DARK_EEM }
 xi.magic.absorbMod           = { xi.mod.FIRE_ABSORB,           xi.mod.ICE_ABSORB,           xi.mod.WIND_ABSORB,            xi.mod.EARTH_ABSORB,           xi.mod.LTNG_ABSORB,                xi.mod.WATER_ABSORB,            xi.mod.LIGHT_ABSORB,        xi.mod.DARK_ABSORB        }
 xi.magic.barSpell            = { xi.effect.BARFIRE,            xi.effect.BARBLIZZARD,       xi.effect.BARAERO,             xi.effect.BARSTONE,            xi.effect.BARTHUNDER,              xi.effect.BARWATER              }
 
@@ -634,7 +634,7 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
 
     if target:getObjType() == xi.objType.MOB then
         evaMult = target:getMod(xi.magic.eleEvaMult[element]) / 100
-        local sortEvaMult = {1.50, 1.30, 1.15, 1.00, 0.85, 0.70, 0.60, 0.50, 0.40, 0.30, 0.25, 0.20, 0.15, 0.10,}
+        local sortEvaMult = { 1.50, 1.30, 1.15, 1.00, 0.85, 0.70, 0.60, 0.50, 0.40, 0.30, 0.25, 0.20, 0.15, 0.10, }
         for _, tier in pairs(sortEvaMult) do -- Finds the highest tier for the resist. We sort just to be safe.
             if evaMult >= tier then
                 evaMult = tier

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -295,7 +295,8 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, f
             -- Duplicate the first hit with an added magical component for hybrid WSes
             if calcParams.hybridHit then
                 -- Calculate magical bonuses and reductions
-                local magicdmg = addBonusesAbility(attacker, wsParams.ele, target, finaldmg, wsParams)
+                local ftpHybrid = fTP(calcParams.tp, wsParams.ftp100, wsParams.ftp200, wsParams.ftp300) + calcParams.bonusfTP
+                local magicdmg = math.floor(finaldmg * ftpHybrid)
 
                 wsParams.bonus = calcParams.bonusAcc
                 magicdmg = magicdmg * applyResistanceAbility(attacker, target, wsParams.ele, wsParams)
@@ -406,6 +407,10 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
 
     local wsMods = calcParams.fSTR + (math.floor(str + dex + vit + agi + int + mnd + chr) * calcParams.alpha)
     local ftp = fTP(tp, wsParams.ftp100, wsParams.ftp200, wsParams.ftp300) + calcParams.bonusfTP
+
+    if wsParams.hybridWS then
+        ftp = 1
+    end
 
     if not isRanged then
         base = (calcParams.weaponDamage[1] + calcParams.fSTR + wsMods) * ftp

--- a/scripts/globals/weaponskills/armor_break.lua
+++ b/scripts/globals/weaponskills/armor_break.lua
@@ -37,7 +37,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false) then
-        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffectWS(player, target, xi.magic.ele.WIND, 0)
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
     end
 

--- a/scripts/globals/weaponskills/blade_kamu.lua
+++ b/scripts/globals/weaponskills/blade_kamu.lua
@@ -45,7 +45,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.ACCURACY_DOWN) then
-            local duration = tp / 1000 * 60 * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+            local duration = tp / 1000 * 60 * applyResistanceAddEffectWS(player, target, xi.magic.ele.EARTH, 0)
             target:addStatusEffect(xi.effect.ACCURACY_DOWN, 10, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/blade_metsu.lua
+++ b/scripts/globals/weaponskills/blade_metsu.lua
@@ -43,7 +43,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.PARALYSIS) then
-            local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+            local duration = 60 * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0)
             target:addStatusEffect(xi.effect.PARALYSIS, 10, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/blade_retsu.lua
+++ b/scripts/globals/weaponskills/blade_retsu.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if (damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false) then
-        local duration = (tp/1000 * 30) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (tp/1000 * 30) * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0)
         -- paralyze proc based on lvl difference
         local power = 30 + (player:getMainLvl() - target:getMainLvl())*3
         if (power > 35) then

--- a/scripts/globals/weaponskills/blade_yu.lua
+++ b/scripts/globals/weaponskills/blade_yu.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.POISON) == false) then
-        local duration = (75 + (tp/1000 * 15)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (75 + (tp/1000 * 15)) * applyResistanceAddEffectWS(player, target, xi.magic.ele.WATER, 0)
         target:addStatusEffect(xi.effect.POISON, 10, 0, duration)
     end
     return tpHits, extraHits, false, damage

--- a/scripts/globals/weaponskills/bora_axe.lua
+++ b/scripts/globals/weaponskills/bora_axe.lua
@@ -37,9 +37,9 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000))) > math.random() * 150
+    local chance = (tp-1000) * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0) > math.random() * 150
     if (damage > 0 and target:hasStatusEffect(xi.effect.BIND) == false and chance) then
-        local duration = 20 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = 20 * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0)
         target:addStatusEffect(xi.effect.BIND, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/brainshaker.lua
+++ b/scripts/globals/weaponskills/brainshaker.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false) then
-        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (tp/500) * applyResistanceAddEffectWS(player, target, xi.magic.ele.LIGHTNING, 0)
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/exenterator.lua
+++ b/scripts/globals/weaponskills/exenterator.lua
@@ -39,7 +39,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.ACCURACY_DOWN) == false) then
-        local duration = (45 + (tp/1000 * 45)) * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (45 + (tp/1000 * 45)) * applyResistanceAddEffectWS(player, target, xi.magic.ele.EARTH, 0)
         target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/flat_blade.lua
+++ b/scripts/globals/weaponskills/flat_blade.lua
@@ -34,9 +34,9 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0) > math.random() * 150
+    local chance = (tp-1000) * applyResistanceAddEffectWS(player, target, xi.magic.ele.LIGHTNING, 0) > math.random() * 150
     if (damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false and chance) then
-        local duration = 4 * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
+        local duration = 4 * applyResistanceAddEffectWS(player, target, xi.magic.ele.LIGHTNING, 0)
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/full_break.lua
+++ b/scripts/globals/weaponskills/full_break.lua
@@ -36,16 +36,16 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     if (damage > 0) then
         local duration = (tp/1000 * 30) + 60
         if (target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false) then
-            target:addStatusEffect(xi.effect.DEFENSE_DOWN, 12.5, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000))))
+            target:addStatusEffect(xi.effect.DEFENSE_DOWN, 12.5, 0, duration * applyResistanceAddEffectWS(player, target, xi.magic.ele.WIND, 0))
         end
         if (target:hasStatusEffect(xi.effect.ATTACK_DOWN) == false) then
-            target:addStatusEffect(xi.effect.ATTACK_DOWN, 12.5, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, ((player:getMainLvl() / 7.5) * (tp / 1000))))
+            target:addStatusEffect(xi.effect.ATTACK_DOWN, 12.5, 0, duration * applyResistanceAddEffectWS(player, target, xi.magic.ele.WATER, 0))
         end
         if (target:hasStatusEffect(xi.effect.EVASION_DOWN) == false) then
-            target:addStatusEffect(xi.effect.EVASION_DOWN, 20, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000))))
+            target:addStatusEffect(xi.effect.EVASION_DOWN, 20, 0, duration * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0))
         end
         if (target:hasStatusEffect(xi.effect.ACCURACY_DOWN) == false) then
-            target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, ((player:getMainLvl() / 7.5) * (tp / 1000))))
+            target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration * applyResistanceAddEffectWS(player, target, xi.magic.ele.EARTH, 0))
         end
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/garland_of_bliss.lua
+++ b/scripts/globals/weaponskills/garland_of_bliss.lua
@@ -40,7 +40,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.DEFENSE_DOWN) then
-            local duration = (30 + tp / 1000 * 30) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+            local duration = (30 + tp / 1000 * 30) * applyResistanceAddEffectWS(player, target, xi.magic.ele.WIND, 0)
             target:addStatusEffect(xi.effect.DEFENSE_DOWN, 12.5, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/gate_of_tartarus.lua
+++ b/scripts/globals/weaponskills/gate_of_tartarus.lua
@@ -41,7 +41,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
-            local duration = tp / 1000 * 3 * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+            local duration = tp / 1000 * 3 * applyResistanceAddEffectWS(player, target, xi.magic.ele.WATER, 0)
             target:addStatusEffect(xi.effect.ATTACK_DOWN, 20, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/glory_slash.lua
+++ b/scripts/globals/weaponskills/glory_slash.lua
@@ -31,7 +31,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false) then
-        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (tp/500) * applyResistanceAddEffectWS(player, target, xi.magic.ele.LIGHTNING, 0)
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end
 

--- a/scripts/globals/weaponskills/guillotine.lua
+++ b/scripts/globals/weaponskills/guillotine.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.SILENCE) == false) then
-        local duration = (30 + (tp/1000 * 30)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (30 + (tp/1000 * 30)) * applyResistanceAddEffectWS(player, target, xi.magic.ele.WIND, 0)
         target:addStatusEffect(xi.effect.SILENCE, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/herculean_slash.lua
+++ b/scripts/globals/weaponskills/herculean_slash.lua
@@ -34,7 +34,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false) then
-        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (tp/1000 * 60) * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0)
         target:addStatusEffect(xi.effect.PARALYSIS, 30, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/infernal_scythe.lua
+++ b/scripts/globals/weaponskills/infernal_scythe.lua
@@ -33,7 +33,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.ATTACK_DOWN) == false) then
-        local duration = (tp/1000 * 180) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0)
+        local duration = (tp/1000 * 180) * applyResistanceAddEffectWS(player, target, xi.magic.ele.WATER, 0)
         target:addStatusEffect(xi.effect.ATTACK_DOWN, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/leg_sweep.lua
+++ b/scripts/globals/weaponskills/leg_sweep.lua
@@ -34,10 +34,10 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0) > math.random() * 150
+    local chance = (tp-1000) * applyResistanceAddEffectWS(player, target, xi.magic.ele.LIGHTNING, 0) > math.random() * 150
     if (damage > 0 and chance) then
         if (target:hasStatusEffect(xi.effect.STUN) == false) then
-            local duration = 4 * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+            local duration = 4 * applyResistanceAddEffectWS(player, target, xi.magic.ele.LIGHTNING, 0)
             target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/metatron_torment.lua
+++ b/scripts/globals/weaponskills/metatron_torment.lua
@@ -43,7 +43,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if damage > 0 then
-        local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = tp / 1000 * 20 * applyResistanceAddEffectWS(player, target, xi.magic.ele.WIND, 0)
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 19, 0, duration)
     end
 

--- a/scripts/globals/weaponskills/nightmare_scythe.lua
+++ b/scripts/globals/weaponskills/nightmare_scythe.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.BLINDNESS) == false) then
-        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, 0)
+        local duration = (tp/1000 * 60) * applyResistanceAddEffectWS(player, target, xi.magic.ele.DARK, 0)
         target:addStatusEffect(xi.effect.BLINDNESS, 15, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/numbing_shot.lua
+++ b/scripts/globals/weaponskills/numbing_shot.lua
@@ -34,7 +34,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false) then
-        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (tp/1000 * 60) * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0)
         target:addStatusEffect(xi.effect.PARALYSIS, 30, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/onslaught.lua
+++ b/scripts/globals/weaponskills/onslaught.lua
@@ -41,7 +41,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.ACCURACY_DOWN) then
-            local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+            local duration = tp / 1000 * 20 * applyResistanceAddEffectWS(player, target, xi.magic.ele.EARTH, 0)
             target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/pyrrhic_kleos.lua
+++ b/scripts/globals/weaponskills/pyrrhic_kleos.lua
@@ -44,7 +44,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
-            local duration = tp / 1000 * 60 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+            local duration = tp / 1000 * 60 * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0)
             target:addStatusEffect(xi.effect.EVASION_DOWN, 10, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/randgrith.lua
+++ b/scripts/globals/weaponskills/randgrith.lua
@@ -39,7 +39,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
-            local duration = tp / 1000 * 20 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+            local duration = tp / 1000 * 20 * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0)
             target:addStatusEffect(xi.effect.EVASION_DOWN, 32, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/shadowstitch.lua
+++ b/scripts/globals/weaponskills/shadowstitch.lua
@@ -35,9 +35,9 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0) then
-        local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0) > math.random() * 150
+        local chance = (tp-1000) * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0) > math.random() * 150
         if (target:hasStatusEffect(xi.effect.BIND) == false and chance) then
-            local duration = (5 + (tp/1000 * 5)) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+            local duration = (5 + (tp/1000 * 5)) * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0)
             target:addStatusEffect(xi.effect.BIND, 1, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/shell_crusher.lua
+++ b/scripts/globals/weaponskills/shell_crusher.lua
@@ -36,7 +36,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false) then
-        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffectWS(player, target, xi.magic.ele.WIND, 0)
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/shield_break.lua
+++ b/scripts/globals/weaponskills/shield_break.lua
@@ -38,7 +38,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.EVASION_DOWN) == false) then
-        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0)
         target:addStatusEffect(xi.effect.EVASION_DOWN, 40, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/shockwave.lua
+++ b/scripts/globals/weaponskills/shockwave.lua
@@ -29,7 +29,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.SLEEP_I) == false) then
-        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (tp/1000 * 60) * applyResistanceAddEffectWS(player, target, xi.magic.ele.DARK, 0)
         target:addStatusEffect(xi.effect.SLEEP_I, 1, 0, duration)
     end
 

--- a/scripts/globals/weaponskills/shoulder_tackle.lua
+++ b/scripts/globals/weaponskills/shoulder_tackle.lua
@@ -34,7 +34,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     end
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false) then
-        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (tp/500) * applyResistanceAddEffectWS(player, target, xi.magic.ele.LIGHTNING, 0)
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/smash_axe.lua
+++ b/scripts/globals/weaponskills/smash_axe.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false) then
-        local duration = (tp/500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (tp/500) * applyResistanceAddEffectWS(player, target, xi.magic.ele.LIGHTNING, 0)
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/tachi_ageha.lua
+++ b/scripts/globals/weaponskills/tachi_ageha.lua
@@ -38,7 +38,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false) then
-        local duration = (tp/1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (tp/1000 * 60) * applyResistanceAddEffectWS(player, target, xi.magic.ele.WIND, 0)
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/tachi_gekko.lua
+++ b/scripts/globals/weaponskills/tachi_gekko.lua
@@ -37,7 +37,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     -- Silence duration changed from 60 to 45 as per bg-wiki: http://www.bg-wiki.com/bg/Tachi:_Gekko
     if (damage > 0 and target:hasStatusEffect(xi.effect.SILENCE) == false) then
-        local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
+        local duration = 60 * applyResistanceAddEffectWS(player, target, xi.magic.ele.WIND, 0)
         target:addStatusEffect(xi.effect.SILENCE, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/tachi_hobaku.lua
+++ b/scripts/globals/weaponskills/tachi_hobaku.lua
@@ -34,7 +34,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    local chance = (tp - 1000) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0) > math.random() * 150
+    local chance = (tp - 1000) * applyResistanceAddEffectWS(player, target, xi.magic.ele.LIGHTNING, 0) > math.random() * 150
     if (damage > 0 and chance) then
         if (target:hasStatusEffect(xi.effect.STUN) == false) then
             target:addStatusEffect(xi.effect.STUN, 1, 0, 4)

--- a/scripts/globals/weaponskills/tachi_kasha.lua
+++ b/scripts/globals/weaponskills/tachi_kasha.lua
@@ -40,7 +40,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false) then
-        local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = 60 * applyResistanceAddEffectWS(player, target, xi.magic.ele.ICE, 0)
         target:addStatusEffect(xi.effect.PARALYSIS, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/tachi_yukikaze.lua
+++ b/scripts/globals/weaponskills/tachi_yukikaze.lua
@@ -38,7 +38,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.BLINDNESS) == false) then
-        local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = 60 * applyResistanceAddEffectWS(player, target, xi.magic.ele.DARK, 0)
         target:addStatusEffect(xi.effect.BLINDNESS, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/ukkos_fury.lua
+++ b/scripts/globals/weaponskills/ukkos_fury.lua
@@ -44,7 +44,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.SLOW) then
-            local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+            local duration = 60 * applyResistanceAddEffectWS(player, target, xi.magic.ele.EARTH, 0)
             target:addStatusEffect(xi.effect.SLOW, 1500, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/viper_bite.lua
+++ b/scripts/globals/weaponskills/viper_bite.lua
@@ -37,7 +37,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.POISON) == false) then
-        local duration = (30 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (30 + (tp/1000 * 60)) * applyResistanceAddEffectWS(player, target, xi.magic.ele.WATER, 0)
         target:addStatusEffect(xi.effect.POISON, 3, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/wasp_sting.lua
+++ b/scripts/globals/weaponskills/wasp_sting.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.POISON) == false) then
-        local duration = (75 + (tp/1000 * 15)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0)
+        local duration = (75 + (tp/1000 * 15)) * applyResistanceAddEffectWS(player, target, xi.magic.ele.WATER, 0)
         target:addStatusEffect(xi.effect.POISON, 1, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/weapon_break.lua
+++ b/scripts/globals/weaponskills/weapon_break.lua
@@ -38,7 +38,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if (damage > 0 and target:hasStatusEffect(xi.effect.ATTACK_DOWN) == false) then
-        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, ((player:getMainLvl() / 7.5) * (tp / 1000)))
+        local duration = (120 + (tp/1000 * 60)) * applyResistanceAddEffectWS(player, target, xi.magic.ele.WATER, 0)
         target:addStatusEffect(xi.effect.ATTACK_DOWN, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Adds FTP values to some mobskills. (https://w.atwiki.jp/studiogobli/pages/30.html)
+ Adjusts the hybrid weaponskill formula to be era-accurate.
+ Adjusts magic weaponskills, status weaponskills, and hybrid weaponskills to use the skill of the weapon as an equivalent stand-in for magic accuracy.
+ Adjust the status weaponskill formula to be era-accurate with a 100, 50, 0 resist rate sort.
+ Fixes an issue with the EEM sort which caused all magic hit rate checks to provide 1 tier lower than the intended sort.
+ Fixes an issue where player avatar MACC was too low.
+ Removed OOE buffs on wyvern parameter increase for master.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/5
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/135
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/136
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/127

## Steps to test these changes

