### PR TITLE
Fixes an Issue with xi.magic.ele.NONE Status Effects

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -807,7 +807,7 @@ xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes, ski
         skillchainCount = 0
     end
 
-    if target ~= nil and element ~= nil and target:getObjType() == xi.objType.MOB then
+    if target ~= nil and element ~= nil and element ~= xi.magic.ele.NONE and target:getObjType() == xi.objType.MOB then
         local eemTier = 1
         eemVal = target:getMod(xi.magic.eleEvaMult[element]) / 100
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes an issue where applying a status effect via bolts or other sources with no element would cause a failure in calculating magic resist rates.

Closes #791

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
