### PR TITLE
Reduce Segian Proc | Fix Avatar Subjobs for Skills

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -980,6 +980,12 @@ void CBattleEntity::SetSLevel(uint8 slvl)
         // But there is no place in the DB to set subLV right now.
         m_slvl = (slvl > (m_mlvl >> 1) ? (m_mlvl == 1 ? 1 : (m_mlvl >> 1)) : slvl);
     }
+    else if (this->objtype == TYPE_PET &&
+             (static_cast<CPetEntity*>(this)->getPetType() == PET_TYPE::AVATAR || static_cast<CPetEntity*>(this)->getPetType() == PET_TYPE::AVATAR) &&
+             static_cast<CPetEntity*>(this)->PMaster->objtype == TYPE_PC)
+    {
+        m_slvl = this->GetMLevel();
+    }
     else
     {
         auto ratio = settings::get<uint8>("map.SUBJOB_RATIO");

--- a/src/map/utils/attackutils.cpp
+++ b/src/map/utils/attackutils.cpp
@@ -94,7 +94,7 @@ namespace attackutils
 
             float powerMulti = std::clamp((32.0f - power * powerMod) / 32.0f, 0.f, 1.f);
             float tickMulti  = std::clamp((127.0f - tickCount * 8) / 128.0f, 0.f, 1.f);
-            float keepChance = std::clamp(tickMulti * powerMulti, 0.f, 1.f);
+            float keepChance = std::clamp((tickMulti * powerMulti) / 1.6f, 0.f, 1.f);
             float random     = xirand::GetRandomNumber(1.0f);
 
             // chance to counter - 25% base plus augment and not preventing action and is facing

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1007,7 +1007,7 @@ namespace petutils
         uint8 grade;
 
         uint8   mlvl = PPet->GetMLevel();
-        uint8   slvl = PPet->GetSLevel();
+        uint8   slvl = PPet->GetSLevel() / 2;
         JOBTYPE mjob = PPet->GetMJob();
         JOBTYPE sjob = PPet->GetSJob();
 
@@ -1844,14 +1844,13 @@ namespace petutils
                 }
 
                 PPet->SetMLevel(mLvl);
-                // For now, assume subjob level is half of main job level
-                // PPet->SetSLevel(mLvl > 1 ? floor(mLvl / 2) : 1);
                 PPet->SetSLevel(mLvl);
             }
             else if (PMaster->GetSJob() == JOB_SMN)
             {
-                PPet->SetMLevel(PMaster->GetSLevel());
-                PPet->SetSLevel(PMaster->GetSLevel());
+                uint8 sLvl = PMaster->GetSLevel();
+                PPet->SetMLevel(sLvl);
+                PPet->SetSLevel(sLvl);
             }
             else
             { // should never happen
@@ -2028,7 +2027,7 @@ namespace petutils
                 PPet->SetMLevel(PMaster->GetMLevel() + PMaster->getMod(Mod::AUTOMATON_LVL_BONUS));
                 PPet->SetSLevel(PMaster->GetMLevel() / 2); // Todo: SetSLevel() already reduces the level?
             }
-            else
+            else if (PMaster->GetSJob() == JOB_PUP)
             {
                 PPet->SetMLevel(PMaster->GetSLevel());
                 PPet->SetSLevel(PMaster->GetSLevel() / 2); // Todo: SetSLevel() already reduces the level?


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Reduced Seigan keep chance.
+ Increases avatar and elemental sub levels while also keeping their stat distributions the same. This is to increase skill levels for these in order to allow them to be more effective. Since stats were already era we opted to simply change the subjob level and divide the subjob level by 2 in stat distributions.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/271

![image](https://user-images.githubusercontent.com/84217630/197368151-85b4ef99-c371-47ab-bad0-b352ce23f54a.png)


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
