### PR TITLE
Adds a Safety Kill Switch to Restore Statues

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -1938,20 +1938,27 @@ xi.dynamis.statueOnFight = function(mob, target)
             end
             if mob:getLocalVar("reset") ~= 1 then
                 mob:setLocalVar("reset", 1)
-                mob:addStatusEffect(xi.effect.STUN, 1, 0, 5)
+                mob:addStatusEffect(xi.effect.STUN, 1, 0, 10)
                 mob:setUntargetable(true)
                 mob:setMagicCastingEnabled(false)
                 mob:setAutoAttackEnabled(false)
                 mob:setMobAbilityEnabled(false)
 
-                mob:timer(1000, function(mob) -- Allows stun to tick
-                    mob:setTP(0)
-                    mob:setMobAbilityEnabled(true)
-                    mob:delStatusEffectSilent(xi.effect.STUN) -- Remove stun so we can do skill.
-                    if mob:getAnimationSub() == 2 then
-                        mob:useMobAbility(1124) -- Use Recover HP
-                    elseif mob:getAnimationSub() == 3 then
-                        mob:useMobAbility(1125) -- Use Recover MP
+                mob:timer(1000, function(mobArg) -- Allows stun to tick
+                    mobArg:setTP(0)
+                    mobArg:setMobAbilityEnabled(true)
+                    mobArg:delStatusEffectSilent(xi.effect.STUN) -- Remove stun so we can do skill.
+                    if mobArg:getAnimationSub() == 2 then
+                        mobArg:useMobAbility(1124) -- Use Recover HP
+                    elseif mobArg:getAnimationSub() == 3 then
+                        mobArg:useMobAbility(1125) -- Use Recover MP
+                    end
+                end)
+
+                mob:timer(5000, function(mobArg)
+                    if mobArg:isAlive() then
+                        mobArg:setUnkillable(false)
+                        mobArg:setHP(0)
                     end
                 end)
             end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Adds a safety kill switch for statues if a player ranges their restore skill.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/953

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
