### PR TITLE
Gilfinder applying to all party member equally

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3702,14 +3702,32 @@ namespace charutils
             // all members might not be in range
             if (!members.empty())
             {
-                // distribute gil
-                int32 gilPerPerson = static_cast<int32>(gil / members.size());
-                for (auto* PMember : members)
+                // Distribute Gil
+                int32 gilPerPerson    = static_cast<int32>(gil / members.size());
+                int16 gilFinderActive = 0;
+
+                for (auto PMember : members)
                 {
-                    // Check for gilfinder
-                    gilPerPerson += gilPerPerson * PMember->getMod(Mod::GILFINDER) / 100;
-                    UpdateItem(PMember, LOC_INVENTORY, 0, gilPerPerson);
-                    PMember->pushPacket(new CMessageBasicPacket(PMember, PMember, gilPerPerson, 0, 565));
+                    // Check for highest gilfinder tier
+                    if (PMember->getMod(Mod::GILFINDER) > gilFinderActive)
+                    {
+                        gilFinderActive = PMember->getMod(Mod::GILFINDER);
+                    }
+                }
+                for (auto PMember : members)
+                {
+                    // Distributte gilfinder gil
+                    if (gilFinderActive > 0)
+                    {
+                        int32 memberGil = gilPerPerson * (100 + gilFinderActive) / 100;
+                        UpdateItem(PMember, LOC_INVENTORY, 0, memberGil);
+                        PMember->pushPacket(new CMessageBasicPacket(PMember, PMember, memberGil, 0, 565));
+                    }
+                    else
+                    {
+                        UpdateItem(PMember, LOC_INVENTORY, 0, gilPerPerson);
+                        PMember->pushPacket(new CMessageBasicPacket(PMember, PMember, gilPerPerson, 0, 565));
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Before: Only the member with gilfinder gets extra gil

After: If there is a gilfinder in the party it will apply the gilfinder to the gil that is drop from the mob and split it with the entire party (retail tested)
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Kill a mob that drops gil with a THF in the party and you should get equal gil values
<!-- Clear and detailed steps to test your changes here -->
