### PR TITLE
Fix CoP Zanshin Trait

### DIFF
--- a/sql/traits.sql
+++ b/sql/traits.sql
@@ -432,10 +432,11 @@ INSERT INTO `traits` VALUES (67,'subtle blow',19,65,3,289,15,'WOTG',0);
 INSERT INTO `traits` VALUES (67,'subtle blow',19,86,4,289,20,'ABYSSEA',0);
 INSERT INTO `traits` VALUES (68,'assassin',6,60,1,0,0,'COP',0);
 INSERT INTO `traits` VALUES (69,'divine veil',3,50,1,0,0,'COP',0);
-INSERT INTO `traits` VALUES (70,'zanshin',12,20,1,306,15,'COP',0);
-INSERT INTO `traits` VALUES (70,'zanshin',12,35,2,306,25,'COP',0);
-INSERT INTO `traits` VALUES (70,'zanshin',12,50,3,306,35,'COP',0);
-INSERT INTO `traits` VALUES (70,'zanshin',12,75,4,306,45,'COP',0);
+INSERT INTO `traits` VALUES (70,'zanshin',12,60,1,306,15,'COP',0); -- One Zanshin trait at 60 in CoP, later lowered to level 20
+INSERT INTO `traits` VALUES (70,'zanshin',12,20,1,306,15,'TOAU',0);
+INSERT INTO `traits` VALUES (70,'zanshin',12,35,2,306,25,'TOAU',0);
+INSERT INTO `traits` VALUES (70,'zanshin',12,50,3,306,35,'TOAU',0);
+INSERT INTO `traits` VALUES (70,'zanshin',12,75,4,306,45,'TOAU',0);
 INSERT INTO `traits` VALUES (70,'zanshin',12,95,5,306,50,'ABYSSEA',0);
 INSERT INTO `traits` VALUES (71,'savagery',1,75,1,0,0,'TOAU',0);
 INSERT INTO `traits` VALUES (72,'aggressive aim',1,75,1,0,0,'TOAU',0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Update all era Zanshins to be ToAU and add a CoP Zanshin at rank 1.

ToAU-disabled server has the trait at 60 but not 59.

ToAU-enabled server has the trait at 20 with 15 potency, and 35 potency at 60.

## Steps to test these changes

Run a ToAU disabled server and make sure you don't have Zanshin at 59 SAM.

Run a ToAU enabled server and make sure Zanshin traits are still as potent as expected.

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1556
