### PR TITLE
Fixed Teacher's Pet Quest awarding fame to Bastok instead of Windurst

### DIFF
--- a/scripts/quests/windurst/Teachers_Pet.lua
+++ b/scripts/quests/windurst/Teachers_Pet.lua
@@ -80,7 +80,7 @@ quest.sections =
                     player:confirmTrade()
 
                     if player:getQuestStatus(quest.areaId, quest.questId) == QUEST_ACCEPTED then
-                        player:addFame(xi.quest.fame_area.BASTOK, 67)
+                        player:addFame(xi.quest.fame_area.WINDURST, 67)
                     end
 
                     if quest:complete(player) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This changes the fame location from Bastok to Windurst on the fame level 1 quest Teacher's Pet.  This is a repeatable quest in Windy Waters North. 
https://ffxi.allakhazam.com/db/quests.html?fquest=115


## Steps to test these changes

Ensure fame accrues on quest completion, however, it is a pretty straightforward change.
