### PR TITLE
Add More Accurate AI to Player SMN Spirits

### DIFF
--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -24,7 +24,9 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../../common/utils.h"
 #include "../../entities/petentity.h"
 #include "../../status_effect_container.h"
+#include "../../utils/battleutils.h"
 #include "../../utils/petutils.h"
+#include "../../utils/zoneutils.h"
 #include "../ai_container.h"
 
 CPetController::CPetController(CPetEntity* _PPet)
@@ -45,6 +47,19 @@ void CPetController::Tick(time_point tick)
         petutils::DespawnPet(PPet->PMaster);
         return;
     }
+
+    if (PPet->m_PetID <= PETID_DARKSPIRIT && PPet->PMaster && PPet->PMaster->objtype == TYPE_PC && !m_Setup)
+    {
+        SetSMNCastTime();
+
+        if (PPet->m_PetID == PETID_LIGHTSPIRIT)
+        {
+            SetSpiritSpellTables();
+        }
+
+        m_Setup = true;
+    }
+
     CMobController::Tick(tick);
 }
 
@@ -67,6 +82,11 @@ void CPetController::DoRoamTick(time_point tick)
     else if (PPet->isBstPet() && PPet->StatusEffectContainer->GetStatusEffect(EFFECT_HEALING))
     {
         return;
+    }
+
+    if (PPet->m_PetID <= PETID::PETID_DARKSPIRIT)
+    {
+        TryIdleSpellCast();
     }
 
     float currentDistance = distance(PPet->loc.p, PPet->PMaster->loc.p);
@@ -106,6 +126,412 @@ bool CPetController::PetIsHealing()
         return false;
     }
     return isMasterHealing;
+}
+
+void CPetController::TryIdleSpellCast()
+{
+    if (!PPet->PMaster || PPet->PMaster->objtype != TYPE_PC ||
+        m_Tick <= PPet->m_lastCast + PPet->m_castCool ||
+        PPet->StatusEffectContainer->HasPreventActionEffect() ||
+        PPet->StatusEffectContainer->HasStatusEffect(EFFECT_SILENCE))
+    {
+        return;
+    }
+    else
+    {
+        uint8 mLvl = PPet->GetMLevel();
+
+        switch (PPet->m_PetID)
+        {
+            case PETID_EARTHSPIRIT:
+                if (mLvl >= 28 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_STONESKIN))
+                {
+                    CastSpell(SpellID::Stoneskin);
+                }
+                break;
+            case PETID_WATERSPIRIT:
+                if (mLvl >= 10 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_AQUAVEIL))
+                {
+                    CastSpell(SpellID::Aquaveil);
+                }
+                break;
+            case PETID_AIRSPIRIT:
+                if (mLvl >= 19 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_BLINK))
+                {
+                    CastSpell(SpellID::Blink);
+                }
+                break;
+            case PETID_FIRESPIRIT:
+                if (mLvl >= 10 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_BLAZE_SPIKES))
+                {
+                    CastSpell(SpellID::Blaze_Spikes);
+                }
+                break;
+            case PETID_ICESPIRIT:
+                if (mLvl >= 20 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_ICE_SPIKES))
+                {
+                    CastSpell(SpellID::Ice_Spikes);
+                }
+                break;
+            case PETID_THUNDERSPIRIT:
+                if (mLvl >= 30 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_SHOCK_SPIKES))
+                {
+                    CastSpell(SpellID::Shock_Spikes);
+                }
+                break;
+            case PETID_DARKSPIRIT:
+                break;
+            case PETID_LIGHTSPIRIT:
+                CBattleEntity* PLowest       = nullptr;
+                float          lowestPercent = 100.f;
+                uint8          choice        = 2;
+
+                // clang-format off
+                PPet->PMaster->ForParty([&](CBattleEntity* PMember)
+                {
+                    if (PMember != nullptr && PPet->PMaster->loc.zone->GetID() == PMember->loc.zone->GetID() && distance(PPet->loc.p, PMember->loc.p) <= 20 &&
+                        !PMember->isDead())
+                    {
+                        float memberPercent = PMember->health.hp / PMember->health.maxhp;
+                        if (PLowest == nullptr ||
+                            (lowestPercent >= memberPercent))
+                        {
+                            PLowest = PMember;
+                            lowestPercent = memberPercent;
+                        }
+                    }
+                });
+                // clang-format on
+
+                if (lowestPercent < 0.5f) // 50% HP
+                {
+                    choice = xirand::GetRandomNumber(1, 3);
+                }
+
+                switch (choice)
+                {
+                    case 1:
+                        CastSpell(static_cast<SpellID>(xirand::GetRandomElement(PPet->m_healSpells)));
+                        break;
+                    case 2:
+                        CastSpell(static_cast<SpellID>(xirand::GetRandomElement(PPet->m_buffSpells)));
+                        break;
+                }
+                break;
+        }
+
+        if (PPet)
+        {
+            PPet->m_lastCast = m_Tick;
+        }
+    }
+}
+
+void CPetController::SetSpiritSpellTables()
+{
+    uint8 mLvl = PPet->GetMLevel();
+
+    if (mLvl >= 71)
+    {
+        PPet->m_healSpells.push_back(static_cast<uint16>(SpellID::Curaga_IV));
+    }
+    if (mLvl >= 68)
+    {
+        PPet->m_buffSpells.push_back(static_cast<uint16>(SpellID::Shell_IV));
+    }
+    if (mLvl >= 65)
+    {
+        PPet->m_offensiveSpells.push_back(static_cast<uint16>(SpellID::Banish_III));
+    }
+    if (mLvl >= 63)
+    {
+        PPet->m_buffSpells.push_back(static_cast<uint16>(SpellID::Protect_IV));
+    }
+    if (mLvl >= 61)
+    {
+        PPet->m_healSpells.push_back(static_cast<uint16>(SpellID::Cure_V));
+    }
+    if (mLvl >= 57 && mLvl < 68)
+    {
+        PPet->m_buffSpells.push_back(static_cast<uint16>(SpellID::Shell_III));
+    }
+    if (mLvl >= 51)
+    {
+        PPet->m_healSpells.push_back(static_cast<uint16>(SpellID::Curaga_III));
+    }
+    if (mLvl >= 50)
+    {
+        PPet->m_offensiveSpells.push_back(static_cast<uint16>(SpellID::Holy));
+    }
+    if (mLvl >= 47 && mLvl < 63)
+    {
+        PPet->m_buffSpells.push_back(static_cast<uint16>(SpellID::Protect_III));
+    }
+    if (mLvl >= 41)
+    {
+        PPet->m_healSpells.push_back(static_cast<uint16>(SpellID::Cure_IV));
+    }
+    if (mLvl >= 40)
+    {
+        PPet->m_buffSpells.push_back(static_cast<uint16>(SpellID::Haste));
+        PPet->m_offensiveSpells.push_back(static_cast<uint16>(SpellID::Banishga_II));
+    }
+    if (mLvl >= 37)
+    {
+        PPet->m_offensiveSpells.push_back(static_cast<uint16>(SpellID::Flash));
+    }
+    if (mLvl >= 37 && mLvl < 57)
+    {
+        PPet->m_buffSpells.push_back(static_cast<uint16>(SpellID::Shell_II));
+    }
+    if (mLvl >= 31)
+    {
+        PPet->m_offensiveSpells.push_back(static_cast<uint16>(SpellID::Dia_II));
+    }
+    if (mLvl >= 31 && mLvl < 71)
+    {
+        PPet->m_healSpells.push_back(static_cast<uint16>(SpellID::Curaga_II));
+    }
+    if (mLvl >= 30)
+    {
+        PPet->m_offensiveSpells.push_back(static_cast<uint16>(SpellID::Banish_II));
+    }
+    if (mLvl >= 27 && mLvl < 57)
+    {
+        PPet->m_buffSpells.push_back(static_cast<uint16>(SpellID::Protect_II));
+    }
+    if (mLvl >= 21)
+    {
+        PPet->m_buffSpells.push_back(static_cast<uint16>(SpellID::Regen));
+    }
+    if (mLvl >= 21 && mLvl < 41)
+    {
+        PPet->m_healSpells.push_back(static_cast<uint16>(SpellID::Cure_III));
+    }
+    if (mLvl >= 17 && mLvl < 37)
+    {
+        PPet->m_buffSpells.push_back(static_cast<uint16>(SpellID::Shell));
+    }
+    if (mLvl >= 16 && mLvl < 51)
+    {
+        PPet->m_healSpells.push_back(static_cast<uint16>(SpellID::Curaga));
+    }
+    if (mLvl >= 11 && mLvl < 41)
+    {
+        PPet->m_healSpells.push_back(static_cast<uint16>(SpellID::Cure_II));
+    }
+    if (mLvl >= 7 && mLvl < 27)
+    {
+        PPet->m_buffSpells.push_back(static_cast<uint16>(SpellID::Protect));
+    }
+    if (mLvl >= 5 && mLvl < 65)
+    {
+        PPet->m_offensiveSpells.push_back(static_cast<uint16>(SpellID::Banish));
+    }
+    if (mLvl >= 1 && mLvl < 21)
+    {
+        PPet->m_healSpells.push_back(static_cast<uint16>(SpellID::Cure));
+    }
+}
+
+void CPetController::SetSMNCastTime()
+{
+    PPet->m_lastCast = std::chrono::system_clock::now();
+    uint32 castTime  = ((48000 + GetSMNSkillReduction()) / 3) + GetDayWeatherBonus();
+
+    if (PPet->PMaster->StatusEffectContainer->HasStatusEffect(EFFECT_ASTRAL_FLOW))
+    {
+        castTime -= 5000;
+    }
+
+    if (static_cast<CCharEntity*>(PPet->PMaster)->getEquip(SLOT_LEGS)->getID() == (15131 | 15594))
+    {
+        castTime -= 5000;
+    }
+
+    PPet->m_castCool = std::chrono::milliseconds(castTime);
+}
+
+int16 CPetController::GetSMNSkillReduction()
+{
+    if (PPet->PMaster && PPet->PMaster->objtype == TYPE_PC)
+    {
+        uint8 masterLvl = PPet->PMaster->GetMLevel();
+
+        if (PPet->PMaster->GetMJob() != JOB_SMN)
+        {
+            masterLvl = PPet->PMaster->GetSLevel();
+        }
+
+        uint16 skill    = PPet->PMaster->GetSkill(SKILL_SUMMONING_MAGIC);
+        uint16 maxSkill = battleutils::GetMaxSkill(SKILL_SUMMONING_MAGIC, JOB_SMN, masterLvl);
+
+        return (1000 * floor(skill - maxSkill));
+    }
+
+    return 0;
+}
+
+int16 CPetController::GetDayWeatherBonus()
+{
+    if (PPet->PMaster == nullptr || PPet->PMaster->objtype != TYPE_PC)
+    {
+        return 0;
+    }
+
+    WEATHER zoneWeather = zoneutils::GetZone(PPet->PMaster->getZone())->GetWeather();
+    uint32  vanaDay     = CVanaTime::getInstance()->getWeekday();
+    int16   bonus       = 0;
+
+    switch (PPet->m_PetID)
+    {
+        case PETID_EARTHSPIRIT:
+            if (zoneWeather == WEATHER_DUST_STORM || zoneWeather == WEATHER_SAND_STORM)
+            {
+                bonus -= 2000;
+            }
+            if (zoneWeather == WEATHER_WIND || zoneWeather == WEATHER_GALES)
+            {
+                bonus += 2000;
+            }
+            if (vanaDay == DAYTYPE::EARTHSDAY)
+            {
+                bonus -= 3000;
+            }
+            if (vanaDay == DAYTYPE::WINDSDAY)
+            {
+                bonus += 3000;
+            }
+            break;
+        case PETID_WATERSPIRIT:
+            if (zoneWeather == WEATHER_RAIN || zoneWeather == WEATHER_SQUALL)
+            {
+                bonus -= 2000;
+            }
+            if (zoneWeather == WEATHER_THUNDER || zoneWeather == WEATHER_THUNDERSTORMS)
+            {
+                bonus += 2000;
+            }
+            if (vanaDay == DAYTYPE::WATERSDAY)
+            {
+                bonus -= 3000;
+            }
+            if (vanaDay == DAYTYPE::LIGHTNINGDAY)
+            {
+                bonus += 3000;
+            }
+            break;
+        case PETID_AIRSPIRIT:
+            if (zoneWeather == WEATHER_WIND || zoneWeather == WEATHER_GALES)
+            {
+                bonus -= 2000;
+            }
+            if (zoneWeather == WEATHER_SNOW || zoneWeather == WEATHER_BLIZZARDS)
+            {
+                bonus += 2000;
+            }
+            if (vanaDay == DAYTYPE::WINDSDAY)
+            {
+                bonus -= 3000;
+            }
+            if (vanaDay == DAYTYPE::ICEDAY)
+            {
+                bonus += 3000;
+            }
+            break;
+        case PETID_FIRESPIRIT:
+            if (zoneWeather == WEATHER_HOT_SPELL || zoneWeather == WEATHER_HEAT_WAVE)
+            {
+                bonus -= 2000;
+            }
+            if (zoneWeather == WEATHER_RAIN || zoneWeather == WEATHER_SQUALL)
+            {
+                bonus += 2000;
+            }
+            if (vanaDay == DAYTYPE::FIRESDAY)
+            {
+                bonus -= 3000;
+            }
+            if (vanaDay == DAYTYPE::WATERSDAY)
+            {
+                bonus += 3000;
+            }
+            break;
+        case PETID_ICESPIRIT:
+            if (zoneWeather == WEATHER_SNOW || zoneWeather == WEATHER_BLIZZARDS)
+            {
+                bonus -= 2000;
+            }
+            if (zoneWeather == WEATHER_HOT_SPELL || zoneWeather == WEATHER_HEAT_WAVE)
+            {
+                bonus += 2000;
+            }
+            if (vanaDay == DAYTYPE::ICEDAY)
+            {
+                bonus -= 3000;
+            }
+            if (vanaDay == DAYTYPE::FIRESDAY)
+            {
+                bonus += 3000;
+            }
+            break;
+        case PETID_THUNDERSPIRIT:
+            if (zoneWeather == WEATHER_THUNDER || zoneWeather == WEATHER_THUNDERSTORMS)
+            {
+                bonus -= 2000;
+            }
+            if (zoneWeather == WEATHER_DUST_STORM || zoneWeather == WEATHER_SAND_STORM)
+            {
+                bonus += 2000;
+            }
+            if (vanaDay == DAYTYPE::LIGHTNINGDAY)
+            {
+                bonus -= 3000;
+            }
+            if (vanaDay == DAYTYPE::EARTHSDAY)
+            {
+                bonus += 3000;
+            }
+            break;
+        case PETID_DARKSPIRIT:
+            if (zoneWeather == WEATHER_GLOOM || zoneWeather == WEATHER_DARKNESS)
+            {
+                bonus -= 2000;
+            }
+            if (zoneWeather == WEATHER_AURORAS || zoneWeather == WEATHER_STELLAR_GLARE)
+            {
+                bonus += 2000;
+            }
+            if (vanaDay == DAYTYPE::DARKSDAY)
+            {
+                bonus -= 3000;
+            }
+            if (vanaDay == DAYTYPE::LIGHTSDAY)
+            {
+                bonus += 3000;
+            }
+            break;
+        case PETID_LIGHTSPIRIT:
+            if (zoneWeather == WEATHER_AURORAS || zoneWeather == WEATHER_STELLAR_GLARE)
+            {
+                bonus -= 2000;
+            }
+            if (zoneWeather == WEATHER_GLOOM || zoneWeather == WEATHER_DARKNESS)
+            {
+                bonus += 2000;
+            }
+            if (vanaDay == DAYTYPE::LIGHTSDAY)
+            {
+                bonus -= 3000;
+            }
+            if (vanaDay == DAYTYPE::DARKSDAY)
+            {
+                bonus += 3000;
+            }
+            break;
+    }
+
+    return bonus;
 }
 
 bool CPetController::TryDeaggro()

--- a/src/map/ai/controllers/pet_controller.h
+++ b/src/map/ai/controllers/pet_controller.h
@@ -35,7 +35,12 @@ public:
     bool                   PetSkill(uint16 targid, uint16 abilityid);
 
 protected:
-    bool PetIsHealing();
+    bool  PetIsHealing();
+    void  TryIdleSpellCast();
+    void  SetSpiritSpellTables();
+    void  SetSMNCastTime();
+    int16 GetSMNSkillReduction();
+    int16 GetDayWeatherBonus();
 
     virtual void Tick(time_point tick) override;
     virtual void HandleEnmity() override
@@ -49,6 +54,8 @@ protected:
 
 private:
     CPetEntity* const PPet;
+
+    bool m_Setup = false;
 };
 
 #endif // _AI_CONTROLLER_H

--- a/src/map/entities/petentity.h
+++ b/src/map/entities/petentity.h
@@ -71,6 +71,12 @@ public:
     virtual bool ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags) override;
     void         OnPetSkillFinished(CPetSkillState& state, action_t& action);
 
+    time_point          m_lastCast;
+    duration            m_castCool;
+    std::vector<uint16> m_buffSpells;
+    std::vector<uint16> m_offensiveSpells;
+    std::vector<uint16> m_healSpells;
+
 private:
     PET_TYPE m_PetType; // the type of pet e.g. avatar/wyvern/jugpet etc
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Adds more accurate AI to all player summoned spirits.
+ Makes light spirit able to cast enhancing and healing spells while in and out of combat.
+ Makes 3 separate spell lists for light spirit to allow for some form of AI control based on conditions. Spell list will include the two top tier spells of each spell group (Cure, Protect, Shell, etc).
+ Allows spirits to idle cast, for non-light spirit elementals this is the appropriate elemental buff, for light spirit this will allow for either buffs or cures to be spent.
+ Fixes the spirit's cast time to be accurate according to BG-Wiki.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/83

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
