### PR TITLE
Update mobskills.lua

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -169,15 +169,13 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
         base = 1
     end
 
-    local lvldiff = mob:getMainLvl() - target:getMainLvl()
 
     --work out hit rate for mobs
     local hitrate = xi.weaponskills.getHitRate(mob, target, 0, 0)
 
-    hitrate = utils.clamp(hitrate, 0.2, 0.95)
 
     --work out the base damage for a single hit
-    local hitdamage = base + lvldiff
+    local hitdamage = base
     if hitdamage < 1 then
         hitdamage = 0 -- If I hit below 1 I actually did 0 damage.
     end

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -169,10 +169,8 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
         base = 1
     end
 
-
     --work out hit rate for mobs
     local hitrate = xi.weaponskills.getHitRate(mob, target, 0, 0)
-
 
     --work out the base damage for a single hit
     local hitdamage = base


### PR DESCRIPTION
There is no evidence for level difference adding to base damage. This was causing high level beastmasters to be able to AoE entire zones in a few TP moves. Clamping hit rate at 20% before adding a +50% hit chance to physical mob TP moves was causing all physical mob TP moves to have a minimum 70% hit rate. This was making certain TP moves that rely on landing to apply their effects too strong (headbutt). There is no evidence for this being the case.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
