### PR TITLE
More SMN Avatar Tuning

### DIFF
--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -100,7 +100,7 @@ local function avatarHitDmg(baseDmg, fSTR, pDif, attacker, target, ftp)
         ftp = 1
     end
 
-    local dmg = (baseDmg + fSTR) * ftp * pDif
+    local dmg = (baseDmg + fSTR) * utils.clamp(ftp * pDif, 0, 4.0)
 
     dmg = handleBlock(attacker, target, dmg)
     return dmg
@@ -193,7 +193,7 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
         local critRate = (baseCritRate + getDexCritRate(avatar, target) + avatar:getMod(xi.mod.CRITHITRATE)) / 100
         critRate = utils.clamp(critRate, minCritRate, maxCritRate)
 
-        local baseDmg = avatar:getWeaponDmg() + (wSC * 0.85)
+        local baseDmg = (avatar:getMainLvl() * 0.75) + (wSC * 0.85)
 
         local fSTR = getAvatarFSTR(avatar:getStat(xi.mod.STR), target:getStat(xi.mod.VIT), avatar)
 
@@ -204,18 +204,24 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
             mtp300 = 1.0
         end
 
+        local pdifSoftCap = { nonCrit = 1.6, crit = 2.1 }
         local tp = avatar:getTP()
         local params = { atk100 = mtp100, atk200 = mtp200, atk300 = mtp300 }
         local pDifTable = cMeleeRatio(avatar, target, params, 0, tp, xi.slot.MAIN)
-        local pDif = utils.clamp(pDifTable[1], 0, 2)
-        local pDifCrit = utils.clamp(pDifTable[2], 0, 3)
+        local pDif = utils.clamp(pDifTable[1], 0, pdifSoftCap.nonCrit)
+        local pDifCrit = utils.clamp(pDifTable[2], 0, pdifSoftCap.crit)
 
         --Everything past this point is randomly computed per hit
 
         numHitsProcessed = 0
 
         if firstHitLanded then
-            local ftp = fTP(tp, 1.25, 2.5, 2.8125)
+            local ftp = fTP(tp, 1.35, 1.65, 1.875)
+
+            if numberofhits > 1 then
+                ftp = fTP(tp, 1.1, 1.3, 1.425)
+            end
+
             local isCrit = math.random() < critRate
 
             if isCrit then
@@ -231,8 +237,8 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
             local ftp = 1
             local isCrit = math.random() < critRate
             pDifTable = cMeleeRatio(avatar, target, params, 0, tp, xi.slot.MAIN)
-            pDif = utils.clamp(pDifTable[1], 0, 2)
-            pDifCrit = utils.clamp(pDifTable[2], 0, 3)
+            pDif = utils.clamp(pDifTable[1], 0, pdifSoftCap.nonCrit)
+            pDifCrit = utils.clamp(pDifTable[2], 0, pdifSoftCap.crit)
 
             if isCrit then
                 pDif = pDifCrit


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Reduces pdif multipliers significantly as these changes were moved into the ftp as a way to scale pdif.
+ Reduces overall ftp values significantly as they were OOE. New values are a fit curve based on data from the previous MR.
+ Adds a multihit ftp change which reduces the ftp multipliers if the number of attacks is greater than 1. This is to solve issues with BPs such as double punch.
+ Adds a hard cap of 4.0 to the total product of ftp and pdif. This in turn allows for mirroring of the actual hard pdif cap in era. 
+ Modifies the calculation of D to be more accurate taking into account the mob's VIT.

## Steps to test these changes
+ Tuned everything using punch as a lv. 75 smn against a lv. 63 lesser colibri. Was able to get all punch values in range then tuned double punch with roughly known values against lv. 35 flesh eaters as a lv. 30 smn.

Sources: https://kegsay.livejournal.com/?utm_medium=endless_scroll and https://web.archive.org/web/20180919080320/http://ffxi.allakhazam.com/forum.html?forum=250&mid=1254863299247793724
