### PR TITLE
Adjusting Crafting Rates/Skillup Rates

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -333,7 +333,7 @@ namespace synthutils
                     chance = 0.0625; // 1/16
                     break;
                 case 0:
-                    chance = 0.018; // 1/64
+                    chance = 0.018;
                     break;
                 case -1:
                     chance = 0.0006;

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -231,8 +231,8 @@ namespace synthutils
     uint8 calcSynthResult(CCharEntity* PChar)
     {
         uint8  result          = SYNTHESIS_SUCCESS; // We assume by default that we succed
-        int8   hqtier          = 3;    // Set base to T3
-        bool   canHQ           = true; // We assume by default that we can HQ
+        int8   hqtier          = 3;                 // Set base to T3
+        bool   canHQ           = true;              // We assume by default that we can HQ
         double success         = 0;
         double chance          = 0;
         double random          = xirand::GetRandomNumber(1.);

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -481,7 +481,7 @@ namespace synthutils
             {
                 skillUpChance = 0.6;
             }
-            else if (charSkill < 1000) // 50-60
+            else if (charSkill < 1000) // 50-99.9
             {
                 skillUpChance = 0.25;
             }
@@ -553,23 +553,24 @@ namespace synthutils
             if (random < skillUpChance) // If character skills up
             {
                 uint8 skillUpAmount = 1;
-                uint8 maxSkillUp    = 4; // Max skill is 0.4
-
-                if (charSkill >= 600)
-                {
-                    maxSkillUp = 1;
-                }
-                else if (baseDiff >= 6)
-                {
-                    maxSkillUp = 3;
-                }
-                else if (baseDiff >= 12)
-                {
-                    maxSkillUp = 4;
-                }
+                uint8 maxSkillUp = 1; // Max skill is 0.1 for over 60
 
                 if (charSkill < 600) // No skill ups over 0.1 happen over level 60 normally, without some sort of buff to it.
                 {
+
+                    if (baseDiff < 6)
+                    {
+                        maxSkillUp = 2;
+                    }
+                    else if (baseDiff < 12)
+                    {
+                        maxSkillUp = 3;
+                    }
+                    else if (baseDiff >= 12)
+                    {
+                        maxSkillUp = 4;
+                    }
+
                     uint8  satier = 0;
                     double chance = 0;
 

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -475,8 +475,8 @@ namespace synthutils
             // Section 2: Skill up equations and penalties
             double skillUpChance         = 0;
             double craftChanceMultiplier = settings::get<double>("map.CRAFT_CHANCE_MULTIPLIER"); // For servers who want increased crafting rates
-            double coeff                 = 0.0;
 
+            // There is no proof or data that supports there being a difference in skilups for the gap difference
             if (charSkill < 500) // 0-49
             {
                 skillUpChance = 0.6;
@@ -486,44 +486,6 @@ namespace synthutils
                 skillUpChance = 0.25;
             }
 
-            switch (baseDiff)
-            {
-                case 1:
-                    coeff = 0.78;
-                    break;
-                case 2:
-                    coeff = 0.87;
-                    break;
-                case 3:
-                    coeff = 0.97;
-                    break;
-                case 4:
-                    coeff = 1.05;
-                    break;
-                case 5:
-                    coeff = 1.10;
-                    break;
-                case 6:
-                    coeff = 1.18;
-                    break;
-                case 7:
-                    coeff = 1.20;
-                    break;
-                case 8:
-                    coeff = 1.22;
-                    break;
-                case 9:
-                    coeff = 1.24;
-                    break;
-                case 10:
-                    coeff = 1.26;
-                    break;
-                default:
-                    coeff = 0.78;
-                    break;
-            }
-
-            skillUpChance *= coeff;
             skillUpChance *= craftChanceMultiplier; // For servers who want increased crafting rates
 
             // Apply synthesis skill gain rate modifier before synthesis fail modifier

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -553,11 +553,10 @@ namespace synthutils
             if (random < skillUpChance) // If character skills up
             {
                 uint8 skillUpAmount = 1;
-                uint8 maxSkillUp = 1; // Max skill is 0.1 for over 60
+                uint8 maxSkillUp    = 1; // Max skill is 0.1 for over 60
 
                 if (charSkill < 600) // No skill ups over 0.1 happen over level 60 normally, without some sort of buff to it.
                 {
-
                     if (baseDiff < 6)
                     {
                         maxSkillUp = 2;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Adjust HQ rate for T1 crafts
- Penalty from gap difference has been removed. If evidence of this is proven to be true then will comment back in
- Chances for skillups above 0.1 have been decreased slightly
- Max skill ups have been added
- Skillup rates and chances have been adjusted to match: https://www.bluegartr.com/threads/57123-Before-you-ask-a-stupid-crafting-question-read-this!?p=1987222&viewfull=1#post1987222
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Craft any item between the gap values and see that the max skill up is 0.4, skill up rates are normalized,
<!-- Clear and detailed steps to test your changes here -->
