### PR TITLE
Fixing Pirates Script + Adding Depart Variable for Re-entry

### DIFF
--- a/scripts/globals/pirates.lua
+++ b/scripts/globals/pirates.lua
@@ -59,12 +59,12 @@ xi.pirates.reset = function(ID)
 end
 
 xi.pirates.spawnMob = function(mobId)
-    local x = math.random(-4,4)
+    local x = math.random(-4, 4)
     local y = -7.263
-    local z = math.random(10,22)
-    local rot = math.random(0,255)
+    local z = math.random(10, 22)
+    local rot = math.random(0, 255)
     local mob = GetMobByID(mobId)
-    mob:setSpawn(x,y,z,rot)
+    mob:setSpawn(x, y, z, rot)
     mob:spawn()
 end
 
@@ -92,7 +92,7 @@ xi.pirates.spawnMobs = function(ID)
             if
                 nm:getLocalVar("killed") == 0 and
                 ship:getLocalVar('HQ') == 1 and
-                math.random(0,100) > 30
+                math.random(0, 100) > 30
             then
                 xi.pirates.spawnMob(ID.mob.CROSSBONES + 5)
             else
@@ -144,12 +144,12 @@ xi.pirates.summonAnimations = function(ID, firstcast)
             npc:setLocalVar("summoning", 1)
             local startTime = 0
             if not firstcast then
-                startTime = 2000 + math.random(2000,3000)
+                startTime = 2000 + math.random(2000, 3000)
             end
             npc:timer(startTime, function(npcArg)
                 if npcArg:getLocalVar("castmode") == 1 then
                     npcArg:entityAnimationPacket("casm")
-                    local randomSummonTime = 2000 + math.random(0,2000)
+                    local randomSummonTime = 2000 + math.random(0, 2000)
                     npcArg:timer(randomSummonTime, function(npcArg2)
                         npcArg2:entityAnimationPacket("shsm")
                         npcArg2:setLocalVar("summoning", 0)
@@ -196,13 +196,13 @@ xi.pirates.update = function(ID, zone, tripTime)
                         npc:setPos(xi.path.first(pirate.enter_path))
                         npc:setStatus(xi.status.NORMAL)
                         local point = xi.path.last(pirate.enter_path)
-                        npc:pathTo(point.x, point.y, point.z)
+                        npc:pathTo(point[1], point[2], point[3])
                         npc:sendUpdateToZoneCharsInRange(2000)
-                    elseif ship:getLocalVar('HQ') == 0 and piratePos ~=4 then
+                    elseif ship:getLocalVar('HQ') == 0 and piratePos ~= 4 then
                         npc:setPos(xi.path.first(pirate.enter_path))
                         npc:setStatus(xi.status.NORMAL)
                         local point = xi.path.last(pirate.enter_path)
-                        npc:pathTo(point.x, point.y, point.z)
+                        npc:pathTo(point[1], point[2], point[3])
                         npc:sendUpdateToZoneCharsInRange(2000)
                     end
                 end
@@ -222,7 +222,7 @@ xi.pirates.update = function(ID, zone, tripTime)
                 ship:setLocalVar("pirateStatus", xi.pirates.status.ATTACKING)
                 for k, pirate in pairs(ID.npc.PIRATES) do
                     local npc = GetNPCByID(k)
-                    npc:setLocalVar("castmode",1)
+                    npc:setLocalVar("castmode", 1)
                     npc:lookAt(pirate.look_at)
                     npc:sendUpdateToZoneCharsInRange(2000)
                 end
@@ -241,13 +241,13 @@ xi.pirates.update = function(ID, zone, tripTime)
                     local npc = GetNPCByID(k)
                     local piratePos = pirate.position
 
-                    npc:setLocalVar("castmode",0)
+                    npc:setLocalVar("castmode", 0)
                     if ship:getLocalVar('HQ') == 1 and piratePos ~= 2 then
                         npc:setPos(xi.path.first(pirate.enter_path))
                         npc:setStatus(xi.status.NORMAL)
                         npc:pathTo(xi.path.last(pirate.exit_path)[1], xi.path.last(pirate.exit_path)[2], xi.path.last(pirate.exit_path)[3])
                         npc:sendUpdateToZoneCharsInRange(2000)
-                    elseif ship:getLocalVar('HQ') == 0 and piratePos ~=4 then
+                    elseif ship:getLocalVar('HQ') == 0 and piratePos ~= 4 then
                         npc:setPos(xi.path.first(pirate.enter_path))
                         npc:setStatus(xi.status.NORMAL)
                         npc:pathTo(xi.path.last(pirate.exit_path)[1], xi.path.last(pirate.exit_path)[2], xi.path.last(pirate.exit_path)[3])

--- a/scripts/zones/Mhaura/Zone.lua
+++ b/scripts/zones/Mhaura/Zone.lua
@@ -92,6 +92,9 @@ zoneObject.onEventFinish = function(player, csid, option)
         end
     elseif csid == 220 and option == 0 then
         player:setLocalVar('[BOAT]Paid', 0)
+
+    elseif csid == 202 then
+        player:setLocalVar('[BOAT]Paid', 1)
     end
 end
 

--- a/scripts/zones/Selbina/Zone.lua
+++ b/scripts/zones/Selbina/Zone.lua
@@ -72,6 +72,8 @@ zoneObject.onEventFinish = function(player, csid, option)
         player:delKeyItem(xi.ki.SEANCE_STAFF)
     elseif csid == 220 and option == 0 then
         player:setLocalVar('[BOAT]Paid', 0)
+    elseif csid == 202 then
+        player:setLocalVar('[BOAT]Paid', 1)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes an error in the pirates script from the new pathfind format and adds departing variable so players can return on ships

## Steps to test these changes
