### PR TITLE
Fix Double Astral Flow | Fix Mob Pathing

### DIFF
--- a/scripts/mixins/families/avatar.lua
+++ b/scripts/mixins/families/avatar.lua
@@ -35,10 +35,13 @@ g_mixins.families.avatar = function(avatarMob)
     end)
 
     avatarMob:addListener("ENGAGE", "AVATAR_ENGAGE", function(mob, target)
-        local modelId = mob:getModelId()
-        local abilityId = abilityIds[modelId - 790]
-        if abilityId ~= nil then
-            mob:useMobAbility(abilityId)
+        if mob:getLocalVar("[ASTRAL_FLOW]Performed") == 0 then
+            local modelId = mob:getModelId()
+            local abilityId = abilityIds[modelId - 790]
+            if abilityId ~= nil then
+                mob:useMobAbility(abilityId)
+                mob:setLocalVar("[ASTRAL_FLOW]Performed", 1)
+            end
         end
     end)
 

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -900,13 +900,13 @@ void CMobController::Move()
                     if (currentDistance > PMob->GetMeleeRange())
                     {
                         // try to find path towards target
-                        PMob->PAI->PathFind->PathInRange(PTarget->loc.p, attack_range - 0.2f, PATHFLAG_WALLHACK | PATHFLAG_RUN);
+                        PMob->PAI->PathFind->PathInRange(PTarget->loc.p, attack_range - 0.2f, PATHFLAG_RUN);
                     }
                 }
                 else if (distanceSquared(PMob->PAI->PathFind->GetDestination(), PTarget->loc.p) > 10)
                 {
                     // try to find path towards target
-                    PMob->PAI->PathFind->PathInRange(PTarget->loc.p, attack_range - 0.2f, PATHFLAG_WALLHACK | PATHFLAG_RUN);
+                    PMob->PAI->PathFind->PathInRange(PTarget->loc.p, attack_range - 0.2f, PATHFLAG_RUN);
                 }
 
                 PMob->PAI->PathFind->FollowPath(m_Tick);
@@ -938,7 +938,7 @@ void CMobController::Move()
 
                                 if (PMob->PAI->PathFind->ValidPosition(new_pos))
                                 {
-                                    PMob->PAI->PathFind->PathTo(new_pos, PATHFLAG_WALLHACK | PATHFLAG_RUN);
+                                    PMob->PAI->PathFind->PathTo(new_pos, PATHFLAG_RUN);
                                     needToMove = true;
                                 }
                                 break;

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -100,7 +100,7 @@ void CPetController::DoRoamTick(time_point tick)
 
     if (currentDistance > PetRoamDistance)
     {
-        if (currentDistance < 35.0f && PPet->PAI->PathFind->PathAround(PPet->PMaster->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK))
+        if (currentDistance < 35.0f && PPet->PAI->PathFind->PathAround(PPet->PMaster->loc.p, 2.0f, PATHFLAG_RUN))
         {
             PPet->PAI->PathFind->FollowPath(m_Tick);
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Removes all instances of mob's wallhack usage during pathing.
+ Adds an additional variable to the engage listener on the avatar mixin to ensure if the target changes after a skill goes off that another skill is not performed.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
