### PR TITLE
Implements garrison wave system

### DIFF
--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -154,6 +154,36 @@ function utils.clamp(input, min_val, max_val)
     return input
 end
 
+--  Returns a table containing all the elements in the specified range.
+--  Source: https://github.com/mebens/range
+function utils.range(from, to, step)
+    local t = {}
+    local argType = type(from)
+    step = step or 1
+
+    if argType == "number" then
+        for i = from, to, step do t[#t + 1] = i end
+    elseif argType == "string" then
+        local e = string.byte(to)
+        for i = string.byte(from), e, step do t[#t + 1] = string.char(i) end
+    elseif argType == "table" then
+        local metaNext = getmetatable(from).__next
+
+        if metaNext then
+            local i = from
+
+            while i < to do
+                t[#t + 1] = i
+                i = metaNext(i, step)
+            end
+
+            t[#t + 1] = to
+        end
+    end
+
+    return t
+end
+
 -- returns unabsorbed damage
 function utils.stoneskin(target, dmg)
     --handling stoneskin

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -165,12 +165,14 @@ xi.settings.main =
     NM_LOTTERY_COOLDOWN = 1.0,
 
 	-- GARRISON SETTINGS
-    GARRISON_LOCKOUT             = 1800, -- Time in seconds before a new garrison can be started (default: 1800)
-    GARRISON_TIME_LIMIT          = 1800, -- Time in seconds before lose ongoing garrison (default: 1800)
-    GARRISON_ONCE_PER_WEEK       = 0,    -- Set to 1 to bypass the limit of one garrison per Conquest Tally Week.
-    GARRISON_PARTY_LIMIT         = 18,   -- Set to max party members you want to do garrison (default: 18).
-    GARRISON_NATION_BYPASS       = 0,    -- Set to 1 to bypass the nation requirement.
-    GARRISON_RANK                = 2,    -- Set to minumum Nation Rank to start Garrison (default: 2).
+    ENABLE_GARRISON              = false,  -- If true, enables garrison functionality
+    DEBUG_GARRISON               = false,  -- If true, garrison will print out debug messages in logs as well as players as smes.
+    GARRISON_LOCKOUT             = 1800,   -- Time in seconds before a new garrison can be started (default: 1800)
+    GARRISON_TIME_LIMIT          = 1800,   -- Time in seconds before lose ongoing garrison (default: 1800)
+    GARRISON_ONCE_PER_WEEK       = 0,      -- Set to 1 to bypass the limit of one garrison per Conquest Tally Week.
+    GARRISON_PARTY_LIMIT         = 18,     -- Set to max party members you want to do garrison (default: 18).
+    GARRISON_NATION_BYPASS       = 0,      -- Set to 1 to bypass the nation requirement.
+    GARRISON_RANK                = 2,      -- Set to minumum Nation Rank to start Garrison (default: 2).
 
     -- DYNAMIS SETTINGS
     BETWEEN_2DYNA_WAIT_TIME     = 72,       -- Hours before player can re-enter Dynamis. Default is 1 Earthday (24 hours).


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Implements wave system that spawns the right amount of mobs at the right time for each wave
- Fixes the number of allies spawned (1 per alliance member based on captures)
- Adds the flow for granting loot on victory (but does not actually grant it)
- Spawns the right bosses / npcs on each zone

## This PR does NOT

- Grant loot on garrison victory
- Save lockout information for player
- Add timer for garrison timeout
- Implement proper loot for each zone

## Known Issues

- Since there isn't a lockout saved, one can trade the item even when garrison is in progress
- NPCs or allies may not be cleaned up if for whatever reason the main garrison loop crashes. We should add a more robust mechanism to clean up garrison in a bad state
- NPC resistances are incorrect (shows as healed when enfeebs are casted by mobs, etc..)
- NPC looks are incorrect (they show naked on spawn). This seems like an entity update issue.
- Sometimes, the ally array is empty after zone load

## Steps to test these changes

* edit settings/main.lua and set ENABLE_GARRISON to true. Maybe set minimum rank to 0 and remove nation lockout for testing. should also set DEBUG_GARRISON=true
* !zone 103
* Run to op, !additem sack_of_galka% and trade it to the npc
* maybe use !immortal on the spawned ally if you suck like I do
* Kill mobs as they pop
