### PR TITLE
Windurst 2-1: Fix Off By One Error

### DIFF
--- a/scripts/missions/windurst/2_1_Lost_for_Words.lua
+++ b/scripts/missions/windurst/2_1_Lost_for_Words.lua
@@ -38,7 +38,8 @@ local handleAcceptMission = function(player, csid, option, npc)
 end
 
 local examineRock = function(player, npc)
-    local rockOffset = npc:getID() - mazeID.npc.FOSSIL_ROCK_OFFSET
+    -- Offset by 1 to leave 0 as a valid terminal mission state
+    local rockOffset = npc:getID() - mazeID.npc.FOSSIL_ROCK_OFFSET + 1
     local correctRock = mission:getVar(player, "Rock")
     local missionStatus = player:getMissionStatus(mission.areaId)
 
@@ -179,7 +180,7 @@ mission.sections =
             {
                 [165] = function(player, csid, option, npc)
                     npcUtil.giveKeyItem(player, xi.ki.LAPIS_MONOCLE)
-                    mission:setVar(player, "Rock", math.random(1, 6))
+                    mission:setVar(player, "Rock", math.random(1, 7))
                     player:setMissionStatus(mission.areaId, 3)
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There are 7 valid rocks to choose from, one of the valid rocks in the main room at (H-5) was not able to be accessed due to Math.random being inclusive between 1 and 6 but the offset starts at the first valid rock.

## Steps to test these changes

Accept the mission, set your Rock variable to 1 and check the rock at (H-4)

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1292
