### PR TITLE
Clear BCNM Mob Charm Status

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -47,6 +47,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #include "utils/charutils.h"
 #include "utils/itemutils.h"
+#include "utils/petutils.h"
 #include "utils/zoneutils.h"
 #include "zone.h"
 #include <chrono>
@@ -557,11 +558,16 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
         charutils::SendClearTimerPacket(PChar);
 
         // Remove the player's pet as well
-        if (PChar->PPet)
+        if (auto* PPet = dynamic_cast<CPetEntity*>(PChar->PPet))
         {
-            PChar->PPet->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
-            PChar->PPet->StatusEffectContainer->DelStatusEffect(EFFECT_LEVEL_RESTRICTION);
-            ClearEnmityForEntity(PChar->PPet);
+            // Player timed out with a battlefield mob as a pet
+            if (PPet->objtype == TYPE_MOB)
+            {
+                petutils::DespawnPet(PPet);
+            }
+            PPet->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
+            PPet->StatusEffectContainer->DelStatusEffect(EFFECT_LEVEL_RESTRICTION);
+            ClearEnmityForEntity(PPet);
         }
     }
     else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Clears charm status for a player's pet if that pet was a BCNM mob entity.

## Steps to test these changes

Lots of Wings of Fury.

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1528
Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1710
