### PR TITLE
Resolving Transport Animation Issues

### DIFF
--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -409,6 +409,33 @@ void CTransportHandler::TransportTimer()
                     else
                     {
                         zoneIterator->voyageZone->SetZoneDirection(0);
+                    }
+                }
+                else if (zoneId == ZONE_MANACLIPPER)
+                {
+                    uint32 hour = CVanaTime::getInstance()->getHour();
+                    switch (hour)
+                    {
+                        case 0:
+                            zoneIterator->voyageZone->SetZoneAnimation(0);
+                            zoneIterator->voyageZone->SetZoneAnimLength(590);
+                            break;
+                        case 4:
+                            [[fallthrough]];
+                        case 16:
+                            zoneIterator->voyageZone->SetZoneAnimation(16);
+                            zoneIterator->voyageZone->SetZoneAnimLength(445);
+                            break;
+                        case 8:
+                            [[fallthrough]];
+                        case 20:
+                            zoneIterator->voyageZone->SetZoneAnimation(24);
+                            zoneIterator->voyageZone->SetZoneAnimLength(445);
+                            break;
+                        case 12:
+                            zoneIterator->voyageZone->SetZoneAnimation(8);
+                            zoneIterator->voyageZone->SetZoneAnimLength(590);
+                            break;
                     }
                 }
             }


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/55
Two related changes:
1. Add Manaclipper voyage animation data so it actually plays while you're on the ship
2. Fix transport so that way if you zone in during docking/departing or while the ship is docked it will be displayed at the correct position.

The second one I fixed by analyzing retail packets. I noticed that 1) we needed to be updating the pos not combat 2) Retail is constantly sending out update and spawn packets while the ship is docked.
![image](https://user-images.githubusercontent.com/1189557/198929671-dde9d40b-a443-462a-b65a-37a54c9da197.png)

The animBegin time being set was wrong as well which would cause the animation to restart when you zone in unless it was docked.

## Steps to test these changes

Go to any dock and talk to the npc to get a time of arrival. You can use `!time 100` to advance the time by a little. Watch the ship start to pull in and once it is about halfway use `!goto <me>`. You'll zone and the ship should be over halfway through its animation. Once docked you can `!goto <me>` again and the ship should still be docked. You can do the same with departing too.
