### PR TITLE
Remove Stay HP Regeneration pre-ToAU

### DIFF
--- a/scripts/globals/abilities/stay.lua
+++ b/scripts/globals/abilities/stay.lua
@@ -23,7 +23,10 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     local pet = player:getPet()
 
     if not pet:hasPreventActionEffect() then
-        pet:addStatusEffectEx(xi.effect.HEALING, 0, 0, 10, 0)
+        -- Pets gradually regaining HP out of combat added in ToAU.
+        if xi.settings.main.ENABLE_TOAU == 1 then
+            pet:addStatusEffectEx(xi.effect.HEALING, 0, 0, 10, 0)
+        end
         pet:setAnimation(0)
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Remove HP regeneration for Stay pre-ToAU.

## Steps to test these changes

Charm pet, Set HP. Stay. No regen.

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1566