### PR TITLE
Fix Bazaar Comments

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -469,6 +469,7 @@ struct search_t
 struct bazaar_t
 {
     std::string message;
+    time_t      timer;
 
     bazaar_t()
     {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -695,6 +695,11 @@ void SmallPacket0x015(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 float distanceTravelled = distance(PChar->m_previousLocation.p, PChar->loc.p);
                 PChar->m_charHistory.distanceTravelled += static_cast<uint32>(distanceTravelled);
+
+                if (PChar->bazaar.timer <= time(NULL))
+                {
+                    PChar->pushPacket(new CBazaarMessagePacket(PChar));
+                }
             }
         }
 
@@ -6103,6 +6108,8 @@ void SmallPacket0x0DD(map_session_data_t* const PSession, CCharEntity* const PCh
                 {
                     PTarget->pushPacket(new CMessageStandardPacket(PChar, 0, 0, MsgStd::Examine));
                 }
+
+                PChar->bazaar.timer = time(NULL) + 30;
 
                 PChar->pushPacket(new CBazaarMessagePacket(PTarget));
                 PChar->pushPacket(new CCheckPacket(PChar, PTarget));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where players would not have their personal bazaar comment updated in the "Edit Comment" field of the menu.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/225

Note: This does create an artifact that if a player is looking at another player's bazaar comment for over 30s and moves that they will then see the message update to theirs. However, given the parameters the chance of this happening is slim. The true fix to this is probably some packet the client sends that we have failed to capture yet. 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
