### PR TITLE
Fixes Summoner using wrong pdif calc

### DIFF
--- a/scripts/globals/abilities/pets/axe_kick.lua
+++ b/scripts/globals/abilities/pets/axe_kick.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Axe Kick M=3.5
+-- Axe Kick
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -13,14 +13,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 512 / 256
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 2 params.ftp150 = 2 params.ftp300 = 2
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/barracuda_dive.lua
+++ b/scripts/globals/abilities/pets/barracuda_dive.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Barracude Dive M=3.5
+-- Barracude Dive
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -13,14 +13,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 512 / 256
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 2 params.ftp150 = 2 params.ftp300 = 2
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/burning_strike.lua
+++ b/scripts/globals/abilities/pets/burning_strike.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Burning Strike M = 6?
+-- Burning Strike
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -21,6 +21,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
+    params.melee = true
 
     local paramsEle = {}
     paramsEle.ftp000 = 2.75 paramsEle.ftp150 = 2.75 paramsEle.ftp300 = 2.75

--- a/scripts/globals/abilities/pets/camisado.lua
+++ b/scripts/globals/abilities/pets/camisado.lua
@@ -13,14 +13,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 512 / 256
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 2 params.ftp150 = 2 params.ftp300 = 2
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.2 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/chaotic_strike.lua
+++ b/scripts/globals/abilities/pets/chaotic_strike.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Chaotic Strike M=9 , 2
+-- Chaotic Strike
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -12,14 +12,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 10
     local params = {}
     params.numHits = 3
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 10 params.ftp150 = 10 params.ftp300 = 10
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/claw.lua
+++ b/scripts/globals/abilities/pets/claw.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Claw M=3.5
+-- Claw
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -12,14 +12,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 512 / 256
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 2 params.ftp150 = 2 params.ftp300 = 2
     params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/crescent_fang.lua
+++ b/scripts/globals/abilities/pets/crescent_fang.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Moonlit Charge M=6
+-- Crescent Fang
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -12,14 +12,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 1.5
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 1.5 params.ftp150 = 1.5 params.ftp300 = 1.5
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/double_punch.lua
+++ b/scripts/globals/abilities/pets/double_punch.lua
@@ -13,14 +13,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 5
     local params = {}
     params.numHits = 2
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 5 params.ftp150 = 5 params.ftp300 = 5
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/double_slap.lua
+++ b/scripts/globals/abilities/pets/double_slap.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Double Slap M=6, 2 (still guessing here)
+-- Double Slap
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -13,14 +13,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 1620 / 256
     local params = {}
     params.numHits = 2
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 6.33 params.ftp150 = 6.33 params.ftp300 = 6.33
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/eclipse_bite.lua
+++ b/scripts/globals/abilities/pets/eclipse_bite.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Eclipse Bite M=8 subsequent hits M=2
+-- Eclipse Bite
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -12,14 +12,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 7
     local params = {}
     params.numHits = 3
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 7 params.ftp150 = 7 params.ftp300 = 7
     params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/flaming_crush.lua
+++ b/scripts/globals/abilities/pets/flaming_crush.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Flaming Crush M=10, 2, 2? (STILL don't know)
+-- Flaming Crush
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -21,6 +21,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
+    params.melee = true
 
     local paramsEle = {}
     paramsEle.ftp000 = 6 paramsEle.ftp150 = 6 paramsEle.ftp300 = 6

--- a/scripts/globals/abilities/pets/moonlit_charge.lua
+++ b/scripts/globals/abilities/pets/moonlit_charge.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Moonlit Charge M=4
+-- Moonlit Charge
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -12,14 +12,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 256 / 256
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 1 params.ftp150 = 1 params.ftp300 = 1
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.3 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/mountain_buster.lua
+++ b/scripts/globals/abilities/pets/mountain_buster.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Mountain Buster M=12
+-- Mountain Buster
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -12,14 +12,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 7.25
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 7.25 params.ftp150 = 7.25 params.ftp300 = 7.25
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.3 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/poison_nails.lua
+++ b/scripts/globals/abilities/pets/poison_nails.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Poison Nails  M=3? guess
+-- Poison Nails
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -12,14 +12,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 512 / 256
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 2 params.ftp150 = 2 params.ftp300 = 2
     params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/predator_claws.lua
+++ b/scripts/globals/abilities/pets/predator_claws.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Predator Claws M=10 subsequent hits M=2
+-- Predator Claws
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -12,14 +12,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 10
     local params = {}
     params.numHits = 3
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 10 params.ftp150 = 10 params.ftp300 = 10
     params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/punch.lua
+++ b/scripts/globals/abilities/pets/punch.lua
@@ -13,14 +13,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 512 / 256
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 2 params.ftp150 = 2 params.ftp300 = 2
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/rock_buster.lua
+++ b/scripts/globals/abilities/pets/rock_buster.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Rock Buster M=4
+-- Rock Buster
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -12,14 +12,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 2.25
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 2.25 params.ftp150 = 2.25 params.ftp300 = 2.25
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.3 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/rush.lua
+++ b/scripts/globals/abilities/pets/rush.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Rush M=5, 2
+-- Rush
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -13,14 +13,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 896 / 256
     local params = {}
     params.numHits = 5
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 3.5 params.ftp150 = 3.5 params.ftp300 = 3.5
     params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/shock_strike.lua
+++ b/scripts/globals/abilities/pets/shock_strike.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Shock Strike M=3.5
+-- Shock Strike
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -13,14 +13,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 512 / 256
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 2 params.ftp150 = 2 params.ftp300 = 2
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/spinning_dive.lua
+++ b/scripts/globals/abilities/pets/spinning_dive.lua
@@ -13,14 +13,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 1792 / 256
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 7 params.ftp150 = 7 params.ftp300 = 7
     params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/tail_whip.lua
+++ b/scripts/globals/abilities/pets/tail_whip.lua
@@ -13,14 +13,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local ftpbase = 768 / 256
     local params = {}
     params.numHits = 1
-    params.ftp000 = ftpbase params.ftp150 = ftpbase params.ftp300 = ftpbase
+    params.ftp000 = 3 params.ftp150 = 3 params.ftp300 = 3
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.3 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 2.0 params.atk200 = 2.0 params.atk300 = 2.0
+    params.melee = true
 
     local damage = xi.summon.avatarPhysicalMove(pet, target, skill, params)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixes an issue where melee physical BPs were using the ranged pdif calcs and not applying the correct attack
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to Fafnir/Tia
Summon Garuda: Use Predator claws and see that it does more than 0 damage
Summon Leviathan: Use Spinning Dive and see that it does more than 0 damage
<!-- Clear and detailed steps to test your changes here -->
