### PR TITLE
Fix an issue with weaponskill damage calculations

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -412,11 +412,7 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
         ftp = 1
     end
 
-    if not isRanged then
-        base = (calcParams.weaponDamage[1] + calcParams.fSTR + wsMods) * ftp
-    else
-        base = (calcParams.weaponDamage[1] + calcParams.weaponDamage[2] + calcParams.fSTR + wsMods) * ftp
-    end
+    base = (calcParams.weaponDamage[1] + calcParams.fSTR + wsMods) * ftp
 
     local dmg = base
 
@@ -877,10 +873,6 @@ function getMeleeDmg(attacker, weaponType, kick)
     end
 
     return { mainhandDamage, offhandDamage }
-end
-
-function getRangedDamage(attacker)
-    return { attacker:getRangedDmg(), attacker:getAmmoDmg() }
 end
 
 function getHitRate(attacker, target, capHitRate, bonus)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes a nil value when using a ranged weaponskill.

## Steps to test these changes
