### PR TITLE
Crustacean Conundrum Fix

### DIFF
--- a/scripts/zones/Waughroon_Shrine/mobs/Heavy_Metal_Crab.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Heavy_Metal_Crab.lua
@@ -30,7 +30,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.HP_DRAIN, {power = 30})
+    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.HP_DRAIN, { power = 30 })
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Waughroon_Shrine/mobs/Metal_Crab.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Metal_Crab.lua
@@ -30,7 +30,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.HP_DRAIN, {power = 30})
+    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.HP_DRAIN, { power = 30 })
 end
 
 entity.onMobFight = function(mob, target)

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -601,7 +601,7 @@ int32 CBattleEntity::addMP(int32 mp)
 int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullptr*/, ATTACK_TYPE attackType /* = ATTACK_NONE*/,
                                 DAMAGE_TYPE damageType /* = DAMAGE_NONE*/)
 {
-    if (this->GetLocalVar("DAMAGE_NULL") != 0)
+    if (this->GetLocalVar("DAMAGE_NULL") == 1)
     {
         amount %= 2;
         this->SetLocalVar("DAMAGE_DEALT", amount);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -738,12 +738,6 @@ namespace battleutils
 
         damage = std::clamp(damage, -99999, 99999);
 
-        // When set mob will only take 0 or 1 damage
-        if (PDefender->GetLocalVar("DAMAGE_NULL") != 0)
-        {
-            damage %= 2;
-        }
-
         return damage;
     }
 
@@ -865,7 +859,7 @@ namespace battleutils
             // When set mob will only take 0 or 1 damage
             if (PDefender->GetLocalVar("DAMAGE_NULL") != 0)
             {
-                spikesDamage = xirand::GetRandomNumber(1);
+                spikesDamage %= 2;
             }
 
             switch (static_cast<SPIKES>(Action->spikesEffect))
@@ -1027,7 +1021,7 @@ namespace battleutils
             // When set mob will only take 0 or 1 damage
             if (PDefender->GetLocalVar("DAMAGE_NULL") != 0)
             {
-                spikesDamage = xirand::GetRandomNumber(1);
+                spikesDamage %= 2;
             }
 
             PAttacker->takeDamage(spikesDamage, PDefender, ATTACK_TYPE::MAGICAL, GetSpikesDamageType(Action->spikesEffect));
@@ -1079,7 +1073,7 @@ namespace battleutils
                 // When set mob will only take 0 or 1 damage
                 if (PDefender->GetLocalVar("DAMAGE_NULL") != 0)
                 {
-                    spikesDamage = PDefender->GetLocalVar("DAMAGE_DEALT");
+                    spikesDamage %= 2;
                 }
 
                 PAttacker->takeDamage(spikesDamage, PDefender, ATTACK_TYPE::MAGICAL, GetSpikesDamageType(spikesType));
@@ -2453,7 +2447,7 @@ namespace battleutils
         // When set mob will only take 0 or 1 damage
         if (PDefender->GetLocalVar("DAMAGE_NULL") != 0)
         {
-            damage = PDefender->GetLocalVar("DAMAGE_DEALT");
+            damage %= 2;
         }
 
         PDefender->takeDamage(damage, PAttacker, attackType, damageType);
@@ -5421,7 +5415,7 @@ namespace battleutils
         // When set mob will only take 0 or 1 damage
         if (PDefender->GetLocalVar("DAMAGE_NULL") != 0)
         {
-            damage = PDefender->GetLocalVar("DAMAGE_DEALT");
+            damage %= 2;
         }
 
         return damage;
@@ -5467,7 +5461,7 @@ namespace battleutils
         // When set mob will only take 0 or 1 damage
         if (PDefender->GetLocalVar("DAMAGE_NULL") != 0)
         {
-            damage = PDefender->GetLocalVar("DAMAGE_DEALT");
+            damage %= 2;
         }
 
         return damage;


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixed players only being able to deal damage after a dot was applied to either of the crabs.
