### PR TITLE
Add dig skill as allowed for get / set craft commands

### DIFF
--- a/scripts/commands/getcraftrank.lua
+++ b/scripts/commands/getcraftrank.lua
@@ -24,7 +24,7 @@ function onTrigger(player, craftName, target)
     local skillID = tonumber(craftName) or xi.skill[string.upper(craftName)]
     local targ = nil
 
-    if skillID == nil or skillID < 48 or skillID > 57 then
+    if (skillID == nil or skillID < 48 or skillID > 57) and skillID ~= 59 then
         error(player, "You must specify a valid craft skill.")
         return
     end

--- a/scripts/commands/setcraftrank.lua
+++ b/scripts/commands/setcraftrank.lua
@@ -24,7 +24,7 @@ function onTrigger(player, craftName, tier, target)
     local skillID = tonumber(craftName) or xi.skill[string.upper(craftName)]
     local targ = nil
 
-    if skillID == nil or skillID < 48 or skillID > 57 then
+    if (skillID == nil or skillID < 48 or skillID > 57) and skillID ~= 59 then
         error(player, "You must specify a valid craft skill.")
         return
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Allows `getcraftrank` and `setcraftrank` to work with digging skill

## Steps to test these changes

use `!setcraftrank dig 9` on a fresh char.
use `!getcraftrank dig`. Should see "9".
Go out and dig. you should have 0 delay.
