### PR TITLE
Refactor Windurst quest 'Wild Card' using quest getVar helper

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1055,7 +1055,8 @@ xi.treasure.treasureInfo =
                 {
                     {
                         test = function(player)
-                            return (player:getCharVar("Quest[2][77]Prog") == 2 or player:getCharVar("Quest[2][77]Prog") == 3) and
+                            return (xi.quest.getVar(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.WILD_CARD, 'Prog') == 2 or
+                            xi.quest.getVar(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.WILD_CARD, 'Prog') == 3) and
                             not player:hasKeyItem(xi.ki.JOKER_CARD)
                         end,
                         code = function(player)

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1055,9 +1055,10 @@ xi.treasure.treasureInfo =
                 {
                     {
                         test = function(player)
-                            return (xi.quest.getVar(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.WILD_CARD, 'Prog') == 2 or
-                            xi.quest.getVar(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.WILD_CARD, 'Prog') == 3) and
-                            not player:hasKeyItem(xi.ki.JOKER_CARD)
+                            return player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.WILD_CARD) == QUEST_ACCEPTED and
+                                (xi.quest.getVar(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.WILD_CARD, 'Prog') == 2 or
+                                xi.quest.getVar(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.WILD_CARD, 'Prog') == 3) and
+                                not player:hasKeyItem(xi.ki.JOKER_CARD)
                         end,
                         code = function(player)
                             npcUtil.giveKeyItem(player, xi.ki.JOKER_CARD)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Refactor San d'Orian quest 'Signed in Blood' using quest getVar helper function instead of charvars string comparison.

## Steps to test these changes

No functional change.

- Talk to Honoi-Gomoi in Windurst Waters
- Talk to Kohlo-Lakolo in Port Windurst
- Interact with the door to the House of the Hero in Windurst Walls
- Go to Toraimarai Canal, obtain a Coffer Key and open a Treasure Coffer using the Coffer Key

You should still obtain Key Item: Joker Card