### PR TITLE
Add Sub Check to Enspell Calculations

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -333,7 +333,7 @@ function doEnspell(caster, target, spell, effect)
 
     -- Add effect bonuses from equipment
     local potencybonus = 0
-    if caster:getEquipID(xi.slot.MAIN) == xi.items.BUZZARD_TUCK then
+    if caster:getEquipID(xi.slot.MAIN) == xi.items.BUZZARD_TUCK or caster:getEquipID(xi.slot.SUB) == xi.items.BUZZARD_TUCK then
         potencybonus = 2 + potencybonus
     elseif caster:getEquipID(xi.slot.EAR1) == xi.items.LYCOPODIUM_EARRING or caster:getEquipID(xi.slot.EAR2) == xi.items.LYCOPODIUM_EARRING then
         potencybonus = 2 + potencybonus
@@ -342,7 +342,7 @@ function doEnspell(caster, target, spell, effect)
     elseif(caster:getHPP() <= 75 and caster:getTP() <= 100) and
     (caster:getEquipID(xi.slot.RING1) == xi.items.FENCERS_RING or caster:getEquipID(xi.slot.RING2) == xi.items.FENCERS_RING) then
         potencybonus = 5 + potencybonus
-    elseif caster:getEquipID(xi.slot.MAIN) == xi.items.ENHANCING_SWORD then
+    elseif caster:getEquipID(xi.slot.MAIN) == xi.items.ENHANCING_SWORD or caster:getEquipID(xi.slot.SUB) == xi.items.ENHANCING_SWORD then
         potencybonus = 5 + potencybonus
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Check Sub slot for weapons that affect enspells.

From https://github.com/TabulaRasaXI/TabulaRasa/issues/290

## Steps to test these changes

Depends on https://github.com/AirSkyBoat/AirSkyBoat/pull/483 to see the changes, but as RDM/NIN put Enhancing Sword and/or Buzzard Tuck in your off-hand and ensure changes are applied as expected.
