### PR TITLE
Add Setting for Chocobos Wounds Cooldown

### DIFF
--- a/scripts/quests/jeuno/Chocobos_Wounds.lua
+++ b/scripts/quests/jeuno/Chocobos_Wounds.lua
@@ -18,6 +18,16 @@ require('scripts/globals/interaction/quest')
 
 local quest = Quest:new(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.CHOCOBOS_WOUNDS)
 
+local function getCurrentTime()
+    -- Check if the day has changed
+    if xi.settings.main.ERA_CHOCOBOS_WOUNDS then
+       return VanadielUniqueDay()
+    end
+
+    -- Check if the hour has changed
+    return 24 * VanadielUniqueDay() + VanadielHour()
+end
+
 quest.reward =
 {
     fame = 30,
@@ -131,7 +141,7 @@ quest.sections =
                     if npcUtil.tradeHasExactly(trade, xi.items.BUNCH_OF_GYSAHL_GREENS) then
                         return quest:progressEvent(76)
                     elseif npcUtil.tradeHasExactly(trade, xi.items.CLUMP_OF_GAUSEBIT_WILDGRASS) then
-                        if quest:getVar(player, 'Timer') <= os.time() then
+                        if getCurrentTime() > quest:getVar(player, 'Timer') then
                             return quest:progressEvent(chocoboFeedTrades[quest:getVar(player, 'Prog')])
                         else
                             return quest:progressEvent(73)
@@ -154,18 +164,18 @@ quest.sections =
             onEventFinish =
             {
                 [57] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Timer', os.time() + 45)
+                    quest:setVar(player, 'Timer', getCurrentTime())
                     quest:setVar(player, 'Prog', 2)
                 end,
 
                 [58] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Timer', os.time() + 45)
+                    quest:setVar(player, 'Timer', getCurrentTime())
                     quest:setVar(player, 'Prog', 3)
                 end,
 
                 [59] = function(player, csid, option, npc)
                     player:confirmTrade()
-                    quest:setVar(player, 'Timer', os.time() + 45)
+                    quest:setVar(player, 'Timer', getCurrentTime())
                     quest:setVar(player, 'Prog', 4)
 
                     return quest:event(99)
@@ -173,13 +183,13 @@ quest.sections =
 
                 [60] = function(player, csid, option, npc)
                     player:confirmTrade()
-                    quest:setVar(player, 'Timer', os.time() + 45)
+                    quest:setVar(player, 'Timer', getCurrentTime())
                     quest:setVar(player, 'Prog', 5)
                 end,
 
                 [63] = function(player, csid, option, npc)
                     player:confirmTrade()
-                    quest:setVar(player, 'Timer', os.time() + 45)
+                    quest:setVar(player, 'Timer', getCurrentTime())
                     quest:setVar(player, 'Prog', 6)
                 end,
 

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -189,13 +189,14 @@ xi.settings.main =
     COSMO_CLEANSE_BASE_COST     = 15000,    -- Base gil cost for a Cosmo Cleanse from Sagheera
 
     -- QUEST/MISSION SPECIFIC SETTINGS
-    AF1_QUEST_LEVEL = 40,    -- Minimum level to start AF1 quest
-    AF2_QUEST_LEVEL = 50,    -- Minimum level to start AF2 quest
-    AF3_QUEST_LEVEL = 50,    -- Minimum level to start AF3 quest
-    OLDSCHOOL_G1    = true, -- Set to true to require farming Exoray Mold, Bombd Coal, and Ancient Papyrus drops instead of allowing key item method.
-    OLDSCHOOL_G2    = true, -- Set true to require the NMs for "Atop the Highest Mountains" be dead to get KI like before SE changed it.
-    FRIGICITE_TIME  = 30,    -- When OLDSCHOOL_G2 is enabled, this is the time (in seconds) you have from killing Boreal NMs to click the "???" target.
-    ASSAULT_MINIMUM = 3,     -- Minimum amount of people needed to start an assault mission. TOAU era is 3, Default is 1.
+    AF1_QUEST_LEVEL     = 40,               -- Minimum level to start AF1 quest
+    AF2_QUEST_LEVEL     = 50,               -- Minimum level to start AF2 quest
+    AF3_QUEST_LEVEL     = 50,               -- Minimum level to start AF3 quest
+    ERA_CHOCOBOS_WOUNDS = true,             -- Era Chocobos Wounds wait times that requires waiting a full Vana'Diel day, set to false to have it be every Vana'Diel hour.
+    OLDSCHOOL_G1        = true,             -- Set to true to require farming Exoray Mold, Bombd Coal, and Ancient Papyrus drops instead of allowing key item method.
+    OLDSCHOOL_G2        = true,             -- Set true to require the NMs for "Atop the Highest Mountains" be dead to get KI like before SE changed it.
+    FRIGICITE_TIME      = 30,               -- When OLDSCHOOL_G2 is enabled, this is the time (in seconds) you have from killing Boreal NMs to click the "???" target.
+    ASSAULT_MINIMUM     = 3,                -- Minimum amount of people needed to start an assault mission. TOAU era is 3, Default is 1.
 
     -- SPELL SPECIFIC SETTINGS
     DIA_OVERWRITE                   = 1,     -- Set to 1 to allow Bio to overwrite same tier Dia.  Default is 1.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add a setting defaulting true to use the accurate era implementation of Chocobos Wounds

## Steps to test these changes

Test and wait for days

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1800
