### PR TITLE
Fixes H2H Damage for Mobs | Corrects H2H Weapon Rank

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -469,6 +469,11 @@ void CAttack::ProcessDamage(bool isCritical, bool isGuarded, bool isKick)
         m_baseDamage       = 0;
         m_naturalH2hDamage = (int32)(m_attacker->GetSkill(SKILL_HAND_TO_HAND) * 0.11f) + 3;
 
+        if (m_attacker->objtype == TYPE_MOB)
+        {
+            m_naturalH2hDamage /= 2;
+        }
+
         if (!isKick)
         {
             m_baseDamage = m_attacker->GetMainWeaponDmg();

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -483,11 +483,19 @@ uint16 CBattleEntity::GetRangedWeaponDmg()
 
 uint16 CBattleEntity::GetMainWeaponRank()
 {
+    // https://www.bg-wiki.com/ffxi/Weapon_Rank
+    // https://ffxiclopedia.fandom.com/wiki/Category:Hand-to-Hand?oldid=342430
+    uint16 wDamage = 0;
     if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
     {
-        return (weapon->getDamage() + getMod(Mod::MAIN_DMG_RANK)) / 9;
+        wDamage = weapon->getDamage() + getMod(Mod::MAIN_DMG_RANK);
+
+        if (weapon->getSkillType() == SKILL_HAND_TO_HAND)
+        {
+            wDamage += 3;
+        }
     }
-    return 0;
+    return wDamage / 9;
 }
 
 uint16 CBattleEntity::GetSubWeaponRank()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
- Fixes H2H mobs doing double damage
- Correct weaponrank calcs for H2H
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Fight a MNK mob and not get one shot
<!-- Clear and detailed steps to test your changes here -->
