### PR TITLE
Fixed messaging on Cermet Gates

### DIFF
--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyd.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyd.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916880
+--  !pos -420 -2.05 5600
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getZPos() < 560 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iye.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iye.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916886
+--  !pos -440 -2.05 540
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getXPos() < -440 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyf.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyf.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916885
+--  !pos -500 -2.05 520
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getZPos() < 520 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyg.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyg.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916884
+--  !pos -540 -2.05 480
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getZPos() < 480 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyh.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyh.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916883
+--  !pos -540 -2.05 440
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getZPos() < 440 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyi.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyi.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916882
+--  !pos -500 -2.05 280
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getZPos() < 280 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyj.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyj.lua
@@ -1,7 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
--- !pos -242 0 460
+--   ID: 16916869
+--  !pos -240 -2.05 460
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -9,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getXPos() < -240 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyk.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyk.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916875
+--  !pos -280 -2.05 260
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getXPos() > 280 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyl.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyl.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916878
+--  !pos 360 -2.05 260
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getXPos() > 360 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iym.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iym.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916877
+--  !pos 480 -2.05 260
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getXPos() > 480 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyn.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyn.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916870
+--  !pos 580 -2.05 440
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getZPos() > 440 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyo.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyo.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916873
+--  !pos 600 -2.05 460
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getXPos() > 600 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyp.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyp.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: Cermet Portal (Security Gate)
+--   ID: 16916872
+--  !pos 700 -2.05 440
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 -----------------------------------
@@ -8,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:getZPos() < 440 then
-        player:messageSpecial(ID.text.DOES_NOT_RESPOND)
+        player:messageSpecial(ID.text.PORTAL_DOES_NOT_RESPOND)
         return 1
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyq.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iyq.lua
@@ -2,6 +2,7 @@
 -- Area: Grand Palace of Hu'Xzoi
 --  NPC: cermet portal
 -- !pos 420 0 401 34
+-- Spawns Ix'Grah
 -----------------------------------
 local ID = require("scripts/zones/Grand_Palace_of_HuXzoi/IDs")
 require("scripts/globals/missions")


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixed messaging on Cermet Gates to use proper IDs and prevent failure.
Closes #1821 

## Steps to test these changes

!zone {Grand Palace of Hu'Xzoi}
Click on the Cermet Gates.  Should remain closed from appropriate directions.
