### PR TITLE
Removes Parry from normal mobs -> ONLY Dynamis Mobs can Parry

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -538,7 +538,12 @@ namespace mobutils
         PMob->addModifier(Mod::EVA, GetBase(PMob, PMob->evaRank)); // Base Evasion for all mobs
         PMob->addModifier(Mod::ATT, GetBase(PMob, PMob->attRank)); // Base Attack for all mobs is Rank A+ but pull from DB for specific cases
         PMob->addModifier(Mod::ACC, GetBase(PMob, PMob->accRank)); // Base Accuracy for all mobs is Rank A+ but pull from DB for specific cases
-        PMob->addModifier(Mod::PARRY, GetBase(PMob, 3));           // Base Parry for all mobs is Rank C
+
+        // Only mobs in dynamis can parry
+        if (((PMob->getZone() >= 39) && (PMob->getZone() <= 42)) || (PMob->getZone() == 134) || (PMob->getZone() == 135) || (PMob->getZone() >= 185 && PMob->getZone() <= 188))
+        {
+            PMob->addModifier(Mod::PARRY, GetBase(PMob, 3)); // Base Parry for all mobs is Rank C
+        }
 
         // natural magic evasion
         PMob->addModifier(Mod::MEVA, GetMagicEvasion(PMob));

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -540,7 +540,7 @@ namespace mobutils
         PMob->addModifier(Mod::ACC, GetBase(PMob, PMob->accRank)); // Base Accuracy for all mobs is Rank A+ but pull from DB for specific cases
 
         // Only mobs in dynamis can parry
-        if (((PMob->getZone() >= 39) && (PMob->getZone() <= 42)) || (PMob->getZone() == 134) || (PMob->getZone() == 135) || (PMob->getZone() >= 185 && PMob->getZone() <= 188))
+        if (PMob->isInDynamis())
         {
             PMob->addModifier(Mod::PARRY, GetBase(PMob, 3)); // Base Parry for all mobs is Rank C
         }


### PR DESCRIPTION
- Removes parry from mobs and only applies them to mobs inside Dynamis

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

From a retail capture it appears ONLY Dynamis mobs can parry =

## What does this pull request do?
Only Dynamis Mobs can Parry

Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1285
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1242
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1159
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!zone to any Dynamis and attack a beastmen
They should have a chance to parry if applicable
<!-- Clear and detailed steps to test your changes here -->
