### PR TITLE
Fixing issue with reraise menu showing up again after closing it

### DIFF
--- a/src/map/ai/states/death_state.cpp
+++ b/src/map/ai/states/death_state.cpp
@@ -37,7 +37,6 @@ CDeathState::CDeathState(CBattleEntity* PEntity, duration death_time)
 : CState(PEntity, PEntity->targid)
 , m_PEntity(PEntity)
 , m_deathTime(death_time)
-, m_lastRaiseSent(GetEntryTime())
 , m_raiseTime(GetEntryTime() + TIME_TO_SEND_RERAISE_MENU)
 {
     m_PEntity->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DEATH, true);
@@ -66,10 +65,8 @@ bool CDeathState::Update(time_point tick)
         auto* PChar = static_cast<CCharEntity*>(m_PEntity);
         if (PChar->m_hasRaise)
         {
-            // client does not mind receiving redundant raise menu packets
-            // TODO: figure out how the server actually decides to resend these packets
             PChar->pushPacket(new CRaiseTractorMenuPacket(PChar, TYPE_RAISE));
-            m_lastRaiseSent = tick;
+            m_raiseSent = true;
         }
     }
     return false;

--- a/src/map/ai/states/death_state.h
+++ b/src/map/ai/states/death_state.h
@@ -54,8 +54,7 @@ public:
 private:
     CBattleEntity* const m_PEntity;
     duration             m_deathTime;
-    time_point           m_lastRaiseSent;
-    bool                 m_raiseSent{ false };
+    bool                 m_raiseSent = false;
     time_point           m_raiseTime;
 };
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/305
Fixing some bad code that was brought into ASB. Restoring proper handling of reraise menu. `allowSendRaise()` is called when the player is ejected from a battlefield which sends reraise menu packet again.

## Steps to test these changes

```
!addeffect reraise
!hp 0
```

Menu should only show up once regardless if you confirm or decline.