### PR TITLE
Various mob_group fixes

### DIFF
--- a/modules/era/sql/era_mob_groups.sql
+++ b/modules/era/sql/era_mob_groups.sql
@@ -423,12 +423,12 @@ UPDATE mob_groups SET minLevel = 3, maxLevel = 6 WHERE name = "Scarab_Beetle"   
 -- ------------------------------------------------------------
 
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Rambukk' AND groupid='20' AND zoneid='101';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='45' AND zoneid='101';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Krabkatoa' AND groupid='46' AND zoneid='101';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yacumama' AND groupid='47' AND zoneid='101';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Capricornus' AND groupid='48' AND zoneid='101';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Quagmire_Pugil' AND groupid='49' AND zoneid='101';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Sunderclaw' AND groupid='50' AND zoneid='101';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='45' AND zoneid='101';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Krabkatoa' AND groupid='46' AND zoneid='101';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yacumama' AND groupid='47' AND zoneid='101';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Capricornus' AND groupid='48' AND zoneid='101';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Quagmire_Pugil' AND groupid='49' AND zoneid='101';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Sunderclaw' AND groupid='50' AND zoneid='101';
 
 UPDATE mob_groups SET minLevel = 1, maxLevel = 5 WHERE name = "Carrion_Worm"   and zoneid = 101;
 UPDATE mob_groups SET minLevel = 1, maxLevel = 5 WHERE name = "Forest_Hare"   and zoneid = 101;
@@ -439,12 +439,12 @@ UPDATE mob_groups SET minLevel = 3, maxLevel = 6 WHERE name = "Scarab_Beetle"   
 -- ------------------------------------------------------------
 
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Slumbering_Samwell' AND groupid='37' AND zoneid='102';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='49' AND zoneid='102';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Dawon' AND groupid='50' AND zoneid='102';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Tammuz' AND groupid='51' AND zoneid='102';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Chesma' AND groupid='52' AND zoneid='102';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Void_Hare' AND groupid='53' AND zoneid='102';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Prickly_Sheep' AND groupid='54' AND zoneid='102';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='49' AND zoneid='102';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Dawon' AND groupid='50' AND zoneid='102';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Tammuz' AND groupid='51' AND zoneid='102';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Chesma' AND groupid='52' AND zoneid='102';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Void_Hare' AND groupid='53' AND zoneid='102';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Prickly_Sheep' AND groupid='54' AND zoneid='102';
 
 -- ------------------------------------------------------------
 -- Valkurm_Dunes (Zone 103)
@@ -461,12 +461,12 @@ UPDATE mob_groups SET minLevel = 15, maxLevel = 18 WHERE name = "Hill_Lizard"   
 
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Supplespine_Mujwuj' AND groupid='41' AND zoneid='104';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Sappy_Sycamore' AND groupid='43' AND zoneid='104';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='73' AND zoneid='104';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Krabkatoa' AND groupid='74' AND zoneid='104';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yacumama' AND groupid='75' AND zoneid='104';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Capricornus' AND groupid='76' AND zoneid='104';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Quagmire_Pugil' AND groupid='77' AND zoneid='104';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Sunderclaw' AND groupid='78' AND zoneid='104';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='73' AND zoneid='104';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Krabkatoa' AND groupid='74' AND zoneid='104';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yacumama' AND groupid='75' AND zoneid='104';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Capricornus' AND groupid='76' AND zoneid='104';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Quagmire_Pugil' AND groupid='77' AND zoneid='104';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Sunderclaw' AND groupid='78' AND zoneid='104';
 
 -- ------------------------------------------------------------
 -- Batallia_Downs (Zone 105)
@@ -475,18 +475,18 @@ UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Sunderclaw' AND group
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Skirling_Liger' AND groupid='25' AND zoneid='105';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Eyegouger' AND groupid='38' AND zoneid='105';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Prankster_Maverix' AND groupid='40' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='50' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Verthandi' AND groupid='51' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Urd' AND groupid='52' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Skuld' AND groupid='53' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Aither' AND groupid='54' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Deorc' AND groupid='55' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Eorthe' AND groupid='56' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Puretos' AND groupid='57' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Pruina' AND groupid='58' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Beorht' AND groupid='59' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Thunor' AND groupid='60' AND zoneid='105';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Lacus' AND groupid='61' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='50' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Verthandi' AND groupid='51' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Urd' AND groupid='52' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Skuld' AND groupid='53' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Aither' AND groupid='54' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Deorc' AND groupid='55' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Eorthe' AND groupid='56' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Puretos' AND groupid='57' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Pruina' AND groupid='58' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Beorht' AND groupid='59' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Thunor' AND groupid='60' AND zoneid='105';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Lacus' AND groupid='61' AND zoneid='105';
 
 UPDATE mob_groups SET minLevel = 30, maxLevel = 36 WHERE name = "Goblin_Furrier" and zoneid = 105;
 UPDATE mob_groups SET minLevel = 30, maxLevel = 36 WHERE name = "Goblin_Pathfinder" and zoneid = 105;
@@ -500,13 +500,13 @@ UPDATE mob_groups SET minLevel = 33, maxLevel = 35 WHERE name = "Kraken_fished" 
 -- ------------------------------------------------------------
 
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Bedrock_Barry' AND groupid='26' AND zoneid='106';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='55' AND zoneid='106';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Blobdingnag' AND groupid='56' AND zoneid='106';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Septic_Boil' AND groupid='57' AND zoneid='106';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Shoggoth' AND groupid='58' AND zoneid='106';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Lamprey_Lord' AND groupid='59' AND zoneid='106';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Ground_Guzzler' AND groupid='60' AND zoneid='106';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Globster' AND groupid='61' AND zoneid='106';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='55' AND zoneid='106';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Blobdingnag' AND groupid='56' AND zoneid='106';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Septic_Boil' AND groupid='57' AND zoneid='106';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Shoggoth' AND groupid='58' AND zoneid='106';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Lamprey_Lord' AND groupid='59' AND zoneid='106';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Ground_Guzzler' AND groupid='60' AND zoneid='106';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Globster' AND groupid='61' AND zoneid='106';
 
 UPDATE mob_groups SET minLevel = 2, maxLevel = 5 WHERE name = "Maneating_Hornet"     and zoneid = 106;
 UPDATE mob_groups SET minLevel = 2, maxLevel = 5 WHERE name = "Stone_Eater"     and zoneid = 106;
@@ -529,12 +529,12 @@ UPDATE mob_groups SET minLevel = 2, maxLevel = 4 WHERE name = "Sand_Crab"   and 
 
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Ghillie_Dhu' AND groupid='8' AND zoneid='108';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Highlander_lizard' AND groupid='26' AND zoneid='108';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='38' AND zoneid='108';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Dawon' AND groupid='39' AND zoneid='108';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Tammuz' AND groupid='40' AND zoneid='108';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Chesma' AND groupid='41' AND zoneid='108';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Void_Hare' AND groupid='42' AND zoneid='108';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Prickly_Sheep' AND groupid='43' AND zoneid='108';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='38' AND zoneid='108';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Dawon' AND groupid='39' AND zoneid='108';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Tammuz' AND groupid='40' AND zoneid='108';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Chesma' AND groupid='41' AND zoneid='108';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Void_Hare' AND groupid='42' AND zoneid='108';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Prickly_Sheep' AND groupid='43' AND zoneid='108';
 
 UPDATE mob_groups SET minLevel = 7, maxLevel = 10 WHERE name = "Huge_Wasp"   and zoneid = 107;
 UPDATE mob_groups SET minLevel = 7, maxLevel = 10 WHERE name = "Strolling_Sapling"   and zoneid = 107;
@@ -546,13 +546,13 @@ UPDATE mob_groups SET minLevel = 11, maxLevel = 13 WHERE name = "Mad_Sheep"   an
 
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='NiZho_Bladebender' AND groupid='28' AND zoneid='109';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Toxic_Tamlyn' AND groupid='38' AND zoneid='109';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='65' AND zoneid='109';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Blobdingnag' AND groupid='66' AND zoneid='109';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Septic_Boil' AND groupid='67' AND zoneid='109';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Shoggoth' AND groupid='68' AND zoneid='109';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Lamprey_Lord' AND groupid='69' AND zoneid='109';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Ground_Guzzler' AND groupid='70' AND zoneid='109';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Globster' AND groupid='71' AND zoneid='109';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='65' AND zoneid='109';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Blobdingnag' AND groupid='66' AND zoneid='109';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Septic_Boil' AND groupid='67' AND zoneid='109';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Shoggoth' AND groupid='68' AND zoneid='109';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Lamprey_Lord' AND groupid='69' AND zoneid='109';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Ground_Guzzler' AND groupid='70' AND zoneid='109';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Globster' AND groupid='71' AND zoneid='109';
 
 UPDATE mob_groups SET minLevel = 19, maxLevel = 22 WHERE name = "Thread_Leech"   and zoneid = 109;
 UPDATE mob_groups SET minLevel = 16, maxLevel = 26 WHERE name = "Ghoul_war"   and zoneid = 109;
@@ -564,18 +564,18 @@ UPDATE mob_groups SET minLevel = 20, maxLevel = 23 WHERE name = "Snipper"   and 
 
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Ravenous_Crawler' AND groupid='36' AND zoneid='110';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Eldritch_Edge' AND groupid='38' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='45' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Verthandi' AND groupid='46' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Urd' AND groupid='47' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Skuld' AND groupid='48' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Aither' AND groupid='49' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Deorc' AND groupid='50' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Eorthe' AND groupid='51' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Puretos' AND groupid='52' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Pruina' AND groupid='53' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Beorht' AND groupid='54' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Thunor' AND groupid='55' AND zoneid='110';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Lacus' AND groupid='56' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='45' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Verthandi' AND groupid='46' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Urd' AND groupid='47' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Skuld' AND groupid='48' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Aither' AND groupid='49' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Deorc' AND groupid='50' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Eorthe' AND groupid='51' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Puretos' AND groupid='52' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Pruina' AND groupid='53' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Beorht' AND groupid='54' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Thunor' AND groupid='55' AND zoneid='110';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Lacus' AND groupid='56' AND zoneid='110';
 
 UPDATE mob_groups SET minLevel = 28, maxLevel = 30 WHERE name = "Greater_Pugil_fished"   and zoneid = 110;
 UPDATE mob_groups SET minLevel = 31, maxLevel = 33 WHERE name = "Big_Leech"   and zoneid = 110;
@@ -586,12 +586,12 @@ UPDATE mob_groups SET minLevel = 31, maxLevel = 33 WHERE name = "Big_Leech"   an
 
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Humbaba' AND groupid='32' AND zoneid='111';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Calcabrina' AND groupid='33' AND zoneid='111';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='52' AND zoneid='111';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Lord_Ruthven' AND groupid='53' AND zoneid='111';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Feuerunke' AND groupid='54' AND zoneid='111';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Erebus' AND groupid='55' AND zoneid='111';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Gjenganger' AND groupid='56' AND zoneid='111';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Gorehound' AND groupid='57' AND zoneid='111';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='52' AND zoneid='111';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Lord_Ruthven' AND groupid='53' AND zoneid='111';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Feuerunke' AND groupid='54' AND zoneid='111';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Erebus' AND groupid='55' AND zoneid='111';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Gjenganger' AND groupid='56' AND zoneid='111';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Gorehound' AND groupid='57' AND zoneid='111';
 
 UPDATE mob_groups SET minLevel = 35, maxLevel = 40 WHERE name = "Ghast_war"  and zoneid = 111;
 UPDATE mob_groups SET minLevel = 35, maxLevel = 40 WHERE name = "Ghast_blm"  and zoneid = 111;
@@ -605,12 +605,12 @@ UPDATE mob_groups SET minLevel = 41, maxLevel = 42 WHERE name = "Morgawr"  and z
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Barbaric_Weapon' AND groupid='11' AND zoneid='112';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Duke_Focalor' AND groupid='21' AND zoneid='112';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Timeworn_Warrior' AND groupid='12' AND zoneid='112';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='48' AND zoneid='112';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Lord_Ruthven' AND groupid='49' AND zoneid='112';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Feuerunke' AND groupid='50' AND zoneid='112';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Erebus' AND groupid='51' AND zoneid='112';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Gjenganger' AND groupid='52' AND zoneid='112';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Gorehound' AND groupid='53' AND zoneid='112';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='48' AND zoneid='112';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Lord_Ruthven' AND groupid='49' AND zoneid='112';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Feuerunke' AND groupid='50' AND zoneid='112';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Erebus' AND groupid='51' AND zoneid='112';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Gjenganger' AND groupid='52' AND zoneid='112';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Gorehound' AND groupid='53' AND zoneid='112';
 
 UPDATE mob_groups SET minLevel = 38, maxLevel = 40 WHERE name = "Gigass_Tiger"  and zoneid = 112 and groupid = 17;
 
@@ -638,12 +638,12 @@ UPDATE mob_groups SET minLevel = 42, maxLevel = 45 WHERE name = "Bigclaw_fished"
 -- ------------------------------------------------------------
 
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Numbing_Norman' AND groupid='27' AND zoneid='115';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='36' AND zoneid='115';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Orcus' AND groupid='37' AND zoneid='115';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Farruca_Fly' AND groupid='38' AND zoneid='115';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Jyeshtha' AND groupid='39' AND zoneid='115';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Rummager_Beetle' AND groupid='40' AND zoneid='115';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Raker_Bee' AND groupid='41' AND zoneid='115';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='36' AND zoneid='115';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Orcus' AND groupid='37' AND zoneid='115';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Farruca_Fly' AND groupid='38' AND zoneid='115';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Jyeshtha' AND groupid='39' AND zoneid='115';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Rummager_Beetle' AND groupid='40' AND zoneid='115';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Raker_Bee' AND groupid='41' AND zoneid='115';
 
 UPDATE mob_groups SET minLevel = 4, maxLevel = 8 WHERE name = "Yagudo_Initiate" and zoneid = 115;
 UPDATE mob_groups SET minLevel = 4, maxLevel = 8 WHERE name = "Yagudo_Acolyte" and zoneid = 115;
@@ -668,12 +668,12 @@ UPDATE mob_groups SET minLevel = 7, maxLevel = 8 WHERE name = "Pug_Pugil_fished"
 
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Habrok' AND groupid='8' AND zoneid='117';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Herbage_Hunter' AND groupid='30' AND zoneid='117';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='36' AND zoneid='117';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Dawon' AND groupid='37' AND zoneid='117';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Tammuz' AND groupid='38' AND zoneid='117';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Chesma' AND groupid='39' AND zoneid='117';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Void_Hare' AND groupid='40' AND zoneid='117';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Prickly_Sheep' AND groupid='41' AND zoneid='117';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='36' AND zoneid='117';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Dawon' AND groupid='37' AND zoneid='117';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Tammuz' AND groupid='38' AND zoneid='117';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Chesma' AND groupid='39' AND zoneid='117';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Void_Hare' AND groupid='40' AND zoneid='117';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Prickly_Sheep' AND groupid='41' AND zoneid='117';
 
 UPDATE mob_groups SET minLevel = 5, maxLevel = 7  WHERE name = "Yagudos_Elemental"  and zoneid = 117;
 UPDATE mob_groups SET minLevel = 7, maxLevel = 10 WHERE name = "Canyon_Rarab"       and zoneid = 117;
@@ -701,12 +701,12 @@ UPDATE mob_groups SET minLevel = 24, maxLevel = 26 WHERE name = "Shoal_Pugil_fis
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Chonchon' AND groupid='19' AND zoneid='119';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Naa_Zeku_the_Unwaiting' AND groupid='29' AND zoneid='119';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Patripatan' AND groupid='37' AND zoneid='119';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='64' AND zoneid='119';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Orcus' AND groupid='65' AND zoneid='119';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Farruca_Fly' AND groupid='66' AND zoneid='119';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Jyeshtha' AND groupid='67' AND zoneid='119';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Rummager_Beetle' AND groupid='68' AND zoneid='119';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Raker_Bee' AND groupid='69' AND zoneid='119';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='64' AND zoneid='119';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Orcus' AND groupid='65' AND zoneid='119';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Farruca_Fly' AND groupid='66' AND zoneid='119';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Jyeshtha' AND groupid='67' AND zoneid='119';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Rummager_Beetle' AND groupid='68' AND zoneid='119';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Raker_Bee' AND groupid='69' AND zoneid='119';
 
 UPDATE mob_groups SET minLevel = 20, maxLevel = 23 WHERE name = "Yagudos_Elemental"  and zoneid = 119 and groupid = 23;
 UPDATE mob_groups SET minLevel = 22, maxLevel = 25 WHERE name = "Coeurl"  and zoneid = 119;
@@ -718,18 +718,18 @@ UPDATE mob_groups SET minLevel = 22, maxLevel = 25 WHERE name = "Coeurl"  and zo
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Bashe' AND groupid='68' AND zoneid='120';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Thunderclaw_Thuban' AND groupid='33' AND zoneid='120';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Blighting_Brand' AND groupid='38' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Yilbegan' AND groupid='46' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Verthandi' AND groupid='47' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Urd' AND groupid='48' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Skuld' AND groupid='49' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Aither' AND groupid='50' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Deorc' AND groupid='51' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Eorthe' AND groupid='52' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Puretos' AND groupid='53' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Pruina' AND groupid='54' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Beorht' AND groupid='55' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Thunor' AND groupid='56' AND zoneid='120';
-UPDATE mob_groups SET content_tag='VOIDWALKER' WHERE name='Lacus' AND groupid='57' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Yilbegan' AND groupid='46' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Verthandi' AND groupid='47' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Urd' AND groupid='48' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Skuld' AND groupid='49' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Aither' AND groupid='50' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Deorc' AND groupid='51' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Eorthe' AND groupid='52' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Puretos' AND groupid='53' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Pruina' AND groupid='54' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Beorht' AND groupid='55' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Thunor' AND groupid='56' AND zoneid='120';
+UPDATE mob_groups SET content_tag='VOIDWATCH' WHERE name='Lacus' AND groupid='57' AND zoneid='120';
 
 UPDATE mob_groups SET minLevel = 23, maxLevel = 25 WHERE name = "Goblins_Beetle"  and zoneid = 120;
 UPDATE mob_groups SET minLevel = 23, maxLevel = 25 WHERE name = "Yagudos_Elemental"  and zoneid = 120;
@@ -1200,3 +1200,82 @@ UPDATE mob_groups SET content_tag='ABYSSEA' WHERE name='Babaulas' AND groupid='3
 UPDATE mob_groups SET content_tag='ABYSSEA' WHERE name='Boribaba' AND groupid='32' AND zoneid='213';
 
 UNLOCK TABLES;
+
+
+-- ------------------------------------------------------------
+-- Dynamis Zones
+-- The mob_groups listed are the mob groups used for determining
+-- all stats for mobs inside dynamis
+-- -----------------------------------------------------------
+UPDATE mob_groups SET HP = 3900 WHERE name = 'Vanguard_Alchemist' AND groupid = 141 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4300 WHERE name = 'Vanguard_Ambusher' AND groupid = 134 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4600 WHERE name = 'Vanguard_Amputator' AND groupid = 67 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5100 WHERE name = 'Vanguard_Armorer' AND groupid = 133 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5000 WHERE name = 'Vanguard_Assassin' AND groupid = 92 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4500 WHERE name = 'Vanguard_Backstabber' AND groupid = 62 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5800 WHERE name = 'Vanguard_Beasttender' AND groupid = 21 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5200 WHERE name = 'Vanguard_Bugler' AND groupid = 81 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4800 WHERE name = 'Vanguard_Chanter' AND groupid = 104 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3500 WHERE name = 'Vanguard_Constable' AND groupid = 29 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4800 WHERE name = 'Vanguard_Defender' AND groupid = 30 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4100 WHERE name = 'Vanguard_Dollmaster' AND groupid = 72 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5100 WHERE name = 'Vanguard_Dragontamer' AND groupid = 140 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4600 WHERE name = 'Vanguard_Drakekeeper' AND groupid = 26 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4000 WHERE name = 'Vanguard_Enchanter' AND groupid = 128 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5500 WHERE name = 'Vanguard_Exemplar' AND groupid = 98 AND zoneid = 134;
+UPDATE mob_groups SET HP = 6300 WHERE name = 'Vanguard_Footsoldier' AND groupid = 59 AND zoneid = 134;
+UPDATE mob_groups SET HP = 7200 WHERE name = 'Vanguard_Grappler' AND groupid = 64 AND zoneid = 134;
+UPDATE mob_groups SET HP = 6200 WHERE name = 'Vanguard_Gutslasher' AND groupid = 66 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4800 WHERE name = 'Vanguard_Hatamoto' AND groupid = 31 AND zoneid = 134;
+UPDATE mob_groups SET HP = 6100 WHERE name = 'Vanguard_Hawker' AND groupid = 76 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4600 WHERE name = 'Vanguard_Hitman' AND groupid = 138 AND zoneid = 134;
+UPDATE mob_groups SET HP = 6200 WHERE name = 'Vanguard_Impaler' AND groupid = 69 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5600 WHERE name = 'Vanguard_Inciter' AND groupid = 103 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4100 WHERE name = 'Vanguard_Kusa' AND groupid = 32 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4900 WHERE name = 'Vanguard_Liberator' AND groupid = 96 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4500 WHERE name = 'Vanguard_Maestro' AND groupid = 131 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3900 WHERE name = 'Vanguard_Mason' AND groupid = 34 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4200 WHERE name = 'Vanguard_Mesmerizer' AND groupid = 75 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5700 WHERE name = 'Vanguard_Militant' AND groupid = 25 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4000 WHERE name = 'Vanguard_Minstrel' AND groupid = 23 AND zoneid = 134;
+UPDATE mob_groups SET HP = 6000 WHERE name = 'Vanguard_Neckchopper' AND groupid = 58 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3300 WHERE name = 'Vanguard_Necromancer' AND groupid = 135 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5600 WHERE name = 'Vanguard_Ogresoother' AND groupid = 99 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3700 WHERE name = 'Vanguard_Oracle' AND groupid = 112 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5700 WHERE name = 'Vanguard_Partisan' AND groupid = 108 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5100 WHERE name = 'Vanguard_Pathfinder' AND groupid = 129 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5700 WHERE name = 'Vanguard_Persecutor' AND groupid = 118 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5400 WHERE name = 'Vanguard_Pillager' AND groupid = 78 AND zoneid = 134;
+UPDATE mob_groups SET HP = 6200 WHERE name = 'Vanguard_Pitfighter' AND groupid = 126 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5200 WHERE name = 'Vanguard_Predator' AND groupid = 70 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3800 WHERE name = 'Vanguard_Prelate' AND groupid = 105 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4400 WHERE name = 'Vanguard_Priest' AND groupid = 101 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3600 WHERE name = 'Vanguard_Protector' AND groupid = 20 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4000 WHERE name = 'Vanguard_Purloiner' AND groupid = 33 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5500 WHERE name = 'Vanguard_Ronin' AND groupid = 137 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4800 WHERE name = 'Vanguard_Salvager' AND groupid = 111 AND zoneid = 134;
+UPDATE mob_groups SET HP = 6700 WHERE name = 'Vanguard_Sentinel' AND groupid = 91 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3800 WHERE name = 'Vanguard_Shaman' AND groupid = 127 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5880 WHERE name = 'Vanguard_Skirmisher' AND groupid = 93 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5400 WHERE name = 'Vanguard_Smithy' AND groupid = 125 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3000 WHERE name = 'Vanguard_Thaumaturge' AND groupid = 42 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5100 WHERE name = 'Vanguard_Tinkerer' AND groupid = 147 AND zoneid = 134;
+UPDATE mob_groups SET HP = 6200 WHERE name = 'Vanguard_Trooper' AND groupid = 57 AND zoneid = 134;
+UPDATE mob_groups SET HP = 2800 WHERE name = 'Vanguard_Undertaker' AND groupid = 35 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4900 WHERE name = 'Vanguard_Vexer' AND groupid = 61 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4650 WHERE name = 'Vanguard_Vigilante' AND groupid = 38 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4900 WHERE name = 'Vanguard_Vindicator' AND groupid = 19 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4500 WHERE name = 'Vanguard_Visionary' AND groupid = 95 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4500 WHERE name = 'Vanguard_Welldigger' AND groupid = 132 AND zoneid = 134;
+UPDATE mob_groups SET HP = 2300 WHERE name = 'Vanguards_Avatar' AND groupid = 36 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3200 WHERE name = 'Vanguards_Crow' AND groupid = 100 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3500 WHERE name = 'Vanguards_Hecteyes' AND groupid = 77 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3250 WHERE name = 'Vanguards_Scorpion' AND groupid = 22 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3500 WHERE name = 'Vanguards_Slime' AND groupid = 130 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5000 WHERE name = 'Vanguards_Wyvern' AND groupid = 27 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3000 WHERE name = 'Vanguards_Avatar' AND groupid = 54 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3700 WHERE name = 'Vanguards_Crow' AND groupid = 117 AND zoneid = 134;
+UPDATE mob_groups SET HP = 4000 WHERE name = 'Vanguards_Hecteyes' AND groupid = 86 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3750 WHERE name = 'Vanguards_Scorpion' AND groupid = 49 AND zoneid = 134;
+UPDATE mob_groups SET HP = 3900 WHERE name = 'Vanguards_Slime' AND groupid = 152 AND zoneid = 134;
+UPDATE mob_groups SET HP = 5500 WHERE name = 'Vanguards_Wyvern' AND groupid = 45 AND zoneid = 134;

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -315,7 +315,7 @@ INSERT INTO `mob_groups` VALUES (37,3944,7,'Tomb_Warrior',330,1,1540,0,0,70,73,0
 INSERT INTO `mob_groups` VALUES (38,2770,7,'Mummy',330,1,1540,0,0,62,64,0);
 INSERT INTO `mob_groups` VALUES (39,2407,7,'Lich',330,1,1540,0,0,62,64,0);
 INSERT INTO `mob_groups` VALUES (40,801,7,'Corse',330,1,517,0,0,66,67,0);
-INSERT INTO `mob_groups` VALUES (41,733,7,'Citipati',0,33,475,0,0,67,70,0);
+INSERT INTO `mob_groups` VALUES (41,733,7,'Citipati',0,32,475,0,0,67,70,0);
 INSERT INTO `mob_groups` VALUES (42,4396,7,'Xolotl',0,128,2683,20000,0,80,81,0);
 INSERT INTO `mob_groups` VALUES (43,4397,7,'Xolotls_Hound_Warrior',0,128,0,0,0,72,72,0);
 INSERT INTO `mob_groups` VALUES (44,4398,7,'Xolotls_Sacrifice',0,128,0,0,0,72,72,0);
@@ -664,7 +664,7 @@ INSERT INTO `mob_groups` VALUES (17,4317,16,'Weeper',960,0,2634,0,0,33,35,0);
 INSERT INTO `mob_groups` VALUES (18,3539,16,'Seether',960,0,2192,0,0,35,37,0);
 INSERT INTO `mob_groups` VALUES (19,4283,16,'Wanderer',960,0,2612,0,0,32,33,0);
 INSERT INTO `mob_groups` VALUES (20,3897,16,'Thinker',960,0,2398,0,0,37,39,0);
-INSERT INTO `mob_groups` VALUES (21,681,16,'Cerebrator',14400,0,447,0,0,38,38,0);
+INSERT INTO `mob_groups` VALUES (21,681,16,'Cerebrator',14400,0,447,3000,0,38,38,0);
 INSERT INTO `mob_groups` VALUES (22,298,16,'Woeful_Weeper',960,0,0,0,0,83,84,0);
 INSERT INTO `mob_groups` VALUES (23,4527,16,'Livid_Seether',960,0,0,0,0,83,84,0);
 
@@ -711,7 +711,7 @@ INSERT INTO `mob_groups` VALUES (17,3539,18,'Seether',960,0,2193,0,0,35,37,0);
 INSERT INTO `mob_groups` VALUES (18,4317,18,'Weeper',960,0,2635,0,0,33,35,0);
 INSERT INTO `mob_groups` VALUES (19,4283,18,'Wanderer',960,0,2613,0,0,31,33,0);
 INSERT INTO `mob_groups` VALUES (20,1768,18,'Gorger',960,0,1207,0,0,37,39,0);
-INSERT INTO `mob_groups` VALUES (21,3483,18,'Satiator',14400,0,2166,0,0,38,38,0);
+INSERT INTO `mob_groups` VALUES (21,3483,18,'Satiator',14400,0,2166,3000,0,38,38,0);
 INSERT INTO `mob_groups` VALUES (22,298,18,'Woeful_Weeper',960,0,0,0,0,83,84,0);
 INSERT INTO `mob_groups` VALUES (23,4527,18,'Livid_Seether',960,0,0,0,0,83,84,0);
 
@@ -755,7 +755,7 @@ INSERT INTO `mob_groups` VALUES (17,3539,20,'Seether',960,0,2194,0,0,35,37,0);
 INSERT INTO `mob_groups` VALUES (18,4317,20,'Weeper',960,0,2636,0,0,33,35,0);
 INSERT INTO `mob_groups` VALUES (19,4283,20,'Wanderer',960,0,2614,0,0,31,33,0);
 INSERT INTO `mob_groups` VALUES (20,830,20,'Craver',960,0,526,0,0,36,40,0);
-INSERT INTO `mob_groups` VALUES (21,820,20,'Coveter',14400,0,522,0,0,38,38,0);
+INSERT INTO `mob_groups` VALUES (21,820,20,'Coveter',14400,0,522,3000,0,38,38,0);
 INSERT INTO `mob_groups` VALUES (22,298,20,'Woeful_Weeper',960,0,0,0,0,83,84,0);
 INSERT INTO `mob_groups` VALUES (23,4527,20,'Livid_Seether',960,0,0,0,0,83,84,0);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
- Fixes the wrong content tag on a lot of OOE mobs
- Adds correct HP values for all Vanguard mobs throughout Dynmis.
- TODO: Nightmare mobs/Hydra/Kindred
- Corrected Citipatis spawntype
- Corrected HP values of NMs in Promys
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
