### PR TITLE
Despawn Ally NPCs After BCNM

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -606,6 +606,12 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
                 {
                     if (std::find(m_AllyList.begin(), m_AllyList.end(), PMobEntity) != m_AllyList.end())
                     {
+                        if (PMobEntity->isAlive() && PMobEntity->PAI->IsSpawned())
+                        {
+                            PEntity->status = STATUS_TYPE::DISAPPEAR;
+                            PEntity->loc.zone->UpdateEntityPacket(PEntity, ENTITY_DESPAWN, UPDATE_NONE);
+                        }
+
                         m_AllyList.erase(std::remove_if(m_AllyList.begin(), m_AllyList.end(), check), m_AllyList.end());
                     }
                 }
@@ -757,6 +763,16 @@ bool CBattlefield::Cleanup(time_point time, bool force)
         {
             PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
             m_Zone->updateCharLevelRestriction(PChar);
+
+            // Remove allies from player's spawn list
+            for (auto* ally : tempAllies)
+            {
+                SpawnIDList_t::iterator MOB = PChar->SpawnMOBList.find(ally->id);
+                if (MOB != PChar->SpawnMOBList.end())
+                {
+                    PChar->SpawnMOBList.erase(MOB);
+                }
+            }
 
             if (PChar->PPet)
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Clean up allies from a BCNM after exiting.

Allied mobs (and pets) don't despawn in the way that everything else does. This leaves these entities lingering after the fight and roaming without a battlefield.

If you try to clean them up without removing them from the player's spawnMOBList it will be okay.... unless they watch the cutscene, in which case the battlefield will clean up before they zone after completion causing the player to crash.

## Steps to test these changes

Enter a BCNM such as Bastok's 9-2 Where Two Paths Converge
Finish the BCNM successfully and skip the event
Finish the BCNM successfully and don't skip the event
Fail the BCNM by letting the ally die
Fail the BCNM by dying and take the homepoint immediately
Fail the BCNM by dying and let it zone you out
Use GM commands to warp out of the BCNM

Ally should despawn. Can redo the BCNM, a different BCNM in the same zone, or use wallhack to find out.

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/991