### PR TITLE
Fix Weight Speed Setting | Hard-code Digging FIND_NOTHING

### DIFF
--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -21,6 +21,8 @@ local DIG_GRANT_BURROW = xi.settings.main.DIG_GRANT_BURROW
 local DIG_GRANT_BORE = xi.settings.main.DIG_GRANT_BORE
 local DIG_DISTANCE_REQ = xi.settings.main.DIG_DISTANCE_REQ
 
+local find_nothing = "You dig and you dig, but you find nothing."
+
 local digReq =
 {
     NONE     = 0,
@@ -1120,7 +1122,7 @@ xi.chocoboDig.start = function(player, precheck)
                 calculateSkillUp(player)
             end
 
-            player:messageText(player, text.FIND_NOTHING, false)
+            player:PrintToPlayer(find_nothing, 13)
             player:setCharVar('[DIG]LastDigTime', os.time())
 
             return true
@@ -1128,7 +1130,7 @@ xi.chocoboDig.start = function(player, precheck)
 
         -- dig chance failure
         if roll > (DIG_RATE * moonmodifier * skillmodifier) then -- base digging rate is 85% and it is multiplied by the moon and skill modifiers
-            player:messageText(player, text.FIND_NOTHING)
+            player:PrintToPlayer(find_nothing, 13)
             player:setCharVar('[DIG]LastDigTime', os.time())
         -- dig chance success
         else
@@ -1149,7 +1151,7 @@ xi.chocoboDig.start = function(player, precheck)
 
             -- got a crystal ore, but lacked weather or skill to dig it up
             else
-                player:messageText(player, text.FIND_NOTHING, false)
+                player:PrintToPlayer(find_nothing, 13)
                 player:setCharVar('[DIG]LastDigTime', os.time())
             end
         end

--- a/scripts/globals/effects/weight.lua
+++ b/scripts/globals/effects/weight.lua
@@ -6,7 +6,7 @@ require("scripts/globals/status")
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.MOVE, -effect:getPower())
+    target:setSpeed(target:getSpeed() - effect:getPower())
     target:addMod(xi.mod.EVA, -10)
 end
 
@@ -14,7 +14,7 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.MOVE, -effect:getPower())
+    target:setSpeed(target:getSpeed() + effect:getPower())
     target:delMod(xi.mod.EVA, -10)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where weight was not properly setting the speed of the target.
+ Fixes an issue where FIND_NOTHING was returning incorrect texts due to shifts. This was hard coded since it is a simple text and doesn't really cause any problems by doing so.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/170

## Steps to test these changes
