### PR TITLE
Fix Dynamic BST, SMN, and DRG in Dynamis

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -1612,10 +1612,6 @@ xi.dynamis.setMobStats = function(mob)
         mob:setMobLevel(math.random(78,80))
         mob:setTrueDetection(true)
 
-        if familyEES[mob:getFamily()] then
-            print(familyEES[mob:getFamily()])
-        end
-
         if     job == xi.job.WAR then
             local params = {  }
             params.specials = {  }
@@ -1702,6 +1698,12 @@ xi.dynamis.setMobStats = function(mob)
             params.specials.skill.hpp = math.random(25,35)
             xi.mix.jobSpecial.config(mob, params)
         elseif job == xi.job.DRG then
+            local params = {  }
+            params.specials = {  }
+            params.specials.skill = {  }
+            params.specials.skill.id = xi.jsa.CALL_WYVERN
+            params.specials.skill.hpp = 100
+            xi.mix.jobSpecial.config(mob, params)
         elseif job == xi.job.SMN then
         end
 
@@ -1969,7 +1971,7 @@ xi.dynamis.mobOnEngaged = function(mob, target)
             mob:SetMagicCastingEnabled(false)
             mob:SetMobAbilityEnabled(false)
 
-            mob:addStatusEffectEx(xi.effect.BIND, xi.effect.BIND, 1, 3, 3, 0, 0, 0, xi.effectFlag.NO_LOSS_MESSAGE)
+            mob:addStatusEffectEx(xi.effect.BIND, xi.effect.BIND, 1, 3, 6, 0, 0, 0, xi.effectFlag.NO_LOSS_MESSAGE)
             mob:timer(3000, function(mobArg)
                 if mob:isAlive() then
                     xi.dynamis.spawnDynamicPet(target, mob, mobArg:getMainJob())
@@ -1977,10 +1979,14 @@ xi.dynamis.mobOnEngaged = function(mob, target)
                     mobArg:SetAutoAttackEnabled(true)
                     mobArg:SetMagicCastingEnabled(true)
                     mobArg:SetMobAbilityEnabled(true)
+
+                    if mobArg:hasStatusEffect(xi.effect.BIND) then
+                        mobArg:delStatusEffectSilent(xi.effect.BIND)
+                    end
                 end
             end)
-        elseif mob:getMainJob() == xi.job.DRG then
-            mob:useMobAbility(xi.jsa.CALL_WYVERN)
+        -- elseif mob:getMainJob() == xi.job.DRG then
+            -- mob:useMobAbility(xi.jsa.CALL_WYVERN)
         end
     end
 end

--- a/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
@@ -10,7 +10,6 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    -- Based on tested stats found at https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit#gid=1789487472
     mob:setMod(xi.mod.SILENCERES, 90)
     mob:addMod(xi.mod.ATT, 40)
     mob:addMod(xi.mod.DEF, 60)

--- a/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
@@ -10,7 +10,6 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    -- Based on tested stats found at https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit#gid=1789487472
     mob:setMod(xi.mod.SILENCERES, 90)
     mob:addMod(xi.mod.DEF, 190)
     mob:addMod(xi.mod.VIT, 84)

--- a/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
@@ -10,7 +10,6 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    -- Based on tested stats found at https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit#gid=1789487472
     mob:setMod(xi.mod.SILENCERES, 90)
     mob:addMod(xi.mod.ATTP, 10)
     mob:addMod(xi.mod.EVA, 50)

--- a/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
@@ -10,7 +10,6 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    -- Based on tested stats found at https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit#gid=1789487472
     mob:setMod(xi.mod.SILENCERES, 90)
     mob:addMod(xi.mod.ATT, 150)
     mob:addMod(xi.mod.DEF, 140)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where a DRG mob would use 2 hour after hitting a low enough HP, then use call wyvern for a 2nd wyvern.
+ Fixes an issue where BST and SMN mobs pulled at range may not spawn pets.
+ Removes references to a spreadsheet used for mob stats, this is done for security purposes. 

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/145

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
