### PR TITLE
Split pre/post-WotG Reward Recast

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1598,6 +1598,16 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
             }
         }
 
+        // Revert WotG job buffs
+        if (!luautils::IsContentEnabled("WOTG"))
+        {
+            // Reward
+            if (PAbility->getID() == 78)
+            {
+                PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), (uint16)(action.recast * 2.f));
+            }
+        }
+
         pushPacket(new CCharRecastPacket(this));
 
         //#TODO: refactor


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Nerf Reward pre-WotG. Doubles the Reward merit value this way as well.

## Steps to test these changes

Get a BST pet, use Reward, it's 3 minute cooldown

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1570