### PR TITLE
Fix crash in CBattleEntity::SetSLevel() with pets

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -982,7 +982,7 @@ void CBattleEntity::SetSLevel(uint8 slvl)
     }
     else if (this->objtype == TYPE_PET &&
              (static_cast<CPetEntity*>(this)->getPetType() == PET_TYPE::AVATAR || static_cast<CPetEntity*>(this)->getPetType() == PET_TYPE::AVATAR) &&
-             static_cast<CPetEntity*>(this)->PMaster->objtype == TYPE_PC)
+             static_cast<CPetEntity*>(this)->PMaster != nullptr && static_cast<CPetEntity*>(this)->PMaster->objtype == TYPE_PC)
     {
         m_slvl = this->GetMLevel();
     }


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Encountered a crash caused by a recent change (https://github.com/AirSkyBoat/AirSkyBoat/commit/25e563caae4f1651c716db6a21a1cf536085ce97) due to not checking PMaster if it is nullptr

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
