### PR TITLE
Audit Summoner's Ward Durations

### DIFF
--- a/scripts/globals/abilities/pets/crimson_howl.lua
+++ b/scripts/globals/abilities/pets/crimson_howl.lua
@@ -14,9 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill, summoner)
-    local bonusTime = utils.clamp(summoner:getSkillLevel(xi.skill.SUMMONING_MAGIC) - 300, 0, 200)
-    local duration = 60 + bonusTime
-
+    local duration = math.min(30 + xi.summon.getSummoningSkillOverCap(pet), 180)
     target:addStatusEffect(xi.effect.WARCRY, 9, 0, duration)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
     return xi.effect.WARCRY

--- a/scripts/globals/abilities/pets/ecliptic_growl.lua
+++ b/scripts/globals/abilities/pets/ecliptic_growl.lua
@@ -14,9 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill, summoner)
-    local bonusTime = utils.clamp(summoner:getSkillLevel(xi.skill.SUMMONING_MAGIC) - 300, 0, 200)
-    local duration = 180 + bonusTime
-
+    local duration = 180
     local moon = VanadielMoonPhase()
     local buffvalue = 0
     if moon > 90 then

--- a/scripts/globals/abilities/pets/ecliptic_howl.lua
+++ b/scripts/globals/abilities/pets/ecliptic_howl.lua
@@ -14,9 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill, summoner)
-    local bonusTime = utils.clamp(summoner:getSkillLevel(xi.skill.SUMMONING_MAGIC) - 300, 0, 200)
-    local duration = 180 + bonusTime
-
+    local duration = 180
     local moon = VanadielMoonPhase()
     local buffvalue = 0
     if moon > 90 then

--- a/scripts/globals/abilities/pets/frost_armor.lua
+++ b/scripts/globals/abilities/pets/frost_armor.lua
@@ -14,9 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill, summoner)
-    local bonusTime = utils.clamp(summoner:getSkillLevel(xi.skill.SUMMONING_MAGIC) - 300, 0, 200)
-    local duration = 180 + bonusTime
-
+    local duration = math.min(90 + xi.summon.getSummoningSkillOverCap(pet) * 3, 180)
     target:delStatusEffect(xi.effect.ICE_SPIKES)
     target:addStatusEffect(xi.effect.ICE_SPIKES, 15, 0, duration)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)

--- a/scripts/globals/abilities/pets/glittering_ruby.lua
+++ b/scripts/globals/abilities/pets/glittering_ruby.lua
@@ -12,9 +12,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
     return 0, 0
 end
 
-abilityObject.onPetAbility = function(target, pet, skill)
-    local bonusTime = utils.clamp(xi.summon.getSummoningSkillOverCap(pet) * 3, 0, 90)-- 3 seconds / skill | Duration is capped at 180 total
-    local duration = 90 + bonusTime
+abilityObject.onPetAbility = function(target, pet, skill, summoner)
     --randomly give str/dex/vit/agi/int/mnd/chr (+12)
     local effect = math.random()
     local effectid = xi.effect.STR_BOOST
@@ -34,7 +32,9 @@ abilityObject.onPetAbility = function(target, pet, skill)
         effectid = xi.effect.CHR_BOOST
     end
 
-    target:addStatusEffect(effectid, math.random(12, 14), 0, duration)
+    local duration = math.min(90 + xi.summon.getSummoningSkillOverCap(pet) * 3, 180)
+    local power = 3 + math.floor(summoner:getJobLevel(xi.job.SMN) / 5)
+    target:addStatusEffect(effectid, power, 10, duration)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
     return effectid
 end

--- a/scripts/globals/abilities/pets/hastega.lua
+++ b/scripts/globals/abilities/pets/hastega.lua
@@ -14,9 +14,8 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill, summoner)
-    local bonusTime = utils.clamp(xi.summon.getSummoningSkillOverCap(pet) * 3, 0, 90)-- 3 seconds / skill | Duration is capped at 180 total
-    local duration = 90 + bonusTime
-    -- Garuda's Hastega is a weird exception and uses 153/1024 instead of 150/1024 like Haste spells
+    local duration = math.min(90 + xi.summon.getSummoningSkillOverCap(pet) * 3, 180)
+    -- Garuda's Hastega is a weird exception and uses 153/1024 instead of 150/1024 like Haste spell
     -- That's why it overwrites some things regular haste won't.
     target:addStatusEffect(xi.effect.HASTE, 1494, 0, duration) -- 153/1024 ~14.94%
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)

--- a/scripts/globals/abilities/pets/lightning_armor.lua
+++ b/scripts/globals/abilities/pets/lightning_armor.lua
@@ -14,9 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill, summoner)
-    local bonusTime = utils.clamp(xi.summon.getSummoningSkillOverCap(pet) * 3, 0, 90)-- 3 seconds / skill | Duration is capped at 180 total
-    local duration = 90 + bonusTime
-
+    local duration = math.min(90 + xi.summon.getSummoningSkillOverCap(pet) * 3, 180)
     target:delStatusEffect(xi.effect.SHOCK_SPIKES)
     target:addStatusEffect(xi.effect.SHOCK_SPIKES, 15, 0, duration)
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)

--- a/scripts/globals/abilities/pets/rolling_thunder.lua
+++ b/scripts/globals/abilities/pets/rolling_thunder.lua
@@ -13,10 +13,8 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill, summoner)
-    local skillOverCap = utils.clamp(xi.summon.getSummoningSkillOverCap(pet) * 2, 0, 120)-- 2 seconds / skill | Duration is capped at 180 total
-    local duration = 60 + skillOverCap
+    local duration = math.min(60 + xi.summon.getSummoningSkillOverCap(pet) * 2, 180)
     local magicskill = utils.getSkillLvl(1, target:getMainLvl())
-
     local potency = 3 + ((6 * magicskill) / 100)
     if magicskill > 200 then
         potency = 5 + ((5 * magicskill) / 100)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a flag to use older durations calculations for Summoner Blood Pact: Ward abilities

## Steps to test these changes

Summon Ifrit, use Crimson Howl - 30s
Add summoning torque and summoner's bracers +1 (+19 skill)
Summon Ifrit, use Crimon Howl - 49s

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1736