### PR TITLE
Audit H2H WS | Change Accuracy Varies with TP to Flat Values | Fix Transport Exploits

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -211,9 +211,14 @@ local function cRangedRatio(attacker, defender, params, ignoredDef, tp)
     return { pdif, pdifcrit }
 end
 
+-- TODO: Fix undefined and non-standard variable usage.
+-- Disable variable checking for this function.
+-- luacheck: ignore 113
+-- luacheck: ignore 111
 local function getRangedHitRate(attacker, target, capHitRate, bonus, wsParams)
+    local accVarryTP = 0
+
     if wsParams and wsParams.acc100 ~= 0 then
-        local accVarryTP = 0
         if calcParams.tp >= 3000 then
             accVarryTP = (wsParams.acc300 - 1) * 100
         elseif calcParams.tp >= 2000 then
@@ -255,18 +260,18 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, f
         ratio = cRangedRatio(attacker, target, wsParams, calcParams.ignoredDef, calcParams.tp)
         pdif = ratio[1]
         pdifCrit =  ratio[2]
-        calcParams.hitRate = getRangedHitRate(attacker, target, false, 0)
+        calcParams.hitRate = getRangedHitRate(attacker, target, false, 0, wsParams, calcParams)
     else
         if isSubAttack and calcParams.extraOffhandHit and calcParams.attackInfo.weaponType ~= xi.skill.HAND_TO_HAND then
             ratio = cMeleeRatio(attacker, target, wsParams, calcParams.ignoredDef, calcParams.tp, xi.slot.SUB)
             pdif = ratio[1]
             pdifCrit =  ratio[2]
-            calcParams.hitRate = getHitRate(attacker, target, false, 0, true)
+            calcParams.hitRate = getHitRate(attacker, target, false, 0, true, wsParams, calcParams)
         else
             ratio = cMeleeRatio(attacker, target, wsParams, calcParams.ignoredDef, calcParams.tp, xi.slot.MAIN)
             pdif = ratio[1]
             pdifCrit =  ratio[2]
-            calcParams.hitRate = getHitRate(attacker, target, false, 0, false)
+            calcParams.hitRate = getHitRate(attacker, target, false, 0, false, wsParams, calcParams)
         end
     end
 
@@ -640,7 +645,7 @@ function doPhysicalWeaponskill(attacker, target, wsID, wsParams, tp, action, pri
     calcParams.bonusfTP = gorgetBeltFTP or 0
     calcParams.bonusAcc = (gorgetBeltAcc or 0) + attacker:getMod(xi.mod.WSACC)
     calcParams.bonusWSmods = wsParams.bonusWSmods or 0
-    calcParams.hitRate = getHitRate(attacker, target, false, calcParams.bonusAcc, false)
+    calcParams.hitRate = getHitRate(attacker, target, false, calcParams.bonusAcc, false, wsParams, calcParams)
     calcParams.skillType = attack.weaponType
 
     if calcParams.extraOffhandHit and attack.weaponType ~= xi.skill.HAND_TO_HAND then
@@ -926,7 +931,11 @@ function getMeleeDmg(attacker, weaponType, kick)
     return { mainhandDamage, offhandDamage }
 end
 
-function getHitRate(attacker, target, capHitRate, bonus, isSubAttack)
+-- TODO: Fix undefined and non-standard variable usage.
+-- Disable variable checking for this function.
+-- luacheck: ignore 113
+-- luacheck: ignore 111
+function getHitRate(attacker, target, capHitRate, bonus, isSubAttack, wsParams, calcParams)
     if isSubAttack == nil then
         isSubAttack = false
     end
@@ -936,7 +945,6 @@ function getHitRate(attacker, target, capHitRate, bonus, isSubAttack)
     local accVarryTP = 0
 
     if wsParams and wsParams.acc100 ~= 0 then
-        local accVarryTP = 0
         if calcParams.tp >= 3000 then
             accVarryTP = (wsParams.acc300 - 1) * 100
         elseif calcParams.tp >= 2000 then

--- a/scripts/globals/weaponskills/dragon_kick.lua
+++ b/scripts/globals/weaponskills/dragon_kick.lua
@@ -21,7 +21,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local params = {}
     params.numHits = 1
-    params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 3.5
+    params.ftp100 = 2 params.ftp200 = 2.75 params.ftp300 = 3.5
     params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.5 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/globals/weaponskills/howling_fist.lua
+++ b/scripts/globals/weaponskills/howling_fist.lua
@@ -27,7 +27,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    params.atk100 = 1.5; params.atk200 = 1.5; params.atk300 = 1.5
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp200 = 4.75 params.ftp300 = 8

--- a/scripts/zones/Kazham/Zone.lua
+++ b/scripts/zones/Kazham/Zone.lua
@@ -32,6 +32,12 @@ end
 
 zoneObject.onTransportEvent = function(player, transport)
     player:startEvent(10000)
+    if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+        player:startEvent(10000)
+    else
+        player:setPos(-17.8247, -4.0000, -17.6277, 191.000)
+        player:setLocalVar('[AIRSHIP]Paid', 0)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option)
@@ -40,6 +46,9 @@ end
 zoneObject.onEventFinish = function(player, csid, option)
     if csid == 10000 then
         player:setPos(0, 0, 0, 0, 226)
+        player:setLocalVar('[AIRSHIP]Paid', 1)
+    elseif csid == 121 and option == 0 then
+        player:setLocalVar('[AIRSHIP]Paid', 0)
     end
 end
 

--- a/scripts/zones/Kazham/npcs/Bhoyu_Halpatacco.lua
+++ b/scripts/zones/Kazham/npcs/Bhoyu_Halpatacco.lua
@@ -27,6 +27,7 @@ entity.onEventFinish = function(player, csid, option)
 
         if (zPos >= -10 and zPos <= -6) then
             player:delGil(200)
+            player:setLocalVar('[AIRSHIP]Paid', 1)
         end
     end
 end

--- a/scripts/zones/Kazham/npcs/Ghemi_Sinterilo.lua
+++ b/scripts/zones/Kazham/npcs/Ghemi_Sinterilo.lua
@@ -27,7 +27,9 @@ entity.onTrigger = function(player, npc)
     }
 
     player:showText(npc, ID.text.GHEMISENTERILO_SHOP_DIALOG)
-    xi.shop.general(player, stock)
+    if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+        xi.shop.general(player, stock)
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Mhaura/Zone.lua
+++ b/scripts/zones/Mhaura/Zone.lua
@@ -55,15 +55,20 @@ zoneObject.onConquestUpdate = function(zone, updatetype)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    if transport == 47 or transport == 46 then
-        if not player:hasKeyItem(xi.ki.BOARDING_PERMIT) or xi.settings.main.ENABLE_TOAU == 0 then
-            player:setPos(8.200, -1.363, 3.445, 192)
-            player:messageSpecial(ID.text.DO_NOT_POSSESS, xi.ki.BOARDING_PERMIT)
+    if player:getLocalVar('[BOAT]Paid') == 1 then
+        if transport == 47 or transport == 46 then
+            if not player:hasKeyItem(xi.ki.BOARDING_PERMIT) or xi.settings.main.ENABLE_TOAU == 0 then
+                player:setPos(8.200, -1.363, 3.445, 192)
+                player:messageSpecial(ID.text.DO_NOT_POSSESS, xi.ki.BOARDING_PERMIT)
+            else
+                player:startEvent(200)
+            end
         else
             player:startEvent(200)
         end
     else
-        player:startEvent(200)
+        player:setPos(48.1156, -8.0000, 40.8011, 66)
+        player:setLocalVar('[BOAT]Paid', 0)
     end
 end
 
@@ -85,6 +90,8 @@ zoneObject.onEventFinish = function(player, csid, option)
         else
             player:setPos(8, -1, 5, 62, 249) -- Something went wrong, dump them on the dock for safety.
         end
+    elseif csid == 220 and option == 0 then
+        player:setLocalVar('[BOAT]Paid', 0)
     end
 end
 

--- a/scripts/zones/Mhaura/npcs/Felisa.lua
+++ b/scripts/zones/Mhaura/npcs/Felisa.lua
@@ -24,6 +24,7 @@ end
 entity.onEventFinish = function(player, csid, option)
     if csid == 221 and option == 333 then
         player:delGil(100)
+        player:setLocalVar('[BOAT]Paid', 1)
     end
 end
 

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -51,7 +51,12 @@ zoneObject.onRegionLeave = function(player, region)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(71)
+    if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+        player:startEvent(71)
+    else
+        player:setPos(-93.8551, -2.6121, -7.9205, 253)
+        player:setLocalVar('[AIRSHIP]Paid', 0)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option)
@@ -62,6 +67,9 @@ zoneObject.onEventFinish = function(player, csid, option)
         player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
     elseif (csid == 71) then
         player:setPos(0, 0, 0, 0, 224)
+        player:setLocalVar('[AIRSHIP]Paid', 1)
+    elseif csid == 140 and option == 0 then
+        player:setLocalVar('[AIRSHIP]Paid', 0)
     end
 end
 

--- a/scripts/zones/Port_Bastok/npcs/Denvihr.lua
+++ b/scripts/zones/Port_Bastok/npcs/Denvihr.lua
@@ -27,7 +27,9 @@ entity.onTrigger = function(player, npc)
     }
 
     player:showText(npc, ID.text.DENVIHR_SHOP_DIALOG)
-    xi.shop.nation(player, stock, xi.nation.BASTOK)
+    if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+        xi.shop.nation(player, stock, xi.nation.BASTOK)
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Port_Bastok/npcs/Rajesh.lua
+++ b/scripts/zones/Port_Bastok/npcs/Rajesh.lua
@@ -27,6 +27,7 @@ entity.onEventFinish = function(player, csid, option)
 
         if xPos >= -58 and xPos <= -55 then
             player:delGil(200)
+            player:setLocalVar('[AIRSHIP]Paid', 1)
         end
     end
 end

--- a/scripts/zones/Port_Bastok/npcs/Sugandhi.lua
+++ b/scripts/zones/Port_Bastok/npcs/Sugandhi.lua
@@ -30,7 +30,9 @@ entity.onTrigger = function(player, npc)
     }
 
     player:showText(npc, ID.text.SUGANDHI_SHOP_DIALOG)
-    xi.shop.nation(player, stock, xi.nation.BASTOK)
+    if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+        xi.shop.nation(player, stock, xi.nation.BASTOK)
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Port_Jeuno/Zone.lua
+++ b/scripts/zones/Port_Jeuno/Zone.lua
@@ -55,14 +55,37 @@ zoneObject.onConquestUpdate = function(zone, updatetype)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    if transport == 223 then
+    if transport == 223 then -- San d'Oria Airship
         player:startEvent(10010)
-    elseif transport == 224 then
+        if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+            player:startEvent(10002)
+        else
+            player:setPos(-77.0152, 8.0021, 40.8033, 195)
+            player:setLocalVar('[AIRSHIP]Paid', 0)
+        end
+    elseif transport == 224 then -- Bastok Airship
         player:startEvent(10012)
-    elseif transport == 225 then
-        player:startEvent(10011)
-    elseif transport == 226 then
+        if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+            player:startEvent(10002)
+        else
+            player:setPos(-60.9037, 8.0007, -41.2909, 64)
+            player:setLocalVar('[AIRSHIP]Paid', 0)
+        end
+    elseif transport == 225 then -- Windurst Airship
+        if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+            player:startEvent(10011)
+        else
+            player:setPos(2.9721, 8.0018, -40.1178, 65)
+            player:setLocalVar('[AIRSHIP]Paid', 0)
+        end
+    elseif transport == 226 then -- Kazham Airship
         player:startEvent(10013)
+        if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+            player:startEvent(10002)
+        else
+            player:setPos(-12.9056, 8.0015, 40.2401, 191)
+            player:setLocalVar('[AIRSHIP]Paid', 0)
+        end
     end
 end
 
@@ -72,12 +95,24 @@ end
 zoneObject.onEventFinish = function(player, csid, option)
     if csid == 10010 then
         player:setPos(0, 0, 0, 0, 223)
+        player:setLocalVar('[AIRSHIP]Paid', 1)
     elseif csid == 10011 then
         player:setPos(0, 0, 0, 0, 225)
+        player:setLocalVar('[AIRSHIP]Paid', 1)
     elseif csid == 10012 then
         player:setPos(0, 0, 0, 0, 224)
+        player:setLocalVar('[AIRSHIP]Paid', 1)
     elseif csid == 10013 then
         player:setPos(0, 0, 0, 0, 226)
+        player:setLocalVar('[AIRSHIP]Paid', 1)
+    elseif csid == 54 and option == 0 then
+        player:setLocalVar('[AIRSHIP]Paid', 0)
+    elseif csid == 53 and option == 0 then
+        player:setLocalVar('[AIRSHIP]Paid', 0)
+    elseif csid == 52 and option == 0 then
+        player:setLocalVar('[AIRSHIP]Paid', 0)
+    elseif csid == 55 and option == 0 then
+        player:setLocalVar('[AIRSHIP]Paid', 0)
     end
 end
 

--- a/scripts/zones/Port_Jeuno/npcs/Illauvolahaut.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Illauvolahaut.lua
@@ -37,6 +37,7 @@ entity.onEventFinish = function(player, csid, option)
 
         if zPos >= 58 and zPos <= 61 then
             player:delGil(200)
+            player:setLocalVar('[AIRSHIP]Paid', 1)
         end
     end
 end

--- a/scripts/zones/Port_Jeuno/npcs/Omiro-Zamiro.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Omiro-Zamiro.lua
@@ -34,6 +34,7 @@ entity.onEventFinish = function(player, csid, option)
 
         if zPos >= -61 and zPos <= -58 then
             player:delGil(200)
+            player:setLocalVar('[AIRSHIP]Paid', 1)
         end
     end
 end

--- a/scripts/zones/Port_Jeuno/npcs/Purequane.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Purequane.lua
@@ -34,6 +34,7 @@ entity.onEventFinish = function(player, csid, option)
 
         if zPos >= 58 and zPos <= 61 then
             player:delGil(200)
+            player:setLocalVar('[AIRSHIP]Paid', 1)
         end
     end
 end

--- a/scripts/zones/Port_Jeuno/npcs/Zedduva.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Zedduva.lua
@@ -34,6 +34,7 @@ entity.onEventFinish = function(player, csid, option)
 
         if zPos >= -61 and zPos <= -58 then
             player:delGil(200)
+            player:setLocalVar('[AIRSHIP]Paid', 1)
         end
     end
 end

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -51,7 +51,12 @@ zoneObject.onRegionLeave = function(player, region)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(700)
+    if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+        player:startEvent(700)
+    else
+        player:setPos(-33.5104, -8.1500, 27.7711, 0)
+        player:setLocalVar('[AIRSHIP]Paid', 0)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option)
@@ -62,6 +67,8 @@ zoneObject.onEventFinish = function(player, csid, option)
         player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
     elseif csid == 700 then
         player:setPos(0, 0, 0, 0, 223)
+    elseif csid == 518 and option == 0 then
+        player:setLocalVar('[AIRSHIP]Paid', 0)
     end
 end
 

--- a/scripts/zones/Port_San_dOria/npcs/Albinie.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Albinie.lua
@@ -27,7 +27,9 @@ entity.onTrigger = function(player, npc)
     }
 
     player:showText(npc, ID.text.ALBINIE_SHOP_DIALOG)
-    xi.shop.nation(player, stock, xi.nation.SANDORIA)
+    if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+        xi.shop.nation(player, stock, xi.nation.SANDORIA)
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Port_San_dOria/npcs/Anton.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Anton.lua
@@ -29,6 +29,7 @@ entity.onEventFinish = function(player, csid, option)
 
         if xPos >= -13 and xPos <= -8 then
             player:delGil(200)
+            player:setLocalVar('[AIRSHIP]Paid', 1)
         end
     end
 end

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -43,7 +43,12 @@ zoneObject.onConquestUpdate = function(zone, updatetype)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(10002)
+    if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+        player:startEvent(10002)
+    else
+        player:setPos(207.0728, -6.5000, 124.9320, 30)
+        player:setLocalVar('[AIRSHIP]Paid', 0)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option)
@@ -54,6 +59,8 @@ zoneObject.onEventFinish = function(player, csid, option)
         player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
     elseif csid == 10002 then
         player:setPos(0, 0, 0, 0, 225)
+    elseif csid == 182 and option == 0 then
+        player:setLocalVar('[AIRSHIP]Paid', 0)
     end
 end
 

--- a/scripts/zones/Port_Windurst/npcs/Honorio.lua
+++ b/scripts/zones/Port_Windurst/npcs/Honorio.lua
@@ -28,6 +28,7 @@ entity.onEventFinish = function(player, csid, option)
 
         if xPos >= 222 and xPos <= 225 then
             player:delGil(200)
+            player:setLocalVar('[AIRSHIP]Paid', 1)
         end
     end
 end

--- a/scripts/zones/Port_Windurst/npcs/Uli_Pehkowa.lua
+++ b/scripts/zones/Port_Windurst/npcs/Uli_Pehkowa.lua
@@ -27,7 +27,9 @@ entity.onTrigger = function(player, npc)
     }
 
     player:showText(npc, ID.text.ULIPEHKOWA_SHOP_DIALOG)
-    xi.shop.nation(player, stock, xi.nation.WINDURST)
+    if player:getLocalVar('[AIRSHIP]Paid') == 1 then
+        xi.shop.nation(player, stock, xi.nation.WINDURST)
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Selbina/Zone.lua
+++ b/scripts/zones/Selbina/Zone.lua
@@ -50,7 +50,12 @@ zoneObject.onConquestUpdate = function(zone, updatetype)
 end
 
 zoneObject.onTransportEvent = function(player, transport)
-    player:startEvent(200)
+    if player:getLocalVar('[BOAT]Paid') == 1 then
+        player:startEvent(200)
+    else
+        player:setPos(33.1626, -2.5586, -26.3290, 69)
+        player:setLocalVar('[BOAT]Paid', 0)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option)
@@ -65,6 +70,8 @@ zoneObject.onEventFinish = function(player, csid, option)
         end
     elseif csid == 1101 and npcUtil.completeQuest(player, xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.I_LL_TAKE_THE_BIG_BOX, { item = 14226, fameArea = xi.quest.fame_area.NORG, var = { "Enagakure_Killed", "illTakeTheBigBoxCS" } }) then
         player:delKeyItem(xi.ki.SEANCE_STAFF)
+    elseif csid == 220 and option == 0 then
+        player:setLocalVar('[BOAT]Paid', 0)
     end
 end
 

--- a/scripts/zones/Selbina/npcs/Lucia.lua
+++ b/scripts/zones/Selbina/npcs/Lucia.lua
@@ -22,6 +22,7 @@ end
 entity.onEventFinish = function(player, csid, option)
     if csid == 221 and player:getZPos() < -28.750 then
         player:delGil(100)
+        player:setLocalVar('[BOAT]Paid', 1)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes calc params for howling fist and dragon kick.
+ Changes accuracy varies with tp to flat values based on a percentage of 100 which will yield appropriate values to era.
+ Fixes multiple issues with being able to potentially bypass airship or boat fees.
+ Limits the availability of shops inside airship or boat staging areas to those who have paid for the ticket.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/262
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/199

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
