### PR TITLE
Fix Multiple Weaponskill Calculations | Change effectRes to be Multiplicative

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -519,6 +519,11 @@ params.skillType = $3
 params.bonus = $4
 params.effect = $5
 ]]
+
+-- TODO: Fix undefined and non-standard variable usage.
+-- Disable variable checking for this function.
+-- luacheck: ignore 113
+-- luacheck: ignore 111
 function applyResistanceEffect(caster, target, spell, params)
     local diff = params.diff
     local skill = params.skillType
@@ -570,7 +575,7 @@ function applyResistanceEffect(caster, target, spell, params)
 
     local p = getMagicHitRate(caster, target, skill, element, effectRes, magicaccbonus, diff)
 
-    return getMagicResist(p, target,params.element)
+    return getMagicResist(p, target, params.element, effectRes)
 end
 
 -- Applies resistance for things that may not be spells - ie. Quick Draw
@@ -586,6 +591,10 @@ function applyResistanceAddEffect(player, target, element, bonus)
     return getMagicResist(p, target, element)
 end
 
+-- TODO: Fix undefined and non-standard variable usage.
+-- Disable variable checking for this function.
+-- luacheck: ignore 113
+-- luacheck: ignore 111
 function applyResistanceAddEffectWS(player, target, element, bonus)
     local p = getMagicHitRate(player, target, 0, element, 0, bonus)
     local resist = getMagicResist(p, target, element)
@@ -601,6 +610,13 @@ function applyResistanceAddEffectWS(player, target, element, bonus)
     return resist
 end
 
+-- TODO: Fix undefined and non-standard variable usage.
+-- Disable variable checking for this function.
+-- luacheck: ignore 113
+-- luacheck: ignore 111
+-- TODO: Reduce complexity
+-- Disable cyclomatic complexity check for this function:
+-- luacheck: ignore 561
 function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc, dStat)
     local magicacc = 0
     local magiceva = 0
@@ -706,10 +722,10 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
     end
 
     if target:isPC() then
-        magiceva = target:getMod(xi.mod.MEVA) * ((100 + effectRes + resMod) / 100)
+        magiceva = target:getMod(xi.mod.MEVA) * ((100 + resMod) / 100)
     else
         dLvl = utils.clamp(dLvl, 0, 200) -- Mobs should not have a disadvantage when targeted
-        magiceva = (target:getMod(xi.mod.MEVA) + (4 * dLvl)) * ((100 + effectRes + resMod) / 100)
+        magiceva = (target:getMod(xi.mod.MEVA) + (4 * dLvl)) * ((100 + resMod) / 100)
     end
 
     bonusAcc = bonusAcc + caster:getMerit(xi.merit.MAGIC_ACCURACY) + caster:getMerit(xi.merit.NIN_MAGIC_ACCURACY)
@@ -724,6 +740,10 @@ function getMagicHitRate(caster, target, skillType, element, effectRes, bonusAcc
 end
 
 -- Returns resistance value from given magic hit rate (p)
+-- TODO: Fix undefined and non-standard variable usage.
+-- Disable variable checking for this function.
+-- luacheck: ignore 113
+-- luacheck: ignore 111
 function getMagicResist(magicHitRate, target, element)
     local evaMult = 1
 
@@ -739,7 +759,16 @@ function getMagicResist(magicHitRate, target, element)
         end
     end
 
+    local baseRes = 1
+
+    if effectRes ~= nil then
+        baseRes = baseRes - (effectRes / 100)
+    end
+
     local p = utils.clamp(((magicHitRate * evaMult) / 100), 0.05, 0.95)
+
+    p = utils.clamp(p * baseRes, -1, 0.95)
+
     local resist = 1
 
     -- Resistance thresholds based on p.  A higher p leads to lower resist rates, and a lower p leads to higher resist rates.
@@ -798,6 +827,10 @@ end
 
 -- Returns the amount of resistance the
 -- target has to the given effect (stun, sleep, etc..)
+-- TODO: Fix undefined and non-standard variable usage.
+-- Disable variable checking for this function.
+-- luacheck: ignore 113
+-- luacheck: ignore 111
 function getEffectResistance(target, effect, returnBuild, caster)
     local effectres = 0
     local buildres = 0
@@ -1456,6 +1489,10 @@ function calculateDurationForLvl(duration, spellLvl, targetLvl)
     return duration
 end
 
+-- TODO: Fix undefined and non-standard variable usage.
+-- Disable variable checking for this function.
+-- luacheck: ignore 113
+-- luacheck: ignore 111
 function calculateDuration(duration, magicSkill, spellGroup, caster, target, useComposure)
     local casterJob = caster:getMainJob()
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11903,14 +11903,14 @@ uint8 CLuaBaseEntity::getParryRate(CLuaBaseEntity* PLuaBaseEntity)
  *  Notes   : Battleutils calculates via GetHitRate
  ************************************************************************/
 
-uint8 CLuaBaseEntity::getCHitRate(CLuaBaseEntity* PLuaBaseEntity)
+uint8 CLuaBaseEntity::getCHitRate(CLuaBaseEntity* PLuaBaseEntity, uint8 attackNum)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
     CBattleEntity* PAttacker = static_cast<CBattleEntity*>(m_PBaseEntity);
     CBattleEntity* PDefender = static_cast<CBattleEntity*>(PLuaBaseEntity->GetBaseEntity());
 
-    return battleutils::GetHitRate(PAttacker, PDefender, 0);
+    return battleutils::GetHitRate(PAttacker, PDefender, attackNum);
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -664,7 +664,7 @@ public:
     uint8  getGuardRate(CLuaBaseEntity* PLuaBaseEntity);                                                                                    // Returns the guard rate for an attack.
     uint8  getBlockRate(CLuaBaseEntity* PLuaBaseEntity);                                                                                    // Returns the block rate for an attack.
     uint8  getParryRate(CLuaBaseEntity* PLuaBaseEntity);                                                                                    // Returns the parry rate for an attack.
-    uint8  getCHitRate(CLuaBaseEntity* PLuaBaseEntity);                                                                                     // Returns the hit rate for an attack.
+    uint8  getCHitRate(CLuaBaseEntity* PLuaBaseEntity, uint8 attackNum = 0);                                                                // Returns the hit rate for an attack. Defaults to main weapon.
     uint8  getCRangedHitRate(CLuaBaseEntity* PLuaBaseEntity);                                                                               // Returns the ranged hit rate for an attack.
     uint8  getShieldAbsorptionRate();                                                                                                       // Returns the shield absorption for an attack.
     uint16 getWeaponDmg();                                                                                                                  // gets the current equipped weapons' DMG rating


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Hard caps multihit weaponskill ftp for all subsequent hits to 1.
+ Fixes extra hit calculation to use the accuracy and skill type of the equipped weapon. This is bypassed by hand to hand calculations which just use main hand to calculate the additional hit.
+ Expands getCHitRate to allow for attack num tracking (main, sub, etc).
+ Fixes the application of WS gorgets accuracy bonus.
+ Fixes ranged weaponskills so they cannot proc multiattack traits or mods.
+ Fixes the application of effectRes to lower by percentage rather than supply additional evasion.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/231
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/251

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
