### PR TITLE
Fixes issue with IX_DRK display message

### DIFF
--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRK.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRK.lua
@@ -84,7 +84,7 @@ entity.onMobSpawn = function(mob)
         specials =
         {
             {
-                id = xi.jsa.BLOOD_WEAPON_IXDRK,
+                id = xi.jsa.BLOOD_WEAPON,
                 hpp = math.random(90, 95),
                 cooldown = 120,
                 endCode = function(mobArg)


### PR DESCRIPTION
Logs showed when its supposed to use blood weapon it displays Refulgent Arrow. Took out _IXDRK form the id=xi.jsa.BLOOD_WEAPON

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->removed [IXDRK ] id=xi.jsa.BLOOD_WEAPON_IXDRK

## Steps to test these changes
pop it and wait. 
<!-- Clear and detailed steps to test your changes here -->
![image](https://user-images.githubusercontent.com/16403542/199133433-0f4f8e39-eeab-4797-80b9-c307a56a2ffb.png)
