### PR TITLE
Adds Ternary Operator Util to Lua

### DIFF
--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -876,3 +876,12 @@ end
 function utils.angleToRotation(radians)
     return radians * ffxiAngleToRotationFactor
 end
+
+-- Returns inline value  boolean      any     any
+function utils.ternary(conditional, trueVal, falseVal)
+    if conditional then
+        return trueVal
+    end
+
+    return falseVal
+end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Adds a ternary operator util to lua. (Allows for CI compliance)

Usage: x = utils.ternary(foo == bar, foo2, bar2)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
