### PR TITLE
Fix Bombs Away Double Reward

### DIFF
--- a/scripts/quests/otherAreas/Bombs_Away.lua
+++ b/scripts/quests/otherAreas/Bombs_Away.lua
@@ -33,14 +33,16 @@ quest.sections =
             onEventFinish =
             {
                 [6] = function(player, csid, option, npc)
-                    quest:begin(player)
+                    if option == 1 then
+                        quest:begin(player)
+                    end
                 end,
             },
         },
     },
     {
         check = function(player, status, vars)
-            return status == QUEST_ACCEPTED
+            return status ~= QUEST_AVAILABLE
         end,
 
         [xi.zone.ULEGUERAND_RANGE] =
@@ -62,38 +64,7 @@ quest.sections =
             {
                 [8] = function(player, csid, option, npc)
                     if quest:complete(player) then
-                        player:tradeComplete()
-                    end
-                end,
-            },
-        },
-    },
-    {
-        check = function(player, status, vars)
-            return status == QUEST_COMPLETED
-        end,
-
-        [xi.zone.ULEGUERAND_RANGE] =
-        {
-            ['Buffalostalker_Dodzbraz'] =
-            {
-                onTrigger = function(player, npc)
-                    return quest:event(7)
-                end,
-
-                onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, { { xi.items.CLUSTER_CORE, 2 } }) then
-                        return quest:progressEvent(8)
-                    end
-                end,
-            },
-
-            onEventFinish =
-            {
-                [8] = function(player, csid, option, npc)
-                    player:delQuest(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.BOMBS_AWAY)
-                    if quest:complete(player) then
-                        player:tradeComplete()
+                        player:confirmTrade()
                     end
                 end,
             },

--- a/scripts/zones/Uleguerand_Range/npcs/Buffalostalker_Dodzbraz.lua
+++ b/scripts/zones/Uleguerand_Range/npcs/Buffalostalker_Dodzbraz.lua
@@ -10,7 +10,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(6)
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Prevents Bombs Away! quest from rewarding double.

## Steps to test these changes

Run the quest on a new character, single reward both on first completion and any completion thereafter.

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1929