### PR TITLE
Add Ruinous Omen to Astral Flow abilities

### DIFF
--- a/scripts/globals/abilities/pets/ruinous_omen.lua
+++ b/scripts/globals/abilities/pets/ruinous_omen.lua
@@ -1,0 +1,73 @@
+---------------------------------------------------
+-- Ruinous Omen (Summoner Player version)
+-- Used by:  Diabolos
+-- Deals damage equal to a random percentage of HP to enemies within area of effect
+-- https://ffxiclopedia.fandom.com/wiki/Ruinous_Omen
+-- Prime Avatar seems to do an unresisted ~66% HP reduction from players' current HP (not max HP)
+-- RO by design cannot KO a target, but can significantly reduce its HP
+-- Version used by player summoners seems capped at ~2% except against Behemoths
+-- https://www.bluegartr.com/threads/108197-Random-Facts-Thread-Abilities?p=6003851&viewfull=1#post6003851
+---------------------------------------------
+require("scripts/globals/settings")
+require("scripts/globals/status")
+require("scripts/globals/mobskills")
+require("scripts/globals/summon")
+---------------------------------------------
+local ability_object = {}
+
+ability_object.onAbilityCheck = function(player, target, ability)
+    local level = player:getMainLvl() * 2
+
+    if(player:getMP() < level) then
+        return 87, 0
+    end
+
+    return 0, 0
+end
+
+ability_object.onPetAbility = function(target, pet, skill)
+    -- INT based: get the dINT
+    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+    local targetHP = target:getHP()
+    -- local dmgmod = 1
+    local ratio = 2
+
+    -- Scale the dINT modifier a bit
+    if dINT > 12 then
+        ratio = 4
+    elseif dINT > 6 then
+        ratio = 3
+    end
+
+    -- Target HPP decrease is small, and even lower against HNMs
+    -- For now: Estimate 10-30% for regular mobs, with 25 as the average
+    local hppMin = 1.0
+    local hppMax = 20.0
+
+    if target:isNM() then
+        hppMin = 0.1
+        hppMax = 5.0
+    end
+
+    local damageMax = targetHP * hppMax / 100
+    local damageMin = targetHP * hppMin / 100
+    local damage = damageMin + math.random(0, (damageMax - damageMin) / 2) + math.random(0, (damageMax - damageMin) / 2)
+
+    damage = damage * (1 + ((dINT / ratio) / 100))  -- A wild estimate appears!  It's super ineffective!
+
+    -- hpp and damage do not correlate, but we can use the system to scale damage numbers
+    -- damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, dmgmod, xi.mobskills.magicalTpBonus, 0)
+    -- damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.DARK)
+    -- damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.magicalTpBonus.NO_EFFECT)
+
+    -- Clamp the HPP reduction to the min/max HP values
+    damage = utils.clamp(damage, damageMin, damageMax)
+    target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
+
+    -- Reset master MP
+    pet:getMaster():setMP(0)
+
+    return damage
+end
+
+return ability_object

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -516,7 +516,7 @@ INSERT INTO `abilities` VALUES (660,'noctoshield',15,49,1,60,174,0,0,92,2000,0,6
 INSERT INTO `abilities` VALUES (661,'dream_shroud',15,56,1,60,174,0,0,121,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (662,'nether_blast',15,65,4,60,173,0,0,109,2000,0,6,18.0,0,1,60,0,0,NULL);
 -- INSERT INTO `abilities` VALUES (663,'cacodemonia',22,1,1,0,300,0,0,???,2000,0,6,20.0,0,450,900,0,0,NULL);
--- INSERT INTO `abilities` VALUES (664,'ruinous_omen',22,1,1,0,300,0,0,???,2000,0,6,20.0,0,450,900,0,0,NULL);
+ INSERT INTO `abilities` VALUES (664,'ruinous_omen',15,1,4,60,173,0,0,0,2000,0,6,18.0,1,1,60,0,2,NULL);
 -- INSERT INTO `abilities` VALUES (665,'night_terror',22,1,1,0,300,0,0,???,2000,0,6,20.0,0,450,900,0,0,NULL);
 -- INSERT INTO `abilities` VALUES (666,'pavor_nocturnus',22,1,1,0,300,0,0,???,2000,0,6,20.0,0,450,900,0,0,NULL);
 -- INSERT INTO `abilities` VALUES (667,'blindside',22,1,1,0,300,0,0,???,2000,0,6,20.0,0,450,900,0,0,NULL);


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds Ruinous Omen to summoner's abilities when Astral Flow is used and Diabolos is active.

## Steps to test these changes

Summon Diabolos.  Use Astral Flow.  Use Ruinous Omen.

TODO:  Still needs work for testing data, but this PR allows for testers to do local comparisons.  Very much a WIP.
