### PR TITLE
Cactrot Rapido Fix

### DIFF
--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Cactrot_Rapido.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Cactrot_Rapido.lua
@@ -118,10 +118,6 @@ local pathNodes =
 }
 
 entity.onMobSpawn = function(mob)
-    -- DEBUGGING ENSURE REMOVED WHEN DONE
-    --------------------------------------------
-    mob:setPos(xi.path.first(pathNodes))
-    --------------------------------------------
     mob:setSpeed(70)
     mob:pathThrough(pathNodes, bit.bor(xi.path.flag.PATROL, xi.path.flag.RUN))
 end

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Cactrot_Rapido.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Cactrot_Rapido.lua
@@ -118,7 +118,11 @@ local pathNodes =
 }
 
 entity.onMobSpawn = function(mob)
-    mob:setSpeed(250)
+    -- DEBUGGING ENSURE REMOVED WHEN DONE
+    --------------------------------------------
+    mob:setPos(xi.path.first(pathNodes))
+    --------------------------------------------
+    mob:setSpeed(70)
     mob:pathThrough(pathNodes, bit.bor(xi.path.flag.PATROL, xi.path.flag.RUN))
 end
 
@@ -131,8 +135,9 @@ entity.onMobFight = function(mob)
 end
 
 entity.onMobDisengage = function(mob)
-    mob:setSpeed(250)
+    mob:setSpeed(70)
     mob:setAnimationSub(5)
+    mob:pathThrough(pathNodes, bit.bor(xi.path.flag.PATROL, xi.path.flag.RUN))
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Gusgen_Mines/IDs.lua
+++ b/scripts/zones/Gusgen_Mines/IDs.lua
@@ -59,7 +59,7 @@ zones[xi.zone.GUSGEN_MINES] =
         PULVERIZED_PFEFFER  = 17580041,
         SMOTHERED_SCHMIDT   = 17580039,
         WOUNDED_WURFEL      = 17580043,
-        JUGGLER_HECATOMB    = 17092827,
+        JUGGLER_HECATOMB    = 17580248,
     },
     npc =
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixes Cactrot Rapido to no longer jump around the zone. At 70 speed, rapido is still significantly faster than the player as he's using the RUN path flag.
- Bonus fix! Fixes incorrect ID being referred to in ID.lua

Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1948
