### PR TITLE
Fix Glyph Hanger Quest XP Reward OOE Bug Report: #1213 

### DIFF
--- a/scripts/quests/windurst/A_Smudge_on_Ones_Record.lua
+++ b/scripts/quests/windurst/A_Smudge_on_Ones_Record.lua
@@ -15,7 +15,6 @@ local quest = Quest:new(xi.quest.log_id.WINDURST, xi.quest.id.windurst.A_SMUDGE_
 
 quest.reward =
 {
-    xp = 2000,
     fame = 120,
     fameArea = xi.quest.fame_area.WINDURST,
     gil = 5000,

--- a/scripts/quests/windurst/Glyph_Hanger.lua
+++ b/scripts/quests/windurst/Glyph_Hanger.lua
@@ -16,6 +16,7 @@ local quest = Quest:new(xi.quest.log_id.WINDURST, xi.quest.id.windurst.GLYPH_HAN
 
 quest.reward =
 {
+    xp = 2000,
     fame = 120,
     fameArea = xi.quest.fame_area.WINDURST,
     keyItem = xi.ki.MAP_OF_THE_HORUTOTO_RUINS,

--- a/scripts/quests/windurst/Glyph_Hanger.lua
+++ b/scripts/quests/windurst/Glyph_Hanger.lua
@@ -16,7 +16,6 @@ local quest = Quest:new(xi.quest.log_id.WINDURST, xi.quest.id.windurst.GLYPH_HAN
 
 quest.reward =
 {
-    xp = 2000,
     fame = 120,
     fameArea = xi.quest.fame_area.WINDURST,
     keyItem = xi.ki.MAP_OF_THE_HORUTOTO_RUINS,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This removes the xp from the quest Glyph Hanger, as it appears to be OOE
This removes the xp from the quest A Smudge on One's Record (comment of bug report #1213), as it appears to be OOE

Not shown as a reward in the 2013 ign wiki:
https://www.ign.com/wikis/final-fantasy-xi/Glyph_Hanger

Or the history, as pointed out to me by Bliven and TheNuclearWalrus:
https://ffxiclopedia.fandom.com/wiki/Glyph_Hanger?oldid=66355

## Steps to test these changes

