### PR TITLE
Gysahl bug

### DIFF
--- a/scripts/globals/items/bunch_of_gysahl_greens.lua
+++ b/scripts/globals/items/bunch_of_gysahl_greens.lua
@@ -26,7 +26,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local chocoboShirt = target:getEquipID(xi.slot.BODY) == 10293
+    local chocoboShirt
+    if target:getEquipID(xi.slot.BODY) == 10293 then
+        chocoboShirt = 1
+    else
+        chocoboShirt = 0
+    end
     target:addStatusEffect(xi.effect.FOOD, chocoboShirt, 0, 300, 4545)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Gysahl Greens were taking a bool into one of their values as an argument. This was causing an error, and resulting in players being able to eat them unlimitedly and gain no status effects.
- Turned value into an int value making the same check to fix the bug

Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1844
