### PR TITLE
Crash and 2h weapon dmg fix

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -695,6 +695,8 @@ uint16 CBattleEntity::CHR()
 uint16 CBattleEntity::ATT(uint16 slot)
 {
     TracyZoneScoped;
+    XI_DEBUG_BREAK_IF(slot >= sizeof(m_Weapons) / sizeof(CItemEquipment*));
+
     // TODO: consider which weapon!
     int32 ATT    = 8 + m_modStat[Mod::ATT];
     auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[slot]);

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -692,7 +692,7 @@ uint16 CBattleEntity::CHR()
     return std::clamp(stats.CHR + m_modStat[Mod::CHR], 0, 999);
 }
 
-uint16 CBattleEntity::ATT(uint16 slot)
+uint16 CBattleEntity::ATT(uint16 slot, bool ignoreWeaponMods)
 {
     TracyZoneScoped;
     XI_DEBUG_BREAK_IF(slot >= sizeof(m_Weapons) / sizeof(CItemEquipment*));
@@ -724,9 +724,12 @@ uint16 CBattleEntity::ATT(uint16 slot)
         {
             ATT += GetSkill(weapon->getSkillType()) + weapon->getILvlSkill();
 
-            if (weapon->getModifier(Mod::ATT_SLOT) > 0)
+            if (!ignoreWeaponMods)
             {
-                ATT += weapon->getModifier(Mod::ATT_SLOT);
+                if (weapon->getModifier(Mod::ATT_SLOT) > 0)
+                {
+                    ATT += weapon->getModifier(Mod::ATT_SLOT);
+                }
             }
 
             // Smite applies when using 2H or H2H weapons

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -556,7 +556,7 @@ public:
     uint16 MND();
     uint16 CHR();
     uint16 DEF();
-    uint16 ATT(uint16 slot = 0x11);
+    uint16 ATT(uint16 slot = SLOT_MAIN, bool ignoreWeaponMods = false);
     uint16 ACC(uint8 attackNumber, uint8 offsetAccuracy);
     uint16 EVA();
     uint16 RATT(uint8 skill, float distance, uint16 bonusSkill = 0);

--- a/src/map/packets/char_stats.cpp
+++ b/src/map/packets/char_stats.cpp
@@ -57,7 +57,7 @@ CCharStatsPacket::CCharStatsPacket(CCharEntity* PChar)
     ref<uint16>(0x2C) = std::clamp<int16>(PChar->getMod(Mod::MND), -999 + PChar->stats.MND, 999 - PChar->stats.MND);
     ref<uint16>(0x2E) = std::clamp<int16>(PChar->getMod(Mod::CHR), -999 + PChar->stats.CHR, 999 - PChar->stats.CHR);
 
-    ref<uint16>(0x30) = PChar->ATT();
+    ref<uint16>(0x30) = PChar->ATT(SLOT_MAIN);
     ref<uint16>(0x32) = PChar->DEF();
 
     ref<uint16>(0x34) = PChar->getMod(Mod::FIRE_MEVA);

--- a/src/map/packets/char_stats.cpp
+++ b/src/map/packets/char_stats.cpp
@@ -57,7 +57,7 @@ CCharStatsPacket::CCharStatsPacket(CCharEntity* PChar)
     ref<uint16>(0x2C) = std::clamp<int16>(PChar->getMod(Mod::MND), -999 + PChar->stats.MND, 999 - PChar->stats.MND);
     ref<uint16>(0x2E) = std::clamp<int16>(PChar->getMod(Mod::CHR), -999 + PChar->stats.CHR, 999 - PChar->stats.CHR);
 
-    ref<uint16>(0x30) = PChar->ATT(SLOT_MAIN);
+    ref<uint16>(0x30) = PChar->ATT(SLOT_MAIN, true);
     ref<uint16>(0x32) = PChar->DEF();
 
     ref<uint16>(0x34) = PChar->getMod(Mod::FIRE_MEVA);


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes a crash caused by calling PChar->Att() on CharStats packets
- Fixes 2h weapon damage not being applied when a crash did not happen
- Fixes Weapon attack bonus not being applied when zoning
 
The crash was reproable by getting charmed then changing jobs with !changejob, or by changing equiped blue spells or by zoning after being charmed, or by killing a mob that grants a title after being charmed (i.e: vrtra)

## Steps to test these chan

- Get charmed
- Changejobs
- Observe no crash


## Crash Repro Screenshots

![Screen Shot 2022-11-22 at 10 39 07 PM](https://user-images.githubusercontent.com/116968546/203488058-0aeaf13b-dd71-45e0-ad23-30577a777ba4.png)

![Screen Shot 2022-11-22 at 10 37 06 PM](https://user-images.githubusercontent.com/116968546/203488078-bbc08ab1-a6ef-4c16-a890-4e94d2604d3b.png)

