### PR TITLE
The Cold Light of Day: Complete Trade on Turn-In

### DIFF
--- a/scripts/quests/bastok/The_Cold_Light_of_Day.lua
+++ b/scripts/quests/bastok/The_Cold_Light_of_Day.lua
@@ -63,6 +63,7 @@ quest.sections =
             onEventFinish =
             {
                 [104] = function(player, csid, option, npc)
+                    player:tradeComplete()
                     quest:complete(player)
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds trade completion on completing quest The Cold Light of Day

## Steps to test these changes

Attempt quest and make sure item is consumed on turn-in.

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1311