### PR TITLE
Clamp Stat and Skill Modifiers to Stop Underflows

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1056,6 +1056,11 @@ void CBattleEntity::addModifier(Mod type, int16 amount)
         m_MSNonItemValues.push_back(amount);
         m_modStat[type] = CalculateMSFromSources();
     }
+    else if ((type >= Mod::STR && type <= Mod::CHR) ||
+             (type >= Mod::HTH && type <= Mod::ANTIHQ_COOK))
+    {
+        m_modStat[type] = std::clamp(m_modStat[type] + amount, 0, 65355);
+    }
     else
     {
         m_modStat[type] += amount;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Adds a clamp to mods for base stats and skills to avoid underflows.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1249

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
