### PR TITLE
Add Item to A Pose By Any Other Name Text

### DIFF
--- a/scripts/quests/windurst/A_Pose_by_Any_Other_Name.lua
+++ b/scripts/quests/windurst/A_Pose_by_Any_Other_Name.lua
@@ -120,7 +120,7 @@ quest.sections =
                     quest:setVar(player, 'Stage', os.time() + 300)
                     quest:setVar(player, 'Prog', requestedBody)
 
-                    return quest:progressEvent(92, 0, requestedBody)
+                    return quest:progressEvent(92, 0, requestedBody, requestedBody)
                 end,
             },
         },
@@ -142,7 +142,7 @@ quest.sections =
                         if player:getEquipID(xi.slot.BODY) == requestedBody then
                             return quest:progressEvent(96)
                         else
-                            return quest:progressEvent(93, 0, requestedBody)
+                            return quest:progressEvent(93, 0, requestedBody, requestedBody)
                         end
                     else -- Over time. Quest failed.
                         return quest:progressEvent(102)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds item to text output for variation 2. Variation 1 is initial request, variation 2 is if you speak with her again. Almost identical but one has a preamble.

## Steps to test these changes

Talk to Angelica

Variation 1:
![image](https://user-images.githubusercontent.com/8849608/204481249-ad593e39-009c-485b-be58-4c5e1c7494f1.png)

Variation 2:
![image](https://user-images.githubusercontent.com/8849608/204480883-03e0fb12-6ebc-4f24-a19f-63df90d04de5.png)

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1920