### PR TITLE
added check to not revert quest status.

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Mertaire.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Mertaire.lua
@@ -35,7 +35,8 @@ entity.onTrigger = function(player, npc)
     -- THE OLD MONUMENT
     if
         player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_OLD_MONUMENT) == QUEST_AVAILABLE and
-        level >= xi.settings.main.ADVANCED_JOB_LEVEL
+        level >= xi.settings.main.ADVANCED_JOB_LEVEL and
+        player:getCharVar("TheOldMonument_Event") == 0
     then
         player:startEvent(102)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Addresses issue where talking to Mertaire after getting subsequent charvar would reset to 1. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Will only give dialog now if player:getCharVar("TheOldMonument_Event") == 0