### PR TITLE
Change Persistence Tooling To Use IDs

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -54,7 +54,7 @@ local function persistLotteryPrimed(phList)
     for k, v in pairs(phList) do
         nm = GetMobByID(v)
         local zone = nm:getZone()
-        local respawnPersist = zone:getLocalVar(string.format("[SPAWN]%s", nm:getName()))
+        local respawnPersist = zone:getLocalVar(string.format("[SPAWN]%s", nm:getID()))
 
         if respawnPersist == 0 then
             return false
@@ -67,15 +67,15 @@ end
 
 -- Needs to be added to the NM's onDespawn() function.
 xi.mob.lotteryPersist = function(mob, cooldown)
-    SetServerVariable(string.format("[SPAWN]%s", mob:getName()), cooldown + os.time())
-    mob:getZone():setLocalVar(string.format("[SPAWN]%s", mob:getName()), cooldown + os.time())
+    SetServerVariable(string.format("[SPAWN]%s", mob:getID()), cooldown + os.time())
+    mob:getZone():setLocalVar(string.format("[SPAWN]%s", mob:getID()), cooldown + os.time())
 end
 
 -- Needs to be added to the NM's zone onInit() function.
 xi.mob.lotteryPersistCache = function(zone, mobId)
     local mob = GetMobByID(mobId)
-    local respawn = GetServerVariable(string.format("[SPAWN]%s", mob:getName()))
-    zone:setLocalVar(string.format("[SPAWN]%s", mob:getName()), respawn)
+    local respawn = GetServerVariable(string.format("[SPAWN]%s", mob:getID()))
+    zone:setLocalVar(string.format("[SPAWN]%s", mob:getID()), respawn)
 end
 
 -- potential lottery placeholder was killed


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Changes both forms of persistence code to use IDs instead of names.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
