### PR TITLE
Fix a Loop in BCNM.lua Causing BCNMs To Break On Multi-instance Release

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -1,7 +1,6 @@
 -----------------------------------
 -- BCNM Functions
 -----------------------------------
-require("scripts/globals/battlefield")
 require("scripts/globals/keyitems")
 require("scripts/globals/missions")
 require("scripts/globals/quests")


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue with a loop on line 4 of bcnm.lua where battlefield.lua being called was causing a require loop stopping bcnm.lua from loading.

## Steps to test these changes
+ Tested on a local (single instance) and was able to operate bcnms normally.
+ Tested on a multi-instance release build and was able to operate bcnms normally.
