### PR TITLE
Add TOD Persistence Functions For Non-Lottery

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -66,6 +66,34 @@ local function persistLotteryPrimed(phList)
 end
 
 -- Needs to be added to the NM's onDespawn() function.
+xi.mob.nmTODPersist = function(mob, cooldown)
+    SetServerVariable(string.format("[SPAWN]%s", mob:getName()), cooldown + os.time())
+    mob:getZone():setLocalVar(string.format("[SPAWN]%s", mob:getName()), cooldown + os.time())
+    mob:setRespawnTime(cooldown)
+end
+
+-- Needs to be added to the NM's zone onInit() function.
+xi.mob.nmTODPersistCache = function(zone, mobId)
+    local mob = GetMobByID(mobId)
+    local respawn = GetServerVariable(string.format("[SPAWN]%s", mob:getName()))
+    zone:setLocalVar(string.format("[SPAWN]%s", mob:getName()), respawn)
+
+    if respawn == 0 then
+        return
+    end
+
+    if mob:isAlive() then
+        DespawnMob(mobId)
+    end
+
+    if respawn <= os.time() then
+        mob:setRespawnTime(300)
+    else
+        mob:setRespawnTime(respawn - os.time())
+    end
+end
+
+-- Needs to be added to the NM's onDespawn() function.
 xi.mob.lotteryPersist = function(mob, cooldown)
     SetServerVariable(string.format("[SPAWN]%s", mob:getName()), cooldown + os.time())
     mob:getZone():setLocalVar(string.format("[SPAWN]%s", mob:getName()), cooldown + os.time())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Adds quick functions for non-lottery NM persistence. 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
