### PR TITLE
Misc Chains of Promathia Missions Bug Fixes

### DIFF
--- a/scripts/globals/mobskills/trinary_absorption.lua
+++ b/scripts/globals/mobskills/trinary_absorption.lua
@@ -22,12 +22,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-
     -- time to drain HP. 50-100
     local power = math.random(0, 151) + 150
     local dmg = xi.mobskills.mobFinalAdjustments(power, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.NUMSHADOWS_1)
 
     skill:setMsg(xi.mobskills.mobPhysicalDrainMove(mob, target, skill, xi.mobskills.drainType.HP, dmg))
+
+    mob:addHP(dmg)
 
     return dmg
 end

--- a/scripts/missions/cop/1_2_Below_the_Arks.lua
+++ b/scripts/missions/cop/1_2_Below_the_Arks.lua
@@ -31,7 +31,7 @@ local cermetGateOnTrigger = function(player, npc)
 end
 
 local shatteredTelepointOnTrigger = function(player, npc)
-    if mission:getVar(player, 'Status') == 1 then
+    if mission:getVar(player, 'Status') >= 1 then
         return xi.cop.helpers.shatteredTelepointOnTrigger(mission, player, npc)
     end
 end
@@ -77,7 +77,7 @@ mission.sections =
             ['High_Wind'] =
             {
                 onTrigger = function(player, npc)
-                    if mission:getVar(player, 'Status') == 1 then
+                    if mission:getVar(player, 'Status') >= 1 then
                         return mission:event(33)
                     end
                 end,
@@ -86,7 +86,7 @@ mission.sections =
             ['Rainhard'] =
             {
                 onTrigger = function(player, npc)
-                    if mission:getVar(player, 'Status') == 1 then
+                    if mission:getVar(player, 'Status') >= 1 then
                         return mission:event(34)
                     end
                 end,
@@ -116,11 +116,21 @@ mission.sections =
         {
             ['Shattered_Telepoint'] =
             {
-                onTrigger = shatteredTelepointOnTrigger,
+                onTrigger = function(player, npc)
+                    if mission:getVar(player, 'Status') == 1 then
+                        return mission:event(3)
+                    else
+                        return shatteredTelepointOnTrigger(player, npc)
+                    end
+                end,
             },
 
             onEventFinish =
             {
+                [3] = function(player, csid, option, npc)
+                    mission:setVar(player, 'Status', 2)
+                end,
+
                 [913] = xi.cop.helpers.shatteredTelepointEntry,
                 [918] = shatteredTelepointSealMemory,
             },
@@ -130,11 +140,21 @@ mission.sections =
         {
             ['Shattered_Telepoint'] =
             {
-                onTrigger = shatteredTelepointOnTrigger,
+                onTrigger = function(player, npc)
+                    if mission:getVar(player, 'Status') == 1 then
+                        return mission:event(14)
+                    else
+                        return shatteredTelepointOnTrigger(player, npc)
+                    end
+                end,
             },
 
             onEventFinish =
             {
+                [14] = function(player, csid, option, npc)
+                    mission:setVar(player, 'Status', 2)
+                end,
+
                 [202] = xi.cop.helpers.shatteredTelepointEntry,
                 [212] = shatteredTelepointSealMemory,
             },
@@ -144,11 +164,21 @@ mission.sections =
         {
             ['Shattered_Telepoint'] =
             {
-                onTrigger = shatteredTelepointOnTrigger,
+                onTrigger = function(player, npc)
+                    if mission:getVar(player, 'Status') == 1 then
+                        return mission:event(41)
+                    else
+                        return shatteredTelepointOnTrigger(player, npc)
+                    end
+                end,
             },
 
             onEventFinish =
             {
+                [41] = function(player, csid, option, npc)
+                    mission:setVar(player, 'Status', 2)
+                end,
+
                 [913] = xi.cop.helpers.shatteredTelepointEntry,
                 [918] = shatteredTelepointSealMemory,
             },

--- a/scripts/missions/cop/helpers.lua
+++ b/scripts/missions/cop/helpers.lua
@@ -106,7 +106,6 @@ xi.cop.helpers.shatteredTelepointEntry = function(player, csid, option, npc)
 end
 
 xi.cop.helpers.shatteredTelepointSealMemory = function(mission, player, csid, option, npc)
-    print(option)
     if option == 0 then
         local zoneId = player:getZoneID()
 

--- a/scripts/zones/Phomiuna_Aqueducts/IDs.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/IDs.lua
@@ -34,6 +34,24 @@ zones[xi.zone.PHOMIUNA_AQUEDUCTS] =
         EBA          = 16887953,
         MAHISHA      = 16887885,
         TRES_DUENDES = 16887908,
+        FOMOR_PARTY_ONE =
+        {
+            16887855,
+            16887857
+        },
+        FOMOR_PARTY_TWO =
+        {
+            16887903,
+            16887904,
+            16887905,
+            16887906
+        },
+        FOMOR_PARTY_THREE =
+        {
+            16887920,
+            16887921,
+            16887922
+        },
     },
     npc =
     {

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Dark_Knight.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Dark_Knight.lua
@@ -3,8 +3,17 @@
 --  Mob: Fomor Dark Knight
 -----------------------------------
 mixins = { require("scripts/mixins/fomor_hate") }
+local ID = require('scripts/zones/Phomiuna_Aqueducts/IDs')
 -----------------------------------
 local entity = {}
+
+entity.onMobSpawn = function(mob)
+    for _, v in pairs(ID.mob.FOMOR_PARTY_TWO) do
+        if mob:getID() == v then
+            mob:setMobMod(xi.mobMod.SUPERLINK, 2)
+        end
+    end
+end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Dragoon.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Dragoon.lua
@@ -3,8 +3,17 @@
 --  Mob: Fomor Dragoon
 -----------------------------------
 mixins = { require("scripts/mixins/fomor_hate") }
+local ID = require('scripts/zones/Phomiuna_Aqueducts/IDs')
 -----------------------------------
 local entity = {}
+
+entity.onMobSpawn = function(mob)
+    for _, v in pairs(ID.mob.FOMOR_PARTY_ONE) do
+        if mob:getID() == v then
+            mob:setMobMod(xi.mobMod.SUPERLINK, 1)
+        end
+    end
+end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Ninja.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Ninja.lua
@@ -3,8 +3,23 @@
 --  Mob: Fomor Ninja
 -----------------------------------
 mixins = { require("scripts/mixins/fomor_hate") }
+local ID = require('scripts/zones/Phomiuna_Aqueducts/IDs')
 -----------------------------------
 local entity = {}
+
+entity.onMobSpawn = function(mob)
+    for _, v in pairs(ID.mob.FOMOR_PARTY_ONE) do
+        if mob:getID() == v then
+            mob:setMobMod(xi.mobMod.SUPERLINK, 1)
+        end
+    end
+
+    for _, v in pairs(ID.mob.FOMOR_PARTY_TWO) do
+        if mob:getID() == v then
+            mob:setMobMod(xi.mobMod.SUPERLINK, 2)
+        end
+    end
+end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Paladin.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Paladin.lua
@@ -3,8 +3,17 @@
 --  Mob: Fomor Paladin
 -----------------------------------
 mixins = { require("scripts/mixins/fomor_hate") }
+local ID = require('scripts/zones/Phomiuna_Aqueducts/IDs')
 -----------------------------------
 local entity = {}
+
+entity.onMobSpawn = function(mob)
+    for _, v in pairs(ID.mob.FOMOR_PARTY_THREE) do
+        if mob:getID() == v then
+            mob:setMobMod(xi.mobMod.SUPERLINK, 3)
+        end
+    end
+end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Ranger.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Ranger.lua
@@ -3,8 +3,17 @@
 --  Mob: Fomor Ranger
 -----------------------------------
 mixins = { require("scripts/mixins/fomor_hate") }
+local ID = require('scripts/zones/Phomiuna_Aqueducts/IDs')
 -----------------------------------
 local entity = {}
+
+entity.onMobSpawn = function(mob)
+    for _, v in pairs(ID.mob.FOMOR_PARTY_TWO) do
+        if mob:getID() == v then
+            mob:setMobMod(xi.mobMod.SUPERLINK, 2)
+        end
+    end
+end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Red_Mage.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Red_Mage.lua
@@ -3,8 +3,17 @@
 --  Mob: Fomor Red Mage
 -----------------------------------
 mixins = { require("scripts/mixins/fomor_hate") }
+local ID = require('scripts/zones/Phomiuna_Aqueducts/IDs')
 -----------------------------------
 local entity = {}
+
+entity.onMobSpawn = function(mob)
+    for _, v in pairs(ID.mob.FOMOR_PARTY_THREE) do
+        if mob:getID() == v then
+            mob:setMobMod(xi.mobMod.SUPERLINK, 3)
+        end
+    end
+end
 
 entity.onMobDeath = function(mob, player, optParams)
 end

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Samurai.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Samurai.lua
@@ -3,9 +3,23 @@
 --  Mob: Fomor Samurai
 -----------------------------------
 mixins = { require("scripts/mixins/fomor_hate") }
+local ID = require('scripts/zones/Phomiuna_Aqueducts/IDs')
 -----------------------------------
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    for _, v in pairs(ID.mob.FOMOR_PARTY_TWO) do
+        if mob:getID() == v then
+            mob:setMobMod(xi.mobMod.SUPERLINK, 2)
+        end
+    end
+
+    for _, v in pairs(ID.mob.FOMOR_PARTY_THREE) do
+        if mob:getID() == v then
+            mob:setMobMod(xi.mobMod.SUPERLINK, 3)
+        end
+    end
+end
 entity.onMobDeath = function(mob, player, optParams)
 end
 

--- a/scripts/zones/Promyvion-Dem/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Dem/mobs/Memory_Receptacle.lua
@@ -8,18 +8,19 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:SetAutoAttackEnabled(false) -- Receptacles only use TP moves.
+    mob:addMod(xi.mod.DEF, 50)
 end
 
 entity.onMobFight = function(mob, target)
     xi.promyvion.receptacleOnFight(mob, target)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
-    xi.promyvion.receptacleOnDeath(mob, optParams)
+entity.onMobRoam = function(mob)
+    xi.promyvion.receptacleIdle(mob)
 end
 
-entity.onMobSpawn = function(mob)
-    mob:addMod(xi.mod.DEF, 55)
+entity.onMobDeath = function(mob, player, optParams)
+    xi.promyvion.receptacleOnDeath(mob, optParams)
 end
 
 return entity

--- a/scripts/zones/Promyvion-Holla/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Holla/mobs/Memory_Receptacle.lua
@@ -8,18 +8,19 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:SetAutoAttackEnabled(false) -- Receptacles only use TP moves.
+    mob:addMod(xi.mod.DEF, 55)
 end
 
 entity.onMobFight = function(mob, target)
     xi.promyvion.receptacleOnFight(mob, target)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
-    xi.promyvion.receptacleOnDeath(mob, optParams)
+entity.onMobRoam = function(mob)
+    xi.promyvion.receptacleIdle(mob)
 end
 
-entity.onMobSpawn = function(mob)
-    mob:addMod(xi.mod.DEF, 55)
+entity.onMobDeath = function(mob, player, optParams)
+    xi.promyvion.receptacleOnDeath(mob, optParams)
 end
 
 return entity

--- a/scripts/zones/Promyvion-Mea/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Mea/mobs/Memory_Receptacle.lua
@@ -8,18 +8,19 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:SetAutoAttackEnabled(false) -- Receptacles only use TP moves.
+    mob:addMod(xi.mod.DEF, 50)
 end
 
 entity.onMobFight = function(mob, target)
     xi.promyvion.receptacleOnFight(mob, target)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
-    xi.promyvion.receptacleOnDeath(mob, optParams)
+entity.onMobRoam = function(mob)
+    xi.promyvion.receptacleIdle(mob)
 end
 
-entity.onMobSpawn = function(mob)
-    mob:addMod(xi.mod.DEF, 55)
+entity.onMobDeath = function(mob, player, optParams)
+    xi.promyvion.receptacleOnDeath(mob, optParams)
 end
 
 return entity

--- a/scripts/zones/Promyvion-Vahzl/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Memory_Receptacle.lua
@@ -14,6 +14,10 @@ entity.onMobFight = function(mob, target)
     xi.promyvion.receptacleOnFight(mob, target)
 end
 
+entity.onMobRoam = function(mob)
+    xi.promyvion.receptacleIdle(mob)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.promyvion.receptacleOnDeath(mob, optParams)
 end

--- a/scripts/zones/RuLude_Gardens/npcs/Harith.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Harith.lua
@@ -53,7 +53,8 @@ end
 entity.onTrigger = function(player, npc)
     if
         player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.EMPTY_MEMORIES) == QUEST_AVAILABLE and
-        player:getCurrentMission(xi.mission.log_id.COP) >= xi.mission.id.cop.THE_MOTHERCRYSTALS
+        (player:getCurrentMission(xi.mission.log_id.COP) >= xi.mission.id.cop.THE_MOTHERCRYSTALS or
+         player:getCharVar("Mission[6][118]Option") > 0)
     then
         player:addQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.EMPTY_MEMORIES)
         player:startEvent(113)

--- a/scripts/zones/Spire_of_Dem/mobs/Progenerator.lua
+++ b/scripts/zones/Spire_of_Dem/mobs/Progenerator.lua
@@ -8,10 +8,14 @@ mixins = { require("scripts/mixins/families/empty_terroanima") }
 
 local entity = {}
 
-entity.onMobSpawn = function(mob)
-    mob:setLocalVar("maxBabies", 4)
+entity.onMobInitialize = function(mob)
     mob:addMod(xi.mod.TRIPLE_ATTACK, 10)
     mob:addMod(xi.mod.DEFP, 35)
+    mob:setMod(xi.mod.STORETP, 100)
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setLocalVar("maxBabies", 4)
 end
 
 entity.onMobWeaponSkillPrepare = function(mob, target)
@@ -21,19 +25,13 @@ entity.onMobWeaponSkillPrepare = function(mob, target)
     if mob:getHPP() <= 50 then
         if random < 0.6 then
             return fission
-        else
-            return 0
         end
     end
 end
 
 entity.onMobFight = function(mob, target)
-    if mob:getTP() >= 2000 then
-        mob:useMobAbility()
-    end
-
     if mob:getHPP() <= 35 then
-       mob:setMod(xi.mod.STORETP, 250)
+        mob:setMod(xi.mod.STORETP, 250)
     end
 end
 

--- a/scripts/zones/Spire_of_Holla/mobs/Wreaker.lua
+++ b/scripts/zones/Spire_of_Holla/mobs/Wreaker.lua
@@ -6,9 +6,10 @@ mixins = { require("scripts/mixins/families/empty_terroanima") }
 -----------------------------------
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
-    mob:addMod(xi.mod.DEFP, 35)
+    mob:addMod(xi.mod.DEFP,35)
+    mob:setMod(xi.mod.STORETP, 100)
 end
 
 entity.onMobWeaponSkillPrepare = function(mob, target)
@@ -23,11 +24,8 @@ entity.onMobWeaponSkillPrepare = function(mob, target)
 end
 
 entity.onMobFight = function(mob, target)
-    if mob:getTP() >= 2000 then
-        mob:useMobAbility()
-    end
     if mob:getHPP() <= 35 then
-       mob:setMod(xi.mod.STORETP, 250)
+        mob:setMod(xi.mod.STORETP, 250)
     end
 end
 

--- a/scripts/zones/Spire_of_Mea/mobs/Delver.lua
+++ b/scripts/zones/Spire_of_Mea/mobs/Delver.lua
@@ -6,9 +6,10 @@ mixins = { require("scripts/mixins/families/empty_terroanima") }
 -----------------------------------
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
     mob:addMod(xi.mod.DEFP,35)
+    mob:setMod(xi.mod.STORETP, 100)
 end
 
 entity.onMobWeaponSkillPrepare = function(mob, target)
@@ -23,11 +24,8 @@ entity.onMobWeaponSkillPrepare = function(mob, target)
 end
 
 entity.onMobFight = function(mob, target)
-    if mob:getTP() >= 2000 then
-        mob:useMobAbility()
-    end
     if mob:getHPP() <= 35 then
-       mob:setMod(xi.mod.STORETP, 250)
+        mob:setMod(xi.mod.STORETP, 250)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
- Trinary Absorption was not healing the mob for the damage done
- Memory Receptacles no longer get stuck in the air when spawning strays.
- Memory Receptacles also trigger all of its strays to attack the current target when engaged.
- Memory Receptacles will also now properly spawn strays during combat and when idle.
- Added a missing cutscene on initial inspection of shattered telepoint.
- Set several groups of fomor in Phomuina Aqueducts to be in a party with each other
- Corrected all Promyvion bosses TPing twice every time they used a mob skill,
- You can now speak with Harith to obtain animas after the initial promvyion cutscenes

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
