### PR TITLE
Fix bug causing overflow in client after /random by long-named chars.

### DIFF
--- a/src/map/packets/message_standard.cpp
+++ b/src/map/packets/message_standard.cpp
@@ -98,7 +98,17 @@ CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint32 param1, uin
 CMessageStandardPacket::CMessageStandardPacket(CCharEntity* PChar, uint32 param0, MsgStd MessageID)
 {
     this->setType(0x09);
-    this->setSize(0x30);
+    auto namesize = PChar->name.size();
+
+    if (namesize == 15)
+    {
+        // Prevents an overflow on 15-character names
+        this->setSize(0x34);
+    }
+    else
+    {
+        this->setSize(0x30);
+    }
 
     // XI_DEBUG_BREAK_IF(MessageID != 0x58);
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds 4-byte spacer to packets when the player's name has 15 chars, or has 14 chars and rolls a 1000.  

## Steps to test these changes

Have long name.  /random around other people.
