### PR TITLE
Adds a Temporary Fix to BCNM Tractor Interaction

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1102,10 +1102,23 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                 // PChar->PBattleAI->SetCurrentAction(ACTION_RAISE_MENU_SELECTION);
                 PChar->loc.p           = PChar->m_StartActionPos;
                 PChar->loc.destination = PChar->getZone();
-                PChar->status          = STATUS_TYPE::DISAPPEAR;
                 PChar->loc.boundary    = 0;
                 PChar->clearPacketList();
-                charutils::SendToZone(PChar, 2, zoneutils::GetZoneIPP(PChar->loc.destination));
+
+                // This is a stopgap until we determine a better solution of how add the member
+                // back to the battlefield member list after the zone.
+                if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
+                {
+                    PChar->status = STATUS_TYPE::INVISIBLE;
+                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CPositionPacket(PChar));
+                    PChar->updatemask |= UPDATE_POS;
+                    PChar->status = STATUS_TYPE::NORMAL;
+                }
+                else
+                {
+                    PChar->status = STATUS_TYPE::DISAPPEAR;
+                    charutils::SendToZone(PChar, 2, zoneutils::GetZoneIPP(PChar->loc.destination));
+                }
             }
 
             PChar->m_hasTractor = 0;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Adds a temporary fix of simply updating the player's position during a tractor packet instead of a zone while in a BCNM. This resolves an issue of the player being unable to interact with others in their party after the tractor.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1452

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
