### PR TITLE
Fix Charmed Mobs Despawning On Player Death

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2143,7 +2143,14 @@ void CCharEntity::Die()
 
     if (this->PPet)
     {
-        petutils::DespawnPet(this);
+        if (PPet->StatusEffectContainer->HasStatusEffect(EFFECT_CHARM))
+        {
+            petutils::DetachPet(this);
+        }
+        else
+        {
+            petutils::DespawnPet(this);
+        }
     }
 
     Die(death_duration);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fix an issue where charmed mobs would despawn when their master dies.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
