### PR TITLE
Corrected ID to spawn NM Vaa Huja the Erudite for DRK Artifact quest: Dark Legacy

### DIFF
--- a/scripts/quests/bastok/Dark_Legacy.lua
+++ b/scripts/quests/bastok/Dark_Legacy.lua
@@ -128,7 +128,7 @@ quest.sections =
                         quest:getVar(player, 'Prog') == 2
                     then
                         player:confirmTrade()
-                        SpawnMob(ID.mob.VAA_HUJA_THE_ERUDITE):updateClaim(player)
+                        SpawnMob(giddeusID.mob.VAA_HUJA_THE_ERUDITE):updateClaim(player)
 
                         return quest:messageSpecial(giddeusID.text.SENSE_OF_FOREBODING)
                     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Corrected ID to spawn NM Vaa Huja the Erudite for DRK Artifact quest: Dark Legacy

## Steps to test these changes

- !changejob drk 40
- !additem 4445 12 (Create some Yagudo Cherries)
- !gotoid 17748012 (Raibaht) and talk to him
- !gotoid 17748025 (Mighty Fist) and talk to him
- !gotoid 17752263 (Cohal-Monchal) and talk to him
- !gotoid 17371593 (Quu Bokye) and trade them a Yagudo Cherry
- !gotoid 17371606 (qm1 ???) and trade Yagudo Cherry to ???

Vaa Huja the Erudite should now spawn properly.

See also issue: https://github.com/AirSkyBoat/AirSkyBoat/issues/536