### PR TITLE
Era Poison Values

### DIFF
--- a/scripts/globals/spells/black/poison.lua
+++ b/scripts/globals/spells/black/poison.lua
@@ -13,14 +13,7 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local dINT = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-
-    local skill = caster:getSkillLevel(xi.skill.ENFEEBLING_MAGIC)
-    local power = math.max(skill / 25, 1)
-    if skill > 400 then
-        power = math.min((skill - 225) / 5, 55) -- Cap is 55 hp/tick
-    end
-    power = xi.magic.calculatePotency(power, spell:getSkillType(), caster, target)
-
+    local power = 4
     local duration = xi.magic.calculateDuration(30, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
     local params = {}

--- a/scripts/globals/spells/black/poison_ii.lua
+++ b/scripts/globals/spells/black/poison_ii.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Spell: Poison
+-- Spell: Poison II
 -----------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
@@ -13,14 +13,7 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local dINT = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-
-    local skill = caster:getSkillLevel(xi.skill.ENFEEBLING_MAGIC)
-    local power = math.max(skill / 20, 4)
-    if skill > 400 then
-        power = math.floor(skill * 49 / 183 - 55) -- No cap can be reached yet
-    end
-    power = xi.magic.calculatePotency(power, spell:getSkillType(), caster, target)
-
+    local power = 10
     local duration = xi.magic.calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
     local params = {}

--- a/scripts/globals/spells/black/poisonga.lua
+++ b/scripts/globals/spells/black/poisonga.lua
@@ -13,14 +13,7 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local dINT = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-
-    local skill = caster:getSkillLevel(xi.skill.ENFEEBLING_MAGIC)
-    local power = math.max(skill / 25, 1)
-    if skill > 400 then
-        power = math.min((skill - 225) / 5, 55) -- Cap is 55 hp/tick
-    end
-    power = xi.magic.calculatePotency(power, spell:getSkillType(), caster, target)
-
+    local power = 3
     local duration = xi.magic.calculateDuration(60, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
     local params = {}

--- a/scripts/globals/spells/black/poisonga_ii.lua
+++ b/scripts/globals/spells/black/poisonga_ii.lua
@@ -13,14 +13,7 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local dINT = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-
-    local skill = caster:getSkillLevel(xi.skill.ENFEEBLING_MAGIC)
-    local power = math.max(skill / 20, 4)
-    if skill > 400 then
-        power = math.floor(skill * 49 / 183 - 55) -- No cap can be reached yet
-    end
-    power = xi.magic.calculatePotency(power, spell:getSkillType(), caster, target)
-
+    local power = 10
     local duration = xi.magic.calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
     local params = {}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Poison(ga) (II) was buffed in [2015](https://forum.square-enix.com/ffxi/threads/46531-Mar-26-2015-%28JST%29-Version-Update?p=545503&viewfull=1#post545503). Nerf it.

## Steps to test these changes

Cast poisons, get poisons casted on you. Read HP values and durations.

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1601
