### PR TITLE
Dreamlands Fixes | Fix Mob Avatar Astral Flows

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis.lua
@@ -1179,8 +1179,8 @@ m:addOverride("xi.dynamis.entryNpcOnEventFinish", function(player, csid, option)
     end
 end)
 
-xi.dynamis.sjQMOnTrigger = function(player, npc)
-    local zone = player:getZone()
+xi.dynamis.sjQMOnTrigger = function(npc)
+    local zone = npc:getZone()
     local playersInZone = zone:getPlayers()
     for _, playerEntity in pairs(playersInZone) do
         if  playerEntity:hasStatusEffect(xi.effect.SJ_RESTRICTION) then -- Does player have SJ restriction?

--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -1465,16 +1465,19 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
             ["Apocalyptic Beast"] =
             {
                 ["onMobFight"] = { function(mob, target) end },
+                ["onMobRoam"] = { function(mob) end },
                 ["mixins"] = {  require("scripts/mixins/families/avatar"),  },
             },
             ["Dagourmarche"] =
             {
                 ["onMobFight"] = { function(mob, target) end },
+                ["onMobRoam"] = { function(mob) end },
                 ["mixins"] = {  require("scripts/mixins/families/avatar"), },
             },
             ["Normal"] =
             {
                 ["onMobFight"] = { function(mob, target) end },
+                ["onMobRoam"] = { function(mob) end },
                 ["mixins"] = { require("scripts/mixins/families/avatar_persist"), },
             },
         },
@@ -1483,11 +1486,13 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
             ["Dagourmarche"] =
             {
                 ["onMobFight"] = { function(mob, target) end },
+                ["onMobRoam"] = { function(mob) end },
                 ["mixins"] = {   },
             },
             ["Normal"] =
             {
                 ["onMobFight"] = { function(mob, target) end },
+                ["onMobRoam"] = { function(mob) end },
                 ["mixins"] = {   },
             },
         },
@@ -1496,16 +1501,19 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
             ["Apocalyptic Beast"] =
             {
                 ["onMobFight"] = { function(mob, target) xi.dynamis.onFightApocDRG(mob, target) end },
+                ["onMobRoam"] = { function(mob) xi.dynamis.onRoamApocDRG(mob) end },
                 ["mixins"] = {   },
             },
             ["Dagourmarche"] =
             {
                 ["onMobFight"] = { function(mob, target) end },
+                ["onMobRoam"] = { function(mob) end },
                 ["mixins"] = {   },
             },
             ["Normal"] =
             {
                 ["onMobFight"] = { function(mob, target) end },
+                ["onMobRoam"] = { function(mob) end },
                 ["mixins"] = {   },
             },
         },
@@ -1532,7 +1540,8 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
         groupId = nameObj[2],
         groupZoneId = nameObj[3],
         onMobSpawn = function(mob) xi.dynamis.setPetStats(mob) end,
-        onMobFight = petFunctions[mobJob][functionLookup]["onMobFight"],
+        onMobFight = petFunctions[mobJob][functionLookup]["onMobFight"][1],
+        onMobRoam = petFunctions[mobJob][functionLookup]["onMobRoam"][1],
         onMobDeath = function(mob, player, optParams) xi.dynamis.onPetDeath(mob) end,
         onMobDespawn = function (mob) xi.dynamis.mobOnDespawn(mob) end,
         releaseIdOnDeath = true,
@@ -1847,7 +1856,7 @@ end
 
 xi.dynamis.setPetStats = function(mob)
     if mob:getFamily() == 34 then
-        mob:setModelId(math.random(791, 798))
+        mob:setModelId(math.random(793, 798)) -- Ifrit -> Ramuh
     end
     mob:setMobType(xi.mobskills.mobType.BATTLEFIELD)
     mob:addStatusEffect(xi.effect.BATTLEFIELD, 1, 0, 0, true)
@@ -1932,13 +1941,15 @@ xi.dynamis.mobOnDeath = function(mob, player, optParams)
             if zoneID == xi.zone.DYNAMIS_VALKURM then
                 local flies = { 21, 22, 23}
                 if mobIndex == flies[1] or mobIndex == flies[2] or mobIndex == flies[3] then
-                    xi.dynamis.valkQMSpawnCheck(mob, zone, zoneID)
+                    xi.dynamis.nightmareFlyCheck(mob, zone, zoneID)
                 end
             end
         end
+
         if mobIndex ~= 0 and mobIndex ~= nil then
             xi.dynamis.addTimeToDynamis(zone, mobIndex) -- Add Time
         end
+
         mob:setLocalVar("dynamisMobOnDeathTriggered", 1) -- onDeath lua happens once per party member that killed the mob, but we want this to only run once per mob
     end
 
@@ -1964,7 +1975,10 @@ m:addOverride("xi.dynamis.megaBossOnDeath", function(mob, player)
         winQM:setStatus(xi.status.NORMAL) -- Make visible
         mob:setLocalVar("GaveTimeExtension", 1)
     end
-    player:addTitle(xi.dynamis.dynaInfoEra[zoneID].winTitle) -- Give player the title
+
+    if player then
+        player:addTitle(xi.dynamis.dynaInfoEra[zoneID].winTitle) -- Give player the title
+    end
 end)
 
 --------------------------------------------

--- a/modules/era/lua_dynamis/globals/era_dynamis_zones.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_zones.lua
@@ -139,7 +139,7 @@ for _, zoneID in pairs(dynamisZones) do
     if zoneID[3] >= 7 then
         m:addOverride(string.format("xi.zones.%s.npcs.qm0.onTrigger", zoneID[2]),
         function(player, npc)
-            xi.dynamis.sjQMOnTrigger(player, npc)
+            xi.dynamis.sjQMOnTrigger(npc)
         end)
     end
 end

--- a/modules/era/lua_dynamis/mobs/era_valkurm_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_valkurm_mobs.lua
@@ -36,7 +36,7 @@ local function checkMorbolKills(mob)
     return killed
 end
 
-xi.dynamis.valkQMSpawnCheck = function(mob, zone, zoneID)
+xi.dynamis.nightmareFlyCheck = function(mob, zone, zoneID)
     local sjNPC = GetNPCByID(xi.dynamis.dynaInfoEra[zoneID].sjRestrictionNPC)
     local req = 0
     for _, fly in pairs(flies) do
@@ -45,10 +45,8 @@ xi.dynamis.valkQMSpawnCheck = function(mob, zone, zoneID)
         end
     end
 
-    if req == 3 and sjNPC:getStatus() ~= xi.status.NORMAL then
-        local pos = mob:getPos()
-        sjNPC:setPos(pos.x,pos.y,pos.z,pos.rot) -- Set to death pos
-        sjNPC:setStatus(xi.status.NORMAL) -- Make visible
+    if req == 3 and zone:getLocalVar("SJUnlock") ~= 1 then
+        xi.dynamis.sjQMOnTrigger(sjNPC)
     end
 end
 

--- a/modules/era/lua_dynamis/mobskills/era_pet_skills.lua
+++ b/modules/era/lua_dynamis/mobskills/era_pet_skills.lua
@@ -14,8 +14,25 @@ require("scripts/globals/msg")
 local m = Module:new("era_pet_skills")
 
 xi.dynamis.onFightApocDRG = function(mob, target)
-    local apoc = GetMobByID(mob:getZone():getLocalVar("Apocalyptic Beast"))
-    if os.time() >= apoc:getLocalVar("next2hrTime") then
+    if not mob:getMaster() or mob:getMaster():getHP() == 0 then
+        DespawnMob(mob:getID())
+    end
+
+    if mob:getMaster() and (os.time() >= mob:getMaster():getLocalVar("next2hrTime")) then
+        DespawnMob(mob:getID())
+    end
+end
+
+xi.dynamis.onRoamApocDRG = function(mob)
+    if not mob:getMaster() or mob:getMaster():getHP() == 0 then
+        DespawnMob(mob:getID())
+    end
+
+    if mob:getMaster() and mob:getMaster():getTarget() then
+        mob:updateEnmity(mob:getMaster():getTarget())
+    end
+
+    if mob:getMaster() and (os.time() >= mob:getMaster():getLocalVar("next2hrTime")) then
         DespawnMob(mob:getID())
     end
 end

--- a/scripts/globals/mobskills/call_wyvern.lua
+++ b/scripts/globals/mobskills/call_wyvern.lua
@@ -27,10 +27,10 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
             end
 
             for i = 5, 1, -1 do
-                xi.dynamis.spawnDynamicPet(target, mob, xi.job.DRG)
+                xi.dynamis.spawnDynamicPet(mob:getTarget(), mob, xi.job.DRG)
             end
         else
-            xi.dynamis.spawnDynamicPet(target, mob, xi.job.DRG)
+            xi.dynamis.spawnDynamicPet(mob:getTarget(), mob, xi.job.DRG)
         end
     else
         mob:spawnPet()

--- a/scripts/globals/mobskills/lodesong.lua
+++ b/scripts/globals/mobskills/lodesong.lua
@@ -10,6 +10,13 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if
+        mob:isInDynamis() and
+        not mob:hasStatusEffect(xi.effect.SILENCE)
+    then
+        return 0
+    end
+
     -- can only used if not silenced
     if
         mob:getMainJob() == xi.job.BRD and

--- a/scripts/globals/mobskills/voidsong.lua
+++ b/scripts/globals/mobskills/voidsong.lua
@@ -15,6 +15,12 @@ require("scripts/globals/msg")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if
+        mob:isInDynamis() and
+        not mob:hasStatusEffect(xi.effect.SILENCE)
+    then
+        return 0
+    end
     -- can only used if not silenced
     if
         mob:getMainJob() == xi.job.BRD and

--- a/scripts/mixins/families/avatar.lua
+++ b/scripts/mixins/families/avatar.lua
@@ -1,24 +1,24 @@
 require("scripts/globals/mixins")
 
 -- If you subtract 790 from the modelId, you're left with a key into to this table :)
-local avatarInfo =
+local abilityIds =
 {
-    { model = 791, ability = 919 }, -- Carbuncle
-    { model = 793, ability = 913 }, -- Ifrit
-    { model = 794, ability = 914 }, -- Titan
-    { model = 795, ability = 915 }, -- Leviathan
-    { model = 796, ability = 916 }, -- Garuda
-    { model = 797, ability = 917 }, -- Shiva
-    { model = 798, ability = 918 }, -- Ramuh
+    919, -- [modelId: 791] Carbuncle
+    839, -- [modelId: 792] Fenrir
+    913, -- [modelId: 793] Ifrit
+    914, -- [modelId: 794] Titan
+    915, -- [modelId: 795] Leviathan
+    916, -- [modelId: 796] Garuda
+    917, -- [modelId: 797] Shiva
+    918, -- [modelId: 798] Ramuh
 }
 
 g_mixins = g_mixins or {}
 g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.avatar = function(avatarMob)
-    local avatarTable = avatarInfo[math.random(1, #avatarInfo)]
     avatarMob:addListener("SPAWN", "AVATAR_SPAWN", function(mob)
-        mob:setModelId(avatarTable.model)
+        mob:setModelId(math.random(791, 798)) -- Carbuncle -> Ramuh
         mob:hideName(false)
         mob:setUntargetable(true)
         mob:setUnkillable(true)
@@ -36,7 +36,8 @@ g_mixins.families.avatar = function(avatarMob)
 
     avatarMob:addListener("ENGAGE", "AVATAR_ENGAGE", function(mob, target)
         if mob:getLocalVar("[ASTRAL_FLOW]Performed") == 0 then
-            local abilityId = avatarTable.ability
+            local modelId = mob:getModelId()
+            local abilityId = abilityIds[modelId - 790]
             if abilityId ~= nil then
                 mob:useMobAbility(abilityId)
                 mob:setLocalVar("[ASTRAL_FLOW]Performed", 1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes an issue with apoc beast's wyverns crashing the zone.
+ Fixes an issue where Aitvaras and Stollenwurm were unable to use their skills.
+ Fixes an issue where killing all 3 nightmare flies did not unlock subjobs immediately. They previously required interacting with a ???.
+ Reverts avatar.lua changes as it resulted in the wrong skills being used. (Unsure on how with this one but it will fix things regardless.)
+ Changes dynamis mobs to not be able to summon carbuncle or fenrir normally. (Only if they are persistent avatars.)
+ Fixes an issue where call wyvern for apoc beast did not have the wyverns properly target.
+ Fixes an issue with the onFight for pets in dynamis where it was not being properly triggered.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1454
closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1460
closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1461

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
