### PR TITLE
Fix More CI Checks | Fix Virtue Weapon Procs

### DIFF
--- a/scripts/globals/abilities/box_step.lua
+++ b/scripts/globals/abilities/box_step.lua
@@ -36,7 +36,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     local hit = 2
     local effect = 1
 
-    if math.random() <= getHitRate(player, target, true, player:getMod(xi.mod.STEP_ACCURACY)) then
+    if math.random() <= xi.weaponskills.getHitRate(player, target, true, player:getMod(xi.mod.STEP_ACCURACY)) then
         hit = 6
         local mjob = player:getMainJob()
         local daze = 1

--- a/scripts/globals/abilities/desperate_flourish.lua
+++ b/scripts/globals/abilities/desperate_flourish.lua
@@ -51,7 +51,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
         isSneakValid = false
     end
 
-    local hitrate = getHitRate(player, target, true, player:getJobPointLevel(xi.jp.FLOURISH_I_EFFECT))
+    local hitrate = xi.weaponskills.getHitRate(player, target, true, player:getJobPointLevel(xi.jp.FLOURISH_I_EFFECT))
 
     if (math.random() <= hitrate or isSneakValid) then
 

--- a/scripts/globals/abilities/feather_step.lua
+++ b/scripts/globals/abilities/feather_step.lua
@@ -36,7 +36,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     local hit = 2
     local effect = 1
 
-    if math.random() <= getHitRate(player, target, true, player:getMod(xi.mod.STEP_ACCURACY)) then
+    if math.random() <= xi.weaponskills.getHitRate(player, target, true, player:getMod(xi.mod.STEP_ACCURACY)) then
         hit = 6
         local mjob = player:getMainJob()
         local daze = 1

--- a/scripts/globals/abilities/quickstep.lua
+++ b/scripts/globals/abilities/quickstep.lua
@@ -36,7 +36,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     local hit = 1
     local effect = 1
 
-    if math.random() <= getHitRate(player, target, true, player:getMod(xi.mod.STEP_ACCURACY)) then
+    if math.random() <= xi.weaponskills.getHitRate(player, target, true, player:getMod(xi.mod.STEP_ACCURACY)) then
         hit = 5
         local mjob = player:getMainJob()
         local daze = 1

--- a/scripts/globals/abilities/stutter_step.lua
+++ b/scripts/globals/abilities/stutter_step.lua
@@ -36,7 +36,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     local hit = 3
     local effect = 1
 
-    if math.random() <= getHitRate(player, target, true, player:getMod(xi.mod.STEP_ACCURACY)) then
+    if math.random() <= xi.weaponskills.getHitRate(player, target, true, player:getMod(xi.mod.STEP_ACCURACY)) then
         hit = 7
         local mjob = player:getMainJob()
         local daze = 1

--- a/scripts/globals/abilities/violent_flourish.lua
+++ b/scripts/globals/abilities/violent_flourish.lua
@@ -67,8 +67,8 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     if (isSneakValid and not player:isBehind(target)) then
         isSneakValid = false
     end
-    local pdif = generatePdif (cratio[1], cratio[2], true)
-    local hitrate = getHitRate(player, target, true)
+    local pdif = cratio[1]
+    local hitrate = xi.weaponskills.getHitRate(player, target, true)
 
     if (math.random() <= hitrate or isSneakValid) then
         local hit = 3

--- a/scripts/globals/automatonweaponskills.lua
+++ b/scripts/globals/automatonweaponskills.lua
@@ -187,7 +187,7 @@ function doAutoPhysicalWeaponskill(attacker, target, wsID, tp, primaryMsg, actio
     }
 
     local calcParams = {}
-    calcParams.weaponDamage = getMeleeDmg(attacker, attack.weaponType, wsParams.kick)
+    calcParams.weaponDamage = xi.weaponskills.getMeleeDmg(attacker, attack.weaponType, wsParams.kick)
     calcParams.attackInfo = attack
     calcParams.fSTR = utils.clamp(attacker:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT), -10, 10)
     calcParams.cratio = cratio

--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -820,10 +820,9 @@ local gearSets =
     {
         items =
         {
-            xi.items.VIRTUE_STONE,
             xi.items.HOPE_STAFF,
         },
-        minEquipped = 2,
+        minEquipped = 1,
         mods =
         {
             { xi.mod.AMMO_SWING, 50 },
@@ -834,10 +833,9 @@ local gearSets =
     {
         items =
         {
-            xi.items.VIRTUE_STONE,
             xi.items.JUSTICE_SWORD,
         },
-        minEquipped = 2,
+        minEquipped = 1,
         mods =
         {
             { xi.mod.AMMO_SWING, 50 },
@@ -848,10 +846,9 @@ local gearSets =
     {
         items =
         {
-            xi.items.VIRTUE_STONE,
             xi.items.TEMPERANCE_AXE,
         },
-        minEquipped = 2,
+        minEquipped = 1,
         mods =
         {
             { xi.mod.AMMO_SWING, 50 },
@@ -862,10 +859,9 @@ local gearSets =
     {
         items =
         {
-            xi.items.VIRTUE_STONE,
             xi.items.LOVE_HALBERD,
         },
-        minEquipped = 2,
+        minEquipped = 1,
         mods =
         {
             { xi.mod.AMMO_SWING, 50 },
@@ -876,10 +872,9 @@ local gearSets =
     {
         items =
         {
-            xi.items.VIRTUE_STONE,
             xi.items.FORTITUDE_AXE,
         },
-        minEquipped = 2,
+        minEquipped = 1,
         mods =
         {
             { xi.mod.AMMO_SWING, 50 },
@@ -890,10 +885,9 @@ local gearSets =
     {
         items =
         {
-            xi.items.VIRTUE_STONE,
             xi.items.FAITH_BAGHNAKHS,
         },
-        minEquipped = 2,
+        minEquipped = 1,
         mods =
         {
             { xi.mod.AMMO_SWING, 50 },
@@ -904,10 +898,9 @@ local gearSets =
     {
         items =
         {
-            xi.items.VIRTUE_STONE,
             xi.items.PRUDENCE_ROD,
         },
-        minEquipped = 2,
+        minEquipped = 1,
         mods =
         {
             { xi.mod.AMMO_SWING, 50 },
@@ -2575,7 +2568,11 @@ xi.gear_sets.checkForGearSet = function(player)
             local modTierIndex = math.min(setCount, maxEquippedReq) - minEquippedReq
 
             for _, modData in ipairs(gearSets[setId].mods) do
-                player:addGearSetMod(setId, modData[1], modData[modTierIndex + 2])
+                if (setId >= 47 and setId <= 53 and player:getEquipID(xi.slot.AMMO) == xi.items.VIRTUE_STONE) then
+                    player:addGearSetMod(setId, modData[1], modData[modTierIndex + 2])
+                elseif setId < 47 or setId > 53 then
+                    player:addGearSetMod(setId, modData[1], modData[modTierIndex + 2])
+                end
             end
         end
     end

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -266,7 +266,7 @@ end
 local function doNuke(caster, target, spell, params)
     local skill = spell:getSpellGroup()
     --calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params)
+    local dmg = xi.magic.calculateMagicDamage(caster, target, spell, params)
     --get resist multiplier (1x if no resist)
     local resist = xi.magic.applyResistance(caster, target, spell, params)
     --get the resisted damage
@@ -383,7 +383,7 @@ xi.magic.doEnspell = function(caster, target, spell, effect)
 end
 
 -----------------------------------
---   getCurePower returns the caster's cure power
+--   xi.magic.getCurePower returns the caster's cure power
 --   xi.magic.getCureFinal returns the final cure amount
 --   Source: http://members.shaw.ca/pizza_steve/cure/Cure_Calculator.html
 -----------------------------------
@@ -1425,7 +1425,7 @@ xi.magic.doDivineBanishNuke = function(caster, target, spell, params)
     params.attribute = xi.mod.MND
 
     --calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params)
+    local dmg = xi.magic.calculateMagicDamage(caster, target, spell, params)
     --get resist multiplier (1x if no resist)
     local resist = xi.magic.applyResistance(caster, target, spell, params)
     --get the resisted damage

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -158,7 +158,7 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
 
     --get dstr (bias to monsters, so no fSTR)
     if tpeffect == xi.mobskills.magicalTpBonus.RANGED then
-        fStr = fSTR2(mob:getStat(xi.mod.STR), target:getStat(xi.mod.VIT), mob:getWeaponDmgRank())
+        fStr = xi.weaponskills.fSTR2(mob:getStat(xi.mod.STR), target:getStat(xi.mod.VIT), mob:getWeaponDmgRank())
     else
         fStr = xi.weaponskills.fSTR(mob:getStat(xi.mod.STR), target:getStat(xi.mod.VIT), mob:getWeaponDmgRank())
     end
@@ -172,7 +172,7 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
     local lvldiff = mob:getMainLvl() - target:getMainLvl()
 
     --work out hit rate for mobs
-    local hitrate = getHitRate(mob, target, 0, 0)
+    local hitrate = xi.weaponskills.getHitRate(mob, target, 0, 0)
 
     hitrate = utils.clamp(hitrate, 0.2, 0.95)
 
@@ -398,7 +398,7 @@ xi.mobskills.mobAddBonuses = function(caster, target, dmg, ele, ignoreres) -- us
 
     if not ignore then dmg = math.floor(dmg * magicDefense) end
 
-    dayWeatherBonus = 1.00
+    local dayWeatherBonus = 1.00
 
     if caster:getWeather() == xi.magic.singleWeatherStrong[ele] then
         if math.random() < 0.33 then

--- a/scripts/globals/spells/white/cura.lua
+++ b/scripts/globals/spells/white/cura.lua
@@ -42,7 +42,7 @@ spellObject.onSpellCast = function(caster, target, spell)
                 constant = 5
         end
     else
-        power = getCurePower(caster)
+        power = xi.magic.getCurePower(caster)
         if (power < 20) then
             divisor = 4
             constant = 10

--- a/scripts/globals/spells/white/cura_ii.lua
+++ b/scripts/globals/spells/white/cura_ii.lua
@@ -42,7 +42,7 @@ spellObject.onSpellCast = function(caster, target, spell)
                 constant = 47.5
         end
     else
-        power = getCurePower(caster)
+        power = xi.magic.getCurePower(caster)
         if (power < 70) then
             divisor = 1
             constant = 60

--- a/scripts/globals/spells/white/cura_iii.lua
+++ b/scripts/globals/spells/white/cura_iii.lua
@@ -42,7 +42,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             constant = 115
         end
     else
-        power = getCurePower(caster)
+        power = xi.magic.getCurePower(caster)
         if (power < 125) then
             divisor = 2.2
             constant = 130

--- a/scripts/globals/spells/white/cure.lua
+++ b/scripts/globals/spells/white/cure.lua
@@ -35,7 +35,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             constant = 5
         end
     else
-        power = getCurePower(caster)
+        power = xi.magic.getCurePower(caster)
         if (power < 20) then
             divisor = 4
             constant = 10

--- a/scripts/globals/spells/white/cure_ii.lua
+++ b/scripts/globals/spells/white/cure_ii.lua
@@ -35,7 +35,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             constant = 47.5
         end
     else
-        power = getCurePower(caster)
+        power = xi.magic.getCurePower(caster)
         if (power < 70) then
             divisor = 1
             constant = 60

--- a/scripts/globals/spells/white/cure_iii.lua
+++ b/scripts/globals/spells/white/cure_iii.lua
@@ -35,7 +35,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             constant = 115
         end
     else
-        power = getCurePower(caster)
+        power = xi.magic.getCurePower(caster)
         if (power < 125) then
             divisor = 2.2
             constant = 130

--- a/scripts/globals/spells/white/cure_iv.lua
+++ b/scripts/globals/spells/white/cure_iv.lua
@@ -34,7 +34,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             constant = 275
         end
     else
-        power = getCurePower(caster)
+        power = xi.magic.getCurePower(caster)
         if (power < 200) then
             divisor = 1
             constant = 270

--- a/scripts/globals/spells/white/cure_v.lua
+++ b/scripts/globals/spells/white/cure_v.lua
@@ -35,7 +35,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             constant = 410
         end
     else
-        power = getCurePower(caster)
+        power = xi.magic.getCurePower(caster)
         if (power < 150) then
             divisor = 0.70
             constant = 450

--- a/scripts/globals/spells/white/cure_vi.lua
+++ b/scripts/globals/spells/white/cure_vi.lua
@@ -23,7 +23,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local final = 0
 
     local minCure = 600
-    power = getCurePower(caster)
+    power = xi.magic.getCurePower(caster)
     if (power < 210) then
         divisor = 1.5
         constant = 600

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -130,7 +130,7 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
     -- bonuses cap at level diff of 38 based on this testing:
     -- https://www.bluegartr.com/threads/114636-Monster-Avatar-Pet-damage
     -- If there are penalties they seem to be applied differently similarly to monsters.
-    local baseHitRate = getHitRate(avatar, target, 0, xi.summon.getSummoningSkillOverCap(avatar))
+    local baseHitRate = xi.weaponskills.getHitRate(avatar, target, 0, xi.summon.getSummoningSkillOverCap(avatar))
     -- First hit gets a +100 ACC bonus which translates to +50 hit
     local firstHitAccBonus = 0.5
 

--- a/scripts/globals/weaponskills/atonement.lua
+++ b/scripts/globals/weaponskills/atonement.lua
@@ -71,13 +71,13 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
         if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
             dmg = (target:getCE(player) + target:getVE(player)) / 6
             -- tp affects enmity multiplier, 1.0 at 1k, 1.5 at 2k, 2.0 at 3k. Gorget/Belt adds 100 tp each.
-            params.enmityMult = params.enmityMult + (tp + handleWSGorgetBelt(player) * 1000 - 1000) / 2000
+            params.enmityMult = params.enmityMult + (tp + xi.weaponskills.handleWSGorgetBelt(player) * 1000 - 1000) / 2000
             params.enmityMult = utils.clamp(params.enmityMult, 1, 2) -- necessary because of Gorget/Belt bonus
         else
-            local effectiveTP = tp + handleWSGorgetBelt(player) * 1000
+            local effectiveTP = tp + xi.weaponskills.handleWSGorgetBelt(player) * 1000
             effectiveTP = utils.clamp(effectiveTP, 0, 3000) -- necessary because of Gorget/Belt bonus
-            local ceMod = fTP(effectiveTP, 0.09, 0.11, 0.20) -- CE portion of Atonement
-            local veMod = fTP(effectiveTP, 0.11, 0.14, 0.25) -- VE portion of Atonement
+            local ceMod = xi.weaponskills.ftp(effectiveTP, 0.09, 0.11, 0.20) -- CE portion of Atonement
+            local veMod = xi.weaponskills.ftp(effectiveTP, 0.11, 0.14, 0.25) -- VE portion of Atonement
             dmg = math.floor(target:getCE(player) * ceMod) + math.floor(target:getVE(player) * veMod)
         end
 

--- a/scripts/globals/weaponskills/dagan.lua
+++ b/scripts/globals/weaponskills/dagan.lua
@@ -18,8 +18,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- Apply aftermath
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.EMPYREAN)
 
-    local ftphp = fTP(tp, 0.22, 0.33, 0.52)
-    local ftpmp = fTP(tp, 0.15, 0.22, 0.35)
+    local ftphp = xi.weaponskills.ftp(tp, 0.22, 0.33, 0.52)
+    local ftpmp = xi.weaponskills.ftp(tp, 0.15, 0.22, 0.35)
     player:addHP(ftphp * player:getMaxHP())
     return 0, 0, false, ftpmp * player:getMaxMP()
 end

--- a/scripts/globals/weaponskills/myrkr.lua
+++ b/scripts/globals/weaponskills/myrkr.lua
@@ -11,7 +11,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- Apply aftermath
     xi.aftermath.addStatusEffect(player, tp, xi.slot.MAIN, xi.aftermath.type.EMPYREAN)
 
-    local ftpmp = fTP(tp, 0.2, 0.4, 0.6)
+    local ftpmp = xi.weaponskills.ftp(tp, 0.2, 0.4, 0.6)
     return 1, 0, false, ftpmp * player:getMaxMP()
 end
 

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -80,25 +80,6 @@ global_objects=(
 
     onBattlefieldHandlerInitialise
 
-    doAutoPhysicalWeaponskill
-    doAutoRangedWeaponskill
-    doPhysicalWeaponskill
-    doRangedWeaponskill
-    doMagicWeaponskill
-    doesElementMatchWeaponskill
-    applyResistanceAddEffect
-    takeWeaponskillDamage
-
-    fTP
-    fSTR
-    fSTR2
-    calculateRawWSDmg
-    calculatedIgnoredDef
-    cMeleeRatio
-    generatePdif
-    getMeleeDmg
-    handleWSGorgetBelt
-
     getRecommendedAssaultLevel
 
     PATHFLAG_WALLHACK
@@ -122,53 +103,18 @@ global_objects=(
 
     salvageUtil
 
-    addBonuses
-    addBonusesAbility
-    applyBarspell
-    applyBarstatus
-    applyResistance
-    applyResistanceAbility
-    applyResistanceEffect
-    adjustForTarget
-    calculateDuration
-    calculateDurationForLvl
-    calculateMagicDamage
-    calculatePotency
-    canOverwrite
-    dayWeatherBonus
-    doBoostGain
-    doDivineBanishNuke
-    doDivineNuke
-    doElementalNuke
-    doEnspell
-    doNinjutsuNuke
-    finalMagicAdjustments
-    finalMagicNonSpellAdjustments
-    getBaseCure
-    getCurePower
-    getCurePowerOld
-    getCureFinal
-    getBaseCureOld
-    getEffectResistance
-    getElementalDamageReduction
-    getElementalDebuffDOT
     getFlourishAnimation
-    getHelixDuration
-    getHitRate
-    getMagicHitRate
-    getMagicResist
     getStepAnimation
-    getElementalDebuffStatDownFromDOT
-    handleAfflatusMisery
-    handleNinjutsuDebuff
-    handleThrenody
     hasSleepEffects
-    isValidHealTarget
     skillchainCount
     takeAbilityDamage
 
+    doAutoRangedWeaponskill
+    doAutoPhysicalWeaponskill
+
     FormMagicBurst
     MobFormMagicBurst
+    doesElementMatchWeaponskill
 
     AbilityFinalAdjustments
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Cleans up the global list of functions in lua.sh.
+ Fixes more CI checks that were masked behind the global list previously.
+ Fixes some errors caused to the refactor of magic and weaponskills lua files.
+ Fixes virtue weapons to properly apply multiattack procs. This was caused by virtue stone being available for all sets, but only 1 set picking up the virtue stone due to the way the loop functioned. Instead this virtue stone gate was put just before the mod application.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/248

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
