### PR TITLE
Remove Ahriman Tears from Guild Vendor

### DIFF
--- a/modules/custom/lua/guild_no_kits.lua
+++ b/modules/custom/lua/guild_no_kits.lua
@@ -119,7 +119,6 @@ m:addOverride("xi.shop.generalGuild", function(player, stock, guildSkillId)
                      943,     320,      xi.craftRank.RECRUIT,      -- Poison Dust
                      637,    1500,     xi.craftRank.INITIATE,      -- Slime Oil
                      928,     515,     xi.craftRank.INITIATE,      -- Bomb Ash
-                     921,     200,     xi.craftRank.INITIATE,      -- Ahriman Tears
                      933,    1200,       xi.craftRank.NOVICE,      -- Glass Fiber
                      947,    5000,       xi.craftRank.NOVICE,      -- Firesand
                     4171,     700,   xi.craftRank.APPRENTICE,      -- Vitriol
@@ -131,6 +130,7 @@ m:addOverride("xi.shop.generalGuild", function(player, stock, guildSkillId)
                      931,    5000,    xi.craftRank.CRAFTSMAN,      -- Cermet Chunk
                      944,    1035,    xi.craftRank.CRAFTSMAN,      -- Venom Dust
                     9257, 1126125,      xi.craftRank.AMATEUR       -- Azure Leaf
+                     -- 921,     200,     xi.craftRank.INITIATE,      -- Ahriman Tears
             },
             [xi.skill.BONECRAFT] =
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Remove Ahriman Tears from guild vendor. First reference in the wiki is [September 2014](https://ffxiclopedia.fandom.com/wiki/Ahriman_Tears?oldid=1498138). Gil exploiters will have to supply their own tears from now on.

## Steps to test these changes

👀 