### PR TITLE
Increase Super Jump Recast pre-ToAU

### DIFF
--- a/scripts/globals/abilities/super_jump.lua
+++ b/scripts/globals/abilities/super_jump.lua
@@ -2,7 +2,7 @@
 -- Ability: Super Jump
 -- Performs a super jump.
 -- Obtained: Dragoon Level 50
--- Recast Time: 3:00
+-- Recast Time: 3:00 (5:00 pre-ToAU)
 -- Duration: Instant
 -----------------------------------
 require("scripts/globals/job_utils/dragoon")

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1588,6 +1588,16 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
             PRecastContainer->Add(RECAST_ABILITY, (recastID == 173 ? 174 : 173), action.recast);
         }
 
+        // Revert ToAU job buffs
+        if (!luautils::IsContentEnabled("TOAU"))
+        {
+            // Super Jump
+            if (PAbility->getID() == 68)
+            {
+                PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), (uint16)(action.recast * (5.f / 3.f)));
+            }
+        }
+
         pushPacket(new CCharRecastPacket(this));
 
         //#TODO: refactor


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Increases Super Jump base recast to 5 minutes with every merit giving a 10 second reduction as it was before ToAU: http://www.playonline.com/pcd/update/ff11us/20061017UJ0a71/detail.html.

## Steps to test these changes

Load a server without ToAU. Use Super Jump, reset job abilities, add merits, use Super Jump

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1559