### PR TITLE
Remove Utusemi:San from Mobs.

### DIFF
--- a/modules/era/sql/era_mob_spell_list.sql
+++ b/modules/era/sql/era_mob_spell_list.sql
@@ -83,5 +83,8 @@ DELETE FROM `mob_spell_lists` WHERE spell_id = 377 AND spell_list_name = "Beastm
 -- Army's Paeon VI
 DELETE FROM `mob_spell_lists` WHERE spell_id = 383 AND spell_list_name = "Beastmen_BRD";
 
+--Utsusemi: San
+DELETE FROM `mob_spell_lists` WHERE spell_id = 340 and spell_list_name = "Beastmen_NIN";
+
 UNLOCK TABLES;
 


### PR DESCRIPTION
updates era_mob_spell_list.sql to remove ninja mobs use of utsusemi:san.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Remove Utusemi:San from Mobs.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
