### PR TITLE
Fix ATT While Dual Wielding For /checkparam | Fix WEIGHT Movement Speed Scaling

### DIFF
--- a/scripts/globals/effects/weight.lua
+++ b/scripts/globals/effects/weight.lua
@@ -6,7 +6,7 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    local moveMod = (effect:getPower() / (50 + xi.settings.map.SPEED_MOD)) * -100
+    local moveMod = effect:getPower() * (-1 * (50 + xi.settings.map.SPEED_MOD) / 50)
     target:addMod(xi.mod.MOVE, moveMod)
     target:addMod(xi.mod.EVA, -10)
 end
@@ -15,7 +15,7 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    local moveMod = (effect:getPower() / (50 + xi.settings.map.SPEED_MOD)) * -100
+    local moveMod = effect:getPower() * (-1 * (50 + xi.settings.map.SPEED_MOD) / 50)
     target:delMod(xi.mod.MOVE, moveMod)
     target:delMod(xi.mod.EVA, -10)
 end

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5973,7 +5973,7 @@ void SmallPacket0x0DD(map_session_data_t* const PSession, CCharEntity* const PCh
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PChar->ACC(0, 0), PChar->ATT(SLOT_MAIN), MSGBASIC_CHECKPARAM_PRIMARY));
             if (PChar->getEquip(SLOT_SUB) && PChar->getEquip(SLOT_SUB)->isType(ITEM_WEAPON))
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PChar->ACC(1, 0), PChar->ATT(SLOT_MAIN), MSGBASIC_CHECKPARAM_AUXILIARY));
+                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PChar->ACC(1, 0), PChar->ATT(SLOT_SUB), MSGBASIC_CHECKPARAM_AUXILIARY));
             }
             else
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where /checkparam while wielding weapons of different types would display the incorrect amount of ATT.
+ Fixes scaling WEIGHT formula to be accurate to more ranges in movement speed reductions.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/268
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/267

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
