### PR TITLE
Fix Nuke Wall | Apply MB Bonuses to Enfeebs

### DIFF
--- a/scripts/globals/effects/dark_eem_mod.lua
+++ b/scripts/globals/effects/dark_eem_mod.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- xi.effect.DARK_EEM_MOD
+-----------------------------------
+local effectObject = {}
+
+effectObject.onEffectGain = function(target, effect)
+end
+
+effectObject.onEffectTick = function(target, effect)
+end
+
+effectObject.onEffectLose = function(target, effect)
+end
+
+return effectObject

--- a/scripts/globals/effects/earth_eem_mod.lua
+++ b/scripts/globals/effects/earth_eem_mod.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- xi.effect.EARTH_EEM_MOD
+-----------------------------------
+local effectObject = {}
+
+effectObject.onEffectGain = function(target, effect)
+end
+
+effectObject.onEffectTick = function(target, effect)
+end
+
+effectObject.onEffectLose = function(target, effect)
+end
+
+return effectObject

--- a/scripts/globals/effects/fire_eem_mod.lua
+++ b/scripts/globals/effects/fire_eem_mod.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- xi.effect.FIRE_EEM_MOD
+-----------------------------------
+local effectObject = {}
+
+effectObject.onEffectGain = function(target, effect)
+end
+
+effectObject.onEffectTick = function(target, effect)
+end
+
+effectObject.onEffectLose = function(target, effect)
+end
+
+return effectObject

--- a/scripts/globals/effects/ice_eem_mod.lua
+++ b/scripts/globals/effects/ice_eem_mod.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- xi.effect.ICE_EEM_MOD
+-----------------------------------
+local effectObject = {}
+
+effectObject.onEffectGain = function(target, effect)
+end
+
+effectObject.onEffectTick = function(target, effect)
+end
+
+effectObject.onEffectLose = function(target, effect)
+end
+
+return effectObject

--- a/scripts/globals/effects/light_eem_mod.lua
+++ b/scripts/globals/effects/light_eem_mod.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- xi.effect.LIGHT_EEM_MOD
+-----------------------------------
+local effectObject = {}
+
+effectObject.onEffectGain = function(target, effect)
+end
+
+effectObject.onEffectTick = function(target, effect)
+end
+
+effectObject.onEffectLose = function(target, effect)
+end
+
+return effectObject

--- a/scripts/globals/effects/thunder_eem_mod.lua
+++ b/scripts/globals/effects/thunder_eem_mod.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- xi.effect.THUNDER_EEM_MOD
+-----------------------------------
+local effectObject = {}
+
+effectObject.onEffectGain = function(target, effect)
+end
+
+effectObject.onEffectTick = function(target, effect)
+end
+
+effectObject.onEffectLose = function(target, effect)
+end
+
+return effectObject

--- a/scripts/globals/effects/water_eem_mod.lua
+++ b/scripts/globals/effects/water_eem_mod.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- xi.effect.WATER_EEM_MOD
+-----------------------------------
+local effectObject = {}
+
+effectObject.onEffectGain = function(target, effect)
+end
+
+effectObject.onEffectTick = function(target, effect)
+end
+
+effectObject.onEffectLose = function(target, effect)
+end
+
+return effectObject

--- a/scripts/globals/effects/wind_eem_mod.lua
+++ b/scripts/globals/effects/wind_eem_mod.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- xi.effect.WIND_EEM_MOD
+-----------------------------------
+local effectObject = {}
+
+effectObject.onEffectGain = function(target, effect)
+end
+
+effectObject.onEffectTick = function(target, effect)
+end
+
+effectObject.onEffectLose = function(target, effect)
+end
+
+return effectObject

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -12,25 +12,46 @@ xi.magic = xi.magic or {}
 -- Tables by element
 -----------------------------------
 
-xi.magic.dayStrong           = { xi.day.FIRESDAY,              xi.day.ICEDAY,               xi.day.WINDSDAY,               xi.day.EARTHSDAY,              xi.day.LIGHTNINGDAY,               xi.day.WATERSDAY,               xi.day.LIGHTSDAY,           xi.day.DARKSDAY           }
-xi.magic.singleWeatherStrong = { xi.weather.HOT_SPELL,         xi.weather.SNOW,             xi.weather.WIND,               xi.weather.DUST_STORM,         xi.weather.THUNDER,                xi.weather.RAIN,                xi.weather.AURORAS,         xi.weather.GLOOM          }
-xi.magic.doubleWeatherStrong = { xi.weather.HEAT_WAVE,         xi.weather.BLIZZARDS,        xi.weather.GALES,              xi.weather.SAND_STORM,         xi.weather.THUNDERSTORMS,          xi.weather.SQUALL,              xi.weather.STELLAR_GLARE,   xi.weather.DARKNESS       }
-local elementalObi           = { xi.mod.FORCE_FIRE_DWBONUS,    xi.mod.FORCE_ICE_DWBONUS,    xi.mod.FORCE_WIND_DWBONUS,     xi.mod.FORCE_EARTH_DWBONUS,    xi.mod.FORCE_LIGHTNING_DWBONUS,    xi.mod.FORCE_WATER_DWBONUS,     xi.mod.FORCE_LIGHT_DWBONUS, xi.mod.FORCE_DARK_DWBONUS }
-local spellAcc               = { xi.mod.FIREACC,               xi.mod.ICEACC,               xi.mod.WINDACC,                xi.mod.EARTHACC,               xi.mod.THUNDERACC,                 xi.mod.WATERACC,                xi.mod.LIGHTACC,            xi.mod.DARKACC            }
-local strongAffinityDmg      = { xi.mod.FIRE_AFFINITY_DMG,     xi.mod.ICE_AFFINITY_DMG,     xi.mod.WIND_AFFINITY_DMG,      xi.mod.EARTH_AFFINITY_DMG,     xi.mod.THUNDER_AFFINITY_DMG,       xi.mod.WATER_AFFINITY_DMG,      xi.mod.LIGHT_AFFINITY_DMG,  xi.mod.DARK_AFFINITY_DMG  }
-local strongAffinityAcc      = { xi.mod.FIRE_AFFINITY_ACC,     xi.mod.ICE_AFFINITY_ACC,     xi.mod.WIND_AFFINITY_ACC,      xi.mod.EARTH_AFFINITY_ACC,     xi.mod.THUNDER_AFFINITY_ACC,       xi.mod.WATER_AFFINITY_ACC,      xi.mod.LIGHT_AFFINITY_ACC,  xi.mod.DARK_AFFINITY_ACC  }
-xi.magic.resistMod           = { xi.mod.FIRE_MEVA,             xi.mod.ICE_MEVA,             xi.mod.WIND_MEVA,              xi.mod.EARTH_MEVA,             xi.mod.THUNDER_MEVA,               xi.mod.WATER_MEVA,              xi.mod.LIGHT_MEVA,          xi.mod.DARK_MEVA          }
-xi.magic.specificDmgTakenMod = { xi.mod.FIRE_SDT,              xi.mod.ICE_SDT,              xi.mod.WIND_SDT,               xi.mod.EARTH_SDT,              xi.mod.THUNDER_SDT,                xi.mod.WATER_SDT,               xi.mod.LIGHT_SDT,           xi.mod.DARK_SDT           }
-xi.magic.eleEvaMult          = { xi.mod.FIRE_EEM,              xi.mod.ICE_EEM,              xi.mod.WIND_EEM,               xi.mod.EARTH_EEM,              xi.mod.THUNDER_EEM,                xi.mod.WATER_EEM,               xi.mod.LIGHT_EEM,           xi.mod.DARK_EEM           }
-xi.magic.absorbMod           = { xi.mod.FIRE_ABSORB,           xi.mod.ICE_ABSORB,           xi.mod.WIND_ABSORB,            xi.mod.EARTH_ABSORB,           xi.mod.LTNG_ABSORB,                xi.mod.WATER_ABSORB,            xi.mod.LIGHT_ABSORB,        xi.mod.DARK_ABSORB        }
-local nullMod                = { xi.mod.FIRE_NULL,             xi.mod.ICE_NULL,             xi.mod.WIND_NULL,              xi.mod.EARTH_NULL,             xi.mod.LTNG_NULL,                  xi.mod.WATER_NULL,              xi.mod.LIGHT_NULL,          xi.mod.DARK_NULL          }
-local blmMerit               = { xi.merit.FIRE_MAGIC_POTENCY,  xi.merit.ICE_MAGIC_POTENCY,  xi.merit.WIND_MAGIC_POTENCY,   xi.merit.EARTH_MAGIC_POTENCY,  xi.merit.LIGHTNING_MAGIC_POTENCY,  xi.merit.WATER_MAGIC_POTENCY                                                          }
-local rdmMerit               = { xi.merit.FIRE_MAGIC_ACCURACY, xi.merit.ICE_MAGIC_ACCURACY, xi.merit.WIND_MAGIC_ACCURACY,  xi.merit.EARTH_MAGIC_ACCURACY, xi.merit.LIGHTNING_MAGIC_ACCURACY, xi.merit.WATER_MAGIC_ACCURACY                                                         }
-xi.magic.barSpell            = { xi.effect.BARFIRE,            xi.effect.BARBLIZZARD,       xi.effect.BARAERO,             xi.effect.BARSTONE,            xi.effect.BARTHUNDER,              xi.effect.BARWATER                                                                    }
+xi.magic.dayStrong             = { xi.day.FIRESDAY,              xi.day.ICEDAY,               xi.day.WINDSDAY,               xi.day.EARTHSDAY,              xi.day.LIGHTNINGDAY,               xi.day.WATERSDAY,               xi.day.LIGHTSDAY,           xi.day.DARKSDAY           }
+xi.magic.singleWeatherStrong   = { xi.weather.HOT_SPELL,         xi.weather.SNOW,             xi.weather.WIND,               xi.weather.DUST_STORM,         xi.weather.THUNDER,                xi.weather.RAIN,                xi.weather.AURORAS,         xi.weather.GLOOM          }
+xi.magic.doubleWeatherStrong   = { xi.weather.HEAT_WAVE,         xi.weather.BLIZZARDS,        xi.weather.GALES,              xi.weather.SAND_STORM,         xi.weather.THUNDERSTORMS,          xi.weather.SQUALL,              xi.weather.STELLAR_GLARE,   xi.weather.DARKNESS       }
+local elementalObi             = { xi.mod.FORCE_FIRE_DWBONUS,    xi.mod.FORCE_ICE_DWBONUS,    xi.mod.FORCE_WIND_DWBONUS,     xi.mod.FORCE_EARTH_DWBONUS,    xi.mod.FORCE_LIGHTNING_DWBONUS,    xi.mod.FORCE_WATER_DWBONUS,     xi.mod.FORCE_LIGHT_DWBONUS, xi.mod.FORCE_DARK_DWBONUS }
+local spellAcc                 = { xi.mod.FIREACC,               xi.mod.ICEACC,               xi.mod.WINDACC,                xi.mod.EARTHACC,               xi.mod.THUNDERACC,                 xi.mod.WATERACC,                xi.mod.LIGHTACC,            xi.mod.DARKACC            }
+local strongAffinityDmg        = { xi.mod.FIRE_AFFINITY_DMG,     xi.mod.ICE_AFFINITY_DMG,     xi.mod.WIND_AFFINITY_DMG,      xi.mod.EARTH_AFFINITY_DMG,     xi.mod.THUNDER_AFFINITY_DMG,       xi.mod.WATER_AFFINITY_DMG,      xi.mod.LIGHT_AFFINITY_DMG,  xi.mod.DARK_AFFINITY_DMG  }
+local strongAffinityAcc        = { xi.mod.FIRE_AFFINITY_ACC,     xi.mod.ICE_AFFINITY_ACC,     xi.mod.WIND_AFFINITY_ACC,      xi.mod.EARTH_AFFINITY_ACC,     xi.mod.THUNDER_AFFINITY_ACC,       xi.mod.WATER_AFFINITY_ACC,      xi.mod.LIGHT_AFFINITY_ACC,  xi.mod.DARK_AFFINITY_ACC  }
+xi.magic.resistMod             = { xi.mod.FIRE_MEVA,             xi.mod.ICE_MEVA,             xi.mod.WIND_MEVA,              xi.mod.EARTH_MEVA,             xi.mod.THUNDER_MEVA,               xi.mod.WATER_MEVA,              xi.mod.LIGHT_MEVA,          xi.mod.DARK_MEVA          }
+xi.magic.specificDmgTakenMod   = { xi.mod.FIRE_SDT,              xi.mod.ICE_SDT,              xi.mod.WIND_SDT,               xi.mod.EARTH_SDT,              xi.mod.THUNDER_SDT,                xi.mod.WATER_SDT,               xi.mod.LIGHT_SDT,           xi.mod.DARK_SDT           }
+xi.magic.eleEvaMult            = { xi.mod.FIRE_EEM,              xi.mod.ICE_EEM,              xi.mod.WIND_EEM,               xi.mod.EARTH_EEM,              xi.mod.THUNDER_EEM,                xi.mod.WATER_EEM,               xi.mod.LIGHT_EEM,           xi.mod.DARK_EEM           }
+xi.magic.absorbMod             = { xi.mod.FIRE_ABSORB,           xi.mod.ICE_ABSORB,           xi.mod.WIND_ABSORB,            xi.mod.EARTH_ABSORB,           xi.mod.LTNG_ABSORB,                xi.mod.WATER_ABSORB,            xi.mod.LIGHT_ABSORB,        xi.mod.DARK_ABSORB        }
+local nullMod                  = { xi.mod.FIRE_NULL,             xi.mod.ICE_NULL,             xi.mod.WIND_NULL,              xi.mod.EARTH_NULL,             xi.mod.LTNG_NULL,                  xi.mod.WATER_NULL,              xi.mod.LIGHT_NULL,          xi.mod.DARK_NULL          }
+local blmMerit                 = { xi.merit.FIRE_MAGIC_POTENCY,  xi.merit.ICE_MAGIC_POTENCY,  xi.merit.WIND_MAGIC_POTENCY,   xi.merit.EARTH_MAGIC_POTENCY,  xi.merit.LIGHTNING_MAGIC_POTENCY,  xi.merit.WATER_MAGIC_POTENCY                                                          }
+local rdmMerit                 = { xi.merit.FIRE_MAGIC_ACCURACY, xi.merit.ICE_MAGIC_ACCURACY, xi.merit.WIND_MAGIC_ACCURACY,  xi.merit.EARTH_MAGIC_ACCURACY, xi.merit.LIGHTNING_MAGIC_ACCURACY, xi.merit.WATER_MAGIC_ACCURACY                                                         }
+xi.magic.barSpell              = { xi.effect.BARFIRE,            xi.effect.BARBLIZZARD,       xi.effect.BARAERO,             xi.effect.BARSTONE,            xi.effect.BARTHUNDER,              xi.effect.BARWATER                                                                    }
 
-xi.magic.dayWeak             = { xi.day.WATERSDAY,             xi.day.FIRESDAY,             xi.day.ICEDAY,                 xi.day.WINDSDAY,               xi.day.EARTHSDAY,                  xi.day.LIGHTNINGDAY,            xi.day.DARKSDAY,            xi.day.LIGHTSDAY          }
-xi.magic.singleWeatherWeak   = { xi.weather.RAIN,              xi.weather.HOT_SPELL,        xi.weather.SNOW,               xi.weather.WIND,               xi.weather.DUST_STORM,             xi.weather.THUNDER,             xi.weather.GLOOM,           xi.weather.AURORAS        }
-xi.magic.doubleWeatherWeak   = { xi.weather.SQUALL,            xi.weather.HEAT_WAVE,        xi.weather.BLIZZARDS,          xi.weather.GALES,              xi.weather.SAND_STORM,             xi.weather.THUNDERSTORMS,       xi.weather.DARKNESS,        xi.weather.STELLAR_GLARE  }
+xi.magic.dayWeak               = { xi.day.WATERSDAY,             xi.day.FIRESDAY,             xi.day.ICEDAY,                 xi.day.WINDSDAY,               xi.day.EARTHSDAY,                  xi.day.LIGHTNINGDAY,            xi.day.DARKSDAY,            xi.day.LIGHTSDAY          }
+xi.magic.singleWeatherWeak     = { xi.weather.RAIN,              xi.weather.HOT_SPELL,        xi.weather.SNOW,               xi.weather.WIND,               xi.weather.DUST_STORM,             xi.weather.THUNDER,             xi.weather.GLOOM,           xi.weather.AURORAS        }
+xi.magic.doubleWeatherWeak     = { xi.weather.SQUALL,            xi.weather.HEAT_WAVE,        xi.weather.BLIZZARDS,          xi.weather.GALES,              xi.weather.SAND_STORM,             xi.weather.THUNDERSTORMS,       xi.weather.DARKNESS,        xi.weather.STELLAR_GLARE  }
+xi.magic.eemStatus             = { xi.effect.FIRE_EEM_MOD,       xi.effect.ICE_EEM_MOD,       xi.effect.WIND_EEM_MOD,        xi.effect.EARTH_EEM_MOD,       xi.effect.THUNDER_EEM_MOD,         xi.effect.WATER_EEM_MOD,        xi.effect.LIGHT_EEM_MOD,    xi.effect.DARK_EEM_MOD    }
+xi.magic.eem                   = { 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.40, 0.50, 0.60, 0.70, 0.85, 1.00, 1.15, 1.30, 1.50 }
+
+xi.magic.eemTiers =
+{
+    { eem = 1.50, tier = 15 },
+    { eem = 1.30, tier = 14 },
+    { eem = 1.15, tier = 13 },
+    { eem = 1.00, tier = 12 },
+    { eem = 0.85, tier = 11 },
+    { eem = 0.70, tier = 10 },
+    { eem = 0.60, tier = 9 },
+    { eem = 0.50, tier = 8 },
+    { eem = 0.40, tier = 7 },
+    { eem = 0.30, tier = 6 },
+    { eem = 0.25, tier = 5 },
+    { eem = 0.20, tier = 4 },
+    { eem = 0.15, tier = 3 },
+    { eem = 0.10, tier = 2 },
+    { eem = 0.05, tier = 1 },
+}
 
 -- USED FOR DAMAGING MAGICAL SPELLS (Stages 1 and 2 in Calculating Magic Damage on wiki)
 --Calculates magic damage using the standard magic damage calc.
@@ -98,13 +119,6 @@ local function getSpellBonusAcc(caster, target, spell, params)
     -- Similar to Elemental Seal but only for Dark Magic
     if caster:hasStatusEffect(xi.effect.DARK_SEAL) and skill == xi.skill.DARK_MAGIC then
         magicAccBonus = magicAccBonus + 256
-    end
-
-    local skillchainTier, _ = FormMagicBurst(element, target)
-
-    -- Add acc for skillchains
-    if skillchainTier > 0 then
-        magicAccBonus = magicAccBonus + 30
     end
 
     -- Add acc for klimaform
@@ -244,7 +258,7 @@ local function calculateMagicBurst(caster, spell, target, params)
 
     -- Obtain second multiplier from skillchain
     -- Starts at 35% damage bonus, increases by 10% for every additional weaponskill in the chain
-    local skillchainTier, skillchainCount = FormMagicBurst(spell:getElement(), target)
+    local skillchainTier, skillchainCount = xi.magic.FormMagicBurst(spell:getElement(), target)
 
     if skillchainTier > 0 then
         if skillchainCount == 1 then -- two weaponskills
@@ -550,6 +564,8 @@ xi.magic.applyResistanceEffect = function(caster, target, spell, params)
         element = xi.magic.ele.NONE
     end
 
+    local _, skillchainCount = xi.magic.FormMagicBurst(element, target)
+
     if spell ~= nil and skill >= 32 and skill <= 45 then
         magicaccbonus = getSpellBonusAcc(caster, target, spell, params)
     end
@@ -562,9 +578,9 @@ xi.magic.applyResistanceEffect = function(caster, target, spell, params)
         effectRes = effectRes + xi.magic.getEffectResistance(target, effect, false, caster)
     end
 
-    local p = xi.magic.getMagicHitRate(caster, target, skill, element, effectRes, magicaccbonus, diff)
+    local p = xi.magic.getMagicHitRate(caster, target, skill, element, effectRes, magicaccbonus, skillchainCount)
 
-    return xi.magic.getMagicResist(p, target, element, effectRes)
+    return xi.magic.getMagicResist(p, target, element, effectRes, skillchainCount)
 end
 
 -- Applies resistance for additional effects
@@ -579,8 +595,14 @@ xi.magic.applyResistanceAddEffect = function(player, target, element, effect, bo
         effectRes = xi.magic.getEffectResistance(target, effect, false, player)
     end
 
-    local p = xi.magic.getMagicHitRate(player, target, nil, element, effectRes, bonus)
-    local resist = xi.magic.getMagicResist(p, target, element)
+    if not element then
+        element = xi.magic.ele.NONE
+    end
+
+    local _, skillchainCount = xi.magic.FormMagicBurst(element, target)
+
+    local p = xi.magic.getMagicHitRate(player, target, nil, element, effectRes, bonus, skillchainCount)
+    local resist = xi.magic.getMagicResist(p, target, element, skillchainCount)
 
     if resist < 0.5 then
         resist = 0
@@ -600,6 +622,8 @@ xi.magic.applyAbilityResistance = function(player, target, params)
         params.element = xi.magic.ele.NONE
     end
 
+    local _, skillchainCount = xi.magic.FormMagicBurst(params.element, target)
+
     if not params.skillType then
         params.skillType = nil
     end
@@ -618,8 +642,8 @@ xi.magic.applyAbilityResistance = function(player, target, params)
         effectRes = xi.magic.getEffectResistance(target, params.effect, false, player)
     end
 
-    local p = xi.magic.getMagicHitRate(player, target, params.skillType, params.element, effectRes, params.maccBonus)
-    local resist = xi.magic.getMagicResist(p, target, params.element, effectRes)
+    local p = xi.magic.getMagicHitRate(player, target, params.skillType, params.element, effectRes, params.maccBonus, skillchainCount)
+    local resist = xi.magic.getMagicResist(p, target, params.element, effectRes, skillchainCount)
 
     if resist < 0.5 then
         resist = 0
@@ -648,12 +672,16 @@ end
 -- TODO: Reduce complexity
 -- Disable cyclomatic complexity check for this function:
 -- luacheck: ignore 561
-xi.magic.getMagicHitRate = function(caster, target, skillType, element, effectRes, bonusAcc, dStat)
+xi.magic.getMagicHitRate = function(caster, target, skillType, element, effectRes, bonusAcc, dStat, skillchainCount)
     local magicacc = 0
     local magiceva = 0
     local resMod = 0
     local dLvl = target:getMainLvl() - caster:getMainLvl()
     local dStatAcc = 0
+
+    if not skillchainCount then
+        skillchainCount = 0
+    end
 
     -- resist everything if real magic shield is active (see effects/magic_shield)
     if target:hasStatusEffect(xi.effect.MAGIC_SHIELD) then
@@ -763,6 +791,10 @@ xi.magic.getMagicHitRate = function(caster, target, skillType, element, effectRe
 
     bonusAcc = bonusAcc + caster:getMerit(xi.merit.MAGIC_ACCURACY) + caster:getMerit(xi.merit.NIN_MAGIC_ACCURACY)
 
+    if skillchainCount > 0 then
+        magicacc = magicacc + 25
+    end
+
     magicacc = magicacc + bonusAcc
 
     -- Add macc% from food
@@ -773,20 +805,34 @@ xi.magic.getMagicHitRate = function(caster, target, skillType, element, effectRe
 end
 
 -- Returns resistance value from given magic hit rate (p)
-xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes)
-    local evaMult = 1
+xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes, skillchainCount)
+    local eemVal = 1
     local resMod = 0
 
-    if target ~= nil and element ~= nil and target:getObjType() == xi.objType.MOB then
-        evaMult = target:getMod(xi.magic.eleEvaMult[element]) / 100
-        local sortEvaMult = { 1.50, 1.30, 1.15, 1.00, 0.85, 0.70, 0.60, 0.50, 0.40, 0.30, 0.25, 0.20, 0.15, 0.10, 0.05 }
+    if not skillchainCount then
+        skillchainCount = 0
+    end
 
-        for _, tier in pairs(sortEvaMult) do -- Finds the highest tier for the resist.
-            if evaMult >= tier then
-                evaMult = tier
+    if target ~= nil and element ~= nil and target:getObjType() == xi.objType.MOB then
+        local eemTier = 1
+        eemVal = target:getMod(xi.magic.eleEvaMult[element]) / 100
+
+        for _, eemTable in pairs(xi.magic.eemTiers) do -- Finds the highest tier for the resist.
+            if eemVal >= eemTable.eem then
+                eemTier = utils.clamp(eemTable.tier, 1, 15)
                 break
             end
         end
+
+        if skillchainCount > 0 then
+            eemTier = eemTier + 1
+        end
+
+        if target:hasStatusEffect(xi.magic.eemStatus[element]) then
+            eemTier = utils.clamp(eemTier - target:getStatusEffect(xi.magic.eemStatus[element]):getPower(), 1, 15)
+        end
+
+        eemVal = xi.magic.eem[eemTier]
     end
 
     local eighthTrigger = false
@@ -816,7 +862,7 @@ xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes)
         baseRes = baseRes - (effectRes / 100)
     end
 
-    local p = utils.clamp(((magicHitRate * evaMult) / 100), 0.05, 0.95)
+    local p = utils.clamp(((magicHitRate * eemVal) / 100), 0.05, 0.95)
 
     p = utils.clamp(p * baseRes, -1, 0.95)
 
@@ -839,7 +885,7 @@ xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes)
         resist = 1.0
     end
 
-    if evaMult <= 0.5 then
+    if eemVal <= 0.5 then
         resist = resist / 2
     end
 

--- a/scripts/globals/magicburst.lua
+++ b/scripts/globals/magicburst.lua
@@ -1,5 +1,4 @@
 require("scripts/globals/status")
-
 SC_NONE          =  0 -- Lv0 None
 SC_TRANSFIXION   =  1 -- Lv1 Light
 SC_COMPRESSION   =  2 -- Lv1 Dark
@@ -18,7 +17,10 @@ SC_DARKNESS      = 14 -- Lv3 Dark, Earth, Water, Ice
 SC_LIGHT_II      = 15 -- Lv4 Light
 SC_DARKNESS_II   = 16 -- Lv4 Darkness
 
-local matches = -- [element id][resonance id]
+xi = xi or {}
+xi.magic = xi.magic or {}
+
+xi.magic.skillchainMatches = -- [element id][resonance id]
 {
 --    1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17
 --    N  T  C  L  S  R  D  I  I  G  D  F  F  L  D  L  D
@@ -39,21 +41,21 @@ local matches = -- [element id][resonance id]
 }
 
 -- Returns a boolean if the spell's element matches the resonace given
-local function doesSpellElementMatchResonance(ele, resonance)
-    local isMatch = matches[ele + 1][resonance:getPower() + 1]
+xi.magic.doesSpellElementMatchResonance = function(ele, resonance)
+    local isMatch = xi.magic.skillchainMatches[ele + 1][resonance:getPower() + 1]
     return (isMatch and isMatch > 0)
 end
 
-local function doesMobSpellElementMatchResonance(element, resonance)
-    local isMatch = matches[element + 1][resonance:getPower() + 1]
+xi.magic.doesMobSpellElementMatchResonance = function(element, resonance)
+    local isMatch = xi.magic.skillchainMatches[element + 1][resonance:getPower() + 1]
     return (isMatch and isMatch > 0)
 end
 
 -- Returns the burst level for a spell / target combination
-function FormMagicBurst(ele, target)
+xi.magic.FormMagicBurst = function(ele, target)
     local resonance = target:getStatusEffect(xi.effect.SKILLCHAIN)
     if resonance and resonance:getTier() > 0 then -- Resonance exists, ignore it if its tier 0
-        if doesSpellElementMatchResonance(ele, resonance) then
+        if xi.magic.doesSpellElementMatchResonance(ele, resonance) then
             return resonance:getTier(), resonance:getSubPower()
         end
     end -- if resonance
@@ -61,11 +63,11 @@ function FormMagicBurst(ele, target)
     return 0, 0
 end
 
-function MobFormMagicBurst(element, target)
+xi.magic.MobFormMagicBurst = function(element, target)
     local resonance = target:getStatusEffect(xi.effect.SKILLCHAIN)
 
     if resonance ~= nil and resonance:getTier() > 0 then -- Resonance exists, ignore it if its tier 0
-        if doesMobSpellElementMatchResonance(element, resonance) then
+        if xi.magic.doesMobSpellElementMatchResonance(element, resonance) then
             return resonance:getTier(), resonance:getSubPower()
         end
     end -- if resonance
@@ -74,7 +76,7 @@ function MobFormMagicBurst(element, target)
 end
 
 -- Returns a boolean if the element matches the skillchain property given
-function doesElementMatchWeaponskill(ele, SCProp)
-    local isMatch = matches[ele + 1][SCProp + 1]
+xi.magic.doesElementMatchWeaponskill = function(ele, SCProp)
+    local isMatch = xi.magic.skillchainMatches[ele + 1][SCProp + 1]
     return (isMatch and isMatch > 0)
 end

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -99,7 +99,7 @@ end
 
 local function calculateMobMagicBurst(caster, ele, target)
     local burst = 1.0
-    local skillchainTier, skillchainCount = MobFormMagicBurst(ele, target)
+    local skillchainTier, skillchainCount = xi.magic.MobFormMagicBurst(ele, target)
 
     if skillchainTier > 0 then
         if skillchainCount == 1 then

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -198,44 +198,6 @@ local pTable =
     [xi.magic.spell.HOLY_II     ] = { xi.mod.MND,  250,    2,  250, 300 },
 }
 
-local function tryBuildResistance(target, resistance, isEnfeeb)
-    local isNM = target:isNM()
-    local baseRes = target:getLocalVar(string.format("[RES]Base_%s", resistance))
-    local castCool = target:getLocalVar(string.format("[RES]CastCool_%s", resistance))
-    local builtPercent = target:getLocalVar(string.format("[RES]BuiltPercent_%s", resistance))
-    local coolTime = 20
-    local buildPercent = 0
-
-    if baseRes == 0 then
-        target:setLocalVar(string.format("[RES]Base_%s", resistance), target:getMod(resistance))
-    end
-
-    if isNM == true then
-        buildPercent = 40 -- Equivalent to 4% Resistance Build (40/1000)
-    else
-        buildPercent = 20 -- Equivalent to 2% Resistance Build (20/1000)
-    end
-
-    if not isEnfeeb then
-        buildPercent = buildPercent / 2 -- Reduce Resistence Build to 2%/1% To Help With Timed Casts
-    end
-
-    if castCool <= os.time() then -- Reset Mod If 20s Since Last Spell Elapsed
-        target:setLocalVar(string.format("[RES]BuiltPercent_%s", resistance), 0) -- Reset BuiltPercent Var
-        target:setMod(resistance, baseRes) -- Reset Mod To Base
-        target:setLocalVar(string.format("[RES]CastCool_%s", resistance), os.time() + coolTime) -- Start Cool Var
-    else
-        if builtPercent + buildPercent + baseRes > 1000 then
-            buildPercent = 1000 - (builtPercent + baseRes)
-        end
-
-        target:setMod(resistance, baseRes + builtPercent + buildPercent)
-        target:setLocalVar(string.format("[RES]BuiltPercent_%s", resistance), builtPercent + buildPercent)
-        target:setLocalVar(string.format("[RES]CastCool_%s", resistance), os.time() + coolTime)
-    end
-
-end
-
 -----------------------------------
 -- Basic Functions
 -----------------------------------
@@ -434,7 +396,7 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     local resMod        = 0 -- Some spells may possibly be non elemental.
 
     -- Magic Bursts of the correct element do not get resisted. SDT isn't involved here.
-    local _, skillchainCount = FormMagicBurst(spellElement, target)
+    local _, skillchainCount = xi.magic.FormMagicBurst(spellElement, target)
 
     -- Function flow:
     -- Step 0: We check for exceptions that would make the next steps obsolete.
@@ -467,7 +429,15 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
 
     if spellElement ~= xi.magic.ele.NONE then
         if target:isMob() and target:isNM() then
-            tryBuildResistance(target, xi.magic.resistMod[spellElement], false)
+            local currentPower = 0
+            local effect = xi.magic.eemStatus[spellElement]
+
+            if target:hasStatusEffect(effect) then
+                currentPower = target:getStatusEffect(effect):getPower()
+                target:delStatusEffectSilent(effect)
+            end
+
+            target:addStatusEffectEx(effect, xi.effect.NONE, currentPower + 1, 0, 10, 0, 0, 0, xi.effectFlag.NO_LOSS_MESSAGE, true)
         end
         -- Mod set in database. Base 0 means not resistant nor weak.
         resMod = target:getMod(xi.magic.resistMod[spellElement])
@@ -645,17 +615,27 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     -----------------------------------
     -- STEP 4: Get Resist Tier
     -----------------------------------
-    local evaMult = 1
+    local eemVal = 1
 
-    if target:getObjType() == xi.objType.MOB then
-        evaMult = target:getMod(xi.magic.eleEvaMult[element]) / 100
-        local sortEvaMult = { 1.50, 1.30, 1.15, 1.00, 0.85, 0.70, 0.60, 0.50, 0.40, 0.30, 0.25, 0.20, 0.15, 0.10, }
-        for _, tier in pairs(sortEvaMult) do -- Finds the highest tier for the resist. We sort just to be safe.
-            if evaMult >= tier then
-                evaMult = tier
+    if target ~= nil and element ~= nil and target:getObjType() == xi.objType.MOB then
+        local eemTier = 1
+        eemVal = target:getMod(xi.magic.eleEvaMult[element]) / 100
+        for _, eemTable in pairs(xi.magic.eemTiers) do -- Finds the highest tier for the resist.
+            if eemVal >= eemTable.eem then
+                eemTier = utils.clamp(eemTable.tier, 1, 15)
                 break
             end
         end
+
+        if skillchainCount > 0 then
+            eemTier = eemTier + 1
+        end
+
+        if target:hasStatusEffect(xi.magic.eemStatus[element]) then
+            eemTier = utils.clamp(eemTier - target:getStatusEffect(xi.magic.eemStatus[element]):getPower(), 1, 15)
+        end
+
+        eemVal = xi.magic.eem[eemTier]
     end
 
     local eighthTrigger = false
@@ -679,7 +659,7 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
         quarterTrigger = true
     end
 
-    local p = utils.clamp(((magicHitRate * evaMult) / 100), 0.05, 0.95) -- clamp at minimum 0.05, clamp at max of 3.0 to be safe
+    local p = utils.clamp(((magicHitRate * eemVal) / 100), 0.05, 0.95) -- clamp at minimum 0.05, clamp at max of 3.0 to be safe
     local resistVal = 1
 
     -- Resistance thresholds based on p.  A higher p leads to lower resist rates, and a lower p leads to higher resist rates.
@@ -699,7 +679,7 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
         resistVal = 1.0
     end
 
-    if evaMult <= 0.5 then
+    if eemVal <= 0.5 then
         resistVal = resistVal / 2
     end
 
@@ -708,7 +688,7 @@ end
 
 xi.spells.damage.calculateIfMagicBurst = function(caster, target, spell, spellElement) -- Calculates if a magic burst should occur.
     local magicBurst         = 1 -- The variable we want to calculate
-    local _, skillchainCount = FormMagicBurst(spellElement, target) -- External function. Not present in magic.lua.
+    local _, skillchainCount = xi.magic.FormMagicBurst(spellElement, target) -- External function. Not present in magic.lua.
 
     if skillchainCount > 0 and target:hasStatusEffect(xi.effect.SKILLCHAIN) then
         magicBurst = 1.25 + (0.1 * skillchainCount) -- Here we add SDT DAMAGE bonus for magic bursts aswell, once SDT is implemented. https://www.bg-wiki.com/ffxi/Resist#SDT_and_Magic_Bursting

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -870,6 +870,14 @@ xi.effect =
     FULL_SPEED_AHEAD         = 803, -- Helper for quest: Full Speed Ahead!
     HYSTERIA                 = 804, -- Used for Hysteroanima to stop after readying a weaponskill with no msg.
     TOMAHAWK                 = 805, -- Silent status effect inflicted by a Warrior using the "Tomahawk" job ability
+    FIRE_EEM_MOD             = 900,
+    ICE_EEM_MOD              = 901,
+    WIND_EEM_MOD             = 902,
+    EARTH_EEM_MOD            = 903,
+    THUNDER_EEM_MOD          = 904,
+    WATER_EEM_MOD            = 905,
+    LIGHT_EEM_MOD            = 906,
+    DARK_EEM_MOD             = 907,
     -- PLACEHOLDER           = 806, -- Description
     -- 806-1022
     -- PLACEHOLDER           = 1023 -- The client dat file seems to have only this many "slots", results of exceeding that are untested.

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -1228,9 +1228,9 @@ xi.weaponskills.handleWSGorgetBelt = function(attacker)
         for i, v in ipairs(elementalGorget) do
             if neck == v then
                 if
-                    doesElementMatchWeaponskill(i, scProp1) or
-                    doesElementMatchWeaponskill(i, scProp2) or
-                    doesElementMatchWeaponskill(i, scProp3)
+                    xi.magic.doesElementMatchWeaponskill(i, scProp1) or
+                    xi.magic.doesElementMatchWeaponskill(i, scProp2) or
+                    xi.magic.doesElementMatchWeaponskill(i, scProp3)
                 then
                     accBonus = accBonus + 10
                     ftpBonus = ftpBonus + 0.1
@@ -1248,9 +1248,9 @@ xi.weaponskills.handleWSGorgetBelt = function(attacker)
         for i, v in ipairs(elementalBelt) do
             if belt == v then
                 if
-                    doesElementMatchWeaponskill(i, scProp1) or
-                    doesElementMatchWeaponskill(i, scProp2) or
-                    doesElementMatchWeaponskill(i, scProp3)
+                    xi.magic.doesElementMatchWeaponskill(i, scProp1) or
+                    xi.magic.doesElementMatchWeaponskill(i, scProp2) or
+                    xi.magic.doesElementMatchWeaponskill(i, scProp3)
                 then
                     accBonus = accBonus + 10
                     ftpBonus = ftpBonus + 0.1

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -744,6 +744,14 @@ enum EFFECT
     EFFECT_FULL_SPEED_AHEAD    = 803, // Used to track Full Speed Ahead quest minigame
     EFFECT_HYSTERIA            = 804, // Used for Hysteroanima to stop after readying a weaponskill with no msg.
     EFFECT_TOMAHAWK            = 805, // Silent status effect inflicted by a Warrior using the "Tomahawk" job ability
+    EFFECT_FIRE_EEM_MOD        = 900,
+    EFFECT_ICE_EEM_MOD         = 901,
+    EFFECT_WIND_EEM_MOD        = 902,
+    EFFECT_EARTH_EEM_MOD       = 903,
+    EFFECT_THUNDER_EEM_MOD     = 904,
+    EFFECT_WATER_EEM_MOD       = 905,
+    EFFECT_LIGHT_EEM_MOD       = 906,
+    EFFECT_DARK_EEM_MOD        = 907,
     // EFFECT_PLACEHOLDER           = 806  // Description
     // 806-1022
     // EFFECT_PLACEHOLDER           = 1023 // The client dat file seems to have only this many "slots", results of exceeding that are untested.

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -112,10 +112,6 @@ global_objects=(
     doAutoRangedWeaponskill
     doAutoPhysicalWeaponskill
 
-    FormMagicBurst
-    MobFormMagicBurst
-    doesElementMatchWeaponskill
-
     AbilityFinalAdjustments
 
     MOBSKILL_MAGICAL


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes the nuke wall to increase EEM resistance (lower the EEM value) based on the number of nukes applied. Removed nuke wall on enfeebs, but they still will be affected if a nuke wall is in place.
+ Added new "fake" status effects to handle EEM modifications based on the nuke wall.
+ Nuke wall now resets 10s after the last elemental cast.
+ Adds magic burst acc bonus to enfeebles later work will be to add magic burst messaging to enfeebs.
+ Converts magicburst.lua to global table function format.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
