### PR TITLE
Change Last Resort to 15% ATTP from 25% ATTP

### DIFF
--- a/scripts/globals/effects/last_resort.lua
+++ b/scripts/globals/effects/last_resort.lua
@@ -10,11 +10,11 @@ effectObject.onEffectGain = function(target, effect)
     local jpValue = target:getJobPointLevel(xi.jp.LAST_RESORT_EFFECT)
 
     target:addMod(xi.mod.ATT, 2 * jpValue)
-    target:addMod(xi.mod.ATTP, 25 + target:getMerit(xi.merit.LAST_RESORT_EFFECT))
+    target:addMod(xi.mod.ATTP, 15 + target:getMerit(xi.merit.LAST_RESORT_EFFECT))
     target:addMod(xi.mod.HASTE_ABILITY, target:getMod(xi.mod.DESPERATE_BLOWS) + target:getMerit(xi.merit.DESPERATE_BLOWS))
 
     -- Gear that affects this mod is handled by a Latent Effect because the gear must remain equipped
-    target:addMod(xi.mod.DEFP, -25 - target:getMerit(xi.merit.LAST_RESORT_EFFECT))
+    target:addMod(xi.mod.DEFP, -15 - target:getMerit(xi.merit.LAST_RESORT_EFFECT))
 end
 
 effectObject.onEffectTick = function(target, effect)
@@ -24,10 +24,10 @@ effectObject.onEffectLose = function(target, effect)
     local jpValue = target:getJobPointLevel(xi.jp.LAST_RESORT_EFFECT)
 
     target:delMod(xi.mod.ATT, 2 * jpValue)
-    target:delMod(xi.mod.ATTP, 25 + target:getMerit(xi.merit.LAST_RESORT_EFFECT))
+    target:delMod(xi.mod.ATTP, 15 + target:getMerit(xi.merit.LAST_RESORT_EFFECT))
     target:delMod(xi.mod.HASTE_ABILITY, target:getMod(xi.mod.DESPERATE_BLOWS) + target:getMerit(xi.merit.DESPERATE_BLOWS))
      -- Gear that affects this mod is handled by a Latent Effect because the gear must remain equipped
-    target:delMod(xi.mod.DEFP, -25 - target:getMerit(xi.merit.LAST_RESORT_EFFECT))
+    target:delMod(xi.mod.DEFP, -15 - target:getMerit(xi.merit.LAST_RESORT_EFFECT))
 end
 
 return effectObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Changes Last Resort's ATTP and DEFP mods to 15% instead of 25%.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/375

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
