### PR TITLE
Red / Purple Mob Name Fix + Treasure Pool Initial Commit

### DIFF
--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -142,6 +142,13 @@ void CCharPacket::updateWith(CCharEntity* PChar, ENTITYUPDATE type, uint8 update
                     ref<uint32>(0x34) = PChar->m_FieldChocobo;
                     ref<uint16>(0x44) = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetPower() << 4;
                 }
+
+                if (false /*Replace false with test that says "This PChar is in a zone with zone-wide alliances, e.g. Old-Style Dynamis, Einherjar(?), etc."*/)
+                {
+                    // Enable the full-size treasure menu + other things for Old-Style Dynamis.
+                    // All claimed mobs show up as red, not purple, etc.
+                    ref<uint8>(0x20) |= 0x08;
+                }
             }
 
             if (PChar->PPet != nullptr)

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -66,10 +66,17 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
         ref<uint8>(0x38) |= 0x08; // New player ?
     }
 
-    ref<uint8>(0x29) = PChar->GetGender() + (PChar->look.size > 0 ? PChar->look.size * 8 : 2); // + model sizing : 0x02 - 0; 0x08 - 1; 0x10 - 2;
+    ref<uint8>(0x29) = PChar->GetGender() + (PChar->look.size << 3);
     ref<uint8>(0x2C) = PChar->GetSpeed();
     ref<uint16>(0x2E) |= PChar->speedsub << 1; // Not sure about this, it was a work around when we set speedsub incorrectly..
     ref<uint8>(0x30) = PChar->isInEvent() ? (uint8)ANIMATION_EVENT : PChar->animation;
+
+    if (false /*Replace false with test that says "This PChar is in a zone with zone-wide alliances, e.g. Old-Style Dynamis, Einherjar(?), etc."*/)
+    {
+        // Enable the full-size treasure menu + other things for Old-Style Dynamis.
+        // All claimed mobs show up as red, not purple, etc.
+        ref<uint8>(0x29) |= 0x02;
+    }
 
     CItemLinkshell* linkshell = (CItemLinkshell*)PChar->getEquip(SLOT_LINK1);
 


### PR DESCRIPTION
Co-Authored-By: Velyn <46884288+mehvvy@users.noreply.github.com>

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes Mob red / purple name and readies treasure pool mob to be selectable (coming soon)