### PR TITLE
Mob Skill Lists Cleanup

### DIFF
--- a/scripts/zones/Mine_Shaft_2716/IDs.lua
+++ b/scripts/zones/Mine_Shaft_2716/IDs.lua
@@ -70,7 +70,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.WAR] =
         {
             modelID = 1209,
-            skillList = 1183,
+            skillList = 4033,
             ability = 1428, -- Warcry
             twoHour = 688, -- Mighty Strikes
             spellListID = 0,
@@ -79,7 +79,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.MNK] =
         {
             modelID = 1210,
-            skillList = 1184,
+            skillList = 4034,
             ability = 1429, -- Counterstance
             twoHour = 690, -- Hundred Fists
             spellListID = 0,
@@ -88,7 +88,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.WHM] =
         {
             modelID = 1214,
-            skillList = 1185,
+            skillList = 4035,
             ability = 0, -- None
             twoHour = 689, -- Benediction
             spellListID = 1,
@@ -97,7 +97,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.BLM] =
         {
             modelID = 1215,
-            skillList = 1185,
+            skillList = 4035,
             ability = 0, -- None
             twoHour = 691, -- Manafont
             spellListID = 2,
@@ -106,7 +106,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.RDM] =
         {
             modelID = 1216,
-            skillList = 1187,
+            skillList = 4037,
             ability = 0, -- None
             twoHour = 692, -- Chainspell
             spellListID = 3,
@@ -115,7 +115,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.THF] =
         {
             modelID = 1218,
-            skillList = 1188,
+            skillList = 4038,
             ability = 0, -- None
             twoHour = 693, -- Perfect Dodge
             spellListID = 0,
@@ -124,7 +124,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.PLD] =
         {
             modelID = 1219,
-            skillList = 1187,
+            skillList = 4037,
             ability = 1431, -- Shield Bash
             twoHour = 694, -- Incincible
             spellListID = 4,
@@ -133,7 +133,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.DRK] =
         {
             modelID = 1220,
-            skillList = 1189,
+            skillList = 4039,
             ability = 1432, -- Weapon Bash
             twoHour = 695, -- Blood Weapon
             spellListID = 5,
@@ -142,7 +142,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.BST] =
         {
             modelID = 1224,
-            skillList = 1183,
+            skillList = 4033,
             petModelID =
             {
                 328, -- Lizzard
@@ -165,7 +165,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.BRD] =
         {
             modelID = 1227,
-            skillList = 1188,
+            skillList = 4038,
             ability = 0, -- None
             twoHour = 696, -- Soul Voice
             spellListID = 6,
@@ -174,7 +174,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.RNG] =
         {
             modelID = 1228,
-            skillList = 1190,
+            skillList = 4040,
             ability = 1434, -- Barrage
             twoHr = 413, -- Eagle Eye Shot
             spellListID = 0,
@@ -183,7 +183,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.SAM] =
         {
             modelID = 1229,
-            skillList = 1191,
+            skillList = 4041,
             ability = 1436, -- Meditate
             twoHour = 730, -- Meikyo Shisui
             spellListID = 0,
@@ -192,7 +192,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.NIN] =
         {
             modelID = 1232,
-            skillList = 1192,
+            skillList = 4042,
             ability = 0, -- None
             twoHour = 731, -- Mjin Gakure
             spellListID = 7,
@@ -201,7 +201,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.DRG] =
         {
             modelID = 1234,
-            skillList = 1193,
+            skillList = 4043,
             ability = 1437, -- Jump
             twoHour = 732, -- Call Wyvern
             spellListID = 0,
@@ -210,7 +210,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.SMN] =
         {
             modelID = 1235,
-            skillList = 1186,
+            skillList = 4036,
             petModelID =
             {
                 793, -- Ifrit
@@ -240,7 +240,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.BLU] =
         {
             modelID = 1396,
-            skillList = 1187,
+            skillList = 4037,
             ability = 0, -- None
             spellListID = 8, -- TODO: Mimic player's set spells
             petID = 0,
@@ -248,7 +248,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.COR] =
         {
             modelID = 1397,
-            skillList = 1194,
+            skillList = 4044,
             ability = 0, -- TODO: Add rolls here
             spellListID = 0, -- ???
             petID = 0,
@@ -256,7 +256,7 @@ zones[xi.zone.MINE_SHAFT_2716] =
         [xi.job.PUP] =
         {
             modelID = 1398,
-            skillList = 1184,
+            skillList = 4034,
             petModelID =
             {
                 { 1983, xi.job.PLD }, -- Melee Automaton

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3819,117 +3819,6 @@ INSERT INTO `mob_skill_lists` VALUES ('Avatar_Titan_TSTBE',1181,850); -- Stone I
 INSERT INTO `mob_skill_lists` VALUES ('Avatar_Leviathan_TSTBW',1182,858); -- Barracuda Dive
 INSERT INTO `mob_skill_lists` VALUES ('Avatar_Leviathan_TSTBW',1182,859); -- Water II
 
--- Fantoccini (ENM "Pulling the Strings")
--- WAR - BST
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',1183,64); -- Raging Axe
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',1183,65); -- Smash Axe
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',1183,66); -- Gale Axe
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',1183,67); -- Avalanche Axe
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',1183,68); -- Spinning Axe
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',1183,69); -- Rampage
--- MNK:
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',1184,1); -- Combo
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',1184,2); -- Shoulder Tackle
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',1184,3); -- One Inch Punch
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',1184,4); -- Backhand Blow
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',1184,5); -- Raging fists
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',1184,6); -- Spinning Attack
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',1184,7); -- Howling Fist
--- WHM
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WHM_BLM',1185,160); -- Shining Strike
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WHM_BLM',1185,161); -- Seraph Strike
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WHM_BLM',1185,162); -- Brainshaker
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WHM_BLM',1185,165); -- Skullbreaker
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WHM_BLM',1185,166); -- True Strike
--- BLM - SMN
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',1186,176); -- Heavy Swing
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',1186,177); -- Rock Crusher
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',1186,178); -- Earth Crusher
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',1186,179); -- Starburst
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',1186,180); -- Sunburst
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',1186,181); -- Shell Crusher
--- RDM - BLU - PLD
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',1187,32); -- Fast Blade
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',1187,33); -- Burning Blade
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',1187,34); -- Red Lotus Blade
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',1187,35); -- Flat Blade
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',1187,36); -- Shining Blade
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',1187,37); -- Seraph Blade
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',1187,38); -- Circle Blade
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',1187,39); -- Spirits Within
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',1187,40); -- Vorpal Blade
--- THF - BRD
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',1188,16); -- Wasp Sting
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',1188,17); -- Viper Bite
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',1188,18); -- Shadowswitch
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',1188,19); -- Gust Slash
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',1188,20); -- Cyclone
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',1188,23); -- Dancing Edge
--- DRK
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',1189,96); -- Slice
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',1189,97); -- Dark Harvest
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',1189,98); -- Shadow of Death
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',1189,99); -- Nightmare Scythe
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',1189,100); -- Spinning Scythe
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',1189,101); -- Vorpal Scythe
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',1189,102); -- Guillotine
--- RNG
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',1190,192); -- Flaming Arrow
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',1190,193); -- Piercing Arrow
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',1190,194); -- Dulling Arrow
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',1190,195); -- Sidewinder
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',1190,196); -- Blast Arrow
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',1190,197); -- Arching Arrow
--- SAM
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',1191,144); -- Tachi: Enpi
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',1191,145); -- Tachi: Hobaku
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',1191,146); -- Tachi: Goten
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',1191,147); -- Tachi: Kagero
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',1191,148); -- Tachi: Jinpu
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',1191,149); -- Tachi: Koki
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',1191,150); -- Tachi: Yukikaze
--- NIN
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',1192,128); -- Blade: Rin
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',1192,129); -- Blade: Retsu
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',1192,130); -- Blade: Teki
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',1192,131); -- Blade: To
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',1192,132); -- Blade: Chi
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',1192,133); -- Blade: Ei
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',1192,134); -- Blade: Jin
--- DRG
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',1193,112); -- Double Thrust
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',1193,113); -- Thunder Thrust
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',1193,114); -- Raiden Thrust
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',1193,115); -- Leg Sweep
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',1193,116); -- Penta Thrust
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',1193,117); -- Vorpal Thrust
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',1193,118); -- Skewer
--- COR
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_COR',1194,208); -- Hot Shot
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_COR',1194,209); -- Split Shot
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_COR',1194,210); -- Sniper Shot
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_COR',1194,212); -- Slug Shot
--- PUP
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',1195,1992); -- Fire Maneuver
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',1195,1993); -- Ice Maneuver
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',1195,1994); -- Wind Maneuver
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',1195,1995); -- Earth Maneuver
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',1195,1996); -- Thunder Maneuver
-INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',1195,1997); -- Water Maneuver
--- Moblin Fantocciniman
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1414); -- Recover MP (player)
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1415); -- Recover HP (player)
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1416); -- Recover MP (player)
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1417); -- Attack Boost (player)
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1418); -- Defense Boost (player)
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1419); -- TP Boost (player)
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1420); -- Ability or Spell (automaton)
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1421); -- Give and use TP (automaton)
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1422); -- Attack Boost (automaton)
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1424); -- Defense Boost (automaton)
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1427); -- 2HR use (automaton)
-INSERT INTO `mob_skill_lists` VALUES('Moblin_Fantocciniman',1196,1457); -- Job ability Reset (player)
-
 INSERT INTO `mob_skill_lists` VALUES ('Swamfisk',1197,452); -- Screwdriver
 INSERT INTO `mob_skill_lists` VALUES ('Swamfisk',1197,453); -- Water Wall
 INSERT INTO `mob_skill_lists` VALUES ('Barbastelle',1198,392); -- Ultrasonics
@@ -4004,6 +3893,104 @@ INSERT INTO `mob_skill_lists` VALUES ('Osschaart',4030,550); -- hypnosis
 INSERT INTO `mob_skill_lists` VALUES ('Osschaart',4030,551); -- mind break
 INSERT INTO `mob_skill_lists` VALUES ('Huwasi',4031,678);
 INSERT INTO `mob_skill_lists` VALUES ('Rogue_Receptacle',4032,520);
+
+-- Fantoccini (ENM "Pulling the Strings")
+-- WAR - BST
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',4033,64); -- Raging Axe
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',4033,65); -- Smash Axe
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',4033,66); -- Gale Axe
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',4033,67); -- Avalanche Axe
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',4033,68); -- Spinning Axe
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WAR_BST',4033,69); -- Rampage
+-- MNK:
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',4034,1); -- Combo
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',4034,2); -- Shoulder Tackle
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',4034,3); -- One Inch Punch
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',4034,4); -- Backhand Blow
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',4034,5); -- Raging fists
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',4034,6); -- Spinning Attack
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_MNK_PUP',4034,7); -- Howling Fist
+-- WHM
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WHM_BLM',4035,160); -- Shining Strike
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WHM_BLM',4035,161); -- Seraph Strike
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WHM_BLM',4035,162); -- Brainshaker
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WHM_BLM',4035,165); -- Skullbreaker
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_WHM_BLM',4035,166); -- True Strike
+-- BLM - SMN
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',4036,176); -- Heavy Swing
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',4036,177); -- Rock Crusher
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',4036,178); -- Earth Crusher
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',4036,179); -- Starburst
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',4036,180); -- Sunburst
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SMN',4036,181); -- Shell Crusher
+-- RDM - BLU - PLD
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',4037,32); -- Fast Blade
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',4037,33); -- Burning Blade
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',4037,34); -- Red Lotus Blade
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',4037,35); -- Flat Blade
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',4037,36); -- Shining Blade
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',4037,37); -- Seraph Blade
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',4037,38); -- Circle Blade
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',4037,39); -- Spirits Within
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RDM_BLU_PLD',4037,40); -- Vorpal Blade
+-- THF - BRD
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',4038,16); -- Wasp Sting
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',4038,17); -- Viper Bite
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',4038,18); -- Shadowswitch
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',4038,19); -- Gust Slash
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',4038,20); -- Cyclone
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_THF_BRD',4038,23); -- Dancing Edge
+-- DRK
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',4039,96); -- Slice
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',4039,97); -- Dark Harvest
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',4039,98); -- Shadow of Death
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',4039,99); -- Nightmare Scythe
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',4039,100); -- Spinning Scythe
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',4039,101); -- Vorpal Scythe
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRK',4039,102); -- Guillotine
+-- RNG
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',4040,192); -- Flaming Arrow
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',4040,193); -- Piercing Arrow
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',4040,194); -- Dulling Arrow
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',4040,195); -- Sidewinder
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',4040,196); -- Blast Arrow
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_RNG',4040,197); -- Arching Arrow
+-- SAM
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',4041,144); -- Tachi: Enpi
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',4041,145); -- Tachi: Hobaku
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',4041,146); -- Tachi: Goten
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',4041,147); -- Tachi: Kagero
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',4041,148); -- Tachi: Jinpu
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',4041,149); -- Tachi: Koki
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_SAM',4041,150); -- Tachi: Yukikaze
+-- NIN
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',4042,128); -- Blade: Rin
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',4042,129); -- Blade: Retsu
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',4042,130); -- Blade: Teki
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',4042,131); -- Blade: To
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',4042,132); -- Blade: Chi
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',4042,133); -- Blade: Ei
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_NIN',4042,134); -- Blade: Jin
+-- DRG
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',4043,112); -- Double Thrust
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',4043,113); -- Thunder Thrust
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',4043,114); -- Raiden Thrust
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',4043,115); -- Leg Sweep
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',4043,116); -- Penta Thrust
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',4043,117); -- Vorpal Thrust
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_DRG',4043,118); -- Skewer
+-- COR
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_COR',4044,208); -- Hot Shot
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_COR',4044,209); -- Split Shot
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_COR',4044,210); -- Sniper Shot
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_COR',4044,212); -- Slug Shot
+-- PUP
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',4045,1992); -- Fire Maneuver
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',4045,1993); -- Ice Maneuver
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',4045,1994); -- Wind Maneuver
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',4045,1995); -- Earth Maneuver
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',4045,1996); -- Thunder Maneuver
+INSERT INTO `mob_skill_lists` VALUES ('Fantoccini_PUP',4045,1997); -- Water Maneuver
 
 -- End of AirSkyBoat section
 

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3884,9 +3884,6 @@ INSERT INTO `mob_skill_lists` VALUES ('Jailer_of_Hope',4022,1358);
 INSERT INTO `mob_skill_lists` VALUES ('Zipacna',4023,678);
 INSERT INTO `mob_skill_lists` VALUES ('EldritchEdge',4024,397);
 INSERT INTO `mob_skill_lists` VALUES ('DynastBeetle',4025,341);
-INSERT INTO `mob_skill_lists` VALUES ('Swamfisk',4026,452); -- Screwdriver
-INSERT INTO `mob_skill_lists` VALUES ('Swamfisk',4027,453); -- Water Wall
-INSERT INTO `mob_skill_lists` VALUES ('Barbastelle',4028,392); -- Ultrasonics
 INSERT INTO `mob_skill_lists` VALUES ('Blighting_Brand',4029,398);
 INSERT INTO `mob_skill_lists` VALUES ('Osschaart',4030,549); -- eyes on me
 INSERT INTO `mob_skill_lists` VALUES ('Osschaart',4030,550); -- hypnosis


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Partially fixes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/307
This simply moves Fantoccini skills into ASB area and removes some unneeded duplicates in the ASB area. Goal here is to keep the ASB mob skill lists out of the way of LSB to avoid conflicts such as what happened here.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
