### PR TITLE
Fix Godmode breaking mordion

### DIFF
--- a/src/map/ai/controllers/CMakeLists.txt
+++ b/src/map/ai/controllers/CMakeLists.txt
@@ -5,6 +5,8 @@ set(AI_CONTROLLER_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/controller.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mob_controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mob_controller.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/noop_controller.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/noop_controller.h
     ${CMAKE_CURRENT_SOURCE_DIR}/pet_controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pet_controller.h
     ${CMAKE_CURRENT_SOURCE_DIR}/player_charm_controller.cpp

--- a/src/map/ai/controllers/noop_controller.cpp
+++ b/src/map/ai/controllers/noop_controller.cpp
@@ -1,0 +1,96 @@
+/*
+===========================================================================
+
+  Copyright (c) 2022 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "noop_controller.h"
+
+NoopController::NoopController(CBattleEntity* entity)
+: CController(entity)
+{
+}
+
+void NoopController::Tick(time_point tick)
+{
+}
+
+void NoopController::Despawn()
+{
+}
+
+void NoopController::Reset()
+{
+}
+
+bool NoopController::Cast(uint16 targid, SpellID spellid)
+{
+    return false;
+}
+
+bool NoopController::Engage(uint16 targid)
+{
+    return false;
+}
+
+bool NoopController::ChangeTarget(uint16 targid)
+{
+    return false;
+}
+
+bool NoopController::Disengage()
+{
+    return false;
+}
+
+bool NoopController::WeaponSkill(uint16 targid, uint16 wsid)
+{
+    return false;
+}
+
+bool NoopController::Ability(uint16 targid, uint16 abilityid)
+{
+    return false;
+}
+
+bool NoopController::IsAutoAttackEnabled() const
+{
+    return false;
+}
+
+void NoopController::setAutoAttackEnabled(bool enabled)
+{
+}
+
+bool NoopController::IsWeaponSkillEnabled() const
+{
+    return false;
+}
+
+void NoopController::SetWeaponSkillEnabled(bool enabled)
+{
+}
+
+bool NoopController::IsMagicCastingEnabled() const
+{
+    return false;
+}
+
+void NoopController::setMagicCastingEnabled(bool enabled)
+{
+}

--- a/src/map/ai/controllers/noop_controller.h
+++ b/src/map/ai/controllers/noop_controller.h
@@ -1,0 +1,59 @@
+/*
+===========================================================================
+
+  Copyright (c) 2022 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#ifndef SERVER_NOOP_CONTROLLER_H
+#define SERVER_NOOP_CONTROLLER_H
+
+#include "../../entities/battleentity.h"
+#include "../common/cbasetypes.h"
+#include "../map/spell.h"
+
+#include "controller.h"
+
+/**
+ * NoopController is an implementation of CController that
+ * does nothing in each of its methods. This can be useful when
+ * intending to disable the AI Controller for an entity.
+ * i.e: When someone is jailed.
+ */
+class NoopController : public CController
+{
+public:
+    NoopController(CBattleEntity* entity);
+    void Tick(time_point tick);
+    void Despawn();
+    void Reset();
+    bool Cast(uint16 targid, SpellID spellid);
+    bool Engage(uint16 targid);
+    bool ChangeTarget(uint16 targid);
+    bool Disengage();
+    bool WeaponSkill(uint16 targid, uint16 wsid);
+    bool Ability(uint16 targid, uint16 abilityid);
+    bool IsAutoAttackEnabled() const;
+    void setAutoAttackEnabled(bool enabled);
+    bool IsWeaponSkillEnabled() const;
+    void SetWeaponSkillEnabled(bool enabled);
+    bool IsMagicCastingEnabled() const;
+    void setMagicCastingEnabled(bool enabled);
+    bool canUpdate{ false };
+};
+
+#endif // SERVER_NOOP_CONTROLLER_H

--- a/src/map/entities/automatonentity.cpp
+++ b/src/map/entities/automatonentity.cpp
@@ -19,26 +19,24 @@
 ===========================================================================
 */
 
-#include "automatonentity.h"
+#include <memory>
+
 #include "../ai/ai_container.h"
-#include "../ai/controllers/automaton_controller.h"
+#include "../ai/controllers/noop_controller.h"
 #include "../ai/states/magic_state.h"
 #include "../ai/states/mobskill_state.h"
-#include "../mob_modifier.h"
 #include "../packets/action.h"
 #include "../packets/char_job_extra.h"
-#include "../packets/entity_update.h"
-#include "../packets/pet_sync.h"
 #include "../recast_container.h"
 #include "../status_effect_container.h"
 #include "../utils/mobutils.h"
 #include "../utils/puppetutils.h"
-#include "common/utils.h"
+#include "automatonentity.h"
 
 CAutomatonEntity::CAutomatonEntity()
 : CPetEntity(PET_TYPE::AUTOMATON)
 {
-    PAI->SetController(nullptr);
+    PAI->SetController(std::make_unique<NoopController>(PPet));
 }
 
 CAutomatonEntity::~CAutomatonEntity() = default;

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -488,6 +488,12 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
         return false;
     }
 
+    if (m_POwner->PAI->GetController() == NULL)
+    {
+        ShowWarning("status_effect_container::AddStatusEffect Owner PAI has null controller");
+        return false;
+    }
+
     uint16 statusId = PStatusEffect->GetStatusID();
 
     if (statusId >= MAX_EFFECTID)

--- a/src/map/utils/jailutils.cpp
+++ b/src/map/utils/jailutils.cpp
@@ -19,19 +19,16 @@
 ===========================================================================
 */
 
+#include <memory>
+
 #include "jailutils.h"
 
 #include "../conquest_system.h"
 #include "../entities/charentity.h"
 
 #include "../ai/ai_container.h"
+#include "../ai/controllers/noop_controller.h"
 #include "../ai/controllers/player_controller.h"
-
-/************************************************************************
- *                                                                       *
- *                                                                       *
- *                                                                       *
- ************************************************************************/
 
 namespace jailutils
 {
@@ -43,15 +40,11 @@ namespace jailutils
 
     void Add(CCharEntity* PChar)
     {
-        PChar->PAI->SetController(nullptr);
-
-        // TODO:
+        PChar->PAI->SetController(std::make_unique<NoopController>(PChar));
     }
 
     void Del(CCharEntity* PChar)
     {
         PChar->PAI->SetController(std::make_unique<CPlayerController>(PChar));
-
-        // TODO:
     }
 }; // namespace jailutils


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes Hundred Fists onLose callback in mordion
- Adds a NoopController to be used instead of setting controller to null
- Jailed players use a NoopController rather than a null one
- AutomatonEntity use a NoopController rather than a null one

## Steps to test these changes

!godmode
!jail <me>
