### PR TITLE
Fixes an Issue Where Pet Mobs Could Link Their Families

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -198,26 +198,29 @@ void CMobController::TryLink()
         ((CMobEntity*)PMob->PPet)->PEnmityContainer->AddBaseEnmity(PTarget);
     }
 
-    // Handle monster linking if they are close enough
-    if (PMob->PParty != nullptr)
+    if (!PMob->PMaster)
     {
-        for (auto& member : PMob->PParty->members)
+        // Handle monster linking if they are close enough
+        if (PMob->PParty != nullptr)
         {
-            CMobEntity* PPartyMember = dynamic_cast<CMobEntity*>(member);
-            if (!PPartyMember)
+            for (auto& member : PMob->PParty->members)
             {
-                continue;
-            }
-
-            if (PPartyMember->PAI->IsRoaming() && PPartyMember->CanLink(&PMob->loc.p, PMob->getMobMod(MOBMOD_SUPERLINK)))
-            {
-                PPartyMember->PEnmityContainer->AddBaseEnmity(PTarget);
-
-                if (PPartyMember->m_roamFlags & ROAMFLAG_IGNORE)
+                CMobEntity* PPartyMember = dynamic_cast<CMobEntity*>(member);
+                if (!PPartyMember)
                 {
-                    // force into attack action
-                    //#TODO
-                    PPartyMember->PAI->Engage(PTarget->targid);
+                    continue;
+                }
+
+                if (PPartyMember->PAI->IsRoaming() && PPartyMember->CanLink(&PMob->loc.p, PMob->getMobMod(MOBMOD_SUPERLINK)))
+                {
+                    PPartyMember->PEnmityContainer->AddBaseEnmity(PTarget);
+
+                    if (PPartyMember->m_roamFlags & ROAMFLAG_IGNORE)
+                    {
+                        // force into attack action
+                        // #TODO
+                        PPartyMember->PAI->Engage(PTarget->targid);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes an issue where pets could link their families. Only the non-pet family member may link the pet.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/909

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
