### PR TITLE
Fix Anon from Config

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5863,17 +5863,27 @@ void SmallPacket0x0DC(map_session_data_t* const PSession, CCharEntity* const PCh
             }
             break;
         case NFLAG_ANON:
+        {
             // /anon [on|off]
-            PChar->nameflags.flags ^= FLAG_ANON;
-            if (PChar->nameflags.flags & FLAG_ANON)
+            auto flags = PChar->nameflags.flags;
+            auto param = data.ref<uint8>(0x10);
+            if (param == 1)
             {
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, 175));
+                PChar->nameflags.flags |= FLAG_ANON;
+                PChar->menuConfigFlags.flags |= NFLAG_ANON;
             }
-            else
+            else if (param == 2)
             {
-                PChar->pushPacket(new CMessageSystemPacket(0, 0, 176));
+                PChar->nameflags.flags &= ~FLAG_ANON;
+                PChar->menuConfigFlags.flags &= ~NFLAG_ANON;
+            }
+
+            if (flags != PChar->nameflags.flags)
+            {
+                PChar->pushPacket(new CMessageSystemPacket(0, 0, param == 1 ? 175 : 176));
             }
             break;
+        }
         case NFLAG_AUTOTARGET:
             // /autotarget [on|off]
             if (data.ref<uint8>(0x10) == 1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes /anon and commits it to the menu config bitmask so the setting is saved and flipping the setting works as expected.

## Steps to test these changes

Spam /anon, change stuff in the menu.

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/803
