### PR TITLE
Fix Mod::MOVE Interaction With Low Speed Targets

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1041,7 +1041,7 @@ uint8 CBattleEntity::GetDeathType()
 
 void CBattleEntity::addModifier(Mod type, int16 amount)
 {
-    if (type == Mod::MOVE && this->objtype == TYPE_PC)
+    if (type == Mod::MOVE)
     {
         m_MSNonItemValues.push_back(amount);
         m_modStat[type] = CalculateMSFromSources();

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5251,7 +5251,7 @@ uint8 CLuaBaseEntity::getSpeed()
 
 void CLuaBaseEntity::setSpeed(uint8 speedVal)
 {
-    auto speed = std::min<uint8>(speedVal, 255);
+    auto speed = std::clamp<uint8>(speedVal, 0, 255);
 
     if (m_PBaseEntity->speed != speed)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Removes an accidental TYPE_PC debug check from a previous PR.
+ Adds a sanity clamp to setSpeed().

## Steps to test these changes
+ Able to test on princess jellies and gravity reduces them to speed 1 even with the Mod::MOVE being -21. This stops weight from being equivalent to bind on lower speed mobs and ensures there is not a speed underflow.
