### PR TITLE
fixed ki not given to player for cids secret

### DIFF
--- a/scripts/quests/bastok/Cids_Secret.lua
+++ b/scripts/quests/bastok/Cids_Secret.lua
@@ -100,7 +100,7 @@ quest.sections =
                 [133] = function(player, csid, option, npc)
                     player:confirmTrade()
 
-                    npcUtil.giveKeyItem(xi.ki.UNFINISHED_LETTER)
+                    npcUtil.giveKeyItem(player, xi.ki.UNFINISHED_LETTER)
                 end,
             },
         },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #1462 

## Steps to test these changes

1. Have bastok fame 4
2. talk to cid (metalworks)
3. this should start the quest "cid's secret"
4. go to port bastok and talk to hilda at the steaming sheep
5. trade hilda a rolanberry 874 (itemid 4530)
6. You should receive the KI "unopened letter"
