### PR TITLE
Fix Application of Elemental MEVA Values During MEVA Calculations

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -696,10 +696,10 @@ xi.magic.getMagicHitRate = function(caster, target, skillType, element, effectRe
     end
 
     if target:isPC() then
-        magiceva = target:getMod(xi.mod.MEVA) * ((100 + resMod) / 100)
+        magiceva = target:getMod(xi.mod.MEVA) + resMod
     else
         dLvl = utils.clamp(dLvl, 0, 200) -- Mobs should not have a disadvantage when targeted
-        magiceva = (target:getMod(xi.mod.MEVA) + (4 * dLvl)) * ((100 + resMod) / 100)
+        magiceva = target:getMod(xi.mod.MEVA) + (4 * dLvl) + resMod
     end
 
     bonusAcc = bonusAcc + caster:getMerit(xi.merit.MAGIC_ACCURACY) + caster:getMerit(xi.merit.NIN_MAGIC_ACCURACY)

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -622,10 +622,10 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     -----------------------------------
     local magiceva = target:getMod(xi.mod.MEVA)
     if target:isPC() then
-        magiceva = magiceva * ((100 + resMod) / 100)
+        magiceva = magiceva + resMod
     else
         levelDiff = utils.clamp(levelDiff, 0, 200) -- Mobs should not have a disadvantage when targeted
-        magiceva =  (magiceva + (4 * levelDiff)) * ((100 + resMod) / 100)
+        magiceva =  magiceva + (4 * levelDiff) + resMod
     end
 
     -----------------------------------


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Fixes what I can only say was a drunk error while coding, but removes the multiplicative effect of elemental MEVA on a target and instead makes it additive to MEVA as a whole.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
