### PR TITLE
Fix 0 Damage Abilities Reporting Shadows Taken

### DIFF
--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -762,7 +762,11 @@ function AbilityFinalAdjustments(dmg, mob, skill, target, skilltype, skillparam,
         dmg = utils.takeShadows(target, mob, dmg, shadowbehav)
 
         -- dealt zero damage, so shadows took hit
-        if dmg == 0 then
+        if
+            (target:hasStatusEffect(xi.effect.COPY_IMAGE) or
+            target:hasStatusEffect(xi.effect.BLINK)) and
+            dmg == 0
+        then
             skill:setMsg(xi.msg.basic.SHADOW_ABSORB)
             return shadowbehav
         end

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -541,7 +541,11 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
         dmg = utils.takeShadows(target, mob, dmg, shadowbehav)
 
         -- dealt zero damage, so shadows took hit
-        if dmg == 0 then
+        if
+            (target:hasStatusEffect(xi.effect.COPY_IMAGE) or
+            target:hasStatusEffect(xi.effect.BLINK)) and
+            dmg == 0
+        then
             skill:setMsg(xi.msg.basic.SHADOW_ABSORB)
             return shadowbehav
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Check shadows before reporting if shadows were taken.

## Steps to test these changes

Equip high defense items, such as Judge's gear and fight low level monsters like Rarabs that use Whirl Claws/Foot Kick. 0 damage should be dealt instead of reporting that shadows were taken. Apply utsusemi/blink/third eye and make sure the messages to the player look correct.

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/962
