### PR TITLE
Finish Magic Accuracy | Fix Engage Animation Bug | Fix MB Messaging | Fix Charmed Mobs Despawning When PC Master Dies

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -716,6 +716,7 @@ end
 -- Returns resistance value from given magic hit rate (p)
 xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes)
     local evaMult = 1
+    local resMod = 0
 
     if target ~= nil and element ~= nil and target:getObjType() == xi.objType.MOB then
         evaMult = target:getMod(xi.magic.eleEvaMult[element]) / 100
@@ -729,42 +730,24 @@ xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes)
         end
     end
 
-    local sixteenthTrigger = false
     local eighthTrigger = false
     local quarterTrigger = false
-    local resMod = 0
 
-    if target and element and element ~= xi.magic.ele.NONE then
+    if element and element ~= xi.magic.ele.NONE then
         resMod = target:getMod(xi.magic.resistMod[element])
     end
 
-    local playerTriggerPoints =
+    local resTriggerPoints =
     {
-        resMod > 200,
-        resMod > 100,
+        resMod > 101,
         resMod >= 0,
     }
-    local mobTriggerPoints =
-    {
-        evaMult <= 0.50,
-        evaMult <= 0.80,
-        evaMult <= 1.00,
-    }
-    local selectedTable = mobTriggerPoints
 
-    if target and target:isPC() then
-        selectedTable = playerTriggerPoints
-    end
-
-    if playerTriggerPoints[1] then
-        sixteenthTrigger = true
-    end
-
-    if selectedTable[2] then
+    if resTriggerPoints[1] then
         eighthTrigger = true
     end
 
-    if selectedTable[3] then
+    if resTriggerPoints[2] then
         quarterTrigger = true
     end
 
@@ -784,13 +767,10 @@ xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes)
     local half      = (1 - p)
     local quart     = ((1 - p)^2)
     local eighth    = ((1 - p)^3)
-    local sixteenth = ((1 - p)^4)
     local resvar    = math.random()
 
     -- Determine final resist based on which thresholds have been crossed.
-    if resvar <= sixteenth and sixteenthTrigger then
-        resist = 0.0625
-    elseif resvar <= eighth and eighthTrigger then
+    if resvar <= eighth and eighthTrigger then
         resist = 0.125
     elseif resvar <= quart and quarterTrigger then
         resist = 0.25
@@ -798,6 +778,10 @@ xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes)
         resist = 0.5
     else
         resist = 1.0
+    end
+
+    if evaMult <= 0.5 then
+        resist = resist / 2
     end
 
     return resist

--- a/scripts/globals/magicburst.lua
+++ b/scripts/globals/magicburst.lua
@@ -41,19 +41,19 @@ local matches = -- [element id][resonance id]
 -- Returns a boolean if the spell's element matches the resonace given
 local function doesSpellElementMatchResonance(ele, resonance)
     local isMatch = matches[ele + 1][resonance:getPower() + 1]
-    return (isMatch ~= nil and isMatch > 0)
+    return (isMatch and isMatch > 0)
 end
 
 local function doesMobSpellElementMatchResonance(element, resonance)
     local isMatch = matches[element + 1][resonance:getPower() + 1]
-    return (isMatch ~= nil and isMatch > 0)
+    return (isMatch and isMatch > 0)
 end
 
 -- Returns the burst level for a spell / target combination
 function FormMagicBurst(ele, target)
     local resonance = target:getStatusEffect(xi.effect.SKILLCHAIN)
-    if (resonance ~= nil and resonance:getTier() > 0) then -- Resonance exists, ignore it if its tier 0
-        if (doesSpellElementMatchResonance(ele, resonance) == true) then
+    if (resonance and resonance:getTier() > 0) then -- Resonance exists, ignore it if its tier 0
+        if (doesSpellElementMatchResonance(ele, resonance)) then
             return resonance:getTier(), resonance:getSubPower()
         end
     end -- if resonance
@@ -64,8 +64,8 @@ end
 function MobFormMagicBurst(element, target)
     local resonance = target:getStatusEffect(xi.effect.SKILLCHAIN)
 
-    if (resonance ~= nil and resonance:getTier() > 0) then -- Resonance exists, ignore it if its tier 0
-        if (doesMobSpellElementMatchResonance(element, resonance) == true) then
+    if (resonance and resonance:getTier() > 0) then -- Resonance exists, ignore it if its tier 0
+        if (doesMobSpellElementMatchResonance(element, resonance)) then
             return resonance:getTier(), resonance:getSubPower()
         end
     end -- if resonance
@@ -76,5 +76,5 @@ end
 -- Returns a boolean if the element matches the skillchain property given
 function doesElementMatchWeaponskill(ele, SCProp)
     local isMatch = matches[ele + 1][SCProp + 1]
-    return (isMatch ~= nil and isMatch > 0)
+    return (isMatch and isMatch > 0)
 end

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -658,7 +658,6 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
         end
     end
 
-    local sixteenthTrigger = false
     local eighthTrigger = false
     local quarterTrigger = false
 
@@ -666,50 +665,31 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
         resMod = target:getMod(xi.magic.resistMod[element])
     end
 
-    local playerTriggerPoints =
+    local resTriggerPoints =
     {
-        resMod > 145,
-        resMod > 100,
+        resMod > 101,
         resMod >= 0,
     }
-    local mobTriggerPoints =
-    {
-        evaMult < 1.15,
-        evaMult < 1.30,
-        evaMult < 1.50,
-    }
-    local selectedTable = mobTriggerPoints
 
-    if target:isPC() then
-        selectedTable = playerTriggerPoints
-    end
-
-    if playerTriggerPoints[1] then
-        sixteenthTrigger = true
-    end
-
-    if selectedTable[2] then
+    if resTriggerPoints[1] then
         eighthTrigger = true
     end
 
-    if selectedTable[3] then
+    if resTriggerPoints[2] then
         quarterTrigger = true
     end
 
-    local p = utils.clamp(((magicHitRate * evaMult) / 100), 0.05, 3.00) -- clamp at minimum 0.05, clamp at max of 3.0 to be safe
+    local p = utils.clamp(((magicHitRate * evaMult) / 100), 0.05, 0.95) -- clamp at minimum 0.05, clamp at max of 3.0 to be safe
     local resistVal = 1
 
     -- Resistance thresholds based on p.  A higher p leads to lower resist rates, and a lower p leads to higher resist rates.
     local half      = (1 - p)
     local quart     = ((1 - p)^2)
     local eighth    = ((1 - p)^3)
-    local sixteenth = ((1 - p)^4)
     local resvar    = math.random()
 
     -- Determine final resist based on which thresholds have been crossed.
-    if resvar <= sixteenth and sixteenthTrigger then
-        resistVal = 0.0625
-    elseif resvar <= eighth and eighthTrigger then
+    if resvar <= eighth and eighthTrigger then
         resistVal = 0.125
     elseif resvar <= quart and quarterTrigger then
         resistVal = 0.25
@@ -717,6 +697,10 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
         resistVal = 0.5
     else
         resistVal = 1.0
+    end
+
+    if evaMult <= 0.5 then
+        resistVal = resistVal / 2
     end
 
     return resistVal
@@ -1064,7 +1048,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     --finalDamage = math.floor(finalDamage * sdt)
     finalDamage = math.floor(finalDamage * resist)
 
-    if target:hasStatusEffect(xi.effect.SKILLCHAIN) and (target:getStatusEffect(xi.effect.SKILLCHAIN):getTier() > 0) then -- Gated since this is recalculated for each target.
+    if target:hasStatusEffect(xi.effect.SKILLCHAIN) and (magicBurst > 1) then -- Gated since this is recalculated for each target.
         finalDamage = math.floor(finalDamage * magicBurst)
         finalDamage = math.floor(finalDamage * magicBurstBonus)
     end
@@ -1109,7 +1093,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
         end
 
         -- Add "Magic Burst!" message
-        if target:hasStatusEffect(xi.effect.SKILLCHAIN) and (target:getStatusEffect(xi.effect.SKILLCHAIN):getTier() > 0) then -- Gated as this is run per target.
+        if target:hasStatusEffect(xi.effect.SKILLCHAIN) and (magicBurst > 1) then -- Gated as this is run per target.
             spell:setMsg(spell:getMagicBurstMessage())
             caster:triggerRoeEvent(xi.roe.triggers.magicBurst)
         end

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -65,7 +65,7 @@ void CPetController::Tick(time_point tick)
 
 void CPetController::DoRoamTick(time_point tick)
 {
-    if ((PPet->PMaster == nullptr || PPet->PMaster->isDead()) && PPet->isAlive())
+    if ((PPet->PMaster == nullptr || PPet->PMaster->isDead()) && PPet->isAlive() && PPet->objtype != TYPE_MOB)
     {
         PPet->Die();
         return;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2191,7 +2191,7 @@ void CCharEntity::Die()
 
     if (this->PPet)
     {
-        if (PPet->StatusEffectContainer->HasStatusEffect(EFFECT_CHARM))
+        if (PPet->objtype == TYPE_MOB)
         {
             petutils::DetachPet(this);
         }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -901,7 +901,10 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                 PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_MOUNTED);
             }
 
-            PChar->PAI->Engage(TargID);
+            if (PChar->animation != ANIMATION_HEALING)
+            {
+                PChar->PAI->Engage(TargID);
+            }
         }
         break;
         case 0x03: // spellcast


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Finishes work on magic accuracy, once EEM is implemented on ASB magic accuracy is fully accurate after extensive testing.
+ Fixes an attack animation bug when engaging from a healing state where it would allow you to spawn psychic fists and pummel your enemies while never being able to engage properly.
+ Fixes MB messaging.
+ Fixes an issue where charmed mobs despawn when their PC master dies.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
