### PR TITLE
Fix Contributing and Code of Conduct Links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees:
 <!-- (it should look like this: - [x] I have ...) -->
 **_I affirm:_**
 - [x] I understand that if I do not agree to the following points by completing the checkboxes my issue will be ignored.
-- [ ] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/server/blob/base/CODE_OF_CONDUCT.md).
+- [ ] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
 - [ ] I have searched existing [issues](https://github.com/AirSkyBoat/AirSkyBoat/issues) to see if the issue has already been opened, and I have checked the commit log to see if the issue has been resolved since my server was last updated.
 
 ## Overview Of Issue

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,8 +10,8 @@ assignees:
 <!-- (it should look like this: - [x] I have ...) -->
 **_I affirm:_**
 - [x] I understand that if I do not agree to the following points by completing the checkboxes my issue will be ignored.
-- [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
-- [ ] I have searched existing [issues](https://github.com/LandSandBoat/server/issues) to see if the issue has already been opened, and I have checked the commit log to see if the issue has been resolved since my server was last updated.
+- [ ] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
+- [ ] I have searched existing [issues](https://github.com/AirSkyBoat/AirSkyBoat/issues) to see if the issue has already been opened, and I have checked the commit log to see if the issue has been resolved since my server was last updated.
 
 ## Describe the feature
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- (it should look like this: - [x] I have ...) -->
 **_I affirm:_**
 - [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
-- [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
+- [ ] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
 - [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.
 
 ## What does this pull request do?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@
 
 ## License
 
-- We operate under [GNU General Public License v3.0](https://github.com/LandSandBoat/server/blob/base/LICENSE).
+- We operate under [GNU General Public License v3.0](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/LICENSE).
 - We do not accept contributions that use other more restrictive licenses (such as AGPLv3).
 
 ## General Guidelines

--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ We are active on our [Discord](https://discord.gg/SM2J2z8Cz6) and any discussion
 
 ## LICENSE
 
-LandSandBoat and AirSkyBoat is licensed under [GNU GPL v3](https://github.com/LandSandBoat/server/blob/base/LICENSE)
+LandSandBoat and AirSkyBoat is licensed under [GNU GPL v3](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/LICENSE)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Redirects some of the links in the repo from the LandSandBoat organization or from the server repository. License, Issues, Code of Conduct, and Contributing. Hopefully leads to less duplicates now that issues will point to the right place.

## Steps to test these changes

Use eyeballs, click on links.

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1133