### PR TITLE
Allow NONE Job Parameter for changesjob

### DIFF
--- a/scripts/commands/changesjob.lua
+++ b/scripts/commands/changesjob.lua
@@ -18,25 +18,32 @@ end
 
 function onTrigger(player, jobId, level)
     -- validate jobId
-    if (jobId == nil) then
+    if jobId == nil then
         error(player, "You must enter a job short-name, e.g. WAR, or its equivalent numeric ID.")
         return
     end
     jobId = tonumber(jobId) or xi.job[string.upper(jobId)]
-    if (jobId == nil or jobId < 0 or jobId >= xi.MAX_JOB_TYPE) then
+    if
+        jobId == nil or
+        jobId < 0 or
+        jobId >= xi.MAX_JOB_TYPE
+    then
         error(player, "Invalid jobID.  Use job short name, e.g. WAR, or its equivalent numeric ID.")
         return
     end
 
     -- validate level
-    if (level ~= nil) then
+    if level ~= nil then
         -- invalid level
-        if (level < 1 or level > 99) then
+        if
+            level < 1 or
+            level > 99
+        then
             error(player, "Invalid level. Level must be between 1 and 99!")
             return
         end
         -- setting none sjob to a different level
-        if (jobId == 0) then
+        if jobId == 0 then
             error(player, "Invalid argument. NONE must have no level parameter, e.g. !changesjob NONE.")
             return
         end
@@ -49,7 +56,7 @@ function onTrigger(player, jobId, level)
     end
 
     -- special case: remove sub
-    if (jobId == 0) then
+    if jobId == 0 then
         -- setting sjob level before sjob change changes the job's actual level
         -- setting sjob level after sjob change calls SQL with an empty query
         -- set the sjob to NONE and change player message to avoid confusion
@@ -60,7 +67,7 @@ function onTrigger(player, jobId, level)
 
     -- change job and (optionally) level
     player:changesJob(jobId)
-    if (level ~= nil) then
+    if level ~= nil then
         player:setsLevel(level)
     end
 

--- a/scripts/commands/changesjob.lua
+++ b/scripts/commands/changesjob.lua
@@ -23,29 +23,45 @@ function onTrigger(player, jobId, level)
         return
     end
     jobId = tonumber(jobId) or xi.job[string.upper(jobId)]
-    if (jobId == nil or jobId <= 0 or jobId >= xi.MAX_JOB_TYPE) then
+    if (jobId == nil or jobId < 0 or jobId >= xi.MAX_JOB_TYPE) then
         error(player, "Invalid jobID.  Use job short name, e.g. WAR, or its equivalent numeric ID.")
         return
     end
 
     -- validate level
     if (level ~= nil) then
+        -- invalid level
         if (level < 1 or level > 99) then
             error(player, "Invalid level. Level must be between 1 and 99!")
             return
         end
-    end
-
-    -- change job and (optionally) level
-    player:changesJob(jobId)
-    if (level ~= nil) then
-        player:setsLevel(level)
+        -- setting none sjob to a different level
+        if (jobId == 0) then
+            error(player, "Invalid argument. NONE must have no level parameter, e.g. !changesjob NONE.")
+            return
+        end
     end
 
     -- invert xi.job table
     local jobNameByNum={}
     for k, v in pairs(xi.job) do
         jobNameByNum[v]=k
+    end
+
+    -- special case: remove sub
+    if (jobId == 0) then
+        -- setting sjob level before sjob change changes the job's actual level
+        -- setting sjob level after sjob change calls SQL with an empty query
+        -- set the sjob to NONE and change player message to avoid confusion
+        player:changesJob(0)
+        player:PrintToPlayer(string.format("You are now a %s%i.", jobNameByNum[player:getMainJob()], player:getMainLvl()))
+        return
+    end
+
+    -- change job and (optionally) level
+    player:changesJob(jobId)
+    if (level ~= nil) then
+        player:setsLevel(level)
     end
 
     -- output new job to player


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Give players the ability to unset their subjob via the changesjob command by passing in NONE or 0 for the jobId argument.

## Steps to test these changes

`!changesjob 0`
`!changesjob NONE`
`!changesjob NONE 1`