### PR TITLE
Fix Battlefield/Level Restriction Pet Interactions | Fix Spirit CD Issue | Fix Ammo Slot Bug

### DIFF
--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -366,7 +366,7 @@ int16 CPetController::GetSMNSkillReduction()
         uint16 skill    = PPet->PMaster->GetSkill(SKILL_SUMMONING_MAGIC);
         uint16 maxSkill = battleutils::GetMaxSkill(SKILL_SUMMONING_MAGIC, JOB_SMN, masterLvl);
 
-        return (1000 * floor(skill - maxSkill));
+        return (1000 * floor(maxSkill - skill));
     }
 
     return 0;

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -567,6 +567,13 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
             {
                 if (auto* PPetEntity = dynamic_cast<CPetEntity*>(PEntity))
                 {
+                    if (PPetEntity->PMaster && PPetEntity->PMaster->objtype == TYPE_PC &&
+                        (PPetEntity->getPetType() == PET_TYPE::WYVERN ||
+                         PPetEntity->getPetType() == PET_TYPE::AUTOMATON))
+                    {
+                        return found;
+                    }
+
                     if (PPetEntity->isAlive() && PPetEntity->PAI->IsSpawned())
                     {
                         PPetEntity->Die();

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5701,16 +5701,42 @@ uint8 CLuaBaseEntity::levelRestriction(sol::object const& level)
                 PChar->updatemask |= UPDATE_HP;
             }
 
-            if (PChar->PPet)
+            if (PChar->PPet || PChar->PAutomaton)
             {
                 CPetEntity* PPet = static_cast<CPetEntity*>(PChar->PPet);
+
+                if (PChar->PAutomaton)
+                {
+                    PPet = static_cast<CPetEntity*>(PChar->PAutomaton);
+                }
+
                 if (PPet->getPetType() == PET_TYPE::WYVERN)
                 {
                     petutils::LoadWyvernStatistics(PChar, PPet, true);
                 }
+                else if (PPet->getPetType() == PET_TYPE::AUTOMATON)
+                {
+                    if (PChar->GetMJob() == JOB_PUP)
+                    {
+                        PPet->SetMLevel(PChar->GetMLevel());
+                    }
+                    else
+                    {
+                        PPet->SetMLevel(PChar->GetSLevel());
+                    }
+
+                    PPet->SetSLevel(PPet->GetMLevel() / 2);
+                    puppetutils::LoadAutomatonStats(PChar);
+                }
                 else
                 {
                     petutils::DespawnPet(PChar);
+                }
+
+                if (PChar->PPet || PChar->PAutomaton)
+                {
+                    petutils::FinalizePetStatistics(PChar, PPet);
+                    PPet->updatemask |= UPDATE_HP;
                 }
             }
         }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2511,7 +2511,7 @@ namespace charutils
         }
         if (equipSlotID == SLOT_MAIN || equipSlotID == SLOT_RANGED || equipSlotID == SLOT_SUB)
         {
-            if (!PItem || !PItem->isType(ITEM_EQUIPMENT) ||
+            if (!PItem || (!PItem->isType(ITEM_EQUIPMENT) && PItem->getID() != 0) ||
                 (((CItemWeapon*)PItem)->getSkillType() != SKILL_STRING_INSTRUMENT && ((CItemWeapon*)PItem)->getSkillType() != SKILL_WIND_INSTRUMENT))
             {
                 // If the weapon ISN'T a wind based instrument or a string based instrument


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes pet interactions with BCNMs on enter and on leave.
+ Wyverns are now properly syncing and unsyncing with level restriction.
+ Automatons are now properly syncing and unsyncing with level restriction.
+ Pets if applicable (Wyverns and Automatons) will now properly leave the battlefield consistently.
+ Fixes an sign error which was causing SMN skill over cap to increase spirit cast times.
+ Fixes an issue where if a player has no ranged weapon and the ammo is swapped, the player loses all tp.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/138
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/36
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/37

## Steps to test these changes
