### PR TITLE
RDM AF2 Boots - Enveloped in Darkness - test for quest progression

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -621,12 +621,8 @@ xi.treasure.treasureInfo =
                 misc =
                 {
                     {
-                        test = function(player) return player:getCharVar("needs_crawler_blood") == 1 end,
-                        code = function(player)
-                            npcUtil.giveKeyItem(player, xi.ki.CRAWLER_BLOOD)
-                            player:setCharVar("needs_crawler_blood", 0)
-                        end,
-                    },
+                        test = function(player) return player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ENVELOPED_IN_DARKNESS) == QUEST_ACCEPTED and player:getCharVar("Quest[" .. xi.quest.log_id.SANDORIA .. "][" .. xi.quest.id.sandoria.ENVELOPED_IN_DARKNESS .. "]Prog") >= 2 and not player:hasKeyItem(xi.ki.CRAWLER_BLOOD) end,
+                        code = function(player) npcUtil.giveKeyItem(player, xi.ki.CRAWLER_BLOOD) end,                    },
                 },
                 points =
                 {

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -622,7 +622,8 @@ xi.treasure.treasureInfo =
                 {
                     {
                         test = function(player) return player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ENVELOPED_IN_DARKNESS) == QUEST_ACCEPTED and player:getCharVar("Quest[" .. xi.quest.log_id.SANDORIA .. "][" .. xi.quest.id.sandoria.ENVELOPED_IN_DARKNESS .. "]Prog") >= 2 and not player:hasKeyItem(xi.ki.CRAWLER_BLOOD) end,
-                        code = function(player) npcUtil.giveKeyItem(player, xi.ki.CRAWLER_BLOOD) end,                    },
+                        code = function(player) npcUtil.giveKeyItem(player, xi.ki.CRAWLER_BLOOD) end,
+                    },
                 },
                 points =
                 {

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -621,7 +621,10 @@ xi.treasure.treasureInfo =
                 misc =
                 {
                     {
-                        test = function(player) return player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ENVELOPED_IN_DARKNESS) == QUEST_ACCEPTED and player:getCharVar("Quest[" .. xi.quest.log_id.SANDORIA .. "][" .. xi.quest.id.sandoria.ENVELOPED_IN_DARKNESS .. "]Prog") >= 2 and not player:hasKeyItem(xi.ki.CRAWLER_BLOOD) end,
+                        test = function(player)
+                            return xi.quest.getVar(player, xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ENVELOPED_IN_DARKNESS, 'Prog') >= 2
+                            and player:hasKeyItem(xi.ki.OLD_BOOTS)
+                            and not player:hasKeyItem(xi.ki.CRAWLER_BLOOD) end,
                         code = function(player) npcUtil.giveKeyItem(player, xi.ki.CRAWLER_BLOOD) end,
                     },
                 },

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -624,7 +624,8 @@ xi.treasure.treasureInfo =
                         test = function(player)
                             return xi.quest.getVar(player, xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ENVELOPED_IN_DARKNESS, 'Prog') >= 2
                             and player:hasKeyItem(xi.ki.OLD_BOOTS)
-                            and not player:hasKeyItem(xi.ki.CRAWLER_BLOOD) end,
+                            and not player:hasKeyItem(xi.ki.CRAWLER_BLOOD)
+                        end,
                         code = function(player) npcUtil.giveKeyItem(player, xi.ki.CRAWLER_BLOOD) end,
                     },
                 },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

RDM AF2 Boots - Enveloped in Darkness - test for quest progression when opening Crawler's Nest Treasure Chest to obtain Crawler Blood key item.

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/561

## Steps to test these changes

Start the RDM AF2 quest - Enveloped in Darkness as a RDM50+
!gotoid 17731596 (Curilla) and talk to her to obtain KI Old Pocket Watch
!gotoid 17723424 (Pagisalis) and talk to him
!additem 828 (Velvet Cloth) and trade Velvet Cloth to Pagisalis, receive KI Old Boots
!gotoid 17731596 (Curilla) and talk to her until she requests KI Crawler Blood
!additem 1040 (Nest Chest Key)
!gotoid 17584475 (Crawler's Nest - Treasure Chest)
Trade the Nest Chest Key to the Treasure Chest

The treasure chest should now give the Crawler Blood key item instead of a regular treasure pool item.