### PR TITLE
Temp disable active zone check in !zone

### DIFF
--- a/scripts/commands/zone.lua
+++ b/scripts/commands/zone.lua
@@ -350,11 +350,12 @@ function onTrigger(player, bytes)
         end
     end
 
-    -- Confirm that the zone is active
-    if not IsZoneActive(zone) then
-        error(player, "Zone currently disabled.")
-        return
-    end
+    -- commenting out until fixed
+    -- -- Confirm that the zone is active
+    -- if not IsZoneActive(zone) then
+    --     error(player, "Zone currently disabled.")
+    --     return
+    -- end
 
     -- send player to destination
     player:setPos(x, y, z, rot, zone)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Temporarily disable checking if a zone is active so !zone works again.

(The zone enable check does not work cross instance currently)