### PR TITLE
Fix Seigan Third Eye Interaction

### DIFF
--- a/scripts/globals/abilities/third_eye.lua
+++ b/scripts/globals/abilities/third_eye.lua
@@ -11,9 +11,6 @@ require("scripts/globals/status")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    if player:hasStatusEffect(xi.effect.SEIGAN) then
-        ability:setRecast(ability:getRecast() / 2)
-    end
     return 0, 0
 end
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1516,7 +1516,14 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
         }
         else
         {
-            PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), action.recast);
+            if (this->StatusEffectContainer->HasStatusEffect(EFFECT_SEIGAN) && PAbility->getID() == 62)
+            {
+                PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), action.recast / 2);
+            }
+            else
+            {
+                PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), action.recast);
+            }
         }
 
         uint16 recastID = PAbility->getRecastId();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where if third eye is used while under the effect of seigan under certain circumstances the player's third eye recast could reach 0 seconds.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
