### PR TITLE
Audit Gaxe WS

### DIFF
--- a/scripts/globals/weaponskills/iron_tempest.lua
+++ b/scripts/globals/weaponskills/iron_tempest.lua
@@ -26,7 +26,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 1; params.atk200 = 2; params.atk300 = 3.5
+    params.atk100 = 1; params.atk200 = 1.125; params.atk300 = 1.25
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6

--- a/scripts/globals/weaponskills/raging_rush.lua
+++ b/scripts/globals/weaponskills/raging_rush.lua
@@ -23,7 +23,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
+    params.crit100 = 0.15 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1

--- a/scripts/globals/weaponskills/steel_cyclone.lua
+++ b/scripts/globals/weaponskills/steel_cyclone.lua
@@ -27,7 +27,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 1.66; params.atk200 = 1.66; params.atk300 = 1.66
+    params.atk100 = 1.5; params.atk200 = 1.5; params.atk300 = 1.5
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp200 = 2.5 params.ftp300 = 4

--- a/scripts/globals/weaponskills/sturmwind.lua
+++ b/scripts/globals/weaponskills/sturmwind.lua
@@ -26,7 +26,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 1; params.atk200 = 2; params.atk300 = 3.5
+    params.atk100 = 1.5; params.atk200 = 1.5; params.atk300 = 1.5
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Audits Gaxe weaponskills to be era values.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/220

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
