### PR TITLE
RNG Quest: Old Sabretooth mob behavior fixes

### DIFF
--- a/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
@@ -15,12 +15,12 @@ entity.onMobSpawn = function(mob)
     mob:SetAutoAttackEnabled(false)
     mob:setRoamFlags(256, 512)
 
-    mob:addListener("TAKE_DAMAGE", "PRIME_TAKE_DAMAGE", function(mob, amount, attacker)
+    mob:addListener("TAKE_DAMAGE", "PRIME_TAKE_DAMAGE", function(tiger, amount, attacker)
         if attacker then
-            mob:setLocalVar("tookDamage", 1)
-            mob:SetMobAbilityEnabled(true)
-            mob:SetAutoAttackEnabled(true)
-            mob:setBehaviour(0)
+            tiger:setLocalVar("tookDamage", 1)
+            tiger:SetMobAbilityEnabled(true)
+            tiger:SetAutoAttackEnabled(true)
+            tiger:setBehaviour(0)
         end
     end)
 end

--- a/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
@@ -9,15 +9,42 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onMobSpawn = function(mob)
+    mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.STANDBACK))
+    mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+    mob:SetMobAbilityEnabled(false)
+    mob:SetAutoAttackEnabled(false)
+    mob:setRoamFlags(256, 512)
+
+    mob:addListener("TAKE_DAMAGE", "PRIME_TAKE_DAMAGE", function(mob, amount, attacker)
+        if attacker then
+            mob:setLocalVar("tookDamage", 1)
+            mob:SetMobAbilityEnabled(true)
+            mob:SetAutoAttackEnabled(true)
+            mob:setBehaviour(0)
+        end
+    end)
+end
+
+entity.onMobFight = function(mob)
+    if mob:getLocalVar("control") == 0 and mob:getLocalVar("tookDamage") == 0 then
+        mob:setLocalVar("control", 1)
+        mob:timer(15000, function(mobArg)
+            local pos = mob:getPos()
+            mob:pathTo(pos.x + math.random(-2, 2), pos.y, pos.z + math.random(-2, 2), 9)
+            mobArg:setLocalVar("control", 0)
+        end)
+    end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    if player == nil then
-        local players = mob:getZone():getPlayers()
+    local players = mob:getZone():getPlayers()
 
-        for i, person in pairs(players) do -- can't use the variable name "player" because it's already being used
-            if person:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_FANGED_ONE) == QUEST_ACCEPTED and person:checkDistance(mob) < 32 then
+    for i, person in pairs(players) do -- can't use the variable name "player" because it's already being used
+        if person:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_FANGED_ONE) == QUEST_ACCEPTED and person:checkDistance(mob) < 32 then
+            if mob:getLocalVar("tookDamage") == 0 then
                 person:setCharVar("TheFangedOneCS", 2)
+            else
+                person:setCharVar("TheFangedOneTimer", os.time() + 300)
             end
         end
     end

--- a/scripts/zones/Sauromugue_Champaign/npcs/Tiger_Bones.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/Tiger_Bones.lua
@@ -16,10 +16,13 @@ end
 entity.onTrigger = function(player, npc)
     local fangedOne = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_FANGED_ONE)
     local fangedOneCS = player:getCharVar("TheFangedOneCS")
+    local timer = player:getCharVar("TheFangedOneTimer")
 
     -- THE FANGED ONE
-    if fangedOne == QUEST_ACCEPTED and fangedOneCS == 1 and not GetMobByID(ID.mob.OLD_SABERTOOTH):isSpawned() then
-        SpawnMob(ID.mob.OLD_SABERTOOTH):addStatusEffect(xi.effect.POISON, 40, 10, 210)
+    local tiger = GetMobByID(ID.mob.OLD_SABERTOOTH)
+    if fangedOne == QUEST_ACCEPTED and fangedOneCS == 1 and not tiger:isSpawned() and os.time() > timer then
+        SpawnMob(tiger:getID()):updateClaim(player)
+        tiger:addStatusEffect(xi.effect.POISON, 10, 10, 500)
         player:messageSpecial(ID.text.OLD_SABERTOOTH_DIALOG_I)
     elseif fangedOne == QUEST_ACCEPTED and fangedOneCS == 2 and not player:hasKeyItem(xi.ki.OLD_TIGERS_FANG) then
         player:addKeyItem(xi.ki.OLD_TIGERS_FANG)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds appropriate retail behavior to the old sabertooth encountered during the ranger unlock quest
- Tiger will now spawn claimed
- will not attack player unless attacked
- moves around occasionally
- won't face players when roaming
- updated spawn point
- Reduced potency of poison as seen in captures
- If players fail, they must wait 5 minutes to restart

Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/951
