### PR TITLE
Fix Mob RA | Mob Distance Correction | Special Skill TP Usage

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -188,6 +188,10 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
     --work out hit rate for mobs
     local hitrate = xi.weaponskills.getHitRate(mob, target, 0, 0)
 
+    if tpeffect == xi.mobskills.magicalTpBonus.RANGED then
+        hitrate = xi.weaponskills.getRangedHitRate(mob, target, 0, 0)
+    end
+
     --work out the base damage for a single hit
     local hitdamage = base
 
@@ -219,9 +223,15 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
 
     -- Set everything to 1 because the FTP for mobs iis not supposed to be for attack only.
     -- TODO: Apply attack modifiers to certain mobskills with params
-    local params = { atk000 = 1, atk150 = 1, atk300 = 1 }
+    local params       = { atk000 = 1, atk150 = 1, atk300 = 1 }
+    local paramsRanged = { atk100 = 1, atk200 = 1, atk300 = 1 }
     -- Getting PDIF
-    local pdifTable = xi.weaponskills.cMeleeRatio(mob, target, params, 0, mob:getTP(), xi.slot.main)
+    local pdifTable = xi.weaponskills.cMeleeRatio(mob, target, params, 0, mob:getTP(), xi.slot.MAIN)
+
+    if tpeffect == xi.mobskills.magicalTpBonus.RANGED then
+        pdifTable = xi.weaponskills.cRangedRatio(mob, target, paramsRanged, 0, mob:getTP())
+    end
+
     local pdif = pdifTable[1]
     local pdifcrit = pdifTable[2]
 
@@ -238,10 +248,17 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
     end
 
     local chance = math.random()
-    chance = xi.weaponskills.handleParry(mob, target, chance)
+
+    if tpeffect ~= xi.mobskills.magicalTpBonus.RANGED then
+        chance = xi.weaponskills.handleParry(mob, target, chance)
+    end
 
     -- first hit has a higher chance to land
     local firstHitChance = hitrate + 0.5
+
+    if tpeffect == xi.mobskills.magicalTpBonus.RANGED then
+        firstHitChance = hitrate
+    end
 
     firstHitChance = utils.clamp(firstHitChance, 0.20, 0.95)
 

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -229,7 +229,7 @@ xi.weaponskills.cRangedRatio = function(attacker, defender, params, ignoredDef, 
     return { pdif, pdifcrit }
 end
 
-local function getRangedHitRate(attacker, target, capHitRate, bonus, wsParams, calcParams)
+xi.weaponskills.getRangedHitRate = function(attacker, target, capHitRate, bonus, wsParams, calcParams)
     local accVarryTP = 0
 
     if bonus == nil then
@@ -266,7 +266,7 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, f
         ratio = xi.weaponskills.cRangedRatio(attacker, target, wsParams, calcParams.ignoredDef, calcParams.tp)
         pdif = ratio[1]
         pdifCrit =  ratio[2]
-        calcParams.hitRate = getRangedHitRate(attacker, target, false, 0, wsParams, calcParams)
+        calcParams.hitRate = xi.weaponskills.getRangedHitRate(attacker, target, false, 0, wsParams, calcParams)
     else
         if isSubAttack and calcParams.extraOffhandHit and calcParams.attackInfo.weaponType ~= xi.skill.HAND_TO_HAND then
             ratio = xi.weaponskills.cMeleeRatio(attacker, target, wsParams, calcParams.ignoredDef, calcParams.tp, xi.slot.SUB)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -464,6 +464,7 @@ bool CMobController::TrySpecialSkill()
 
     if (luautils::OnMobSkillCheck(PAbilityTarget, PMob, PSpecialSkill) == 0)
     {
+        PMob->m_defaultAttack = PSpecialSkill->getID();
         return MobSkill(PAbilityTarget->targid, PSpecialSkill->getID());
     }
 

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -88,6 +88,15 @@ void CMobSkillState::SpendCost()
         m_spentTP            = 1000;
         m_PEntity->health.tp = (m_PEntity->health.tp > 1000 ? m_PEntity->health.tp - 1000 : 0);
     }
+    else if (m_PEntity->m_defaultAttack && m_PEntity->m_defaultAttack == m_PSkill->getID())
+    {
+        m_spentTP      = 0;
+        auto PAttacker = static_cast<CBattleEntity*>(m_PEntity);
+        auto baseTp    = battleutils::CalculateBaseTP((int16)(PAttacker->GetWeaponDelay(true) * 60.0f / 1000.0f / 1.f));
+
+        PAttacker->addTP(
+            (int16)(1.f * (baseTp * (1.0f + 0.01f * (float)((PAttacker->getMod(Mod::STORETP)))))));
+    }
     else if (!m_PSkill->isTpFreeSkill())
     {
         if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_SEKKANOKI))

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -255,6 +255,8 @@ public:
     uint8 m_unk1; // (entity_update 0x25)
     uint8 m_unk2; // (entity_update 0x26)
 
+    uint16 m_defaultAttack;
+
     bool m_CallForHelpBlocked;
 
     CEnmityContainer* PEnmityContainer; // система ненависти монстров

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1540,6 +1540,11 @@ namespace battleutils
 
             acc = std::max({ archery_acc, marksmanship_acc, throwing_acc });
         }
+        else
+        {
+            acc = PAttacker->RACC(SKILL_AUTOMATON_RANGED, distance(PAttacker->loc.p, PDefender->loc.p));
+        }
+
         // Check for Yonin evasion bonus while in front of target
         if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN) && infront(PDefender->loc.p, PAttacker->loc.p, 64))
         {

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -535,9 +535,11 @@ namespace mobutils
         }
 
         PMob->addModifier(Mod::DEF, GetDefense(PMob, PMob->defRank));
-        PMob->addModifier(Mod::EVA, GetBase(PMob, PMob->evaRank)); // Base Evasion for all mobs
-        PMob->addModifier(Mod::ATT, GetBase(PMob, PMob->attRank)); // Base Attack for all mobs is Rank A+ but pull from DB for specific cases
-        PMob->addModifier(Mod::ACC, GetBase(PMob, PMob->accRank)); // Base Accuracy for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::EVA, GetBase(PMob, PMob->evaRank));  // Base Evasion for all mobs
+        PMob->addModifier(Mod::ATT, GetBase(PMob, PMob->attRank));  // Base Attack for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::ACC, GetBase(PMob, PMob->accRank));  // Base Accuracy for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::RATT, GetBase(PMob, PMob->attRank)); // Base Ranged Attack for all mobs is Rank A+ but pull from DB for specific cases
+        PMob->addModifier(Mod::RACC, GetBase(PMob, PMob->accRank)); // Base Ranged Accuracy for all mobs is Rank A+ but pull from DB for specific cases
 
         // Only mobs in dynamis can parry
         if (PMob->isInDynamis())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes mob ranged skills, namely default auto ranged attacks, to utilize the proper ranged formulations. This fixes damage and accuracy problems associated to these skills.
+ Adds distance correction to mob ranged attacks (YES! THEY ACTUALLY HAVE THIS!).
+ Fixes the tp usage of special skills by removing the tp usage and applying the appropriate single hit tp amount. Downside, even if the mob misses it will still provide tp. Generally this is ~60tp and with most hit rates over 50% the likelyhood of this being a problem is slim. For a 1.0 this is a good implementation and further revisions are welcome.
+ Adds default mods at A+ skill (same as ACC and ATT) for RACC and RATT on mobs. This is to allow for working within the new formulas for pdif, hitrate, etc.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1751

## Steps to test these changes
+ Tonberries, lots of tonberries.
