### PR TITLE
Update Reward for pre/post-Abyssea Values

### DIFF
--- a/scripts/globals/abilities/reward.lua
+++ b/scripts/globals/abilities/reward.lua
@@ -62,44 +62,62 @@ abilityObject.onUseAbility = function(player, target, ability, action)
 
     switch (rangeObj) : caseof {
         [17016] = function (x) -- pet food alpha biscuit
-            minimumHealing = 50
+            minimumHealing = 20
+            if xi.settings.main.ENABLE_ABYSSEA == 1 then
+                minimumHealing = 50
+            end
             regenAmount = 1
-            totalHealing = math.floor(minimumHealing + 2 * (playerMnd-10))
+            totalHealing = math.floor(minimumHealing + 2 * (playerMnd - 10))
             end,
         [17017] = function (x) -- pet food beta biscuit
-            minimumHealing = 180
+            minimumHealing = 50
+            if xi.settings.main.ENABLE_ABYSSEA == 1 then
+                minimumHealing = 180
+            end
             regenAmount = 3
-            totalHealing = math.floor(minimumHealing + 1 * (playerMnd-33))
+            totalHealing = math.floor(minimumHealing + 1 * (playerMnd - 33))
             end,
         [17018] = function (x) -- pet food gamma biscuit
-            minimumHealing = 300
+            minimumHealing = 100
+            if xi.settings.main.ENABLE_ABYSSEA == 1 then
+                minimumHealing = 300
+            end
             regenAmount = 5
-            totalHealing = math.floor(minimumHealing + 1 * (playerMnd-35)) -- TO BE VERIFIED.
+            totalHealing = math.floor(minimumHealing + 1 * (playerMnd - 35)) -- TO BE VERIFIED.
             end,
         [17019] = function (x) -- pet food delta biscuit
-            minimumHealing = 530
+            minimumHealing = 150
+            if xi.settings.main.ENABLE_ABYSSEA == 1 then
+                minimumHealing = 530
+            end
             regenAmount = 8
-            totalHealing = math.floor(minimumHealing + 2 * (playerMnd-40)) -- TO BE VERIFIED.
+            totalHealing = math.floor(minimumHealing + 2 * (playerMnd - 40)) -- TO BE VERIFIED.
             end,
         [17020] = function (x) -- pet food epsilon biscuit
-            minimumHealing = 750
+            minimumHealing = 300
+            if xi.settings.main.ENABLE_ABYSSEA == 1 then
+                minimumHealing = 750
+            end
             regenAmount = 11
-            totalHealing = math.floor(minimumHealing + 2 * (playerMnd-45))
+            totalHealing = math.floor(minimumHealing + 2 * (playerMnd - 45))
             end,
         [17021] = function (x) -- pet food zeta biscuit
-            minimumHealing = 900
+            minimumHealing = 350
+            if xi.settings.main.ENABLE_ABYSSEA == 1 then
+                minimumHealing = 900
+            end
             regenAmount = 14
-            totalHealing = math.floor(minimumHealing + 3 * (playerMnd-45))
+            totalHealing = math.floor(minimumHealing + 3 * (playerMnd - 45))
             end,
         [17022] = function (x) -- pet food eta biscuit
             minimumHealing = 1200
             regenAmount = 17
-            totalHealing = math.floor(minimumHealing + 4 * (playerMnd-50))
+            totalHealing = math.floor(minimumHealing + 4 * (playerMnd - 50))
             end,
         [17023] = function (x) -- pet food theta biscuit
             minimumHealing = 1600
             regenAmount = 20
-            totalHealing = math.floor(minimumHealing + 4 * (playerMnd-55))
+            totalHealing = math.floor(minimumHealing + 4 * (playerMnd - 55))
             end,
     }
 
@@ -155,9 +173,11 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     pet:wakeUp()
 
     -- Apply regen xi.effect.
+    if xi.settings.main.ENABLE_ABYSSEA == 1 then
+        pet:delStatusEffect(xi.effect.REGEN)
+        pet:addStatusEffect(xi.effect.REGEN, regenAmount, 3, regenTime) -- 3 = tick, each 3 seconds.
+    end
 
-    pet:delStatusEffect(xi.effect.REGEN)
-    pet:addStatusEffect(xi.effect.REGEN, regenAmount, 3, regenTime) -- 3 = tick, each 3 seconds.
     player:removeAmmo()
 
     pet:updateEnmityFromCure(pet, totalHealing)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Splits Reward from pre- and post-Abyssea implementations.

## Steps to test these changes

Feed your pets!

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1577
