### PR TITLE
Added Z check to Starway Door fixess issue #1858

### DIFF
--- a/scripts/zones/Heavens_Tower/npcs/_6q1.lua
+++ b/scripts/zones/Heavens_Tower/npcs/_6q1.lua
@@ -14,7 +14,7 @@ end
 entity.onTrigger = function(player, npc)
     if player:getNation() == 2 then
         if player:hasKeyItem(xi.ki.STARWAY_STAIRWAY_BAUBLE) then
-            if player:getXPos() < -14 then
+            if player:getXPos() < -14 and player:getZPos() < 29 then
                 player:startEvent(106)
             else
                 player:startEvent(105)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Added a Z check to the starway door. fixes issue # 1858
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Closes #1858 
## Steps to test these changes
https://www.youtube.com/watch?v=zgMmiFquWXA
<!-- Clear and detailed steps to test your changes here -->
