### PR TITLE
Adjust Idol Thoughts NM's to use correct element

### DIFF
--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -2297,13 +2297,13 @@ INSERT INTO `mob_skill_lists` VALUES ('Fire_Golem',499,678);  -- Crystal Rain
 INSERT INTO `mob_skill_lists` VALUES ('Fire_Golem',499,679);  -- Crystal Weapon (Fire)
 INSERT INTO `mob_skill_lists` VALUES ('Water_Golem',500,676); -- Ice Break
 INSERT INTO `mob_skill_lists` VALUES ('Water_Golem',500,678); -- Crystal Rain
-INSERT INTO `mob_skill_lists` VALUES ('Water_Golem',500,680); -- Crystal Weapon (Water)
+INSERT INTO `mob_skill_lists` VALUES ('Water_Golem',500,681); -- Crystal Weapon (Water)
 INSERT INTO `mob_skill_lists` VALUES ('Wind_Golem',501,677);   -- Thunder Break
 INSERT INTO `mob_skill_lists` VALUES ('Wind_Golem',501,678);   -- Crystal Rain
-INSERT INTO `mob_skill_lists` VALUES ('Wind_Golem',501,681);   -- Crystal Weapon (Wind)
+INSERT INTO `mob_skill_lists` VALUES ('Wind_Golem',501,682);   -- Crystal Weapon (Wind)
 INSERT INTO `mob_skill_lists` VALUES ('Earth_Golem',502,677); -- Ice Break
 INSERT INTO `mob_skill_lists` VALUES ('Earth_Golem',502,678); -- Crystal Rain
-INSERT INTO `mob_skill_lists` VALUES ('Earth_Golem',502,682); -- Crystal Weapon (Earth)
+INSERT INTO `mob_skill_lists` VALUES ('Earth_Golem',502,680); -- Crystal Weapon (Earth)
 INSERT INTO `mob_skill_lists` VALUES ('Mammet',503,347); -- velocious blade
 INSERT INTO `mob_skill_lists` VALUES ('Mammet',503,419); -- scission thrust
 INSERT INTO `mob_skill_lists` VALUES ('Mammet',503,422); -- sonic blade


### PR DESCRIPTION
Compared mob_skills.sql with mob_skills_lists adjusted to correct entries.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits
They were obviously mistyped... didn't fire it up but pretty sure this is correct...
## What does this pull request do?
![image](https://user-images.githubusercontent.com/16403542/199372424-e21604f7-c6a2-43de-b0d2-b2584f92080d.png)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
enter BCNM and verify they use the correct elemental crystal weapon
<!-- Clear and detailed steps to test your changes here -->
