### PR TITLE
Fix Dreamland Dynamis Entry

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis.lua
@@ -712,7 +712,7 @@ local function checkEntryReqs(player, zoneId)
     end
 
     if player:getMainLvl() <= dynamis_min_lvl or
-        (xi.dynamis.entryInfoEra[zoneId].csBit >= 7 and not player:hasCompletedMission(COP, xi.mission.id.cop.DARKNESS_NAMED))
+        (xi.dynamis.entryInfoEra[zoneId].csBit >= 7 and not player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.DARKNESS_NAMED))
     then
         return false
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fix Dreamland Dynamis entry

## Steps to test these changes

Add Shrouded Sand KI
!addkeyitem vial_of_shrouded_sand
Set yourself to Shattering Doubt (mission after Darkness Named)
!addmission 6 368
Enter!

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1490
