### PR TITLE
Ranged PDIF | Base Monster Damage

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1598,7 +1598,6 @@ namespace battleutils
         // get ratio (not capped for RAs)
         float ratio = (float)rAttack / ((float)PDefender->DEF() - ignoredDef);
 
-        ratio        = std::clamp<float>(ratio, 0, 3);
         float cRatio = ratio;
 
         // level correct (0.025 not 0.05 like for melee)
@@ -1606,12 +1605,11 @@ namespace battleutils
         {
             cRatio = cRatio - (PDefender->GetMLevel() - PAttacker->GetMLevel()) * 0.025f;
         }
-
         // calculate min/max PDIF
         float minPdif = 0.0f;
         float maxPdif = 3.0f;
 
-        if (ratio < 0.9f)
+        if (cRatio < 0.9f)
         {
             minPdif = cRatio;
             maxPdif = (10.0f / 9.0f) * cRatio;
@@ -1621,7 +1619,7 @@ namespace battleutils
                 maxPdif = std::clamp<float>((10.0f / 8.0f) * cRatio, 0, 1);
             }
         }
-        else if (ratio <= 1.1f)
+        else if (cRatio <= 1.1f)
         {
             minPdif = 1.0f;
             maxPdif = 1.0f;

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -56,31 +56,16 @@ namespace mobutils
     uint16 GetWeaponDamage(CMobEntity* PMob, uint16 slot)
     {
         uint16 lvl    = PMob->GetMLevel();
-        int8   bonus  = 0;
+        int8   bonus  = 2;
         uint16 damage = 0;
 
         if (slot == SLOT_RANGED)
         {
             bonus = 5;
         }
-        else
+        else if (lvl == 1)
         {
-            if (lvl >= 75)
-            {
-                bonus = 3;
-            }
-            else if (lvl >= 60)
-            {
-                bonus = 2;
-            }
-            else if (lvl >= 50)
-            {
-                bonus = 1;
-            }
-            else if (lvl == 1)
-            {
-                bonus = -1;
-            }
+            bonus = -1;
         }
 
         damage = lvl + bonus;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixed ranged PDIF caps and type in if statement. This was causing the brackets to be calculated incorrectly and was returning values lower than they should be.
- Fixes base monster damage for various levels
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
- Go to any mob and be the correct distance for the sweet spot
- Increase your attack and see your damage go up, instead of down
<!-- Clear and detailed steps to test your changes here -->
