### PR TITLE
San d'Oria 8-2 "Coming of Age" has 1 minute wait rather than Japanese…

### DIFF
--- a/scripts/missions/sandoria/8_1_Coming_of_Age.lua
+++ b/scripts/missions/sandoria/8_1_Coming_of_Age.lua
@@ -106,7 +106,7 @@ mission.sections =
                         -- This cutscene is blocking after the mission has been completed.  Check this
                         -- before allowing further gate guard interaction (Mission[0][20]Progress).  Required
                         -- final CS will set this to 0, and we should disallow on non-zero values
-                        mission:setVar(player, 'Progress', os.time() + 60)
+                        mission:setVar(player, 'Progress', getMidnight())
                         player:delKeyItem(xi.ki.DROPS_OF_AMNIO)
                     end
                 end,


### PR DESCRIPTION
… Midnight

Fixes issue #1933

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Changes timer to JP Midnight. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1933