### PR TITLE
Fix Being Able To Attack Invalid Mobs With AOEs

### DIFF
--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -458,6 +458,24 @@ bool CTargetFind::validEntity(CBattleEntity* PTarget)
         return false;
     }
 
+    if (PTarget->objtype == TYPE_MOB)
+    {
+        if (m_PBattleEntity &&
+            m_PBattleEntity->objtype == TYPE_PC &&
+            !static_cast<CCharEntity*>(m_PBattleEntity)->IsMobOwner(PTarget))
+        {
+            return false; // If character isn't allowed to attack don't count it.
+        }
+
+        if (m_PBattleEntity &&
+            m_PBattleEntity->PMaster &&
+            m_PBattleEntity->PMaster->objtype == TYPE_PC &&
+            !static_cast<CCharEntity*>(m_PBattleEntity->PMaster)->IsMobOwner(PTarget))
+        {
+            return false; // If pet's master isn't allowed to attack don't count it.
+        }
+    }
+
     // shouldn't add if target is charmed by the enemy
     if (PTarget->PMaster != nullptr)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes both player pets and players from damaging/claiming monsters via an AOE attack when it is an invalid target.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1897

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
