### PR TITLE
Give World Pass Merchants Custom Text

### DIFF
--- a/scripts/zones/Heavens_Tower/npcs/Gamimi.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Gamimi.lua
@@ -10,7 +10,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(10000) -- , 0, 0, 0, 0, 0, -1, 2)
+    player:PrintToPlayer("The Vana'diel Adventurer Recruitment Program isn't running currently. World Passes aren't available for purchase at this time.", xi.msg.channel.SAY, npc:getPacketName())
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Port_Bastok/npcs/Kachada.lua
+++ b/scripts/zones/Port_Bastok/npcs/Kachada.lua
@@ -8,7 +8,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(96)--, 0, 0, 0, 0, 0, -1, 2)
+    player:PrintToPlayer("The Vana'diel Adventurer Recruitment Program isn't running currently. World Passes aren't available for purchase at this time.", xi.msg.channel.SAY, npc:getPacketName())
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Port_San_dOria/npcs/Ambleon.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Ambleon.lua
@@ -10,7 +10,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(710)
+    player:PrintToPlayer("The Vana'diel Adventurer Recruitment Program isn't running currently. World Passes aren't available for purchase at this time.", xi.msg.channel.SAY, npc:getPacketName())
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes the menu event from World Pass Merchants because they can lock the character. Make up some text.

## Steps to test these changes

:eyes:

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/735