### PR TITLE
Change Third Eye Duration by Expansion

### DIFF
--- a/scripts/globals/abilities/third_eye.lua
+++ b/scripts/globals/abilities/third_eye.lua
@@ -22,7 +22,11 @@ abilityObject.onUseAbility = function(player, target, ability)
         -- Returns "no effect" message when Copy Image is active when Third Eye is used.
         ability:setMsg(xi.msg.basic.JA_NO_EFFECT)
     else
-        player:addStatusEffect(xi.effect.THIRD_EYE, 0, 0, 30) -- Power keeps track of procs
+        local duration = 55
+        if xi.settings.main.ENABLE_TOAU == 1 then
+            duration = 30
+        end
+        player:addStatusEffect(xi.effect.THIRD_EYE, 0, 0, duration) -- Power keeps track of procs
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Third Eye duration was nerfed in ToAU

## Steps to test these changes

Use Third Eye in CoP, 55 seconds.

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1558