### PR TITLE
Fix Desynth HQ Rate

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -345,7 +345,7 @@ namespace synthutils
 
             if (PChar->CraftContainer->getCraftType() == 1) // if it's a desynth raise HQ chance
             {
-                chance *= 0.4 + (hqtier * 0.03);
+                chance = 0.4 + (hqtier * 0.03);
             }
 
             // Using x/512 calculation for HQ success rate modifier


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixes Desynth rate base.

## Steps to test these changes

Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/335