### PR TITLE
Fixes missed melee attacks not applying TH

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2158,12 +2158,6 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 {
                     charutils::TrySkillUP((CCharEntity*)PTarget, SKILL_EVASION, GetMLevel());
                 }
-
-                if (PTarget->objtype == TYPE_MOB && this->objtype == TYPE_PC)
-                {
-                    // 1 ce for a missed attack for TH application
-                    ((CMobEntity*)PTarget)->PEnmityContainer->UpdateEnmity(this, 1, 0);
-                }
             }
         }
         else
@@ -2180,6 +2174,12 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
             if (PTarget->objtype == TYPE_PC)
             {
                 charutils::TrySkillUP((CCharEntity*)PTarget, SKILL_EVASION, GetMLevel());
+            }
+
+            if (PTarget->objtype == TYPE_MOB && this->objtype == TYPE_PC)
+            {
+                // 1 ce for a missed attack for TH application
+                ((CMobEntity*)PTarget)->PEnmityContainer->UpdateEnmity(this, 1, 0);
             }
         }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Missed melee attacks now apply TH.

## Steps to test these changes

Go as level 15 thf to fafnir, with immortal on.
Call !getstats (after https://github.com/LandSandBoat/server/pull/3124 is merged) to check for TH level. should be 0.
Whiff fafnir once.
Call !getstats. TH level should be 1.

## Test proof

Melee Hit:
![thHit](https://user-images.githubusercontent.com/116968546/199645634-f5d35018-dbe1-4044-946b-e8341cb67fde.png)

Melee Miss:
![thMiss](https://user-images.githubusercontent.com/116968546/199645652-c141a8d7-16b1-4613-a253-762ef0bf465e.png)

RA Hit:
![thRaHit](https://user-images.githubusercontent.com/116968546/199645673-90ab42d8-5d38-467a-a1d6-942d82e59fa2.png)

RA Miss:
![thRaMiss](https://user-images.githubusercontent.com/116968546/199645692-b2e34827-6d41-4978-b639-6c928bef3254.png)

Closes #542
