### PR TITLE
Fix Dynamis Interactions | Fix Rampart | Fix Weaponskill Dmg | Fix Kicks | Fix RA Interruption

### DIFF
--- a/scripts/globals/abilities/rampart.lua
+++ b/scripts/globals/abilities/rampart.lua
@@ -19,6 +19,8 @@ end
 ability_object.onUseAbility = function(player, target, ability)
     local duration = 30 + player:getMod(xi.mod.RAMPART_DURATION)
     target:addStatusEffect(xi.effect.RAMPART, 2500, 0, duration)
+
+    return xi.effect.RAMPART
 end
 
 return ability_object

--- a/scripts/globals/mobskills/astral_flow_pet.lua
+++ b/scripts/globals/mobskills/astral_flow_pet.lua
@@ -25,6 +25,10 @@ mobskill_object.onMobSkillCheck = function(target, mob, skill)
 
     local pet = mob:getPet()
 
+    if pet:getID() == mob:getID() then
+        return 1
+    end
+
     -- pet must be an avatar, and active
     if pet:getSystem() ~= 5 or petInactive(pet) then
         return 1

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -485,7 +485,6 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
     calcParams.hybridHit = false
     calcParams.sneakApplicable = false
     calcParams.trickApplicable = false
-    dmg = base
 
     -- For items that apply bonus damage to the first hit of a weaponskill (but not later hits),
     -- store bonus damage for first hit, for use after other calculations are done
@@ -493,6 +492,8 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
 
     -- Reset fTP if it's not supposed to carry over across all hits for this WS
     if not wsParams.multiHitfTP then ftp = 1 end -- We'll recalculate our mainhand damage after doing offhand
+
+    base = (calcParams.weaponDamage[1] + calcParams.fSTR + wsMods) * ftp
 
     -- Do the extra hit for our offhand if applicable
     if calcParams.extraOffhandHit and finaldmg < targetHp then

--- a/scripts/mixins/job_special.lua
+++ b/scripts/mixins/job_special.lua
@@ -316,7 +316,12 @@ g_mixins.job_special = function(jobSpecialMob)
             for _,v in pairs(charmList) do
                 if mob:getName() == v and not mob:hasPet() then
                     ability = 710
+                    break
                 end
+            end
+
+            if mob:isInDynamis() and ((mob:getPet():getID() == mob:getID()) or not mob:hasPet()) then
+                ability = 710
             end
 
             mob:useMobAbility(ability)

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -134,6 +134,8 @@ bool CRangeState::Update(time_point tick)
             {
                 PChar->pushPacket(m_errorMsg.release());
             }
+
+            m_aimTime = std::chrono::seconds(0);
             m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
         }
         else

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -471,7 +471,7 @@ bool CAttack::CheckCover()
  *  Processes the damage for this swing.                                    *
  *                                                                      *
  ************************************************************************/
-void CAttack::ProcessDamage(bool isCritical, bool isGuarded)
+void CAttack::ProcessDamage(bool isCritical, bool isGuarded, bool isKick)
 {
     // Sneak attack.
     if (m_attacker->GetMJob() == JOB_THF && m_isFirstSwing && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK) &&
@@ -501,9 +501,15 @@ void CAttack::ProcessDamage(bool isCritical, bool isGuarded)
 
     if (m_attackRound->IsH2H())
     {
+        m_baseDamage       = 0;
         m_naturalH2hDamage = (int32)(m_attacker->GetSkill(SKILL_HAND_TO_HAND) * 0.11f) + 3;
-        m_baseDamage       = m_attacker->GetMainWeaponDmg();
-        m_damage           = (uint32)(((m_baseDamage + m_naturalH2hDamage + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_MAIN, 0, isGuarded)));
+
+        if (!isKick)
+        {
+            m_baseDamage = m_attacker->GetMainWeaponDmg();
+        }
+
+        m_damage = (uint32)(((m_baseDamage + m_naturalH2hDamage + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0, SLOT_MAIN, 0, isGuarded)));
     }
     else if (slot == SLOT_MAIN)
     {

--- a/src/map/attack.h
+++ b/src/map/attack.h
@@ -91,9 +91,9 @@ public:
     bool                      CheckAnticipated();
     bool                      IsCountered() const;
     bool                      CheckCounter();
-    bool                      IsCovered() const;                              // Returns the covered flag.
-    bool                      CheckCover();                                   // Sets the covered flag and returns it.
-    void                      ProcessDamage(bool isCritical, bool isGuarded); // Processes the damage for this swing.
+    bool                      IsCovered() const;                                           // Returns the covered flag.
+    bool                      CheckCover();                                                // Sets the covered flag and returns it.
+    void                      ProcessDamage(bool isCritical, bool isGuarded, bool isKick); // Processes the damage for this swing.
 
     void SetAttackType(PHYSICAL_ATTACK_TYPE type); // Sets the attack type.
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2051,7 +2051,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 }
 
                 // Process damage.
-                attack.ProcessDamage(attack.IsCritical(), attack.IsGuarded());
+                attack.ProcessDamage(attack.IsCritical(), attack.IsGuarded(), attack.GetAttackType() == PHYSICAL_ATTACK_TYPE::KICK);
 
                 // Try shield block
                 if (attack.IsBlocked())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where weapon damage was being added to kick attacks.
+ Fixes an issue causing Dynamis SMNs to use seering light after astral flow.
+ Fixes an issue where dynamis BST mobs would not charm after their pets die.
+ Fixes an issue with ftp application on multiple hits of a weaponskill.
+ Fixes messaging for Rampart.
+ Fixes a bug where interrupting an RA caused you to wait the full duration of the time the animation would have taken for a successful RA. This has now been collapsed to ~2.7s as this is the return animation + small wait period normally experienced after an RA.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
