### PR TITLE
Era Dark Knight Timer Fixes

### DIFF
--- a/scripts/globals/job_utils/dark_knight.lua
+++ b/scripts/globals/job_utils/dark_knight.lua
@@ -56,7 +56,12 @@ xi.job_utils.dark_knight.useArcaneCircle = function(player, target, ability)
     -- Job Points bonus will need to be handled in the Bonus vs Ecosystem handling system
     -- https://www.bg-wiki.com/ffxi/Job_Points#Dark_Knight
     -- Arcane Circle Effect: Reduces the amount of damage taken from arcana while under the effects of Arcane Circle.
-    local duration = 180 * (1 + (player:getMod(xi.mod.ARCANE_CIRCLE_DURATION) / 100))
+    local duration
+    if xi.settings.main.ENABLE_ROV == 1 then
+        duration = 180 * (1 + (player:getMod(xi.mod.ARCANE_CIRCLE_DURATION) / 100))
+    else
+        duration = 60 * (1 + (player:getMod(xi.mod.ARCANE_CIRCLE_DURATION) / 100))
+    end
     local power    = 15 + player:getMod(xi.mod.ARCANE_CIRCLE_POTENCY)
 
     if player:getMainJob() ~= xi.job.DRK then

--- a/scripts/globals/job_utils/dark_knight.lua
+++ b/scripts/globals/job_utils/dark_knight.lua
@@ -98,7 +98,11 @@ xi.job_utils.dark_knight.useDiabolicEye = function(player, target, ability)
 end
 
 xi.job_utils.dark_knight.useLastResort = function(player, target, ability)
-    player:addStatusEffect(xi.effect.LAST_RESORT, 0, 0, 180)
+    if xi.settings.main.ENABLE_ABYSSEA == 1 then
+        player:addStatusEffect(xi.effect.LAST_RESORT, 0, 0, 180)
+    else
+        player:addStatusEffect(xi.effect.LAST_RESORT, 0, 0, 30)
+    end
 end
 
 xi.job_utils.dark_knight.useNetherVoid = function(player, target, ability)

--- a/scripts/globals/spells/black/dread_spikes.lua
+++ b/scripts/globals/spells/black/dread_spikes.lua
@@ -13,7 +13,12 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local duration = xi.magic.calculateDuration(xi.settings.main.SPIKE_EFFECT_DURATION, spell:getSkillType(), spell:getSpellGroup(), caster, target)
+    local duration
+    if xi.settings.main.ENABLE_ROV == 1 then
+        duration = xi.magic.calculateDuration(xi.settings.main.SPIKE_EFFECT_DURATION, spell:getSkillType(), spell:getSpellGroup(), caster, target)
+    else
+        duration = xi.magic.calculateDuration(60, spell:getSkillType(), spell:getSpellGroup(), caster, target)
+    end
     local typeEffect = xi.effect.DREAD_SPIKES
     local drainAmount = target:getMaxHP() / 2
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Reduces Last Resort duration from 3 minutes to 30 seconds only if abyssea is not enabled
- Reduces Dread Spikes duration from 3 minutes to 1 minute when RoV is not enabled
- Reduces Arcane Circle duration from 3 minutes to 1 minute when RoV is not enabled

Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/873
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/868
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/878