### PR TITLE
[core] Fix Spirit recast time reduction item ID check

### DIFF
--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -363,7 +363,9 @@ void CPetController::SetSMNCastTime()
         castTime -= 5000;
     }
 
-    if (static_cast<CCharEntity*>(PPet->PMaster)->getEquip(SLOT_LEGS) != nullptr && static_cast<CCharEntity*>(PPet->PMaster)->getEquip(SLOT_LEGS)->getID() == (15131 | 15594))
+    CItemEquipment* legSlotItem = static_cast<CCharEntity*>(PPet->PMaster)->getEquip(SLOT_LEGS);
+    // Summoner's Spats & Summoner's Spats +1
+    if (legSlotItem && (legSlotItem->getID() == 15131 || legSlotItem->getID() == 15594))
     {
         castTime -= 5000;
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

This fixes the item ID check for SMN AF2 legs to explicitly check both items instead of an bitwise OR of both nq and +1 relic legs

## Steps to test these changes

equip AF2 legs or AF2 legs +1, summon light spirit and see it take 5 seconds less time between spell casts as compared to without