### PR TITLE
Fix Equipment Movement Speed Calculation For Negative Mod Values

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1097,7 +1097,7 @@ int16 CBattleEntity::CalculateMSFromSources()
         }
     }
 
-    return std::clamp((highestItemPositiveValue + totalItemReducedValue) + (highestNonItemPositve + totalNonItemReducedValue), 0, 255);
+    return (highestItemPositiveValue + totalItemReducedValue) + (highestNonItemPositve + totalNonItemReducedValue);
 }
 
 void CBattleEntity::addEquipModifiers(std::vector<CModifier>* modList, uint8 itemLevel, uint8 slotid)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes the application of negative movement speed effects such as equipping dusk gear. Attempted to get -movement speed but was stopped at 0 movement speed as intended. 

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/254
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
