### PR TITLE
Improve Mobs Casting on Engage

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1218,19 +1218,14 @@ bool CMobController::Engage(uint16 targid)
         // Don't cast magic or use special ability right away
         if (PMob->getBigMobMod(MOBMOD_MAGIC_DELAY) != 0)
         {
-            m_LastMagicTime =
-                m_Tick - std::chrono::milliseconds(PMob->getBigMobMod(MOBMOD_MAGIC_COOL) + xirand::GetRandomNumber(PMob->getBigMobMod(MOBMOD_MAGIC_DELAY)));
-        }
-        else if (PMob->getBigMobMod(MOBMOD_MAGIC_COOL) != 0)
-        {
-            m_LastMagicTime =
-                m_Tick - std::chrono::milliseconds(PMob->getBigMobMod(MOBMOD_MAGIC_COOL));
+            m_LastMagicTime = m_Tick - std::chrono::milliseconds(PMob->getBigMobMod(MOBMOD_MAGIC_COOL)) +
+                              std::chrono::milliseconds(xirand::GetRandomNumber(PMob->getBigMobMod(MOBMOD_MAGIC_DELAY)));
         }
 
         if (PMob->getBigMobMod(MOBMOD_SPECIAL_DELAY) != 0)
         {
-            m_LastSpecialTime = m_Tick - std::chrono::milliseconds(PMob->getBigMobMod(MOBMOD_SPECIAL_COOL) +
-                                                                   xirand::GetRandomNumber(PMob->getBigMobMod(MOBMOD_SPECIAL_DELAY)));
+            m_LastSpecialTime = m_Tick - std::chrono::milliseconds(PMob->getBigMobMod(MOBMOD_SPECIAL_COOL)) +
+                                std::chrono::milliseconds(xirand::GetRandomNumber(PMob->getBigMobMod(MOBMOD_SPECIAL_DELAY)));
         }
     }
     return ret;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

MOBMOD_MAGIC_COOL and MOBMOD_MAGIC_DELAY are two separate values where MOBMOD_MAGIC_COOL should be subtracted from m_Tick and MOBMOD_MAGIC_DELAY should be added to m_Tick. Without C++ jargon:

`m_LastMagicTime = m_Tick - MOBMOD_MAGIC_COOL + random(0, MOBMOD_MAGIC_DELAY)`

This would lead to something that has a magic cooldown and a delay to cast immediately once the delay has finished.

Napkin Math:

```
m_Tick = 100
MOBMOD_MAGIC_COOL = 35
MOBMOD_MAGIC_DELAY = 10

m_LastMagicTime = m_Tick - MOBMOD_MAGIC_COOL + random(0, MOBMOD_MAGIC_DELAY)

m_LastMagicTime = 100 - 35 + random(0, 10) // Let's call this 7.

m_LastMagicTime = 100 - 35 + 7

m_LastMagicTime = 72
```

IsSpellReady() checks a couple of things, but the default formula is:

`m_Tick >= m_LastMagicTime + MOBMOD_MAGIC_COOL`

For the above values, we'd get:

```
m_Tick >= m_LastMagicTime + MOBMOD_MAGIC_COOL

100 >= 72 + 35

100 >= 107
```

Which means IsSpellReady() won't return true for another 7 seconds, which is what we assumed the value for `random(0, MOBMOD_MAGIC_DELAY)` would be.

Instead, they're currently being added together and then subtracted from m_Tick, leading to a m_LastMagicTime that will always return true when passed into IsSpellReady().

This could be improved upon further, I have a feeling that MOBMOD_MAGIC_DELAY should be doubled to compensate for MOB_MAGIC_COOLDOWN being halved for all TryCastSpell() values, but this should be a large improvement over the current implementation.

## Steps to test these changes

Fight some mobs that cast spells!

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1830
