### PR TITLE
Audit Outpost Warp Values

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -84,6 +84,31 @@ local outposts =
     [xi.region.TAVNAZIANARCH]   = { zone =  24, ki = xi.ki.TAVNAZIAN_ARCHIPELAGO_SUPPLIES, cp = 70, lvl = 30, fee = 300 },
 }
 
+-- Pre-ToAU outpost values
+if xi.settings.main.ENABLE_TOAU == 0 then
+    outposts[xi.region.RONFAURE].lvl        = 20
+    outposts[xi.region.ZULKHEIM].lvl        = 20
+    outposts[xi.region.NORVALLEN].lvl       = 25
+    outposts[xi.region.GUSTABERG].lvl       = 20
+    outposts[xi.region.DERFLAND].lvl        = 25
+    outposts[xi.region.SARUTABARUTA].lvl    = 20
+    outposts[xi.region.KOLSHUSHU].lvl       = 20
+    outposts[xi.region.ARAGONEU].lvl        = 25
+    outposts[xi.region.FAUREGANDI].lvl      = 35
+    outposts[xi.region.VALDEAUNIA].lvl      = 40
+    outposts[xi.region.QUFIMISLAND].lvl     = 25
+    outposts[xi.region.LITELOR].lvl         = 35
+    outposts[xi.region.KUZOTZ].lvl          = 40
+    outposts[xi.region.VOLLBOW].lvl         = 65
+    outposts[xi.region.ELSHIMOLOWLANDS].lvl = 35
+    outposts[xi.region.ELSHIMOUPLANDS].lvl  = 45
+    outposts[xi.region.TAVNAZIANARCH].lvl   = 25
+
+    for _, outpost in pairs(outposts) do
+        outpost.fee = outpost.lvl * 10
+    end
+end
+
 local function hasOutpost(player, region)
     local hasOP = player:hasTeleport(player:getNation(), region + 5)
     if not hasOP then
@@ -961,9 +986,14 @@ xi.conquest.outpostFee = function(player, region)
     end
 
     local fee = outposts[region].fee
-    if GetRegionOwner(region) == player:getNation() then
+    local regionOwner = GetRegionOwner(region)
+    if regionOwner == player:getNation() then
         return fee
     else
+        if xi.settings.main.ENABLE_TOAU == 0 then
+            -- Other nation control is 4x Beastmen is 5x
+            return fee * utils.ternary(regionOwner ~= 3, 4, 5)
+        end
         return fee * 3
     end
 end
@@ -1407,7 +1437,13 @@ xi.conquest.teleporterOnEventUpdate = function(player, csid, option, teleporterE
         local fee = xi.conquest.outpostFee(player, region)
         local cpFee = fee / 10
 
-        player:updateEvent(player:getGil(), fee, 0, cpFee, player:getCP())
+        local cp = player:getCP()
+        -- Always report not enough CP if Abyssea is not enabled
+        if xi.settings.main.ENABLE_ABYSSEA == 0 then
+            cp = 0
+        end
+
+        player:updateEvent(player:getGil(), fee, 0, cpFee, cp)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Aligns Outpost Warp NPCs with pre-ToAU and pre-Abyssea values.

## Steps to test these changes

Change server expansions and see what's possible.

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1706
