### PR TITLE
Initial Event Flags Commit

### DIFF
--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -18,7 +18,8 @@ zoneObject.onZoneIn = function(player, prevZone)
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 0
+            ---@diagnostic disable-next-line: cast-local-type
+            cs = { 0, -1, 0x93 }
         end
         player:setPos(-280, -12, -91, 15)
         player:setHomePoint()

--- a/scripts/zones/Bastok_Mines/Zone.lua
+++ b/scripts/zones/Bastok_Mines/Zone.lua
@@ -23,7 +23,8 @@ zoneObject.onZoneIn = function(player, prevZone)
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 1
+            ---@diagnostic disable-next-line: cast-local-type
+            cs = { 1, -1, 0x93 }
         end
         player:setPos(-45, -0, 26, 213)
         player:setHomePoint()

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -29,7 +29,8 @@ zoneObject.onZoneIn = function(player, prevZone)
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 535
+            ---@diagnostic disable-next-line: cast-local-type
+            cs = { 535, -1, 0x93 }
         end
 
         player:setPos(0, 0, -11, 191)

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -24,7 +24,8 @@ zoneObject.onZoneIn = function(player, prevZone)
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 1
+            ---@diagnostic disable-next-line: cast-local-type
+            cs = { 1, -1, 0x93 }
         end
 
         player:setPos(132, -8.5, -13, 179)

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -20,7 +20,8 @@ zoneObject.onZoneIn = function(player, prevZone)
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 500
+            ---@diagnostic disable-next-line: cast-local-type
+            cs = { 500, -1, 0x93 }
         end
 
         player:setPos(-104, -8, -128, 227)

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -18,7 +18,8 @@ zoneObject.onZoneIn = function(player, prevZone)
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 305
+            ---@diagnostic disable-next-line: cast-local-type
+            cs = { 305, -1, 0x93 }
         end
 
         player:setPos(-120, -5.5, 175, 48)

--- a/scripts/zones/Southern_San_dOria/Zone.lua
+++ b/scripts/zones/Southern_San_dOria/Zone.lua
@@ -25,7 +25,8 @@ zoneObject.onZoneIn = function(player, prevZone)
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 503
+            ---@diagnostic disable-next-line: cast-local-type
+            cs = { 503, -1, 0x93 }
         end
 
         player:setPos(-96, 1, -40, 224)

--- a/scripts/zones/Windurst_Waters/Zone.lua
+++ b/scripts/zones/Windurst_Waters/Zone.lua
@@ -22,7 +22,8 @@ zoneObject.onZoneIn = function(player, prevZone)
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 531
+            ---@diagnostic disable-next-line: cast-local-type
+            cs = { 531, -1, 0x93 }
         end
         player:setPos(-40, -5, 80, 64)
         player:setHomePoint()

--- a/scripts/zones/Windurst_Woods/Zone.lua
+++ b/scripts/zones/Windurst_Woods/Zone.lua
@@ -22,7 +22,8 @@ zoneObject.onZoneIn = function(player, prevZone)
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 367
+            ---@diagnostic disable-next-line: cast-local-type
+            cs = { 367, -1, 0x93 }
         end
 
         player:setPos(0, 0, -50, 0)

--- a/src/map/event_info.h
+++ b/src/map/event_info.h
@@ -62,6 +62,7 @@ struct EventInfo : EventPrep
     EVENT_TYPE         type = NORMAL;
     std::vector<int32> cutsceneOptions;
     uint16             interruptText = 0;
+    uint32             eventFlags    = 0;
 
     bool hasCutsceneOption(int32 _option)
     {
@@ -76,7 +77,8 @@ struct EventInfo : EventPrep
         cutsceneOptions.clear();
         params.clear();
         strings.clear();
-        textTable = -1;
+        textTable  = -1;
+        eventFlags = 0;
     }
 };
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -858,6 +858,7 @@ EventInfo* CLuaBaseEntity::ParseEvent(int32 EventID, sol::variadic_args va, Even
         // Parse out other misc. possible arguments for events.
         eventToStart->textTable     = table.get_or<int16>("text_table", -1);
         eventToStart->interruptText = table.get_or<int16>("interrupt_text", 0);
+        eventToStart->eventFlags    = table.get_or<uint32>("flags", 0);
 
         sol::object csOption = table["cs_option"];
         if (csOption.is<int32>())

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1876,8 +1876,9 @@ namespace luautils
         {
             auto resultTable = result.get<sol::table>();
 
-            PChar->currentEvent->eventId   = resultTable.get_or(1, -1);
-            PChar->currentEvent->textTable = resultTable.get_or(2, -1);
+            PChar->currentEvent->eventId    = resultTable.get_or(1, -1);
+            PChar->currentEvent->textTable  = resultTable.get_or(2, -1);
+            PChar->currentEvent->eventFlags = resultTable.get_or(3, 0);
         }
         else if (result.get_type() == sol::type::number)
         {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -394,7 +394,7 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
         }
 
         PChar->pushPacket(new CDownloadingDataPacket());
-        PChar->pushPacket(new CZoneInPacket(PChar, PChar->currentEvent->eventId));
+        PChar->pushPacket(new CZoneInPacket(PChar, PChar->currentEvent));
         PChar->pushPacket(new CZoneVisitedPacket(PChar));
     }
 }

--- a/src/map/packets/event.cpp
+++ b/src/map/packets/event.cpp
@@ -77,7 +77,16 @@ CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
         }
 
         ref<uint16>(0x2C) = eventInfo->eventId;
-        ref<uint8>(0x2E)  = 8; // if the parameter is less than 8, then after the event is over the camera will "jump" behind the character
+        if (eventInfo->eventFlags != 0)
+        {
+            ref<uint16>(0x2E) = eventInfo->eventFlags & 0xFFFF;
+            ref<uint16>(0x32) = eventInfo->eventFlags >> 16;
+        }
+        else
+        {
+            // Backwards compatibility kludge!
+            ref<uint8>(0x2E) = 8; // if the parameter is less than 8, then after the event is over the camera will "jump" behind the character
+        }
     }
     else
     {
@@ -86,5 +95,8 @@ CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
 
         ref<uint16>(0x0A) = PChar->getZone();
         ref<uint16>(0x10) = PChar->getZone();
+
+        ref<uint16>(0x0E) = eventInfo->eventFlags & 0xFFFF;
+        ref<uint16>(0x12) = eventInfo->eventFlags >> 16;
     }
 }

--- a/src/map/packets/event_string.cpp
+++ b/src/map/packets/event_string.cpp
@@ -52,7 +52,17 @@ CEventStringPacket::CEventStringPacket(CCharEntity* PChar, EventInfo* eventInfo)
     ref<uint16>(0x08) = npcLocalID;
     ref<uint16>(0x0A) = PChar->getZone();
     ref<uint16>(0x0C) = eventInfo->eventId;
-    ref<uint8>(0x0E)  = 8; // camera "jumps" behind the character if < 8 params
+
+    if (eventInfo->eventFlags != 0)
+    {
+        // Note that only the first 16 bits are supported by this packet type.
+        ref<uint16>(0x0E) = eventInfo->eventFlags & 0xFFFF;
+    }
+    else
+    {
+        // Backwards compatibility kludge!
+        ref<uint16>(0x0E) = 8; // if the parameter is less than 8, then after the event is over the camera will "jump" behind the character
+    }
 
     for (auto stringPair : eventInfo->strings)
     {

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -21,13 +21,13 @@
 
 #include "common/socket.h"
 
-#include "zone_in.h"
-#include "map/zone.h"
 #include "../entities/charentity.h"
 #include "../instance.h"
 #include "../status_effect_container.h"
 #include "../utils/zoneutils.h"
 #include "../vana_time.h"
+#include "map/zone.h"
+#include "zone_in.h"
 
 /************************************************************************
  *                                                                       *
@@ -114,7 +114,7 @@ uint8 GetMogHouseFlag(CCharEntity* PChar)
  *                                                                       *
  ************************************************************************/
 
-CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
+CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
 {
     this->setType(0x0A);
     this->setSize(0x104);
@@ -151,8 +151,8 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
     ref<uint8>(0x21) = PChar->GetGender() * 128 + (1 << PChar->look.size);
 
     // Zone Animation for Transports
-    ref<uint8>(0x27) = PChar->loc.zone->GetZoneDirection();
-    ref<uint8>(0x2A) = PChar->loc.zone->GetZoneAnimation();
+    ref<uint8>(0x27)  = PChar->loc.zone->GetZoneDirection();
+    ref<uint8>(0x2A)  = PChar->loc.zone->GetZoneAnimation();
     ref<uint32>(0x78) = PChar->loc.zone->GetZoneAnimStartTime();
     ref<uint16>(0x7C) = PChar->loc.zone->GetZoneAnimLength();
 
@@ -186,6 +186,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
     // ref<uint32>(0x6C) = PChar->loc.zone->GetWeather();
     // ref<uint32>(0x70) = PChar->loc.zone->GetWeatherChangeTime();
 
+    auto csid = currentEvent->eventId;
     if (csid != -1)
     {
         // ref<uint8>(data,(0x1F)) = 4;                             // предположительно animation
@@ -193,7 +194,10 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
 
         ref<uint16>(0x40) = PChar->currentEvent->textTable == -1 ? PChar->getZone() : PChar->currentEvent->textTable;
         ref<uint16>(0x62) = PChar->getZone();
-        ref<uint16>(0x64) = csid;
+        ref<uint16>(0x64) = currentEvent->eventId;
+
+        // Note that only the first 16 bits are supported by this packet type.
+        ref<uint16>(0x66) = currentEvent->eventFlags & 0xFFFF;
     }
 
     ref<uint16>(0x30) = PChar->getZone();

--- a/src/map/packets/zone_in.h
+++ b/src/map/packets/zone_in.h
@@ -27,11 +27,12 @@
 #include "basic.h"
 
 class CCharEntity;
+struct EventInfo;
 
 class CZoneInPacket : public CBasicPacket
 {
 public:
-    CZoneInPacket(CCharEntity* PChar, int16);
+    CZoneInPacket(CCharEntity* PChar, const EventInfo*);
 };
 
 #endif


### PR DESCRIPTION
Co-Authored-By: Velyn <46884288+mehvvy@users.noreply.github.com>

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds initial optional flags to events support structure

Also adds the optional flags to the new player cutscenes which hides NPCs not involved and players not involved in the CS
