### PR TITLE
Fix Shen Quest Marker Repop

### DIFF
--- a/scripts/zones/Bibiki_Bay/mobs/Shen.lua
+++ b/scripts/zones/Bibiki_Bay/mobs/Shen.lua
@@ -109,10 +109,14 @@ entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller then
         local mobId = mob:getID()
         for i = 1, 2 do
-            local petID = GetMobByID(mobId+i)
+            local petID = GetMobByID(mobId + i)
             petID:setHP(0)
         end
+        -- Save off quest marker local variable
+        local qmVar = mob:getLocalVar("qm")
+        -- Clear everything else
         mob:resetLocalVars()
+        mob:setLocalVar("qm", qmVar)
         mob:removeListener("SHEN_MAGIC_EXIT")
     end
 end

--- a/scripts/zones/Bibiki_Bay/npcs/qm_shen.lua
+++ b/scripts/zones/Bibiki_Bay/npcs/qm_shen.lua
@@ -4,15 +4,16 @@
 -- Note: Used to spawn Shen
 -- !pos -115.108 0.300 -724.664 4
 -----------------------------------
-require('scripts/globals/npc_util')
+local ID = require("scripts/zones/Bibiki_Bay/IDs")
+require("scripts/globals/items")
+require("scripts/globals/npc_util")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local shenId = player:getZone():queryEntitiesByName("Shen")[1]:getID()
     if
         npcUtil.tradeHasExactly(trade, xi.items.SHRIMP_LANTERN) and
-        npcUtil.popFromQM(player, npc, shenId)
+        npcUtil.popFromQM(player, npc, ID.mob.SHEN, { hide = 900 }) -- 15 minutes
     then
         player:confirmTrade()
         player:messageSpecial(ID.text.SHEN_SPAWN)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Shen clears local variables on death. Unfortunately for us, we needed one of those.

Also minor clean up since there's some errors thrown and Shen's repop is 15 minutes instead of the default 5.

## Steps to test these changes

`!pos -115.108 0.300 -724.664 4`
`!additem shrimp_lantern`
Kill Shen
15 minutes
`!additem shrimp_lantern`
Kill Shen

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1457