### PR TITLE
Fix Application of Mods for Weapons to Account for Slot

### DIFF
--- a/modules/era/sql/item_mods.sql
+++ b/modules/era/sql/item_mods.sql
@@ -6,6 +6,28 @@
 -- 
 -- 
 -- --------------------------------------------------------
+LOCK TABLES `item_mods` WRITE,
+            `item_weapon` WRITE;
 
 REPLACE INTO `item_mods` (`itemid`, `modid`, `value`) VALUES
     (15070,163,-2500); -- Aegis DMGMAGIC: -2500
+
+UPDATE item_mods
+SET modId = 1168
+WHERE itemId IN (
+    SELECT itemId
+    FROM item_weapon
+    WHERE skill < 25
+    )
+AND modId = 165;
+
+UPDATE item_mods
+SET modId = 1169
+WHERE itemId IN (
+    SELECT itemId
+    FROM item_weapon
+    WHERE skill < 25
+    )
+AND modId = 23;
+
+UNLOCK TABLES;

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1806,6 +1806,8 @@ xi.mod =
     DARK_EEM                      = 1165, -- Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
     TAME_SUCCESS_RATE             = 1166, -- Tame Success Rate +
     RAMPART_MAGIC_SHIELD          = 1167, -- Rampart Magic Shield
+    CRITHITRATE_SLOT              = 1168, -- CRITHITRATE for slot
+    ATT_SLOT                      = 1169, -- ATT for slot
 
     -- IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN src/map/modifier.h ASWELL!
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -722,6 +722,11 @@ uint16 CBattleEntity::ATT(uint16 slot)
         {
             ATT += GetSkill(weapon->getSkillType()) + weapon->getILvlSkill();
 
+            if (weapon->getModifier(Mod::ATT_SLOT) > 0)
+            {
+                ATT += weapon->getModifier(Mod::ATT_SLOT);
+            }
+
             // Smite applies when using 2H or H2H weapons
             if (weapon->isTwoHanded() || weapon->isHandToHand())
             {
@@ -2077,7 +2082,8 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
             else
             {
                 // Set this attack's critical flag.
-                attack.SetCritical(xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(this, PTarget, !attack.IsFirstSwing()), SLOT_MAIN, attack.IsGuarded());
+                SLOTTYPE weaponSlot = (SLOTTYPE)attack.GetWeaponSlot();
+                attack.SetCritical(xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(this, PTarget, !attack.IsFirstSwing(), weaponSlot), weaponSlot, attack.IsGuarded());
 
                 actionTarget.reaction = REACTION::HIT;
 
@@ -2128,7 +2134,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 }
 
                 actionTarget.param =
-                    battleutils::TakePhysicalDamage(this, PTarget, attack.GetAttackType(), attack.GetDamage(), attack.IsBlocked(), attack.GetWeaponSlot(), 1,
+                    battleutils::TakePhysicalDamage(this, PTarget, attack.GetAttackType(), attack.GetDamage(), attack.IsBlocked(), weaponSlot, 1,
                                                     attackRound.GetTAEntity(), true, true, attack.IsCountered(), attack.IsCovered(), POriginalTarget);
                 if (actionTarget.param < 0)
                 {

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -946,6 +946,8 @@ enum class Mod
     DARK_EEM             = 1165, // Elemental Evasion Multiplier (Known as SDT in common magic accuracy formulas) (out of 100)
     TAME_SUCCESS_RATE    = 1166, // Tame Success Rate +
     RAMPART_MAGIC_SHIELD = 1167, // Rampart Magic Shield
+    CRITHITRATE_SLOT     = 1168, // CRITHITRATE for slot
+    ATT_SLOT             = 1169, // ATT for slot
 
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/globals/status.lua ASWELL!
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2684,7 +2684,7 @@ namespace battleutils
      *                                                                       *
      ************************************************************************/
 
-    uint8 GetCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool ignoreSneakTrickAttack)
+    uint8 GetCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool ignoreSneakTrickAttack, SLOTTYPE weaponSlot)
     {
         int32 critHitRate = 5;
         if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_MIGHTY_STRIKES, 0) ||
@@ -2745,6 +2745,16 @@ namespace battleutils
             critHitRate += GetDexCritBonus(PAttacker, PDefender);
             critHitRate += PAttacker->getMod(Mod::CRITHITRATE);
             critHitRate += PDefender->getMod(Mod::ENEMYCRITRATE);
+
+            if (PAttacker->objtype & TYPE_PC)
+            {
+                auto* weapon = dynamic_cast<CItemWeapon*>(static_cast<CCharEntity*>(PAttacker)->getEquip(weaponSlot));
+                if (weapon && weapon->getModifier(Mod::CRITHITRATE_SLOT) > 0)
+                {
+                    critHitRate += weapon->getModifier(Mod::CRITHITRATE_SLOT);
+                }
+            }
+
             critHitRate = std::clamp(critHitRate, 0, 100);
         }
         return (uint8)critHitRate;

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -144,7 +144,7 @@ namespace battleutils
     uint8 GetHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8 GetHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber);
     uint8 GetHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber, int8 offsetAccuracy);
-    uint8 GetCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool ignoreSneakTrickAttack);
+    uint8 GetCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool ignoreSneakTrickAttack, SLOTTYPE weaponSlot = SLOT_MAIN);
     uint8 GetRangedCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     int8  GetDexCritBonus(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     int8  GetAGICritBonus(CBattleEntity* PAttacker, CBattleEntity* PDefender);


### PR DESCRIPTION
Co-authored-by: Damarus (leblanc.jlj@gmail.com)

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Makes mods for CRITHITRATE and ATT to be weapon specific.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/356

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
