### PR TITLE
Fixes Mob H2H Damage

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -483,7 +483,7 @@ void CAttack::ProcessDamage(bool isCritical, bool isGuarded, bool isKick)
         {
             // mobdamage = (floor((level + 2 + fstr) * .9) / 2) * pdif
             int8 mobH2HDamage = m_attacker->GetMLevel() + 2;
-            m_damage = (uint32)((std::floor( (mobH2HDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * 0.9f) / 2 ) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 1, slot, 0, isGuarded));
+            m_damage          = (uint32)((std::floor((mobH2HDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * 0.9f) / 2) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 1, slot, 0, isGuarded));
         }
         else
         {

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -479,7 +479,16 @@ void CAttack::ProcessDamage(bool isCritical, bool isGuarded, bool isKick)
             m_baseDamage = m_attacker->GetMainWeaponDmg();
         }
 
-        m_damage = (uint32)(((m_baseDamage + m_naturalH2hDamage + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 1, slot, 0, isGuarded)));
+        if (m_attacker->objtype == TYPE_MOB)
+        {
+            // mobdamage = (floor((level + 2 + fstr) * .9) / 2) * pdif
+            int8 mobH2HDamage = m_attacker->GetMLevel() + 2;
+            m_damage = (uint32)((std::floor( (mobH2HDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * 0.9f) / 2 ) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 1, slot, 0, isGuarded));
+        }
+        else
+        {
+            m_damage = (uint32)(((m_baseDamage + m_naturalH2hDamage + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 1, slot, 0, isGuarded)));
+        }
     }
     else if (slot == SLOT_MAIN)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
- Fixes mob H2H damage for good
- Mob h2h damage is calculated very differently from players:
Mob damage is calculated with: mobdamage = (floor((level + 2 + fstr) * .9) / 2) * pdif

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go fight any mob that uses H2H skill and see that it does the correct damage
<!-- Clear and detailed steps to test your changes here -->
