### PR TITLE
Updated !zone to prevent zoning to inactive zones

### DIFF
--- a/scripts/commands/zone.lua
+++ b/scripts/commands/zone.lua
@@ -346,6 +346,12 @@ function onTrigger(player, bytes)
         end
     end
 
+    -- Confirm that the zone is active
+    if not IsZoneActive(zone) then
+        error(player, "Zone currently disabled.")
+        return
+    end
+
     -- send player to destination
     player:setPos(x, y, z, rot, zone)
 end

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -125,6 +125,7 @@ namespace luautils
         lua.set_function("GarbageCollectStep", &luautils::garbageCollectStep);
         lua.set_function("GarbageCollectFull", &luautils::garbageCollectFull);
         lua.set_function("GetZone", &luautils::GetZone);
+        lua.set_function("IsZoneActive", &luautils::IsZoneActive);
         lua.set_function("GetNPCByID", &luautils::GetNPCByID);
         lua.set_function("GetMobByID", &luautils::GetMobByID);
         lua.set_function("WeekUpdateConquest", &luautils::WeekUpdateConquest);
@@ -933,6 +934,11 @@ namespace luautils
         }
 
         return std::nullopt;
+    }
+
+    bool IsZoneActive(uint16 zoneId)
+    {
+        return zoneutils::IsZoneActive(zoneId);
     }
 
     std::optional<CLuaBaseEntity> GetMobByID(uint32 mobid, sol::object const& instanceObj)

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -139,6 +139,7 @@ namespace luautils
     void  SendEntityVisualPacket(uint32 npcid, const char* command);
     void  InitInteractionGlobal();
     auto  GetZone(uint16 zoneId) -> std::optional<CLuaZone>;
+    bool  IsZoneActive(uint16 zoneId);
     auto  GetNPCByID(uint32 npcid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
     auto  GetMobByID(uint32 mobid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
     void  WeekUpdateConquest(sol::variadic_args va);

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -1198,4 +1198,22 @@ namespace zoneutils
         return PChar->m_moghouseID != 0;
     }
 
+    /************************************************************************
+     *                                                                       *
+     *  Checks whether or not the zone is enabled                            *
+     *                                                                       *
+     ************************************************************************/
+
+    bool IsZoneActive(uint16 zoneId)
+    {
+        if (auto* PZone = GetZone(zoneId))
+        {
+            if (PZone->GetIP() == 0 || PZone->GetPort() == 0)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
 }; // namespace zoneutils

--- a/src/map/utils/zoneutils.h
+++ b/src/map/utils/zoneutils.h
@@ -54,6 +54,7 @@ namespace zoneutils
     uint64       GetZoneIPP(uint16 zoneid);          // returns IPP for zone ID
     bool         IsResidentialArea(CCharEntity*);    // returns whether or not the area is a residential zone
     uint8        GetFameAreaFromZone(uint16 ZoneID); // returns fame from zone
+    bool         IsZoneActive(uint16 zoneId);        // determines whether the zone is currently enabled based on IP / Port
 
 }; // namespace zoneutils
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Updated !zone to check to see whether a zone is active or not based on IP or Port being 0.  This is to prevent testers and GMs from getting their chars stuck in a dead zone.

## Steps to test these changes

Disable a zone and try to !zone there.
