### PR TITLE
Fix Wyvern Stats | Fix Wyvern Parameter Increase

### DIFF
--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -189,27 +189,31 @@ entity.onMobSpawn = function(mob)
         player:petRetreat()
     end)
 
-    -- master:addListener("EXPERIENCE_POINTS", "PET_WYVERN_EXP", function(player, exp)
-        -- local pet = player:getPet()
-        -- local prev_exp = pet:getLocalVar("wyvern_exp")
-        -- if prev_exp < 1000 then
-            -- cap exp at 1000 to prevent wyvern leveling up many times from large exp awards
-            -- local currentExp = exp
-            -- if prev_exp + exp > 1000 then
-                -- currentExp = 1000 - prev_exp
-            -- end
-            -- local diff = math.floor((prev_exp + currentExp) / 200) - math.floor(prev_exp / 200)
-            -- if diff ~= 0 then
-                -- wyvern levelled up (diff is the number of level ups)
-                -- pet:addMod(xi.mod.ACC, 6 * diff)
-                -- pet:addMod(xi.mod.HPP, 6 * diff)
-                -- pet:addMod(xi.mod.ATTP, 5 * diff)
-                -- pet:setHP(pet:getMaxHP())
-                -- player:messageBasic(xi.msg.basic.STATUS_INCREASED, 0, 0, pet)
-            -- end
-            -- pet:setLocalVar("wyvern_exp", prev_exp + exp)
-        -- end
-    -- end)
+    if xi.settings.main.ENABLE_WOTG == 1 then
+        master:addListener("EXPERIENCE_POINTS", "PET_WYVERN_EXP", function(player, exp)
+            local pet = player:getPet()
+            local prev_exp = pet:getLocalVar("wyvern_exp")
+            local levels_gained = pet:getLocalVar("wyvern_level_ups")
+            if prev_exp < 1000 and levels_gained < 5 then
+                -- cap exp at 1000 to prevent wyvern leveling up many times from large exp awards
+                local currentExp = utils.clamp(exp + prev_exp, 0, 1000)
+                local diff = math.floor(currentExp / 200) - levels_gained
+
+                while diff > 0 do
+                    -- wyvern levelled up (diff is the number of level ups)
+                    pet:addMod(xi.mod.ACC, 6)
+                    pet:addMod(xi.mod.HPP, 6)
+                    pet:addMod(xi.mod.ATTP, 5)
+                    pet:setHP(pet:getMaxHP())
+                    player:messageBasic(xi.msg.basic.STATUS_INCREASED, 0, 0, pet)
+                    pet:setLocalVar("wyvern_level_ups", levels_gained + 1)
+                    diff = diff - 1
+                end
+
+                pet:setLocalVar("wyvern_exp", prev_exp + exp)
+            end
+        end)
+    end
 end
 
 entity.onMobDeath = function(mob, player)

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -2089,6 +2089,7 @@ namespace petutils
         uint8 iLvl = std::clamp(charutils::getMainhandItemLevel(static_cast<CCharEntity*>(PMaster)) - 99, 0, 20);
 
         PPet->SetMLevel(mLvl + iLvl + PMaster->getMod(Mod::WYVERN_LVL_BONUS));
+        PPet->SetSLevel(PPet->GetMLevel() / 2);
 
         LoadAvatarStats(PMaster, PPet);                                                                               // follows PC calcs (w/o SJ)
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (320.0f / 60.0f)))); // 320 delay
@@ -2097,9 +2098,20 @@ namespace petutils
         // Set A+ weapon skill
         PPet->setModifier(Mod::ATT, battleutils::GetMaxSkill(SKILL_GREAT_AXE, JOB_WAR, mLvl > 99 ? 99 : mLvl));
         PPet->setModifier(Mod::ACC, battleutils::GetMaxSkill(SKILL_GREAT_AXE, JOB_WAR, mLvl > 99 ? 99 : mLvl));
-        // Set D evasion and def
+        PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(SKILL_GREAT_AXE, JOB_WAR, mLvl > 99 ? 99 : mLvl));
+        // Set D evasion
         PPet->setModifier(Mod::EVA, battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_WAR, mLvl > 99 ? 99 : mLvl));
-        PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_WAR, mLvl > 99 ? 99 : mLvl));
+
+        // Psuedo add accuracy bonus
+        if (PPet->GetMLevel() >= 50)
+        {
+            PPet->addModifier(Mod::ACC, 22);
+        }
+        else if (PPet->GetMLevel() >= 10)
+        {
+            PPet->addModifier(Mod::ACC, 10);
+        }
+
         // Set wyvern damageType to slashing damage. "Wyverns do slashing damage..." https://www.bg-wiki.com/ffxi/Wyvern_(Dragoon_Pet)
         PPet->m_dmgType = DAMAGE_TYPE::SLASHING;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Gates wyvern parameter increase behinds WotG.
+ Resolves an issue where parameter increase would not properly trigger until 5 increases were accumulated.
+ Fixes an issue where wyvern stats were too low. Wyverns were missing any stats from subjobs.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/263

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
