### PR TITLE
Fix Magic Issues | Increase Seal Potency | Fix Rampart | Fix Cover Duration

### DIFF
--- a/scripts/globals/abilities/mijin_gakure.lua
+++ b/scripts/globals/abilities/mijin_gakure.lua
@@ -29,6 +29,7 @@ abilityObject.onUseAbility = function(player, target, ability)
         player:delStatusEffect(xi.effect.WEAKNESS)
     end
 
+    dmg = utils.rampart(target, dmg)
     dmg = utils.stoneskin(target, dmg)
     target:takeDamage(dmg, player, xi.attackType.SPECIAL, xi.damageType.ELEMENTAL)
 

--- a/scripts/globals/abilities/rampart.lua
+++ b/scripts/globals/abilities/rampart.lua
@@ -17,7 +17,7 @@ end
 
 abilityObject.onUseAbility = function(player, target, ability)
     local duration = 30 + player:getMod(xi.mod.RAMPART_DURATION)
-    target:addStatusEffect(xi.effect.RAMPART, 2500, 0, duration)
+    target:addStatusEffect(xi.effect.RAMPART, (player:getStat(xi.mod.VIT) * 2), 0, duration)
 
     return xi.effect.RAMPART
 end

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -791,6 +791,7 @@ function AbilityFinalAdjustments(dmg, mob, skill, target, skilltype, skillparam,
 
     if skilltype == xi.attackType.MAGICAL then
         dmg = utils.oneforall(target, dmg)
+        dmg = utils.rampart(target, dmg)
     end
 
     dmg = utils.stoneskin(target, dmg)

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -408,6 +408,7 @@ function BlueFinalAdjustments(caster, target, spell, dmg, params)
             return dmg
         end
         dmg = utils.oneforall(target, dmg)
+        dmg = utils.rampart(target, dmg)
     end
 
     -- Handle Phalanx

--- a/scripts/globals/effects/flash.lua
+++ b/scripts/globals/effects/flash.lua
@@ -10,10 +10,13 @@ effectObject.onEffectGain = function(target, effect)
 end
 
 effectObject.onEffectTick = function(target, effect)
+    local delAmount = -effect:getPower() / 3 -- Determine how much to remove.
+    target:setLocalVar('[FLASH_TICK]DeletedMod', target:getLocalVar('[FLASH_TICK]DeletedMod') + delAmount) -- Keep track of how much we have removed.
+    target:delMod(xi.mod.ACC, delAmount) -- Remove more.
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.ACC, -effect:getPower())
+    target:delMod(xi.mod.ACC, -effect:getPower() - target:getLocalVar('[FLASH_TICK]DeletedMod')) -- Cleanup any potential lost accuracy after a resist.
 end
 
 return effectObject

--- a/scripts/globals/effects/helix.lua
+++ b/scripts/globals/effects/helix.lua
@@ -9,7 +9,8 @@ effectObject.onEffectGain = function(target, effect)
 end
 
 effectObject.onEffectTick = function(target, effect)
-    local dmg = utils.stoneskin(target, effect:getPower())
+    local dmg = utils.rampart(target, effect:getPower())
+    dmg = utils.stoneskin(target, dmg)
 
     if (dmg > 0) then
         target:takeDamage(dmg)

--- a/scripts/globals/effects/rampart.lua
+++ b/scripts/globals/effects/rampart.lua
@@ -6,42 +6,16 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    local power = effect:getPower()
-
-    if target:isPC() and target:hasTrait(77) then -- Iron Will
-        target:addMod(xi.mod.SPELLINTERRUPT, target:getMerit(xi.merit.IRON_WILL))
-    end
-
-    if target:getMod(xi.mod.ENHANCES_IRON_WILL) > 0 then
-        local subPower = target:getMod(xi.mod.ENHANCES_IRON_WILL) * (target:getMerit(xi.merit.IRON_WILL) / 19)
-
-        target:addMod(xi.mod.FASTCAST, subPower)
-        effect:setSubPower(subPower)
-    end
-
-    for i = xi.mod.SLASH_SDT, xi.mod.DARK_SDT do
-        target:addMod(i, -power)
-    end
+    target:addMod(xi.mod.DEF, 23)
+    target:addMod(xi.mod.RAMPART_MAGIC_SHIELD, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    local power    = effect:getPower()
-    local subPower = effect:getSubPower()
-
-    if target:isPC() and target:hasTrait(77) then -- Iron Will
-        target:delMod(xi.mod.SPELLINTERRUPT, target:getMerit(xi.merit.IRON_WILL))
-    end
-
-    if subPower > 0 then
-        target:delMod(xi.mod.FASTCAST, subPower)
-    end
-
-    for i = xi.mod.SLASH_SDT, xi.mod.DARK_SDT do
-        target:delMod(i, -power)
-    end
+    target:delMod(xi.mod.DEF, 23)
+    target:setMod(xi.mod.RAMPART_MAGIC_SHIELD, 0)
 end
 
 return effectObject

--- a/scripts/globals/job_utils/paladin.lua
+++ b/scripts/globals/job_utils/paladin.lua
@@ -77,7 +77,7 @@ end
 
 xi.job_utils.paladin.useCover = function(player, target, ability)
     local baseDuration = 15
-    local bonusTime    = utils.clamp(math.floor((player:getStat(xi.mod.VIT) + player:getStat(xi.mod.MND) - target:getStat(xi.mod.VIT) * 2) / 4), 0, 15)
+    local bonusTime    = 0
     local jpValue      = player:getJobPointLevel(xi.jp.COVER_DURATION)
     local duration     = baseDuration + bonusTime + player:getMerit(xi.merit.COVER_EFFECT_LENGTH) + player:getMod(xi.mod.COVER_DURATION) + jpValue
 
@@ -211,12 +211,12 @@ xi.job_utils.paladin.useShieldBash = function(player, target, ability)
     -- Calculate stun proc chance
     chance = chance + (player:getMainLvl() - target:getMainLvl()) * 5
 
-    if math.random()*100 < chance then
+    if math.random() * 100 < chance then
         target:addStatusEffect(xi.effect.STUN, 1, 0, 6)
     end
 
     -- Randomize damage
-    local ratio = player:getStat(xi.mod.ATT)/target:getStat(xi.mod.DEF)
+    local ratio = player:getStat(xi.mod.ATT) / target:getStat(xi.mod.DEF)
 
     if ratio > 1.3 then
         ratio = 1.3

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -134,12 +134,12 @@ local function getSpellBonusAcc(caster, target, spell, params)
     if casterJob == xi.job.DRK then
         -- Add MACC for Dark Seal
         if skill == xi.skill.DARK_MAGIC and caster:hasStatusEffect(xi.effect.DARK_SEAL) then
-            magicAccBonus = magicAccBonus + 75
+            magicAccBonus = magicAccBonus + 100
         end
     end
 
     if caster:hasStatusEffect(xi.effect.ELEMENTAL_SEAL) then
-        magicAccBonus = magicAccBonus + 75
+        magicAccBonus = magicAccBonus + 100
     end
 
     switch(casterJob): caseof
@@ -734,7 +734,7 @@ xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes)
     local quarterTrigger = false
     local resMod = 0
 
-    if element and element ~= xi.magic.ele.NONE then
+    if target and element and element ~= xi.magic.ele.NONE then
         resMod = target:getMod(xi.magic.resistMod[element])
     end
 
@@ -746,13 +746,13 @@ xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes)
     }
     local mobTriggerPoints =
     {
-        evaMult < 1.15,
-        evaMult < 1.30,
-        evaMult < 1.50,
+        evaMult <= 0.50,
+        evaMult <= 0.80,
+        evaMult <= 1.00,
     }
     local selectedTable = mobTriggerPoints
 
-    if target:isPC() then
+    if target and target:isPC() then
         selectedTable = playerTriggerPoints
     end
 
@@ -960,6 +960,9 @@ xi.magic.finalMagicAdjustments = function(caster, target, spell, dmg)
     -- handle one for all
     dmg = utils.oneforall(target, dmg)
 
+    -- Handle Rampart Magic Shield
+    dmg = utils.rampart(target, dmg)
+
     --handling stoneskin
     dmg = utils.stoneskin(target, dmg)
     dmg = utils.clamp(dmg, -99999, 99999)
@@ -992,6 +995,11 @@ xi.magic.finalMagicNonSpellAdjustments = function(caster, target, ele, dmg)
 
     -- handle one for all
     dmg = utils.oneforall(target, dmg)
+
+    -- Handle Rampart Magic Shield
+    if dmg > 0 then
+        dmg = utils.clamp(utils.rampart(target, dmg), -99999, 99999)
+    end
 
     -- handling stoneskin
     dmg = utils.stoneskin(target, dmg)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -371,6 +371,7 @@ end
 xi.mobskills.applyPlayerResistance = function(mob, effect, target, diff, bonus, element)
     local magicaccbonus = 0
     local percentBonus = 0
+    local effectRes = 0
 
     if diff > 10 then
         magicaccbonus = magicaccbonus + 10 + (diff - 10) / 2
@@ -383,7 +384,8 @@ xi.mobskills.applyPlayerResistance = function(mob, effect, target, diff, bonus, 
     end
 
     if effect ~= nil then
-        percentBonus = percentBonus - xi.magic.getEffectResistance(target, effect)
+        effectRes = xi.magic.getEffectResistance(target, effect, nil, mob)
+        percentBonus = percentBonus - effectRes
     end
 
     local p = xi.magic.getMagicHitRate(mob, target, 0, element, percentBonus, magicaccbonus)
@@ -604,6 +606,7 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
 
     if attackType == xi.attackType.MAGICAL then
         dmg = utils.oneforall(target, dmg)
+        dmg = utils.rampart(target, dmg)
 
         if dmg < 0 then
             return 0

--- a/scripts/globals/mobskills/spirits_within.lua
+++ b/scripts/globals/mobskills/spirits_within.lua
@@ -41,6 +41,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         return 0
     end
 
+    dmg = utils.rampart(target, dmg)
     dmg = utils.stoneskin(target, dmg)
 
     if (dmg > 0) then

--- a/scripts/globals/spells/black/gravity.lua
+++ b/scripts/globals/spells/black/gravity.lua
@@ -15,7 +15,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Pull base stats.
     local dINT = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
 
-    local power = 20
+    local power = 26
 
     -- Duration, including resistance.  Unconfirmed.
     local duration = xi.magic.calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -1080,18 +1080,10 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     finalDamage = math.floor(finalDamage * undeadDivinePenalty)
     finalDamage = math.floor(finalDamage * nukeAbsorbOrNullify)
 
-    -- Handle Phalanx
     if finalDamage > 0 then
         finalDamage = utils.clamp(finalDamage - target:getMod(xi.mod.PHALANX), 0, 99999)
-    end
-
-    -- Handle One For All
-    if finalDamage > 0 then
         finalDamage = utils.clamp(utils.oneforall(target, finalDamage), 0, 99999)
-    end
-
-    -- Handle Stoneskin
-    if finalDamage > 0 then
+        finalDamage = utils.clamp(utils.rampart(target, finalDamage), -99999, 99999)
         finalDamage = utils.clamp(utils.stoneskin(target, finalDamage), -99999, 99999)
     end
 

--- a/scripts/globals/spells/white/flash.lua
+++ b/scripts/globals/spells/white/flash.lua
@@ -27,7 +27,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local duration = 12 * resist
 
     if (resist > 0.0625) then
-        if (target:addStatusEffect(xi.effect.FLASH, 200, 0, duration)) then
+        if (target:addStatusEffect(xi.effect.FLASH, 300, 4, duration)) then -- Flash should be 300 and quickly wear off, tick value results in 1 ACC penalty at max duration.
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1805,6 +1805,7 @@ xi.mod =
     LIGHT_EEM                     = 1164, -- Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
     DARK_EEM                      = 1165, -- Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
     TAME_SUCCESS_RATE             = 1166, -- Tame Success Rate +
+    RAMPART_MAGIC_SHIELD          = 1167, -- Rampart Magic Shield
 
     -- IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN src/map/modifier.h ASWELL!
 

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -336,6 +336,7 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
 
     if skilltype == xi.attackType.MAGICAL then
         dmg = utils.oneforall(target, dmg)
+        dmg = utils.rampart(target, dmg)
     end
 
     -- handling stoneskin

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -154,6 +154,23 @@ function utils.stoneskin(target, dmg)
     return dmg
 end
 
+function utils.rampart(target, dmg)
+    if dmg > 0 then
+        local shield = target:getMod(xi.mod.RAMPART_MAGIC_SHIELD)
+        if shield > 0 then
+            if shield > dmg then -- absorbs damage
+                target:delMod(xi.mod.RAMPART_MAGIC_SHIELD, dmg)
+                return 0
+            else -- absorbs some damage
+                target:setMod(xi.mod.RAMPART_MAGIC_SHIELD, 0)
+                return dmg - shield
+            end
+        end
+    end
+
+    return dmg
+end
+
 -- returns reduced magic damage from RUN buff, "One for All"
 function utils.oneforall(target, dmg)
     if dmg > 0 then
@@ -232,7 +249,7 @@ function utils.takeShadows(target, mob, dmg, shadowbehav)
             target:addEnmity(mob, -25 * shadowbehav, 0)
         end
 
-        target:setMod(shadowType, shadowsLeft);
+        target:setMod(shadowType, shadowsLeft)
 
         if shadowsLeft <= 0 then
             target:delStatusEffect(xi.effect.COPY_IMAGE)
@@ -289,7 +306,7 @@ function utils.thirdeye(target)
 
     if prevAnt == 0 or (math.random() * 100) < (80 - (prevAnt * 10)) then
         --anticipated!
-        if seigan == nil or prevAnt == 6 or math.random()*100 > 100-(prevAnt+1)*15 then
+        if seigan == nil or prevAnt == 6 or math.random() * 100 > 100 - (prevAnt + 1) * 15 then
             target:delStatusEffect(xi.effect.THIRD_EYE)
         else
             teye:setPower(prevAnt + 1)

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -318,6 +318,7 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, f
                     magicdmg = magicdmg - target:getMod(xi.mod.PHALANX)
                     magicdmg = utils.clamp(magicdmg, 0, 99999)
                     magicdmg = utils.oneforall(target, magicdmg)
+                    magicdmg = utils.rampart(target, magicdmg)
                     magicdmg = utils.stoneskin(target, magicdmg)
                 end
 
@@ -358,6 +359,7 @@ local function modifyMeleeHitDamage(attacker, target, attackTbl, wsParams, rawDa
         adjustedDamage = utils.clamp(adjustedDamage, 0, 99999)
     end
 
+    adjustedDamage = utils.rampart(target, adjustedDamage)
     adjustedDamage = utils.stoneskin(target, adjustedDamage)
 
     return adjustedDamage
@@ -838,6 +840,7 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
         end
 
         dmg = utils.oneforall(target, dmg)
+        dmg = utils.rampart(target, dmg)
         dmg = utils.stoneskin(target, dmg)
 
         dmg = dmg * xi.settings.main.WEAPON_SKILL_POWER -- Add server bonus

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -621,7 +621,7 @@ enum class Mod
     SAVETP      = 880, // SAVETP Effect for Miser's Roll / ATMA / Hagakure.
     CONSERVE_TP = 944, // Conserve TP trait, random chance between 10 and 200 TP
 
-    WYRMAL_ABJ_KILLER_EFFECT = 53,  // Wyrmal Abjuration(Crimson / Blood) which makes players susceptible to Dragon Killer effects
+    WYRMAL_ABJ_KILLER_EFFECT = 53, // Wyrmal Abjuration(Crimson / Blood) which makes players susceptible to Dragon Killer effects
 
     // Rune Fencer
     INQUARTATA                  = 963,  // Increases parry rate by a flat %.
@@ -936,15 +936,16 @@ enum class Mod
     PET_DMG_TAKEN_BREATH   = 1156, // Percent increase/decrease in pet physical damage taken for the target.
     DIG_BYPASS_FATIGUE     = 1157, // Chocobo digging modifier found in "Blue Race Silks". Modifier works as a direct percent. Used in Chocobo_Digging.lua
 
-    FIRE_EEM          = 1158, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
-    ICE_EEM           = 1159, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
-    WIND_EEM          = 1160, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
-    EARTH_EEM         = 1161, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
-    THUNDER_EEM       = 1162, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
-    WATER_EEM         = 1163, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
-    LIGHT_EEM         = 1164, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
-    DARK_EEM          = 1165, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
-    TAME_SUCCESS_RATE = 1166, // Tame Success Rate +
+    FIRE_EEM             = 1158, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
+    ICE_EEM              = 1159, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
+    WIND_EEM             = 1160, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
+    EARTH_EEM            = 1161, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
+    THUNDER_EEM          = 1162, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
+    WATER_EEM            = 1163, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
+    LIGHT_EEM            = 1164, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
+    DARK_EEM             = 1165, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
+    TAME_SUCCESS_RATE    = 1166, // Tame Success Rate +
+    RAMPART_MAGIC_SHIELD = 1167, // Rampart Magic Shield
 
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/globals/status.lua ASWELL!
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Implements an era correct version of Rampart using a VIT * 2 magic shield.
+ Increases seal accuracy bonus to 100.
+ Fixes EEM tier sorting to be more player favorable and keep mobs more in line with how player resist tiers operate. 
+ Fixes flash to have the correct potency and decay. Used a local var to ensure we always end back at the correct accuracy.
+ Adds the correct gravity potency back in after fixing the other issues related to weight. 
+ Removes bonus duration based on stats from Cover.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/324
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/301

Sources: https://www.bg-wiki.com/index.php?title=Rampart&oldid=96827

## Steps to test these changes
+ Tested rampart VIT scaling and usage where it acted as a stoneskin for only magic.
+ Flash was tested in both a non-resist and a resist scenario always leading to a -300 ACC mod at the start and a 0 dACC after the effect wears.
+ Gravity potency testing was tested to ensure things ran at the proper speeds.
