### PR TITLE
Ro'Maeve fountain behaviour for Era and ROV

### DIFF
--- a/scripts/zones/RoMaeve/Zone.lua
+++ b/scripts/zones/RoMaeve/Zone.lua
@@ -16,35 +16,40 @@ local function updateFullMoonStatus()
     local rovEnabled = xi.settings.main.ENABLE_ROV
     -- ROV: Make Ro'Maeve come to life between 6pm and 6am during a full moon, any weather
     -- Pre-ROV: between midnight and 3am during a full moon and clear weather
-    if IsMoonFull() then
-        if (rovEnabled == 1 and (vanadielHour >= 18 or vanadielHour < 6)) or
+    if
+        IsMoonFull()
+    then
+        if
+            (rovEnabled == 1 and (vanadielHour >= 18 or vanadielHour < 6)) or
             (rovEnabled == 0 and (vanadielHour >= 0 and vanadielHour < 3) and
-            (weather == xi.weather.NONE or weather == xi.weather.SUNSHINE)) then
-                local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
-                local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
-
-                if moongate1:getLocalVar("romaeveActive") == 0 then
-                    -- Loop over the affected NPCs: Moongates, bridges and fountain
-                    for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
-                        GetNPCByID(i):setAnimation(xi.anim.OPEN_DOOR) -- Open them
-                    end
-                    moongate2:setUntargetable(true)
-                    moongate1:setUntargetable(true)
-                    moongate1:setLocalVar("romaeveActive", 1) -- Make this loop unavailable after firing
+            (weather == xi.weather.NONE or weather == xi.weather.SUNSHINE))
+        then
+            local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
+            local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
+            if
+                moongate1:getLocalVar("romaeveActive") == 0
+            then
+                -- Loop over the affected NPCs: Moongates, bridges and fountain
+                for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
+                    GetNPCByID(i):setAnimation(xi.anim.OPEN_DOOR) -- Open them
                 end
-
+                moongate2:setUntargetable(true)
+                moongate1:setUntargetable(true)
+                moongate1:setLocalVar("romaeveActive", 1) -- Make this loop unavailable after firing
+            end
             -- Clean up outside of full moon window
-            else
-                local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
-                local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
-            
-                if moongate1:getLocalVar("romaeveActive") == 1 then
-                    for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
-                        GetNPCByID(i):setAnimation(xi.anim.CLOSE_DOOR)
-                    end
-                    moongate2:setUntargetable(false)
-                    moongate1:setUntargetable(false)
-                    moongate1:setLocalVar("romaeveActive", 0) -- Make loop available again
+        else
+            local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
+            local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
+            if
+                moongate1:getLocalVar("romaeveActive") == 1
+            then
+                for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
+                    GetNPCByID(i):setAnimation(xi.anim.CLOSE_DOOR)
+                end
+                moongate2:setUntargetable(false)
+                moongate1:setUntargetable(false)
+                moongate1:setLocalVar("romaeveActive", 0) -- Make loop available again
             end
         end
     end

--- a/scripts/zones/RoMaeve/Zone.lua
+++ b/scripts/zones/RoMaeve/Zone.lua
@@ -9,6 +9,47 @@ require('scripts/globals/status')
 -----------------------------------
 local zoneObject = {}
 
+local function updateFullMoonStatus()
+    local vanadielHour = VanadielHour()
+    local zone = GetZone(xi.zone.ROMAEVE)
+    local weather = zone:getWeather()
+    local rovEnabled = xi.settings.main.ENABLE_ROV
+    -- ROV: Make Ro'Maeve come to life between 6pm and 6am during a full moon, any weather
+    -- Pre-ROV: between midnight and 3am during a full moon and clear weather
+    if IsMoonFull() then
+        if (rovEnabled == 1 and (vanadielHour >= 18 or vanadielHour < 6)) or
+            (rovEnabled == 0 and (vanadielHour >= 0 and vanadielHour < 3) and
+            (weather == xi.weather.NONE or weather == xi.weather.SUNSHINE)) then
+                local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
+                local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
+
+                if moongate1:getLocalVar("romaeveActive") == 0 then
+                    -- Loop over the affected NPCs: Moongates, bridges and fountain
+                    for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
+                        GetNPCByID(i):setAnimation(xi.anim.OPEN_DOOR) -- Open them
+                    end
+                    moongate2:setUntargetable(true)
+                    moongate1:setUntargetable(true)
+                    moongate1:setLocalVar("romaeveActive", 1) -- Make this loop unavailable after firing
+                end
+
+            -- Clean up outside of full moon window
+            else
+                local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
+                local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
+            
+                if moongate1:getLocalVar("romaeveActive") == 1 then
+                    for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
+                        GetNPCByID(i):setAnimation(xi.anim.CLOSE_DOOR)
+                    end
+                    moongate2:setUntargetable(false)
+                    moongate1:setUntargetable(false)
+                    moongate1:setLocalVar("romaeveActive", 0) -- Make loop available again
+            end
+        end
+    end
+end
+
 zoneObject.onInitialize = function(zone)
     local newPosition = npcUtil.pickNewPosition(ID.npc.BASTOK_7_1_QM, ID.npc.BASTOK_7_1_QM_POS, true)
     GetNPCByID(ID.npc.BASTOK_7_1_QM):setPos(newPosition.x, newPosition.y, newPosition.z)
@@ -32,37 +73,11 @@ zoneObject.onRegionEnter = function(player, region)
 end
 
 zoneObject.onGameHour = function(zone)
-    local vanadielHour = VanadielHour()
+    updateFullMoonStatus()
+end
 
-    -- Make Ro'Maeve come to life between 6pm and 6am during a full moon
-    if IsMoonFull() and (vanadielHour >= 18 or vanadielHour < 6) then
-        local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
-        local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
-
-        if moongate1:getLocalVar("romaeveActive") == 0 then
-            -- Loop over the affected NPCs: Moongates, bridges and fountain
-            for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
-                GetNPCByID(i):setAnimation(xi.anim.OPEN_DOOR) -- Open them
-            end
-            moongate2:setUntargetable(true)
-            moongate1:setUntargetable(true)
-            moongate1:setLocalVar("romaeveActive", 1) -- Make this loop unavailable after firing
-        end
-
-    -- Clean up at 6am
-    elseif vanadielHour == 6 then
-        local moongate1 = GetNPCByID(ID.npc.MOONGATE_OFFSET)
-        local moongate2 = GetNPCByID(ID.npc.MOONGATE_OFFSET + 1)
-
-        if moongate1:getLocalVar("romaeveActive") == 1 then
-            for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do
-                GetNPCByID(i):setAnimation(xi.anim.CLOSE_DOOR)
-            end
-            moongate2:setUntargetable(false)
-            moongate1:setUntargetable(false)
-            moongate1:setLocalVar("romaeveActive", 0) -- Make loop available again
-        end
-    end
+zoneObject.onZoneWeatherChange = function(weather)
+    updateFullMoonStatus()
 end
 
 zoneObject.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/RoMaeve/npcs/QuHau_Spring.lua
+++ b/scripts/zones/RoMaeve/npcs/QuHau_Spring.lua
@@ -18,15 +18,29 @@ entity.onTrade = function(player, npc, trade)
     local hour     = VanadielHour()
     local rovEnabled = xi.settings.main.ENABLE_ROV
 
-    if IsMoonFull() then
+    if
+        IsMoonFull()
+    then
         -- ROV: Make Ro'Maeve come to life between 6pm and 6am during a full moon, any weather
         -- Pre-ROV: between midnight and 3am during a full moon and clear weather
-        if (rovEnabled == 0 and (hour >= 0 and hour < 3) and (weather == xi.weather.NONE or weather == xi.weather.SUNSHINE)) or
-            (rovEnabled == 1 and (hour >= 18 or hour < 7)) then
-            if dmFirst == QUEST_ACCEPTED or dmRepeat == QUEST_ACCEPTED then -- allow for Ark Pentasphere on both first and repeat quests
-                if npcUtil.tradeHasExactly(trade, { 1408, 917 }) then
+        if
+            (rovEnabled == 0 and (hour >= 0 and hour < 3) and
+            (weather == xi.weather.NONE or weather == xi.weather.SUNSHINE)) or
+            (rovEnabled == 1 and (hour >= 18 or hour < 7))
+        then
+            if
+                dmFirst == QUEST_ACCEPTED or dmRepeat == QUEST_ACCEPTED
+            then
+                -- allow for Ark Pentasphere on both first and repeat quests
+                if
+                    npcUtil.tradeHasExactly(trade, { 1408, 917 })
+                then
                     player:startEvent(7, 917, 1408) -- Ark Pentasphere Trade
-                elseif dmRepeat == QUEST_ACCEPTED and npcUtil.tradeHasExactly(trade, 1261) and not player:hasKeyItem(xi.ki.MOONLIGHT_ORE) then
+                elseif
+                    dmRepeat == QUEST_ACCEPTED and
+                    npcUtil.tradeHasExactly(trade, 1261) and
+                    not player:hasKeyItem(xi.ki.MOONLIGHT_ORE)
+                then
                     player:startEvent(8) -- Moonlight Ore trade
                 end
             end

--- a/scripts/zones/RoMaeve/npcs/QuHau_Spring.lua
+++ b/scripts/zones/RoMaeve/npcs/QuHau_Spring.lua
@@ -26,7 +26,7 @@ entity.onTrade = function(player, npc, trade)
         if
             (rovEnabled == 0 and (hour >= 0 and hour < 3) and
             (weather == xi.weather.NONE or weather == xi.weather.SUNSHINE)) or
-            (rovEnabled == 1 and (hour >= 18 or hour < 7))
+            (rovEnabled == 1 and (hour >= 18 or hour < 6))
         then
             if
                 dmFirst == QUEST_ACCEPTED or dmRepeat == QUEST_ACCEPTED

--- a/scripts/zones/RoMaeve/npcs/QuHau_Spring.lua
+++ b/scripts/zones/RoMaeve/npcs/QuHau_Spring.lua
@@ -11,16 +11,24 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
+    local zone     = player:getZone()
+    local weather  = zone:getWeather()
     local dmFirst  = player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT)
     local dmRepeat = player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT_REPEAT)
     local hour     = VanadielHour()
+    local rovEnabled = xi.settings.main.ENABLE_ROV
 
-    if (hour >= 18 or hour < 6) and IsMoonFull() then
-        if dmFirst == QUEST_ACCEPTED or dmRepeat == QUEST_ACCEPTED then -- allow for Ark Pentasphere on both first and repeat quests
-            if npcUtil.tradeHasExactly(trade, { 1408, 917 }) then
-                player:startEvent(7, 917, 1408) -- Ark Pentasphere Trade
-            elseif dmRepeat == QUEST_ACCEPTED and npcUtil.tradeHasExactly(trade, 1261) and not player:hasKeyItem(xi.ki.MOONLIGHT_ORE) then
-                player:startEvent(8) -- Moonlight Ore trade
+    if IsMoonFull() then
+        -- ROV: Make Ro'Maeve come to life between 6pm and 6am during a full moon, any weather
+        -- Pre-ROV: between midnight and 3am during a full moon and clear weather
+        if (rovEnabled == 0 and (hour >= 0 and hour < 3) and (weather == xi.weather.NONE or weather == xi.weather.SUNSHINE)) or
+            (rovEnabled == 1 and (hour >= 18 or hour < 7)) then
+            if dmFirst == QUEST_ACCEPTED or dmRepeat == QUEST_ACCEPTED then -- allow for Ark Pentasphere on both first and repeat quests
+                if npcUtil.tradeHasExactly(trade, { 1408, 917 }) then
+                    player:startEvent(7, 917, 1408) -- Ark Pentasphere Trade
+                elseif dmRepeat == QUEST_ACCEPTED and npcUtil.tradeHasExactly(trade, 1261) and not player:hasKeyItem(xi.ki.MOONLIGHT_ORE) then
+                    player:startEvent(8) -- Moonlight Ore trade
+                end
             end
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Sets up the Ro'Meave fountain (Qu'Hau Spring) and zone behavior depending on era.

Pre-ROV the zone came alive during Full Moon and 00:00 and 03:00 and only during clear weather conditions.
Post-ROV the timeframe was extended to 18:00 - 06:00 and weather conditions are ignored.

Added functionality to check fountain conditions on every weather change and not just on the hour.

https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-%28JST%29-Version-Update

## Steps to test these changes

Prerequisites:
- Be on Zilart Mission: Divine Might and talk to the palace console to trigger Ark Pentasphere cutscene
- VanaTime should be full moon, or adjust luautils.cpp to always return true on IsMoonFull()

In main.lua set ENABLE_ROV to 0 (Disabled)
- !zone Ro'Meave
- !setweather 0
- Wait for 00:00
- Fountain should now fill up, and the middle walkway should be accessible
- Trade Illuminink and Parchment to Qu'Hau Spring to create an Ark Pentasphere
- !setweather 3 (fog)
- Fountain should empty out, walkway bridges should go down
- Trade Illuminink and Parchment to Qu'Hau Spring. No cutscene should occur.
- !setweather 0 (none) - fountain should fill up again
- Wait for 03:00 and check for the fountain to empty

In main.lua set ENABLE_ROV to 1 (Enabled)
- !zone Ro'Meave
- Wait for 18:00
- Fountain should now fill up, and the middle walkway should be accessible
- !setweather 3  (fog) - Qu'Hau Spring should stay full as weather conditions are ignored
- Trade Illuminink and Parchment to Qu'Hau Spring to create an Ark Pentasphere
- Wait for 06:00
- Fountain should empty out, walkway bridges should go down