### PR TITLE
Add checks to prevent null pointer on breaklinkshell

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1339,8 +1339,12 @@ void SmallPacket0x028(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 PLinkshell = linkshell::LoadLinkshell(lsid);
             }
-            PLinkshell->BreakLinkshell((int8*)PLinkshell->getName(), false);
-            linkshell::UnloadLinkshell(lsid);
+
+            if (PLinkshell)
+            {
+                PLinkshell->BreakLinkshell((int8*)PLinkshell->getName(), false);
+                linkshell::UnloadLinkshell(lsid);
+            }
         }
     }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Addresses a potential issue with finding a nullptr if a linkshell object cannot be produced.

## Steps to test these changes

