### PR TITLE
Adds Functionality to Allow Skillchains to Resist

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -628,14 +628,25 @@ xi.magic.applyResistanceAddEffect = function(player, target, element, effect, bo
 
     local _, skillchainCount = xi.magic.FormMagicBurst(element, target)
 
-    local p = xi.magic.getMagicHitRate(player, target, nil, element, effectRes, bonus, skillchainCount)
-    local resist = xi.magic.getMagicResist(p, target, element, skillchainCount)
+    local p = xi.magic.getMagicHitRate(player, target, nil, element, effectRes, bonus, 0, skillchainCount)
+    local resist = xi.magic.getMagicResist(p, target, element, effectRes, skillchainCount)
 
     if resist < 0.5 then
         resist = 0
     elseif resist < 1 then
         resist = 0.5
     end
+
+    return resist
+end
+
+xi.magic.applySkillchainResistance = function(player, target, element)
+    if not element then
+        element = xi.magic.ele.NONE
+    end
+
+    local p = xi.magic.getMagicHitRate(player, target, nil, element, 0, 0, 0, 0)
+    local resist = xi.magic.getMagicResist(p, target, element, 0, 0)
 
     return resist
 end
@@ -784,10 +795,10 @@ xi.magic.getMagicHitRate = function(caster, target, skillType, element, effectRe
         else
             magicacc = utils.getSkillLvl(1, caster:getMainLvl()) + dStatAcc + caster:getMod(xi.mod.MACC)
         end
-    elseif caster:isPC() and skillType and caster:getEquippedItem(xi.slot.MAIN) ~= nil then
-        magicacc = dStatAcc + caster:getSkillLevel(caster:getEquippedItem(xi.slot.MAIN):getSkillType()) + caster:getMod(xi.mod.MACC)
     elseif caster:isPC() and skillType and skillType <= xi.skill.STAFF then
         magicacc = dStatAcc + caster:getSkillLevel(skillType) + caster:getMod(xi.mod.MACC)
+    elseif caster:isPC() and not skillType and caster:getEquippedItem(xi.slot.MAIN) ~= nil then
+        magicacc = dStatAcc + caster:getSkillLevel(caster:getEquippedItem(xi.slot.MAIN):getSkillType()) + caster:getMod(xi.mod.MACC)
     elseif caster:isMob() and skillType == nil then
         magicacc = dStatAcc + utils.getMobSkillLvl(1, caster:getMainLvl()) + caster:getMod(xi.mod.MACC)
     elseif caster:isPet() and skillType == nil then

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -133,6 +133,7 @@ namespace battleutils
     uint8                GetSkillchainTier(SKILLCHAIN_ELEMENT skillchain);
     uint8                GetSkillchainSubeffect(SKILLCHAIN_ELEMENT skillchain);
     int16                GetSkillchainMinimumResistance(SKILLCHAIN_ELEMENT element, CBattleEntity* PDefender, ELEMENT* appliedEle);
+    ELEMENT              GetSkillChainAppliedElement(SKILLCHAIN_ELEMENT element, CBattleEntity* PDefender);
     std::vector<ELEMENT> GetSkillchainMagicElement(SKILLCHAIN_ELEMENT skillchain);
 
     bool IsParalyzed(CBattleEntity* PAttacker);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Skillchains now resist the same as any other source of magic damage.
+ Fixes an out of date function in magic.lua.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
