### PR TITLE
Fix Model Radius CanAttack Function For NMs

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -955,9 +955,16 @@ bool CCharEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket
 {
     TracyZoneScoped;
 
+    auto modelRadius = PTarget->m_ModelRadius;
+
     if (PTarget->PAI->IsUntargetable())
     {
         return false;
+    }
+
+    if (auto PMob = dynamic_cast<CMobEntity*>(PTarget))
+    {
+        modelRadius = PMob->m_Type & MOBTYPE_NORMAL ? modelRadius - 1 : modelRadius;
     }
 
     float dist    = distance(loc.p, PTarget->loc.p);
@@ -981,7 +988,7 @@ bool CCharEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket
         errMsg = std::make_unique<CMessageBasicPacket>(this, PTarget, 0, 0, MSGBASIC_UNABLE_TO_SEE_TARG);
         return false;
     }
-    else if (distNoY > GetMeleeRange() || abs(loc.p.y - PTarget->loc.p.y) > 3)
+    else if (distNoY - modelRadius > GetMeleeRange() || abs(loc.p.y - PTarget->loc.p.y) > 3)
     {
         errMsg = std::make_unique<CMessageBasicPacket>(this, PTarget, 0, 0, MSGBASIC_TARG_OUT_OF_RANGE);
         return false;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes the CanAttack function to account for NM models that are larger than their family models. Also make it so model radius 2+ mobs have an additional attack range.

TLDR: Normal mobs have -1 to their radius to keep the player closer to the mob. NMs have no adjustments to their model radius. 

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1805

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
