### PR TITLE
Refactor San d'Orian quest 'Signed in Blood' using quest getVar helper

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -504,7 +504,9 @@ xi.treasure.treasureInfo =
                 {
                     {
                         test = function(player)
-                            return player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.SIGNED_IN_BLOOD) == QUEST_ACCEPTED and player:getCharVar("Quest[0][108]Prog") == 2 and not player:hasKeyItem(xi.ki.TORN_OUT_PAGES)
+                            return player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.SIGNED_IN_BLOOD) == QUEST_ACCEPTED and
+                            xi.quest.getVar(player, xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.SIGNED_IN_BLOOD, 'Prog') == 2 and
+                            not player:hasKeyItem(xi.ki.TORN_OUT_PAGES)
                         end,
                         code = function(player) npcUtil.giveKeyItem(player, xi.ki.TORN_OUT_PAGES) end,
                     },


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Refactor San d'Orian quest 'Signed in Blood' using quest getVar helper function instead of charvars string comparison.

## Steps to test these changes

No functional change.

- Talk to Sobane in South San d'Oria
- Obtain Cathedral Tapestry and trade it to Sobane
- Talk to Abelard in Selbina
- Zone to Ordelle's Caves, obtain an Ordelle Chest Key, trade chest key to a Treasure Chest

Should still obtain key item Torn-Out Pages while on this quest's progression and should still obtain treasure from the chest pool while not on this quest's progression or already possessing key item.