### PR TITLE
Fix Jug Pets Spawning Too Low and Underflowing Stats

### DIFF
--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -484,6 +484,8 @@ namespace petutils
         uint8 lvlmax = petStats->maxLevel;
         uint8 lvlmin = petStats->minLevel;
 
+        lvl = std::clamp(lvl, lvlmin, lvlmax);
+
         // give hp boost every 10 levels after 25
         // special boosts at 25 and 50
         if (lvl > 75)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes an issue where specific jug pets can spawn under their minimum stat distribution levels. Thus this caused an underflow on stats and force capped multiple stats such as EVA, ATT, and other non-mainline stats.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
