### PR TITLE
Fix Issues Pertaining to Spirits Being Able to Crash a Zone

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -674,6 +674,7 @@ void CMobController::DoCombatTick(time_point tick)
                 CBattleEntity* PLowest       = nullptr;
                 float          lowestPercent = 100.f;
                 uint8          choice        = xirand::GetRandomNumber(2, 4);
+                uint16         chosenSpell   = static_cast<uint16>(SpellID::Cure);
 
                 // clang-format off
                 PPet->PMaster->ForParty([&](CBattleEntity* PMember)
@@ -700,14 +701,28 @@ void CMobController::DoCombatTick(time_point tick)
                 switch (choice)
                 {
                     case 1:
-                        CastSpell(static_cast<SpellID>(xirand::GetRandomElement(PPet->m_healSpells)));
+                        if (PPet->m_healSpells.size() > 0)
+                        {
+                            chosenSpell = xirand::GetRandomElement(PPet->m_healSpells);
+                        }
                         break;
                     case 2:
-                        CastSpell(static_cast<SpellID>(xirand::GetRandomElement(PPet->m_buffSpells)));
+                        if (PPet->m_buffSpells.size() > 0)
+                        {
+                            chosenSpell = xirand::GetRandomElement(PPet->m_buffSpells);
+                        }
                         break;
                     case 3:
-                        CastSpell(static_cast<SpellID>(xirand::GetRandomElement(PPet->m_offensiveSpells)));
+                        if (PPet->m_offensiveSpells.size() > 0)
+                        {
+                            chosenSpell = xirand::GetRandomElement(PPet->m_offensiveSpells);
+                        }
                         break;
+                }
+
+                if (CanCastSpells())
+                {
+                    CastSpell(static_cast<SpellID>(chosenSpell));
                 }
 
                 if (PPet)

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -150,37 +150,37 @@ void CPetController::TryIdleSpellCast()
         switch (PPet->m_PetID)
         {
             case PETID_EARTHSPIRIT:
-                if (mLvl >= 28 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_STONESKIN))
+                if (mLvl >= 28 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_STONESKIN) && CanCastSpells())
                 {
                     CastSpell(SpellID::Stoneskin);
                 }
                 break;
             case PETID_WATERSPIRIT:
-                if (mLvl >= 10 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_AQUAVEIL))
+                if (mLvl >= 10 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_AQUAVEIL) && CanCastSpells())
                 {
                     CastSpell(SpellID::Aquaveil);
                 }
                 break;
             case PETID_AIRSPIRIT:
-                if (mLvl >= 19 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_BLINK))
+                if (mLvl >= 19 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_BLINK) && CanCastSpells())
                 {
                     CastSpell(SpellID::Blink);
                 }
                 break;
             case PETID_FIRESPIRIT:
-                if (mLvl >= 10 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_BLAZE_SPIKES))
+                if (mLvl >= 10 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_BLAZE_SPIKES) && CanCastSpells())
                 {
                     CastSpell(SpellID::Blaze_Spikes);
                 }
                 break;
             case PETID_ICESPIRIT:
-                if (mLvl >= 20 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_ICE_SPIKES))
+                if (mLvl >= 20 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_ICE_SPIKES) && CanCastSpells())
                 {
                     CastSpell(SpellID::Ice_Spikes);
                 }
                 break;
             case PETID_THUNDERSPIRIT:
-                if (mLvl >= 30 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_SHOCK_SPIKES))
+                if (mLvl >= 30 && !PPet->StatusEffectContainer->HasStatusEffect(EFFECT_SHOCK_SPIKES) && CanCastSpells())
                 {
                     CastSpell(SpellID::Shock_Spikes);
                 }
@@ -191,6 +191,7 @@ void CPetController::TryIdleSpellCast()
                 CBattleEntity* PLowest       = nullptr;
                 float          lowestPercent = 100.f;
                 uint8          choice        = 2;
+                uint16         chosenSpell   = static_cast<uint16>(SpellID::Cure);
 
                 // clang-format off
                 PPet->PMaster->ForParty([&](CBattleEntity* PMember)
@@ -217,12 +218,24 @@ void CPetController::TryIdleSpellCast()
                 switch (choice)
                 {
                     case 1:
-                        CastSpell(static_cast<SpellID>(xirand::GetRandomElement(PPet->m_healSpells)));
+                        if (PPet->m_healSpells.size() > 0)
+                        {
+                            chosenSpell = xirand::GetRandomElement(PPet->m_healSpells);
+                        }
                         break;
                     case 2:
-                        CastSpell(static_cast<SpellID>(xirand::GetRandomElement(PPet->m_buffSpells)));
+                        if (PPet->m_buffSpells.size() > 0)
+                        {
+                            chosenSpell = xirand::GetRandomElement(PPet->m_buffSpells);
+                        }
                         break;
                 }
+
+                if (CanCastSpells())
+                {
+                    CastSpell(static_cast<SpellID>(chosenSpell));
+                }
+
                 break;
         }
 
@@ -350,7 +363,7 @@ void CPetController::SetSMNCastTime()
         castTime -= 5000;
     }
 
-    if (static_cast<CCharEntity*>(PPet->PMaster)->getEquip(SLOT_LEGS)->getID() == (15131 | 15594))
+    if (static_cast<CCharEntity*>(PPet->PMaster)->getEquip(SLOT_LEGS) != nullptr && static_cast<CCharEntity*>(PPet->PMaster)->getEquip(SLOT_LEGS)->getID() == (15131 | 15594))
     {
         castTime -= 5000;
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where if a SMN has no leg gear on caused a zone crash.
+ Fixes an issue where if a SMN's level was too low to populate 1 spell per category for light spirit, the spirit's vector would index 0 causing GetRandomElement() to crash the zone.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
