### PR TITLE
Garrison System

### DIFF
--- a/scripts/commands/stopgarrison.lua
+++ b/scripts/commands/stopgarrison.lua
@@ -1,0 +1,17 @@
+---------------------------------------------------------------------------------------------------
+-- func: stopgarrison
+-- desc: stops the garrison (if any) currently running in the player's zone
+---------------------------------------------------------------------------------------------------
+
+require("scripts/globals/status")
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+function onTrigger(player)
+    xi.garrison.stop(player:getZone())
+    player:PrintToPlayer("Garrison event stopped")
+end

--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -1,424 +1,66 @@
 -----------------------------------
 -- Garrison
 -----------------------------------
-require('scripts/globals/mobs')
 require('scripts/globals/common')
+require('scripts/globals/garrison_data')
 require('scripts/globals/items')
+require('scripts/globals/mobs')
 require('scripts/globals/npc_util')
+require('scripts/globals/pathfind')
 require('scripts/globals/status')
 require('scripts/globals/utils')
 require('scripts/globals/zone')
-require('scripts/globals/pathfind')
 -----------------------------------
 xi = xi or {}
 xi.garrison = xi.garrison or {}
-xi.garrison.lookup = xi.garrison.lookup or {}
 
 xi.garrison.state =
 {
-    INACTIVE   = 0,
-    SPAWN_NPCS = 1,
-    WAITING    = 2,
-    SPAWN_MOBS = 3,
-    ACTIVE     = 4,
-    ENDED      = 5,
+    SPAWN_NPCS          = 0,
+    BATTLE              = 1,
+    SPAWN_MOBS          = 2,
+    SPAWN_BOSS          = 3,
+    ADVANCE_WAVE        = 4,
+    GRANT_LOOT          = 5,
+    ENDED               = 6,
 }
 
 -----------------------------------
--- Data
+-- Helpers: Logging / Messaging
 -----------------------------------
 
--- Loot for each Garrison, by level
-xi.garrison.loot =
-{
-    [20] =
-    {
-        { itemId = xi.items.DRAGON_CHRONICLES, dropRate = 1000 },
-        { itemId = xi.items.GARRISON_TUNICA,   dropRate = 350  },
-        { itemId = xi.items.GARRISON_BOOTS,    dropRate = 350  },
-        { itemId = xi.items.GARRISON_HOSE,     dropRate = 350  },
-        { itemId = xi.items.GARRISON_GLOVES,   dropRate = 350  },
-        { itemId = xi.items.GARRISON_SALLET,   dropRate = 350  },
-    },
-    [30] =
-    {
-        { itemId = xi.items.DRAGON_CHRONICLES, dropRate = 1000 },
-        { itemId = xi.items.MILITARY_GUN,      dropRate = 350  },
-        { itemId = xi.items.MILITARY_POLE,     dropRate = 350  },
-        { itemId = xi.items.MILITARY_HARP,     dropRate = 350  },
-        { itemId = xi.items.MILITARY_PICK,     dropRate = 350  },
-        { itemId = xi.items.MILITARY_SPEAR,    dropRate = 350  },
-        { itemId = xi.items.MILITARY_AXE,      dropRate = 350  },
-    },
-    [40] =
-    {
-        { itemId = xi.items.DRAGON_CHRONICLES, dropRate = 1000 },
-        { itemId = xi.items.VARIABLE_MANTLE,   dropRate = 350  },
-        { itemId = xi.items.VARIABLE_CAPE,     dropRate = 350  },
-        { itemId = xi.items.PROTEAN_RING,      dropRate = 350  },
-        { itemId = xi.items.VARIABLE_RING,     dropRate = 350  },
-        { itemId = xi.items.MECURIAL_EARRING,  dropRate = 350  },
-    },
-    [50] =
-    {
-        { itemId = xi.items.DRAGON_CHRONICLES, dropRate = 1000 },
-        { itemId = xi.items.UNDEAD_EARRING,    dropRate = 350  },
-        { itemId = xi.items.ARCANA_EARRING,    dropRate = 350  },
-        { itemId = xi.items.VERMIN_EARRING,    dropRate = 350  },
-        { itemId = xi.items.BIRD_EARRING,      dropRate = 350  },
-        { itemId = xi.items.AMORPH_EARRING,    dropRate = 350  },
-        { itemId = xi.items.LIZARD_EARRING,    dropRate = 350  },
-        { itemId = xi.items.AQUAN_EARRING,     dropRate = 350  },
-        { itemId = xi.items.PLANTOID_EARRING,  dropRate = 350  },
-        { itemId = xi.items.BEAST_EARRING,     dropRate = 350  },
-        { itemId = xi.items.DEMON_EARRING,     dropRate = 350  },
-        { itemId = xi.items.DRAGON_EARRING,    dropRate = 350  },
-        { itemId = xi.items.REFRESH_EARRING,   dropRate = 350  },
-        { itemId = xi.items.ACCURATE_EARRING,  dropRate = 350  },
-    },
-    [99] =
-    {
-        { itemId = xi.items.MIRATETES_MEMOIRS, dropRate = 1000 },
-        { itemId = xi.items.MIGHTY_BOW,        dropRate = 350  },
-        { itemId = xi.items.MIGHTY_CUDGEL,     dropRate = 350  },
-        { itemId = xi.items.MIGHTY_POLE,       dropRate = 350  },
-        { itemId = xi.items.MIGHTY_TALWAR,     dropRate = 350  },
-        { itemId = xi.items.RAI_KUNIMITSU,     dropRate = 350  },
-        { itemId = xi.items.NUKEMARU,          dropRate = 350  },
-        { itemId = xi.items.MIGHTY_PICK,       dropRate = 350  },
-        { itemId = xi.items.MIGHTY_KNIFE,      dropRate = 350  },
-        { itemId = xi.items.MIGHTY_ZAGHNAL,    dropRate = 350  },
-        { itemId = xi.items.MIGHTY_LANCE,      dropRate = 350  },
-        { itemId = xi.items.MIGHTY_AXE,        dropRate = 350  },
-        { itemId = xi.items.MIGHTY_PATAS,      dropRate = 350  },
-        { itemId = xi.items.MIGHTY_SWORD,      dropRate = 350  },
-    },
-}
+-- Prints the given message if DEBUG_GARRISON is enabled
+local debugLog = function(msg)
+    if xi.settings.main.DEBUG_GARRISON then
+        print("[Garrison]: " .. msg)
+    end
+end
 
--- Zone Data, used for the spawning of enemies and allies
--- allies: { Sandoria name, Bastok name, Windurst name }
-xi.garrison.data =
-{
-    [xi.zone.WEST_RONFAURE] =
-    {
-        itemReq = xi.items.RED_CRYPTEX,
-        textRegion = 0,
-        levelCap = 20,
-        mobBoss = "Orcish_Fighterchief",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = -436,
-        yPos = -20,
-        zPos = -217,
-        xChange = 0,
-        zChange = 2,
-        xSecondLine = 2,
-        zSecondLine = 0,
-        xThirdLine = 4,
-        zThirdLine = 0,
-        rot = 0,
-    },
-    [xi.zone.NORTH_GUSTABERG] =
-    {
-        itemReq = xi.items.DARKSTEEL_ENGRAVING,
-        textRegion = 1,
-        levelCap = 20,
-        mobBoss = "Lead_Quadav",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = -580, -- TODO: Needs adjusting
-        yPos = 40,
-        zPos = 69,
-        xChange = 1,
-        zChange = 2,
-        xSecondLine = 2,
-        zSecondLine = 0,
-        xThirdLine = 4,
-        zThirdLine = 0,
-        rot = 106,
-    },
-    [xi.zone.WEST_SARUTABARUTA] =
-    {
-        itemReq = xi.items.SEVEN_KNOT_QUIPU,
-        textRegion = 2,
-        levelCap = 20,
-        mobBoss = "Yagudo_Condottiere",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = -20, -- TODO: Needs adjusting
-        yPos = -12,
-        zPos = 325,
-        xChange = 0,
-        zChange = 2,
-        xSecondLine = 2,
-        zSecondLine = 0,
-        xThirdLine = 4,
-        zThirdLine = 0,
-        rot = 115,
-    },
-    [xi.zone.VALKURM_DUNES] =
-    {
-        itemReq = xi.items.GALKA_FANG_SACK,
-        textRegion = 3,
-        levelCap = 30,
-        mobBoss = "Goblin_Swindler",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = 141, -- TODO: Needs adjusting
-        yPos = -8,
-        zPos = 87,
-        xChange = -2,
-        zChange = -2,
-        xSecondLine = 2,
-        zSecondLine = 0,
-        xThirdLine = 4,
-        zThirdLine = 0,
-        rot = 32,
-    },
-    [xi.zone.JUGNER_FOREST] =
-    {
-        itemReq = xi.items.JADE_CRYPTEX,
-        textRegion = 4,
-        levelCap = 30,
-        mobBoss = "Orcish_Colonel",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = 54, -- TODO: Needs adjusting
-        yPos = 1,
-        zPos = -1,
-        xChange = -2,
-        zChange = 0,
-        xSecondLine = 0,
-        zSecondLine = 2,
-        xThirdLine = 0,
-        zThirdLine = 4,
-        rot = 210,
-    },
-    [xi.zone.PASHHOW_MARSHLANDS] =
-    {
-        itemReq = xi.items.SILVER_ENGRAVING,
-        textRegion = 5,
-        levelCap = 30,
-        mobBoss = "Cobalt_Quadav",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = 458, -- TODO: Needs adjusting
-        yPos = 24,
-        zPos = 421,
-        xChange = -2,
-        zChange = -2,
-        xSecondLine = 2,
-        zSecondLine = 0,
-        xThirdLine = 4,
-        zThirdLine = 0,
-        rot = 130,
-    },
-    [xi.zone.BUBURIMU_PENINSULA] =
-    {
-        itemReq = xi.items.MITHRA_FANG_SACK,
-        textRegion = 6,
-        levelCap = 30,
-        mobBoss = "Goblin_Guide",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = -485, -- TODO: Needs adjusting
-        yPos = -29,
-        zPos = 58,
-        xChange = -2,
-        zChange = 0,
-        xSecondLine = 0,
-        zSecondLine = -2,
-        xThirdLine = 0,
-        zThirdLine = -4,
-        rot = 0,
-    },
-    [xi.zone.MERIPHATAUD_MOUNTAINS] =
-    {
-        itemReq = xi.items.THIRTEEN_KNOT_QUIPU,
-        textRegion = 7,
-        levelCap = 30,
-        mobBoss = "Yagudo_Missionary",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = -299, -- TODO: Needs adjusting
-        yPos = 17,
-        zPos = 411,
-        xChange = 2,
-        zChange = -2,
-        xSecondLine = 0,
-        zSecondLine = 2,
-        xThirdLine = 0,
-        zThirdLine = 4,
-        rot = 30,
-    },
-    [xi.zone.QUFIM_ISLAND] =
-    {
-        itemReq = xi.items.RAM_LEATHER_MISSIVE,
-        textRegion = 10,
-        levelCap = 30,
-        mobBoss = "Hunting_Chief",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = -247, -- TODO: Needs adjusting
-        yPos = -19,
-        zPos = 310,
-        xChange = -2,
-        zChange = 0,
-        xSecondLine = 0,
-        zSecondLine = -2,
-        xThirdLine = 0,
-        zThirdLine = -4,
-        rot = 0,
-    },
-    [xi.zone.BEAUCEDINE_GLACIER] =
-    {
-        itemReq = xi.items.TIGER_LEATHER_MISSIVE,
-        textRegion = 8,
-        levelCap = 40,
-        mobBoss = "Gigas_Overseer",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = -25, -- TODO: Needs adjusting
-        yPos = -60,
-        zPos = -110,
-        xChange = -2,
-        zChange = -1,
-        xSecondLine = 0,
-        zSecondLine = -1,
-        xThirdLine = 0,
-        zThirdLine = -2,
-        rot = 220,
-    },
-    [xi.zone.THE_SANCTUARY_OF_ZITAH] =
-    {
-        itemReq = xi.items.HOUND_FANG_SACK,
-        textRegion = 11,
-        levelCap = 40,
-        mobBoss = "Goblin_Doyen",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = -43,
-        yPos = 1,
-        zPos = -140,
-        xChange = -2,
-        zChange = 0,
-        xSecondLine = 0,
-        zSecondLine = 2,
-        xThirdLine = 0,
-        zThirdLine = 4,
-        rot = 180,
-    },
-    [xi.zone.YUHTUNGA_JUNGLE] =
-    {
-        itemReq = xi.items.SHEEP_LEATHER_MISSIVE,
-        textRegion = 14,
-        levelCap = 40,
-        mobBoss = "Sahagin_Patriarch",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = -248,
-        yPos = 1,
-        zPos = -392,
-        xChange = -2,
-        zChange = 0,
-        xSecondLine = 0,
-        zSecondLine = 2,
-        xThirdLine = 0,
-        zThirdLine = 4,
-        rot = 180,
-    },
-    [xi.zone.XARCABARD] =
-    {
-        itemReq = xi.items.BEHEMOTH_LEATHER_MISSIVE,
-        textRegion = 9,
-        levelCap = 50,
-        mobBoss = "Demon_Aristocrat",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = 216, -- TODO: Needs adjusting
-        yPos = -22,
-        zPos = -208,
-        xChange = 2,
-        zChange = 0,
-        xSecondLine = 0,
-        zSecondLine = 2,
-        xThirdLine = 0,
-        zThirdLine = 4,
-        rot = 90,
-    },
-    [xi.zone.EASTERN_ALTEPA_DESERT] =
-    {
-        itemReq = xi.items.DHALMEL_LEATHER_MISSIVE,
-        textRegion = 12,
-        levelCap = 50,
-        mobBoss = "Centurio_XIII-V",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = -245,
-        yPos = -9,
-        zPos = -249,
-        xChange = 0,
-        zChange = 2,
-        xSecondLine = 2,
-        zSecondLine = 0,
-        xThirdLine = 4,
-        zThirdLine = 0,
-        rot = 0,
-    },
-    [xi.zone.YHOATOR_JUNGLE] =
-    {
-        itemReq = xi.items.COEURL_LEATHER_MISSIVE,
-        textRegion = 15,
-        levelCap = 50,
-        mobBoss = "Tonberry_Decimator",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = 214,
-        yPos = 1,
-        zPos = -80,
-        xChange = 1,
-        zChange = 2,
-        xSecondLine = 2,
-        zSecondLine = -1,
-        xThirdLine = 4,
-        zThirdLine = -2,
-        rot = 0,
-    },
-    [xi.zone.CAPE_TERIGGAN] =
-    {
-        itemReq = xi.items.BUNNY_FANG_SACK,
-        textRegion = 13,
-        levelCap = 99,
-        mobBoss = "Goblin_Boss",
-        allies = { "Trader", "Patrician", "Scholar" },
-        xPos = -174,
-        yPos = 8,
-        zPos = -61,
-        xChange = 0,
-        zChange = 2,
-        xSecondLine = 2,
-        zSecondLine = 0,
-        xThirdLine = 4,
-        zThirdLine = 0,
-        rot = 0,
-    },
-}
+-- Prints the given message with printf if DEBUG_GARRISON is enabled
+local debugLogf = function(msg, ...)
+    if xi.settings.main.DEBUG_GARRISON then
+        printf("[Garrison]: " .. msg, ...)
+    end
+end
 
-local allyLooks =
-{
-    ["Patrician"] = -- Gustaberg Sandoria
-    {
-        "0x01000C030010262000303A403A5008611B700000",
-    },
-    ["Trader"] = -- Dunes Sandoria
-    {
-        "0x010009040010762076303A400650736000700000",
-        "0x010006030010762076303A400650736000700000",
-    },
-    ["Recruit"] = -- Gustaberg Bastok
-    {
-        "0x01000701361005206630664066500C6129700000",
-    },
-    ["Candidate"] = -- West Saru Windurst
-    {
-        "0x010007070110322032300E401550AC6000700000",
-        "0x01000E0718101820183015401850B76024700000",
-    },
-    ["Scholar"] = -- Dunes Windurst
-    {
-        "0x01000B051C1073201430144014506C6000700000",
-        "0x0100010777106920693066406950B46000700000",
-        "0x010000067D107820033066406850E96000700000",
-    },
-}
+-- Shows the given server message to all players if DEBUG_GARRISON is enabled
+local debugPrintToPlayers = function(players, msg)
+    if xi.settings.main.DEBUG_GARRISON then
+        for _, player in pairs(players) do
+            player:PrintToPlayer(msg)
+        end
+    end
+end
+
+-- Sends a message packet to all players
+local messagePlayers = function(npc, players, msg)
+    for _, player in ipairs(players) do
+        player:messageText(npc, msg)
+    end
+end
 
 -----------------------------------
--- Helpers
+-- Helpers: Spawning
 -----------------------------------
 
 -- Add level restriction effect
@@ -426,7 +68,7 @@ local allyLooks =
 -- Any players that are KO'd lose their level restriction and will be unable to help afterward.
 -- Giving this the CONFRONTATION flag hooks into the target validation systme and stops outsiders
 -- participating, for mobs, allies, and players.
-local addLevelCap = function(entity, cap)
+xi.garrison.addLevelCap = function(entity, cap)
     entity:addStatusEffectEx(
         xi.effect.LEVEL_RESTRICTION,
         xi.effect.LEVEL_RESTRICTION,
@@ -436,19 +78,31 @@ local addLevelCap = function(entity, cap)
         0,
         0,
         0,
-        xi.effectFlag.DEATH + xi.effectFlag.ON_ZONE + xi.effectFlag.CONFRONTATION)
+        -- Note the level restriction does not wear on death.
+        -- Some sources say it does, but we have captures showing otherwise.
+        xi.effectFlag.ON_ZONE + xi.effectFlag.CONFRONTATION)
 end
 
-local aggroGroups = function(group1, group2)
-    for _, id1 in pairs(group1) do
-        for _, id2 in pairs(group2) do
-            GetMobByID(id1):addEnmity(GetMobByID(id2), math.random(1, 5), math.random(1, 5))
-            GetMobByID(id2):addEnmity(GetMobByID(id1), math.random(1, 5), math.random(1, 5))
+-- Randomly assigns aggro between the given groups of entity IDs
+xi.garrison.aggroGroups = function(group1, group2)
+    for _, entityId1 in pairs(group1) do
+        for _, entityId2 in pairs(group2) do
+            local entity1 = GetMobByID(entityId1)
+            local entity2 = GetMobByID(entityId2)
+
+            if entity1 == nil or entity2 == nil then
+                printf("[warning] Could not apply aggro because either %i or %i are not valid entities", entityId1, entityId2)
+            else
+                entity1:addEnmity(entity2, math.random(1, 5), math.random(1, 5))
+                entity2:addEnmity(entity1, math.random(1, 5), math.random(1, 5))
+            end
         end
     end
 end
 
-local spawnNPC = function(zone, x, y, z, rot, name, look)
+-- Spawns and npc for the given zone and with the given name, look, pose
+-- Uses dynamic entities
+xi.garrison.spawnNPC = function(zone, zoneData, x, y, z, rot, name, look)
     local mob = zone:insertDynamicEntity({
         objtype = xi.objType.MOB,
         allegiance = xi.allegiance.PLAYER,
@@ -482,22 +136,31 @@ local spawnNPC = function(zone, x, y, z, rot, name, look)
     mob:SetMagicCastingEnabled(false)
     mob:SetMobAbilityEnabled(false)
 
+    -- Death listener for tracking win/lose condition
+    mob:addListener("DEATH", "GARRISON_NPC_DEATH", function(mobArg)
+        zoneData.deadNPCCount = zoneData.deadNPCCount + 1
+    end)
+
     return mob
 end
 
-local spawnNPCs = function(npc)
-    local zone     = npc:getZone()
-    local zoneData = xi.garrison.data[zone:getID()]
+-- Spawns all npcs for the zone in the given garrison starting npc
+xi.garrison.spawnNPCs = function(zone, zoneData)
     local xPos     = zoneData.xPos
     local yPos     = zoneData.yPos
     local zPos     = zoneData.zPos
     local rot      = zoneData.rot
-    local allyName = zoneData.allies[GetRegionOwner(zone:getRegionID()) + 1]
 
-    for i = 0, math.random(2, 6) do
-        local mob = spawnNPC(zone, xPos, yPos, zPos, rot, allyName, utils.randomEntry(allyLooks[allyName]))
+    -- xi.nation starts at 0. Since we use it as index, add off by 1
+    local regionIndex = GetRegionOwner(zone:getRegionID()) + 1
+    local allyName    = xi.garrison.allyNames[zoneData.levelCap][regionIndex]
+    local allyLooks   = xi.garrison.allyLooks[zoneData.levelCap][regionIndex]
+
+    -- Spawn 1 npc per player in alliance
+    for i = 1, #zoneData.players do
+        local mob = xi.garrison.spawnNPC(zone, zoneData, xPos, yPos, zPos, rot, allyName, utils.randomEntry(allyLooks))
         mob:setMobLevel(zoneData.levelCap - math.floor(zoneData.levelCap / 5))
-        addLevelCap(mob, zoneData.levelCap)
+        xi.garrison.addLevelCap(mob, zoneData.levelCap)
         table.insert(zoneData.npcs, mob:getID())
 
         if i == 6 then
@@ -513,165 +176,318 @@ local spawnNPCs = function(npc)
     end
 end
 
+-- Spawns a mob with the given id for the given zone.
+xi.garrison.spawnMob = function(mobID, zoneData)
+    local mob = SpawnMob(mobID)
+    if mob == nil then
+        return nil
+    end
+
+    xi.garrison.addLevelCap(mob, zoneData.levelCap)
+    mob:setRoamFlags(xi.roamFlag.SCRIPTED)
+    table.insert(zoneData.mobs, mobID)
+
+    -- Death listener for tracking win/lose condition
+    mob:addListener("DEATH", "GARRISON_MOB_DEATH", function(mobArg)
+        zoneData.deadMobCount = zoneData.deadMobCount + 1
+    end)
+
+    -- A wave is considered complete when all mobs are done despawning
+    -- and not just dead. This matters a lot because of spawn timings.
+    -- I.e: If mob A dies on wave 1, and another instance of mob A is supposed
+    -- to spawn on wave 2, it will not spawn as long as the previous mob is still
+    -- despawning
+    -- For this reason, we track both death and despawn as separate events
+    mob:addListener("DESPAWN", "GARRISON_MOB_DESPAWN", function(mobArg)
+        zoneData.despawnedMobCount = zoneData.despawnedMobCount + 1
+    end)
+
+    return mob
+end
+
+-- Given a starting mobID, return the list of randomly selected
+-- mob ids. The amount of mobs selected is determined by numMobs.
+-- The ids in the given excludedMobs table will not be included in the result.
+-- This method assumes that the mob pool is composed by mobIDs
+-- that are sequential between firstMobID and lastMobID
+-- e.g: If firstMobId = 1, lastMobID = 4 and numMobs is 2,
+-- Then 2 ids randomly selected between { 1, 2, 3, 4 } will be returned
+-- without repetitions.
+xi.garrison.pickMobsFromPool = function(firstMobID, lastMobID, numMobs, excludedMobIDs)
+    -- unfiltered pool, from first to last mob id (inclusive)
+    local unfilteredPool = utils.range(firstMobID, lastMobID)
+
+    -- filter the pool, removing excludedMobIDs
+    local pool = {}
+    local excludedSet = set(excludedMobIDs)
+    for _, v in ipairs(unfilteredPool) do
+        if not excludedSet[v] then
+            table.insert(pool, v)
+        end
+    end
+
+    -- validate input
+    local mobs = {}
+    if numMobs > #pool then
+        printf("[warning] pickMobsFromPool called with numMobs > mobIds. Num Mobs: %i. Pool size: %i", numMobs, #pool)
+        numMobs = #pool
+    end
+
+    if numMobs <= 0 then
+        printf("[error] Invalid numMobs picked. Should be > 0.")
+        return {}
+    end
+
+    -- Now we can apply a common algorithm used to "shuffle a deck of cards"
+    for i = 1, numMobs do
+        -- Pick random index from J to pool end. Add the picked element to result
+        local pickedIndex = math.random(i, #pool)
+        table.insert(mobs, pool[pickedIndex])
+
+        -- Now swap the picked element with the first element of the array.
+        -- This effectively makes the picked element not elegible for future picks.
+        pool[pickedIndex], pool[i] = pool[i], pool[pickedIndex]
+    end
+
+    return mobs
+end
+
 -----------------------------------
 -- Main Functions
 -----------------------------------
 
 xi.garrison.tick = nil -- Prototype
 xi.garrison.tick = function(npc)
-    local zone     = npc:getZone()
-    local zoneData = xi.garrison.data[zone:getID()]
+    local zone         = npc:getZone()
+    local zoneData     = xi.garrison.zoneData[zone:getID()]
+    local ID           = zones[npc:getZoneID()]
+    local entityMapper = function (_, entityId) return GetPlayerByID(entityId) end
+    local players      = utils.map(zoneData.players, entityMapper)
 
     switch (zoneData.state) : caseof
     {
-        [xi.garrison.state.INACTIVE] = function()
-            -- print("State: Inactive")
-            local time = os.time()
-            if time > zoneData.stateTime + 2 then
-                zoneData.stateTime = time
-                zoneData.state = xi.garrison.state.SPAWN_NPCS
-            end
-        end,
-
         [xi.garrison.state.SPAWN_NPCS] = function()
-            -- print("State: Spawn NPCs")
-            spawnNPCs(npc)
+            debugLog("State: Spawn NPCs")
+            xi.garrison.spawnNPCs(zone, zoneData)
 
             zoneData.stateTime = os.time()
-            zoneData.state = xi.garrison.state.WAITING
+            zoneData.state = xi.garrison.state.BATTLE
         end,
 
-        [xi.garrison.state.WAITING] = function()
-            -- print("State: Waiting")
+        [xi.garrison.state.BATTLE] = function()
+            debugLog("State: Battle")
 
-            local time = os.time()
-            if time > zoneData.stateTime + 2 then
-                zoneData.stateTime = time
+            -- We do not cache player entity state as they can reraise or DC,
+            -- making caching more error prone
+            local isAliveFn = function(_, player) return player ~= nil and player:isAlive() end
+            local allPlayersDead = not utils.any(players, isAliveFn)
+
+            -- This caching works because the same mob ID is never used to respawn a mob
+            -- within the same wave.
+            local allMobsDead      = zoneData.deadMobCount == #zoneData.mobs
+            local allMobsDespawned = zoneData.despawnedMobCount == #zoneData.mobs
+
+            -- case 1: Either npcs or players are dead. End event.
+            local allNPCsDead = #zoneData.npcs == zoneData.deadNPCCount
+            if allNPCsDead or allPlayersDead then
+                -- You fought hard, and you proved yourself worthy...
+                debugPrintToPlayers(players, "Mission failed by death")
+                messagePlayers(npc, players, ID.text.GARRISON_BASE + 39)
+                zoneData.state = xi.garrison.state.ENDED
+                return
+            end
+
+            -- case 2: More mobs to spawn in this wave, and past next spawn time. Spawn Mobs.
+            local shouldSpawnMobs = os.time() >= zoneData.nextSpawnTime
+            local isLastGroup = zoneData.groupIndex > xi.garrison.waves.groupsPerWave[zoneData.waveIndex]
+            if shouldSpawnMobs and not isLastGroup then
                 zoneData.state = xi.garrison.state.SPAWN_MOBS
-            end
-        end,
-
-        [xi.garrison.state.SPAWN_MOBS] = function()
-            -- print("State: Spawn Mobs")
-            -- TODO: There is a delay before the mobs spawn
-            -- There are always 8 mobs + 1 boss for Garrison, so we will look up the
-            -- boss's ID using their name and then subtract 8 to get the starting mob ID.
-            local firstMobID = zone:queryEntitiesByName(zoneData.mobBoss)[1]:getID() - 8
-            for id = firstMobID, firstMobID do
-                local mob = SpawnMob(id)
-                addLevelCap(mob, zoneData.levelCap)
-                mob:setRoamFlags(xi.roamFlag.SCRIPTED)
-                table.insert(zoneData.mobs, mob:getID())
+                return
             end
 
-            -- Once the mobs are spawned, make them aggro whatever NPCs are already up
-            aggroGroups(zoneData.mobs, zoneData.npcs)
-
-            zoneData.state = xi.garrison.state.ACTIVE
-        end,
-
-        [xi.garrison.state.ACTIVE] = function()
-            -- print("State: Active")
-            local allNPCsDead = true
-            for _, entityId in pairs(zoneData.npcs) do
-                -- TODO: Don't use GetMobByID here
-                -- Keep a table with { bool: alive/dead, mob object } entries
-                local entity = GetMobByID(entityId)
-                if entity and entity:isAlive() then
-                    allNPCsDead = false
-                end
+            -- case 3: All mobs spawned for last wave. Spawn boss
+            local isLastWave = zoneData.waveIndex == #xi.garrison.waves.groupsPerWave
+            if shouldSpawnMobs and isLastWave and isLastGroup and not zoneData.bossSpawned then
+                zoneData.state = xi.garrison.state.SPAWN_BOSS
+                return
             end
 
-            local allPlayersDead = true
-            for _, entityId in pairs(zoneData.players) do
-                local entity = GetPlayerByID(entityId)
-                -- TODO: Only check valid players
-                if entity and entity:isAlive() then
-                    allPlayersDead = false
-                end
+            -- case 4: All Mobs despawned and this was last group. Check if we advance to next wave
+            if allMobsDespawned and isLastGroup and not isLastWave then
+                zoneData.state = xi.garrison.state.ADVANCE_WAVE
+                return
             end
 
-            local allMobsDead = true
-            for _, entityId in pairs(zoneData.mobs) do
-                -- TODO: Don't use GetMobByID here
-                -- Keep a table with { bool: alive/dead, mob object } entries
-                local entity = GetMobByID(entityId)
-                if entity and entity:isAlive() then
-                    allMobsDead = false
-                end
+            -- case 5: All mobs are dead and this was last group and last wave. Grant loot.
+            if allMobsDead and isLastGroup and isLastWave and zoneData.bossSpawned then
+                zoneData.state = xi.garrison.state.GRANT_LOOT
+                return
             end
 
-            if
-                allNPCsDead or
-                allPlayersDead or
-                allMobsDead
-            then
-                -- TODO: Only check valid players
-                for _, entityId in pairs(zoneData.players) do
-                    local entity = GetPlayerByID(entityId)
-                    entity:delStatusEffect(xi.effect.LEVEL_RESTRICTION)
-                end
-
-                for _, entityId in pairs(zoneData.npcs) do
-                    DespawnMob(entityId)
-                end
-
-                for _, entityId in pairs(zoneData.mobs) do
-                    DespawnMob(entityId)
-                end
+            -- case 6: Timeout
+            if os.time() > zoneData.endTime then
+                -- You fought hard, and you proved yourself worthy...
+                debugPrintToPlayers(players, "Mission failed by timeout")
+                messagePlayers(npc, players, ID.text.GARRISON_BASE + 39)
 
                 zoneData.state = xi.garrison.state.ENDED
             end
         end,
 
+        [xi.garrison.state.SPAWN_BOSS] = function()
+            debugLog("State: Spawn Boss")
+            debugPrintToPlayers(players, "Spawning boss")
+
+            local bossID = zone:queryEntitiesByName(zoneData.mobBoss)[1]:getID()
+            local mob = xi.garrison.spawnMob(bossID, zoneData)
+            if mob == nil then
+                print("[error] Could not spawn boss (%i). Ending garrison.", bossID)
+                zoneData.state = xi.garrison.state.ENDED
+                return
+            end
+
+            xi.garrison.aggroGroups({ bossID }, zoneData.npcs)
+            zoneData.bossSpawned = true
+            zoneData.state = xi.garrison.state.BATTLE
+        end,
+
+        [xi.garrison.state.ADVANCE_WAVE] = function()
+            debugLog("State: Advance Wave")
+            debugLogf("Wave Idx: %i. Waves: %i", zoneData.waveIndex, #xi.garrison.waves.groupsPerWave)
+            debugLogf("Next wave: %i", zoneData.waveIndex)
+            debugPrintToPlayers(players, "Wave " .. zoneData.waveIndex .. " cleared")
+
+            zoneData.waveIndex = zoneData.waveIndex + 1
+            zoneData.groupIndex = 1
+            zoneData.nextSpawnTime = os.time() + xi.garrison.waves.delayBetweenGroups
+            zoneData.state = xi.garrison.state.BATTLE
+            zoneData.mobs = {}
+            -- reset mob state cache, but not npc since they dont respawn each wave
+            zoneData.deadMobCount      = 0
+            zoneData.despawnedMobCount = 0
+        end,
+
+        [xi.garrison.state.SPAWN_MOBS] = function()
+            debugLog("State: Spawn Mobs")
+
+            -- There are always at most 8 mobs + 1 boss for Garrison, so we will look up the
+            -- boss's ID using their name and then subtract 8 to get the starting mob ID.
+            local firstMobID = zone:queryEntitiesByName(zoneData.mobBoss)[1]:getID() - 8
+            local numMobs = xi.garrison.waves.mobsPerGroup
+            local poolSize = xi.garrison.waves.mobsPerGroup * xi.garrison.waves.groupsPerWave[zoneData.waveIndex]
+            local lastMobID = firstMobID + poolSize - 1
+
+            -- Pick mobs randomly and spawn them
+            local mobIDs = xi.garrison.pickMobsFromPool(firstMobID, lastMobID, numMobs, zoneData.mobs)
+            for _, mobID in ipairs(mobIDs) do
+                xi.garrison.spawnMob(mobID, zoneData)
+            end
+
+            -- Once the mobs are spawned, make them aggro whatever NPCs are already up
+            -- This method should work fine even if some of these mobs or npcs are invalid / dead
+            xi.garrison.aggroGroups(mobIDs, zoneData.npcs)
+
+            debugPrintToPlayers(players, "Spawn: " .. #zoneData.mobs .. "/" .. poolSize .. ". Wave: " .. zoneData.waveIndex)
+            zoneData.nextSpawnTime = os.time() + xi.garrison.waves.delayBetweenGroups
+            zoneData.state = xi.garrison.state.BATTLE
+            zoneData.groupIndex = zoneData.groupIndex + 1
+        end,
+
+        [xi.garrison.state.GRANT_LOOT] = function()
+            debugLog("State: Grant Loot")
+            debugPrintToPlayers(players, "Mission success")
+
+            messagePlayers(npc, players, ID.text.GARRISON_BASE + 36)
+            xi.garrison.handleLootRolls(xi.garrison.loot[zoneData.levelCap], zoneData.players)
+            zoneData.state = xi.garrison.state.ENDED
+        end,
+
         [xi.garrison.state.ENDED] = function()
-            -- print("State: Ended")
-            zoneData.continue = false
+            debugLog("State: Ended")
+
+            xi.garrison.stop(zone)
         end,
     }
 
-    -- TODO: Check to see if current wave is complete
-
-    -- TODO: Check to if all waves are completed
-
-    if zoneData.continue then
-        npc:timer(2000, function(npcArg)
+    if zoneData.isRunning then
+        npc:timer(1000, function(npcArg)
             xi.garrison.tick(npcArg)
         end)
     end
 end
 
 xi.garrison.start = function(player, npc)
-    -- TODO: Write lockout information to player
+    local zone           = player:getZone()
+    local zoneData       = xi.garrison.zoneData[zone:getID()]
+    zoneData.players     = {}
+    zoneData.npcs        = {}
+    zoneData.mobs        = {}
+    zoneData.state       = xi.garrison.state.SPAWN_NPCS
+    zoneData.isRunning    = true
+    zoneData.stateTime   = os.time()
+    zoneData.waveIndex   = 1
+    zoneData.groupIndex  = 1
+    zoneData.bossSpawned = false
+    -- First mob spawn takes xi.garrison.waves.delayBetweenGroups to start
+    zoneData.nextSpawnTime = os.time() + xi.garrison.waves.delayBetweenGroups
+    zoneData.endTime           = os.time() + xi.settings.main.GARRISON_TIME_LIMIT
+    zoneData.deadNPCCount      = 0
+    zoneData.deadMobCount      = 0
+    zoneData.despawnedMobCount = 0
 
-    local zone         = player:getZone()
-    local zoneData     = xi.garrison.data[zone:getID()]
-    zoneData.players   = {}
-    zoneData.npcs      = {}
-    zoneData.mobs      = {}
-    zoneData.state     = xi.garrison.state.INACTIVE
-    zoneData.continue  = true
-    zoneData.stateTime = os.time()
-
+    -- Adds level cap / registers lockout for all players
+    -- We register lockout at the beginning and end, in case players DC
     for _, member in pairs(player:getAlliance()) do
-        addLevelCap(member, zoneData.levelCap)
-        table.insert(zoneData.players, member:getID())
+        if member:getZoneID() == player:getZoneID() then
+            xi.garrison.addLevelCap(member, zoneData.levelCap)
+            xi.garrison.savePlayerLockout(member)
+
+            table.insert(zoneData.players, member:getID())
+        end
     end
 
-    -- The starting NPC is the 'anchor' for all timers and logic for this Garrison. Even though they
+    -- The starting NPC is the 'anchor' for all timers and logic for this Garrison
     xi.garrison.tick(npc)
+end
+
+-- Stops and cleans up the current garrison event (if any) on the given zone
+-- Can be called externally from GM commands
+xi.garrison.stop = function(zone)
+    local zoneData = xi.garrison.zoneData[zone:getID()]
+    for _, entityId in pairs(zoneData.players or {}) do
+        local entity = GetPlayerByID(entityId)
+        if entity ~= nil then
+            entity:delStatusEffect(xi.effect.LEVEL_RESTRICTION)
+            xi.garrison.savePlayerLockout(entity)
+        end
+    end
+
+    for _, entityId in pairs(zoneData.npcs or {}) do
+        DespawnMob(entityId, zone)
+    end
+
+    for _, entityId in pairs(zoneData.mobs or {}) do
+        DespawnMob(entityId, zone)
+    end
+
+    zoneData.players     = {}
+    zoneData.npcs        = {}
+    zoneData.mobs        = {}
+    zoneData.isRunning   = false
 end
 
 xi.garrison.onTrade = function(player, npc, trade, guardNation)
     if not xi.settings.main.ENABLE_GARRISON then
+        debugLog("Garrison not enabled. Set ENABLE_GARRISON if desired.")
         return false
     end
 
-    -- TODO: If there is currently an active Garrison, bail out now
-
-    local zoneData = xi.garrison.data[player:getZoneID()]
+    local zoneData = xi.garrison.zoneData[player:getZoneID()]
     if npcUtil.tradeHasExactly(trade, zoneData.itemReq) then
-        -- TODO: Check lockout
+        if not xi.garrison.validateEntry(zoneData, player, npc, guardNation) then
+            debugLog("Player does not meet entry requirements")
+            return false
+        end
 
         -- Start CS
         player:startEvent(32753 + player:getNation())
@@ -692,6 +508,7 @@ end
 
 xi.garrison.onEventFinish = function(player, csid, option, guardNation, guardType, guardRegion)
     if not xi.settings.main.ENABLE_GARRISON then
+        debugLog("Garrison not enabled. Set ENABLE_GARRISON if desired.")
         return false
     end
 
@@ -700,6 +517,125 @@ xi.garrison.onEventFinish = function(player, csid, option, guardNation, guardTyp
         local npc = GetNPCByID(player:getLocalVar("GARRISON_NPC"))
         xi.garrison.start(player, npc)
         return true
+    end
+
+    return false
+end
+
+-- Distributes loot amongst all players
+-- TODO: Use a central loot system: https://github.com/LandSandBoat/server/issues/3188
+xi.garrison.handleLootRolls = function(lootTable, players)
+    local max = 0
+
+    for _, entry in ipairs(lootTable) do
+        max = max + entry.droprate
+    end
+
+    local roll = math.random(max)
+
+    for _, entry in pairs(lootTable) do
+        max = max - entry.droprate
+
+        if roll > max then
+            if entry.itemid ~= 0 then
+                for _, entityId in ipairs(players) do
+                    local player = GetPlayerByID(entityId)
+                    if player ~= nil then
+                        player:addTreasure(entry.itemid)
+                        return
+                    end
+                end
+            end
+
+            break
+        end
+    end
+end
+
+-----------------------------------
+-- Entry
+-----------------------------------
+
+-- Validates that the player meets the requirements to enter garrison:
+-- * Another garrison is not currently active
+-- * Outpost is controlled by the player's nation, or GARRISON_NATION_BYPASS setting is true
+-- * No player in the alliance (in zone) is level synced
+-- * Player hasn't entered garrison since last tally, or GARRISON_ONCE_PER_WEEK setting is false
+-- * Player has not finished a garrison since in the last GARRISON_LOCKOUT seconds
+-- * Player does not have more than GARRISON_PARTY_LIMIT alliance memebrs
+-- * Player is at least at GARRISON_RANK rank level
+xi.garrison.validateEntry = function(zoneData, player, npc, guardNation)
+    local ID = zones[player:getZoneID()]
+    if zoneData.isRunning then
+        debugLog("Another garrison in progress")
+        player:messageText(npc, ID.text.GARRISON_BASE + 1)
+        return false
+    end
+
+    local sameZone = function (_, v) return v ~= nil and v:getZoneID() == player:getZoneID() end
+    local membersInZone = utils.filterArray(player:getAlliance(), sameZone)
+
+    -- This assumes that only the player trading the item has to be from the right nation
+    if xi.settings.main.GARRISON_NATION_BYPASS == false and guardNation ~= player:getNation() then
+        debugLog("Outpost not controller by player's nation")
+        player:messageSpecial(ID.text.GARRISON_BASE + player:getNation(), zoneData.itemReq)
+        return false
+    end
+
+    if utils.any(membersInZone, function(_, v) return v:isLevelSync() end) then
+        -- Your party is unable to participate because certain members' levels are restricted
+        debugLog("One or more alliance members have level sync on")
+        player:messageText(npc, ID.text.MEMBERS_LEVELS_ARE_RESTRICTED, false)
+        return false
+    end
+
+    if #membersInZone > xi.settings.main.GARRISON_PARTY_LIMIT then
+        -- This is a custom message. I don't believe retail has this limitation
+        debugLogf("Alliance exceeds member limit: %d", xi.settings.main.GARRISON_PARTY_LIMIT)
+        player:PrintToPlayer(printf("Maximum garrison alliance size is %d", xi.settings.main.GARRISON_PARTY_LIMIT))
+        return false
+    end
+
+    local doesNotMeetRank = function(_, v)
+        return v:getRank(v:getNation()) < xi.settings.main.GARRISON_RANK
+    end
+    if utils.any(membersInZone, doesNotMeetRank) then
+        -- These young participants are quite spirited, but they lack valuable battle experience
+        debugLogf("Leader does not meet required rank: %d", xi.settings.main.GARRISON_RANK)
+        player:messageText(npc, ID.text.GARRISON_BASE + 4)
+        return false
+    end
+
+    if xi.garrison.isAnyPlayerOnEntryCooldown(membersInZone) then
+        -- We commend you on your services in helping us avert the beastmen's attack. I do not see them attacking us again any time soon
+        debugLogf("Alliance members on cooldown")
+        player:messageText(npc, ID.text.GARRISON_BASE + 40)
+        return false
+    end
+
+    return true
+end
+
+-- Stores data related to player entry time / lockout
+xi.garrison.savePlayerLockout = function(player)
+    local nextEntryTime = os.time() + xi.settings.main.GARRISON_LOCKOUT
+    if xi.settings.main.GARRISON_ONCE_PER_WEEK then
+        nextEntryTime = math.max(nextEntryTime, getConquestTally())
+    end
+
+    player:setCharVar("[Garrison]NextEntryTime", nextEntryTime)
+end
+
+-- Returns true if any player in the given table has entered garrison too recently
+-- according to the GARRISON_LOCKOUT and GARRISON_ONCE_PER_WEEK settings
+-- and their last entry time
+xi.garrison.isAnyPlayerOnEntryCooldown = function(players)
+    for _, player in pairs(players) do
+        local nextValidAttemptTime = player:getCharVar("[Garrison]NextEntryTime")
+        if os.time() < nextValidAttemptTime then
+            debugLogf("Cooldown time remaining: %d", nextValidAttemptTime - os.time())
+            return true
+        end
     end
 
     return false

--- a/scripts/globals/garrison_data.lua
+++ b/scripts/globals/garrison_data.lua
@@ -8,106 +8,31 @@ xi = xi or {}
 xi.garrison = xi.garrison or {}
 
 -- Name is Determined by Nation and LevelCap
-xi.garrison.names =
+-- Names in order of xi.nation values (sandoria, bastok, windurst)
+xi.garrison.allyNames =
 {
-    --level 20 garrison names
-    [20] =
-    {
-        [0] =
-        {
-            npcName = "Patrician"
-        },
-        [1] =
-        {
-            npcName = "Recruit"
-        },
-        [2] =
-        {
-            npcName = "Candidate"
-        },
-    },
-    --level 30 garrison names
-    [30] =
-    {
-        [0] =
-        {
-            npcName = "Trader"
-        },
-        [1] =
-        {
-            npcName = "Mariner"
-        },
-        [2] =
-        {
-            npcName = "Scholar"
-        },
-    },
-    --level 40 garrison names
-    [40] =
-    {
-        [0] =
-        {
-            npcName = "TempleKnight"
-        },
-        [1] =
-        {
-            npcName = "GoldMusketeer"
-        },
-        [2] =
-        {
-            npcName = "UNKNOWN"
-        },
-    },
-    --level 50 garrison names
-    [50] =
-    {
-        [0] =
-        {
-            npcName = "RoyalGuard"
-        },
-        [1] =
-        {
-            npcName = "GoldMusketeer"
-        },
-        [2] =
-        {
-            npcName = "Patriarch"
-        },
-    },
-    --level 99 garrison names
-    [75] =
-    {
-        [0] =
-        {
-            npcName = "MilitaryAttache"
-        },
-        [1] =
-        {
-            npcName = "MilitaryAttache"
-        },
-        [2] =
-        {
-            npcName = "MilitaryAttache"
-        },
-    },
+    [20] = { "Patrician", "Recruit", "Candidate" },
+    [30] = { "Trader", "Mariner", "Scholar" },
+    -- TODO: Capture Windy npc. Shouldn't be TempleKnight.
+    [40] = { "TempleKnight", "GoldMusketeer", "TempleKnight" },
+    [50] = { "RoyalGuard", "GoldMusketeer", "Patriarch" },
+    [75] = { "MilitaryAttache", "MilitaryAttache", "MilitaryAttache" },
 }
+
 -- Look is Determined by Nation and LevelCap (Appears to be 4 for each outpost need more data though)
-xi.garrison.looks =
+xi.garrison.allyLooks =
 {
     --level 20 garrison looks
     [20] =
     {
-        [0] =
         {
             "0x01000C030010262000303A403A5008611B700000",
             "0x01000A040010262019303A40195008611C700000"
         },
-        [1] =
         {
             804,
             805
         },
-        [2] =
         {
             804,
             805
@@ -116,19 +41,16 @@ xi.garrison.looks =
     --level 30 garrison looks
     [30] =
     {
-        [0] =
         {
             "0x010006030010762076303A400650736000700000",
             "0x01000F0300101520153015401550006000700000",
             "0x010009040010762076303A400650736000700000",
             "0x01000E0400101520003015401550006000700000"
         },
-        [1] =
         {
             804,
             805
         },
-        [2] =
         {
             804,
             805
@@ -137,19 +59,16 @@ xi.garrison.looks =
     --level 40 garrison looks
     [40] =
     {
-        [0] =
         {
             "0x01000E04191019201930194019506B601C700000",
             "0x01000903191019201930194019506B601C700000"
         },
-        [1] =
         {
             "0x0100020260102420603060406050B56000700000",
             "0x010008083D1024203D3010401050756075700000",
             "0x01000008371024203730374037506F6018700000",
             "0x0100040105102420053005400550BB6000700000"
         },
-        [2] =
         {
             804,
             805
@@ -158,17 +77,14 @@ xi.garrison.looks =
     --level 50 garrison looks
     [50] =
     {
-        [0] =
         {
             804,
             805
         },
-        [1] =
         {
             804,
             805
         },
-        [2] =
         {
             "0x0100020600106320633063406350056122700000",
             "0x010004067C102D20193019401950506100700000",
@@ -176,24 +92,23 @@ xi.garrison.looks =
         },
     },
     --level 75 garrison looks
+    --TODO: Era Module
     [75] =
     {
-        [0] =
         {
             804,
             805
         },
-        [1] =
         {
             "0x010002071C1070201C301C401C50C46000700000"
         },
-        [2] =
         {
             804,
             805
         },
     },
 }
+
 -- Loot is determined by LevelCap
 xi.garrison.loot =
 {
@@ -247,6 +162,7 @@ xi.garrison.loot =
         { itemid = xi.items.ACCURATE_EARRING, droprate = 350 },
     },
     --level 75 garrison loot
+    --TODO: 75 era module
     [75] =
     {
         { itemid = xi.items.MIRATETES_MEMOIRS, droprate = 1000 },
@@ -265,18 +181,35 @@ xi.garrison.loot =
         { itemid = xi.items.MIGHTY_SWORD, droprate = 350 },
     },
 }
+
+-- Defines the structure of each wave and the wave count
+-- groupsPerWave: How many groups of mobs spawn for each wave.
+-- mobsPerGroup: How many mobs spawn per group. Each wave consists of different
+-- 'mini waves', which are separated from each other by a certain interval of time.
+-- delayBetweenGroups: How many seconds before each group spawns.
+-- After all groups in a wave are killed, the wave ends and after delayBetweenGroups,
+-- the next wave begins.
+-- Constraints: A wave can only spawn 8 mobs at a time at most. This is due to the assumption
+-- That the boss is always 8 IDs after the mobs spawning in each wave.
+-- e.g:
+-- Wave 2 contains 2 groups. Each group has 2 mobs and 15 second between group.
+-- 2 mobs will spawn initially, then 15 seconds later 2 new mobs will spawn.
+xi.garrison.waves =
+{
+    -- The last wave is a special case. It's 4 groups + Boss
+    groupsPerWave = { 1, 2, 3, 4 },
+    mobsPerGroup = 2,
+    delayBetweenGroups = 15
+}
+
 --Zone Data
-xi.garrison.data =
+xi.garrison.zoneData =
 {
     [xi.zone.WEST_RONFAURE] =
     {
         itemReq = xi.items.RED_CRYPTEX,
         textRegion = 0,
         levelCap = 20,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Orcish_Fighterchief",
         xPos = -436,
         yPos = -20,
@@ -288,52 +221,12 @@ xi.garrison.data =
         xThirdLine = 4,
         zThirdLine = 0,
         rot = 0,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-            [1] =
-            {
-                4, -- Orcish Fighter
-                3  -- Orcish Fighter
-            },
-            [2] =
-            {
-                4, -- Orcish Fighter
-                3, -- Orcish Fighter
-                2, -- Orcish Chasseur
-                1  -- Orcish Chasseur
-            },
-            [3] =
-            {
-                6, -- Orcish Serjeant
-                5, -- Orcish Serjeant
-                4, -- Orcish Fighter
-                3, -- Orcish Fighter
-                2, -- Orcish Chasseur
-                1  -- Orcish Chasseur
-            },
-            [4] =
-            {
-                8, -- Orcish_Cursemaker
-                7, -- Orcish_Cursemaker
-                6, -- Orcish Serjeant
-                5, -- Orcish Serjeant
-                4, -- Orcish Fighter
-                3, -- Orcish Fighter
-                2, -- Orcish Chasseur
-                1  -- Orcish Chasseur
-            },
-        },
     },
     [xi.zone.NORTH_GUSTABERG] =
     {
         itemReq = xi.items.DARKSTEEL_ENGRAVING,
         textRegion = 1,
         levelCap = 20,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Lead_Quadav",
         xPos = -580, --needs adjusting
         yPos = 40,
@@ -345,53 +238,12 @@ xi.garrison.data =
         xThirdLine = 4,
         zThirdLine = 0,
         rot = 106,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.WEST_SARUTABARUTA] =
     {
         itemReq = xi.items.SEVEN_KNOT_QUIPU,
         textRegion = 2,
         levelCap = 20,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Yagudo_Condottiere",
         xPos = -20, -- needs adjusting
         yPos = -12,
@@ -403,53 +255,12 @@ xi.garrison.data =
         xThirdLine = 4,
         zThirdLine = 0,
         rot = 115,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.VALKURM_DUNES] =
     {
         itemReq = xi.items.GALKA_FANG_SACK,
         textRegion = 3,
         levelCap = 30,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Goblin_Swindler",
         xPos = 141, -- needs adjusting
         yPos = -8,
@@ -461,53 +272,12 @@ xi.garrison.data =
         xThirdLine = 4,
         zThirdLine = 0,
         rot = 32,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.JUGNER_FOREST] =
     {
         itemReq = xi.items.JADE_CRYPTEX,
         textRegion = 4,
         levelCap = 30,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Orcish_Colonel",
         xPos = 54, -- needs adjusting
         yPos = 1,
@@ -519,53 +289,12 @@ xi.garrison.data =
         xThirdLine = 0,
         zThirdLine = 4,
         rot = 210,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.PASHHOW_MARSHLANDS] =
     {
         itemReq = xi.items.SILVER_ENGRAVING,
         textRegion = 5,
         levelCap = 30,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Cobalt_Quadav",
         xPos = 458, -- needs adjusting
         yPos = 24,
@@ -577,53 +306,12 @@ xi.garrison.data =
         xThirdLine = 4,
         zThirdLine = 0,
         rot = 130,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.BUBURIMU_PENINSULA] =
     {
         itemReq = xi.items.MITHRA_FANG_SACK,
         textRegion = 6,
         levelCap = 30,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Goblin_Guide",
         xPos = -485, -- needs adjusting
         yPos = -29,
@@ -635,53 +323,12 @@ xi.garrison.data =
         xThirdLine = 0,
         zThirdLine = -4,
         rot = 0,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.MERIPHATAUD_MOUNTAINS] =
     {
         itemReq = xi.items.THIRTEEN_KNOT_QUIPU,
         textRegion = 7,
         levelCap = 30,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Yagudo_Missionary",
         xPos = -299, -- needs adjusting
         yPos = 17,
@@ -693,53 +340,12 @@ xi.garrison.data =
         xThirdLine = 0,
         zThirdLine = 4,
         rot = 30,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.QUFIM_ISLAND] =
     {
         itemReq = xi.items.RAM_LEATHER_MISSIVE,
         textRegion = 10,
         levelCap = 30,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Hunting_Chief",
         xPos = -247, -- needs adjusting
         yPos = -19,
@@ -751,53 +357,12 @@ xi.garrison.data =
         xThirdLine = 0,
         zThirdLine = -4,
         rot = 0,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.BEAUCEDINE_GLACIER] =
     {
         itemReq = xi.items.TIGER_LEATHER_MISSIVE,
         textRegion = 8,
         levelCap = 40,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Gigas_Overseer",
         xPos = -25, -- needs adjusting
         yPos = -60,
@@ -809,53 +374,12 @@ xi.garrison.data =
         xThirdLine = 0,
         zThirdLine = -2,
         rot = 220,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.THE_SANCTUARY_OF_ZITAH] =
     {
         itemReq = xi.items.HOUND_FANG_SACK,
         textRegion = 11,
         levelCap = 40,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Goblin_Doyen",
         xPos = -43,
         yPos = 1,
@@ -867,52 +391,12 @@ xi.garrison.data =
         xThirdLine = 0,
         zThirdLine = 4,
         rot = 180,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-            [1] =
-            {
-                8, -- Goblin Enchanter
-                7  -- Goblin Enchanter
-            },
-            [2] =
-            {
-                8, -- Goblin Enchanter
-                7, -- Goblin Enchanter
-                6, -- Goblin Poacher
-                5  -- Goblin Poacher
-            },
-            [3] =
-            {
-                8, -- Goblin Enchanter
-                7, -- Goblin Enchanter
-                6, -- Goblin Poacher
-                5, -- Goblin Poacher
-                4, -- Goblin Bouncer
-                3  -- Goblin Bouncer
-            },
-            [4] =
-            {
-                8, -- Goblin Enchanter
-                7, -- Goblin Enchanter
-                6, -- Goblin Poacher
-                5, -- Goblin Poacher
-                4, -- Goblin Bouncer
-                3, -- Goblin Bouncer
-                2, -- Goblin Reaper
-                1  -- Goblin Reaper
-            },
-        },
     },
     [xi.zone.YUHTUNGA_JUNGLE] =
     {
         itemReq = xi.items.SHEEP_LEATHER_MISSIVE,
         textRegion = 14,
         levelCap = 40,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Sahagin_Patriarch",
         xPos = -248,
         yPos = 1,
@@ -924,53 +408,12 @@ xi.garrison.data =
         xThirdLine = 0,
         zThirdLine = 4,
         rot = 180,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.XARCABARD] =
     {
         itemReq = xi.items.BEHEMOTH_LEATHER_MISSIVE,
         textRegion = 9,
         levelCap = 50,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Demon_Aristocrat",
         xPos = 216, -- needs adjusting
         yPos = -22,
@@ -982,53 +425,12 @@ xi.garrison.data =
         xThirdLine = 0,
         zThirdLine = 4,
         rot = 90,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.EASTERN_ALTEPA_DESERT] =
     {
         itemReq = xi.items.DHALMEL_LEATHER_MISSIVE,
         textRegion = 12,
         levelCap = 50,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Centurio_XIII-V",
         xPos = -245,
         yPos = -9,
@@ -1040,53 +442,12 @@ xi.garrison.data =
         xThirdLine = 4,
         zThirdLine = 0,
         rot = 0,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
-            [1] =
-            {
-                8,
-                7
-            },
-            [2] =
-            {
-                8,
-                7,
-                6,
-                5
-            },
-            [3] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
-            },
-            [4] =
-            {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
-            },
-        },
     },
     [xi.zone.YHOATOR_JUNGLE] =
     {
         itemReq = xi.items.COEURL_LEATHER_MISSIVE,
         textRegion = 15,
         levelCap = 50,
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Tonberry_Decimator",
         xPos = 214,
         yPos = 1,
@@ -1098,52 +459,12 @@ xi.garrison.data =
         xThirdLine = 4,
         zThirdLine = -2,
         rot = 0,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-            [1] =
-            {
-                8, -- Tonberry Creeper
-                7  -- Tonberry Creeper
-            },
-            [2] =
-            {
-                8, -- Tonberry Creeper
-                7, -- Tonberry Creeper
-                6, -- Tonberry Hexer
-                5  -- Tonberry Hexer
-            },
-            [3] =
-            {
-                8, -- Tonberry Creeper
-                7, -- Tonberry Creeper
-                6, -- Tonberry Hexer
-                5, -- Tonberry Hexer
-                4, -- Tonberry Creeper
-                3  -- Tonberry Creeper
-            },
-            [4] =
-            {
-                8, -- Tonberry Creeper
-                7, -- Tonberry Creeper
-                6, -- Tonberry Hexer
-                5, -- Tonberry Hexer
-                4, -- Tonberry Creeper
-                3, -- Tonberry Creeper
-                2, -- Tonberry Hexer
-                1  -- Tonberry Hexer
-            },
-        },
     },
     [xi.zone.CAPE_TERIGGAN] =
     {
         itemReq = xi.items.BUNNY_FANG_SACK,
         textRegion = 13,
         levelCap = 75, -- 75 Mobs/NPCs Is uncapped
-        npcs =
-        {
-        -- empty filled with dynamic entries
-        },
         mobBoss = "Goblin_Boss",
         xPos = -174,
         yPos = 8,
@@ -1155,41 +476,5 @@ xi.garrison.data =
         xThirdLine = 4,
         zThirdLine = 0,
         rot = 0,
-        waveOrder =
-        {
-        -- # Represents the negative offset from boss to spawn
-            [1] =
-            {
-                8, -- Goblin Pirate
-                7  -- Goblin Pirate
-            },
-            [2] =
-            {
-                8, -- Goblin Pirate
-                7, -- Goblin Pirate
-                6, -- Goblin Duelist
-                5  -- Goblin Duelist
-            },
-            [3] =
-            {
-                8, -- Goblin Pirate
-                7, -- Goblin Pirate
-                6, -- Goblin Duelist
-                5, -- Goblin Duelist
-                4, -- Goblin Doctor
-                3  -- Goblin Doctor
-            },
-            [4] =
-            {
-                8, -- Goblin Pirate
-                7, -- Goblin Pirate
-                6, -- Goblin Duelist
-                5, -- Goblin Duelist
-                4, -- Goblin Doctor
-                3, -- Goblin Doctor
-                2, -- Goblin Professor
-                1  -- Goblin Professor
-            },
-        },
     },
 }

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -154,6 +154,126 @@ function utils.clamp(input, min_val, max_val)
     return input
 end
 
+--  Returns a table containing all the elements in the specified range.
+--  Source: https://github.com/mebens/range
+function utils.range(from, to, step)
+    local t = {}
+    local argType = type(from)
+    step = step or 1
+
+    if argType == "number" then
+        for i = from, to, step do t[#t + 1] = i end
+    elseif argType == "string" then
+        local e = string.byte(to)
+        for i = string.byte(from), e, step do t[#t + 1] = string.char(i) end
+    elseif argType == "table" then
+        local metaNext = getmetatable(from).__next
+
+        if metaNext then
+            local i = from
+
+            while i < to do
+                t[#t + 1] = i
+                i = metaNext(i, step)
+            end
+
+            t[#t + 1] = to
+        end
+    end
+
+    return t
+end
+
+-----------------------------------
+--
+-- Functional
+--
+-- Functional methods provide a means to simplify logic that consists in
+-- simple operations when iterating a table.
+-- In general, they can make code much more concise and readable, but they
+-- can also end up making it a cluttered mess, so use your judgement
+-- when deciding if you want to use these methods
+-----------------------------------
+
+-- Given a table and a mapping function, returns a new table created by
+-- applying the given mapping function to the given table elements
+function utils.map(tbl, func)
+    local t = {}
+    for k, v in pairs(tbl) do
+        t[k] = func(k, v)
+    end
+    return t
+end
+
+-- Given a table and a filter function, returns a new table composed of the
+-- elements that pass the given filter.
+-- e.g: utils.filter({ "a", "b", "c", "d" }, function(k, v) return v >= "c" end)  --> { "c", "d }
+function utils.filter(tbl, func)
+    local out = {}
+
+    for k, v in pairs(tbl) do
+        if func(k, v) then
+            out[k] = v
+        end
+    end
+
+    return out
+end
+
+-- Given a table and a filter function, returns a new table composed of the
+-- elements that pass the given filter.
+-- Unlike utils.filter, this method will return an iterable table.
+-- e.g utils.filterArray({ "a", "b", "c", "d" }, function(k, v) return v >= "c" end)  --> { 1 => "c", 2 => "d" }
+function utils.filterArray(tbl, func)
+    local out = {}
+
+    for k, v in pairs(tbl) do
+        if func(k, v) then
+            table.insert(out, v)
+        end
+    end
+
+    return out
+end
+
+-- Returns true if any member of the given table passes the given
+-- predicate function
+function utils.any(tbl, predicate)
+    for k, v in pairs(tbl) do
+        if predicate(k, v) then
+            return true
+        end
+    end
+
+    return false
+end
+
+-- Returns the sum of applying the given function to each element of the given table
+-- e.g: utils.sum({ 1, 2, 3 }, function(k, v) return v end)  --> 6
+function utils.sum(tbl, func)
+    local sum = 0
+
+    for k, v in pairs(tbl) do
+        sum = sum + func(k, v)
+    end
+
+    return sum
+end
+
+-- To be used with utils.sum.
+-- Used to count the number of times an element in a table
+-- matches the given predicate
+-- e.g: utils.sum({ "a, "a", "b" }, utils.counter(function (k, v) return v == "a" end)) --> 2
+function utils.counter(predicate)
+    return function (k, v)
+        if predicate(k, v) then
+            return 1
+        else
+            return 0
+        end
+    end
+end
+
 -- returns unabsorbed damage
 function utils.stoneskin(target, dmg)
     --handling stoneskin

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -165,12 +165,14 @@ xi.settings.main =
     NM_LOTTERY_COOLDOWN = 1.0,
 
 	-- GARRISON SETTINGS
-    GARRISON_LOCKOUT             = 1800, -- Time in seconds before a new garrison can be started (default: 1800)
-    GARRISON_TIME_LIMIT          = 1800, -- Time in seconds before lose ongoing garrison (default: 1800)
-    GARRISON_ONCE_PER_WEEK       = 0,    -- Set to 1 to bypass the limit of one garrison per Conquest Tally Week.
-    GARRISON_PARTY_LIMIT         = 18,   -- Set to max party members you want to do garrison (default: 18).
-    GARRISON_NATION_BYPASS       = 0,    -- Set to 1 to bypass the nation requirement.
-    GARRISON_RANK                = 2,    -- Set to minumum Nation Rank to start Garrison (default: 2).
+    ENABLE_GARRISON              = false,  -- If true, enables garrison functionality
+    DEBUG_GARRISON               = false,  -- If true, garrison will print out debug messages in logs as well as players as smes.
+    GARRISON_LOCKOUT             = 1800,   -- Time in seconds before a new garrison can be started (default: 1800)
+    GARRISON_TIME_LIMIT          = 1800,   -- Time in seconds before lose ongoing garrison (default: 1800)
+    GARRISON_ONCE_PER_WEEK       = false,  -- Set to false to bypass the limit of one garrison per Conquest Tally Week.
+    GARRISON_PARTY_LIMIT         = 18,     -- Set to max party members you want to do garrison (default: 18).
+    GARRISON_NATION_BYPASS       = false,  -- Set to true to bypass the nation requirement.
+    GARRISON_RANK                = 2,      -- Set to minumum Nation Rank to start Garrison (default: 2).
 
     -- DYNAMIS SETTINGS
     BETWEEN_2DYNA_WAIT_TIME     = 72,       -- Hours before player can re-enter Dynamis. Default is 1 Earthday (24 hours).

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -49,8 +49,8 @@ public:
     bool DelStatusEffect(EFFECT StatusID);
     bool DelStatusEffectSilent(EFFECT StatusID);
     bool DelStatusEffect(EFFECT StatusID, uint16 SubID);
-    void DelStatusEffectsByFlag(uint32 flag, bool silent = false); // удаляем все эффекты с указанным типом
-    void DelStatusEffectsByIcon(uint16 IconID);                    // удаляем все эффекты с указанной иконкой
+    void DelStatusEffectsByFlag(uint32 flag, bool silent = false); // Remove all the status effects with the specified type
+    void DelStatusEffectsByIcon(uint16 IconID);                    // Remove all effects with the specified icon
     void DelStatusEffectsByType(uint16 Type);
     bool DelStatusEffectByTier(EFFECT StatusID, uint16 power);
     void KillAllStatusEffect();


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Implements wave system that spawns the right amount of mobs at the right time for each wave
* Fixes the number of allies spawned (1 per alliance member based on captures)
* Grants correct loot on victory
* Spawns the right bosses / npcs on each zone
* Save lockout information for player
* Add timer for garrison timeout
* Gates entry based on rank and other requirements

## Known Issues

* NPC looks are incorrect (they show naked on spawn). This seems like an entity update issue.
* Some zones (Qufim, buburimbu) have an issue where npcs will path incorrectly to mobs and never attack. This is a bigger issue that is not related to the garrison system so I'm not fixing it here, but it makes certain zones harder to play.
* On victory / loss, the win / lose message is shouted out by the npc immediately. This is not accurate to captures, as the npc is supposed to tell a player that message after the player talks to the npc on victory / loss. However, this felt like a fair simplification given the little impact on players.

## Steps to test these changes

* edit settings/main.lua and set ENABLE_GARRISON to true. Maybe set minimum rank to 0 and remove nation lockout for testing. should also set DEBUG_GARRISON=true
* !zone 103
* Run to op, !additem sack_of_galka% and trade it to the npc maybe use !immortal on the spawned ally if you suck like I do
* Kill mobs as they pop
