### PR TITLE
Fix Lagging Players Triggering Multiple Of The Same Event

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2807,6 +2807,15 @@ void CCharEntity::endCurrentEvent()
 
 void CCharEntity::queueEvent(EventInfo* eventToQueue)
 {
+    for (auto& eventElement : eventQueue)
+    {
+        if (eventElement->eventId == eventToQueue->eventId)
+        {
+            ShowError("CCharEntity::queueEvent: Character attempted to start multiple of the same event.");
+            return;
+        }
+    }
+
     eventQueue.push_back(eventToQueue);
     tryStartNextEvent();
 }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -803,6 +803,12 @@ void CLuaBaseEntity::StartEventHelper(int32 EventID, sol::variadic_args va, EVEN
         return;
     }
 
+    if (PChar->currentEvent->eventId == EventID)
+    {
+        ShowError("CLuaBaseEntity::StartEventHelper: Could not start event, Character Entity already triggered.");
+        return;
+    }
+
     PChar->StatusEffectContainer->DelStatusEffect(EFFECT_BOOST);
 
     PChar->queueEvent(ParseEvent(EventID, va, PChar->eventPreparation, eventType));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes lagging players triggering multiple cutscenes. This change both checks against the current events and cleans the event queue if the player queues multiple of a different event. 

Example
1. Player lags.
2. Player starts event 2 with an npc.
3. Player starts event 3 with another npc.
4. Player starts event 2 with the original npc.
5. Player starts event 3 with another npc.
6. Player starts event 4 with yet another npc.

The event order would look like this: event 2, event 3, event 4

The duplicate of event 2 is purged in the event helper function, 3 is purged in charentity as the current event's id is not event 3's id. 

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1863

Note: The magic and text portions of this bug are no concern as they are not exploitable in any meaningful manner. Changing either of these interactions could lead to players with high latency being unable to perform actions consistently.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
