### PR TITLE
Implements 'Citizens of X' gear latent

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1924,6 +1924,7 @@ xi.latent =
     VS_ECOSYSTEM             = 59, -- Vs. Specific Ecosystem ID (e.g. Vs. Plantoid: Accuracy+3)
     VS_FAMILY                = 60, -- Vs. Specific Family ID (e.g. Vs. Korrigan: Accuracy+3)
     VS_SUPERFAMILY           = 61, -- Vs. Specific Family ID (e.g. Vs. Mandragora: Accuracy+3)
+    CITIZEN_OF_NATION        = 70, -- Player is a citizen of the provided nation
 }
 
 -----------------------------------

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -918,7 +918,7 @@ INSERT INTO `item_latents` VALUES (14014,68,7,53,1);     -- EVA +7 in areas outs
 -- Praefectus's Gloves
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES (14015,10,2,53,1);     -- VIT +2 in areas outside own nation's control
-INSERT INTO `item_latents` VALUES (14015,68,5,53,1);     -- EVA +5 in areas outside own nation's control
+INSERT INTO `item_latents` VALUES (14015,108,5,53,1);    -- Evasion Skill +5 in areas outside own nation's control
 INSERT INTO `item_latents` VALUES (14015,110,5,53,1);    -- Parrying skill +5 in areas outside own nation's control
 
 -- -------------------------------------------------------
@@ -2078,10 +2078,22 @@ INSERT INTO `item_latents` VALUES (16792,25,7,59,19);    -- Goshisho's Scythe - 
 INSERT INTO `item_latents` VALUES (16793,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (16793,19,-10,47,0);
 INSERT INTO `item_latents` VALUES (16793,21,-10,47,0);
+
+-- -------------------------------------------------------
+-- Senior Gold Musketeer's Scythe
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (16799,25,7,70,1);    -- Citizens of Bastok: Accuracy +7
+
 INSERT INTO `item_latents` VALUES (16883,25,10,52,6);    -- Spear: Accuracy +10 in Water weather
 INSERT INTO `item_latents` VALUES (16892,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (16892,20,-10,47,0);
 INSERT INTO `item_latents` VALUES (16892,22,-10,47,0);
+
+-- -------------------------------------------------------
+-- Reserve Captain's Lance
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (16893,1,10,70,0);    -- Citizens of San d'Oria: Def +10
+
 INSERT INTO `item_latents` VALUES (16899,110,5,25,0);    -- Hototogisu,parry skill +5 song/roll active
 
 -- -------------------------------------------------------
@@ -2110,6 +2122,12 @@ INSERT INTO `item_latents` VALUES (16949,10,3,53,1);     -- VIT +3 in areas outs
 INSERT INTO `item_latents` VALUES (16952,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (16952,16,-10,47,0);
 INSERT INTO `item_latents` VALUES (16952,18,-10,47,0);
+
+-- -------------------------------------------------------
+-- Reserve Captain's Greatsword
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (16953,25,7,70,0);    -- Citizens of San d'Oria: Accuracy +7
+
 INSERT INTO `item_latents` VALUES (16968,165,7,59,3);    -- Kamewari - Vs. arcana: Critical hit rate +7%
 INSERT INTO `item_latents` VALUES (16969,165,5,59,9);    -- Onikiri - Vs. demons: Critical hit rate +5%
 
@@ -2208,6 +2226,17 @@ INSERT INTO `item_latents` VALUES (17456,2,-10,47,0);
 INSERT INTO `item_latents` VALUES (17456,5,-10,47,0);
 INSERT INTO `item_latents` VALUES (17456,18,-10,47,0);
 INSERT INTO `item_latents` VALUES (17456,20,-10,47,0);
+
+-- -------------------------------------------------------
+-- Senior Gold Musketeer's Rod
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (17457,71,7,70,1);    -- Citizens of Bastok: hMP +7
+
+-- -------------------------------------------------------
+-- Reserve Captain's Mace
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (17458,71,7,70,0);    -- Citizens of San d'Oria: hMP +7
+
 INSERT INTO `item_latents` VALUES (17461,23,10,56,0);    -- Rune Rod +10 Atk.
 INSERT INTO `item_latents` VALUES (17461,112,6,56,0);    -- Rune Rod +6 Healing Magic Skill
 INSERT INTO `item_latents` VALUES (17461,369,-4,56,0);   -- Rune Rod -4MP/tic
@@ -2239,7 +2268,7 @@ INSERT INTO `item_latents` VALUES (17507,20,-10,47,0);
 -- -------------------------------------------------------
 -- Master Caster's baghnakhs
 -- -------------------------------------------------------
--- INSERT INTO `item_latents` VALUES (17508,23,10,?,?);  -- Citizens of Windurst: Attack+10
+INSERT INTO `item_latents` VALUES (17508,23,10,70,2);  -- Citizens of Windurst: Attack+10
 
 INSERT INTO `item_latents` VALUES (17509,165,6,47,0);    -- Destroyers Crit Rate +6% when broken (500 WS points)
 INSERT INTO `item_latents` VALUES (17509,287,13,47,0);   -- Destroyers DMG+13 when broken (500 WS points)
@@ -2247,6 +2276,11 @@ INSERT INTO `item_latents` VALUES (17527,2,-10,47,0);
 INSERT INTO `item_latents` VALUES (17527,5,-10,47,0);
 INSERT INTO `item_latents` VALUES (17527,15,-10,47,0);
 INSERT INTO `item_latents` VALUES (17527,21,-10,47,0);
+
+-- -------------------------------------------------------
+-- Master Caster's Pole
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (17530,71,8,70,2);    -- Citizens of Windurst: hMP +8
 
 -- -------------------------------------------------------
 -- Ramuh's Staff
@@ -2286,6 +2320,12 @@ INSERT INTO `item_latents` VALUES (17599,315,25,52,8);   -- +25% drain/aspir pot
 
 INSERT INTO `item_latents` VALUES (17616,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (17616,16,-10,47,0);
+
+-- -------------------------------------------------------
+-- Master Caster's Knife
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (17617,1,10,70,2);    -- Citizens of Windurst: DEF +10
+
 INSERT INTO `item_latents` VALUES (17616,18,-10,47,0);
 
 -- -------------------------------------------------------
@@ -2313,6 +2353,12 @@ INSERT INTO `item_latents` VALUES (17649,25,12,26,1);    -- Nighttime: ACC +12
 INSERT INTO `item_latents` VALUES (17654,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (17654,15,-10,47,0);
 INSERT INTO `item_latents` VALUES (17654,17,-10,47,0);
+
+-- -------------------------------------------------------
+-- Senior Gold Musketeer's Scimitar
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (17655,1,10,70,1);    -- Citizens of Bastok: DEF +10
+
 INSERT INTO `item_latents` VALUES (17661,27,5,58,0);     -- Storm Scimitar Enmity +5 in Assault
 INSERT INTO `item_latents` VALUES (17661,287,4,58,0);    -- Storm Scimitar DMG+4 in Assault
 
@@ -2467,6 +2513,12 @@ INSERT INTO `item_latents` VALUES (17932,9,3,53,1);      -- DEX +3 in areas outs
 INSERT INTO `item_latents` VALUES (17933,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (17933,17,-10,47,0);
 INSERT INTO `item_latents` VALUES (17933,19,-10,47,0);
+
+-- -------------------------------------------------------
+-- Reserve Captain's Pick
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (17934,23,10,70,0);    -- Citizens of San d'Oria: Attack +10
+
 INSERT INTO `item_latents` VALUES (17941,17,15,31,0);    -- Mighty Pick [Element: Wind]+15 on Windsday
 INSERT INTO `item_latents` VALUES (17941,287,5,31,0);    -- Mighty Pick DMG+5 on Windsday
 INSERT INTO `item_latents` VALUES (17944,165,6,47,0);    -- Retributor Crit Rate +6% when broken (500 WS points)
@@ -2639,6 +2691,12 @@ INSERT INTO `item_latents` VALUES (18135,8,3,53,1);      -- STR +3 in areas outs
 INSERT INTO `item_latents` VALUES (18144,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (18144,17,-10,47,0);
 INSERT INTO `item_latents` VALUES (18144,19,-10,47,0);
+
+-- -------------------------------------------------------
+-- Master Caster's Bow
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (18145,26,7,70,2);    -- Citizens of Windurst: Ranged Accuracy +7
+
 INSERT INTO `item_latents` VALUES (18146,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (18146,18,-10,47,0);
 INSERT INTO `item_latents` VALUES (18146,20,-10,47,0);
@@ -2648,6 +2706,11 @@ INSERT INTO `item_latents` VALUES (18146,20,-10,47,0);
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES (18165,2,30,26,0);     -- Daytime: HP+30
 INSERT INTO `item_latents` VALUES (18165,68,10,26,1);    -- Nighttime: Evasion+10
+
+-- -------------------------------------------------------
+-- Senior Gold Musketeer's Axe
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (18196,23,10,70,1);    -- Citizens of Bastok: Attack +10
 
 INSERT INTO `item_latents` VALUES (18206,25,5,56,0);     -- Rune Chopper +5 Acc.
 INSERT INTO `item_latents` VALUES (18206,369,-3,56,0);   -- Rune Chopper -3MP/tic

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -8403,7 +8403,7 @@ INSERT INTO `mob_groups` VALUES (5,6765,118,'Clipper_fished',0,128,0,0,0,15,18,0
 
 INSERT INTO `mob_groups` VALUES (6,3830,118,'Sylvestre',330,0,2369,0,0,15,19,0);
 INSERT INTO `mob_groups` VALUES (7,2652,118,'Mighty_Rarab',330,0,1670,0,0,15,18,0);
-INSERT INTO `mob_groups` VALUES (8,4523,118,'Zu',330,0,2812,0,0,20,24,0);
+INSERT INTO `mob_groups` VALUES (8,4523,118,'Zu',330,0,2812,0,0,20,23,0);
 INSERT INTO `mob_groups` VALUES (9,1635,118,'Goblin_Ambusher',330,0,1017,0,0,17,20,0);
 INSERT INTO `mob_groups` VALUES (10,1738,118,'Goblin_Tinkerer',330,0,6029,0,0,17,20,0);
 INSERT INTO `mob_groups` VALUES (11,1643,118,'Goblin_Butcher',330,0,6029,0,0,17,20,0);
@@ -8411,7 +8411,7 @@ INSERT INTO `mob_groups` VALUES (12,4516,118,'Zombie_war',330,1,2809,0,0,18,22,0
 INSERT INTO `mob_groups` VALUES (13,1518,118,'Ghoul_blm',330,1,960,0,0,20,24,0);
 INSERT INTO `mob_groups` VALUES (14,4345,118,'Will-o-the-Wisp',330,8,6027,0,0,25,27,0);
 INSERT INTO `mob_groups` VALUES (15,485,118,'Bogy',330,1,322,0,0,23,25,0);
-INSERT INTO `mob_groups` VALUES (16,578,118,'Bull_Dhalmel',330,0,385,0,0,20,24,0);
+INSERT INTO `mob_groups` VALUES (16,578,118,'Bull_Dhalmel',330,0,385,0,0,20,23,0);
 INSERT INTO `mob_groups` VALUES (17,1690,118,'Goblin_Mugger',330,0,1117,0,0,22,25,0);
 INSERT INTO `mob_groups` VALUES (18,1683,118,'Goblin_Leecher',330,0,1103,0,0,22,25,0);
 INSERT INTO `mob_groups` VALUES (19,1666,118,'Goblin_Gambler',330,0,1078,0,0,22,25,0);

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -91,6 +91,7 @@ enum class LATENT : uint16
     VS_ECOSYSTEM          = 59, // Vs. Specific Ecosystem ID (e.g. Vs. Plantoid: Accuracy+3)
     VS_FAMILY             = 60, // Vs. Specific Family ID (e.g. Vs. Korrigan: Accuracy+3)
     VS_SUPERFAMILY        = 61, // Vs. Specific SuperFamily ID (e.g. Vs. Mandragora: Accuracy+3)
+    CITIZEN_OF_NATION     = 70, // Player is a citizen of the provided nation
 };
 
 #define MAX_LATENTEFFECTID 61

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -1145,6 +1145,9 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
         case LATENT::EQUIPPED_IN_SLOT:
             expression = latentEffect.GetSlot() == latentEffect.GetConditionsValue();
             break;
+        case LATENT::CITIZEN_OF_NATION:
+            expression = m_POwner->profile.nation == latentEffect.GetConditionsValue();
+            break;
         default:
             latentFound = false;
             ShowWarning("Latent ID %d unhandled in ProcessLatentEffect", static_cast<uint16>(latentEffect.GetConditionsID()));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Implements a latent to trigger gear that depends on the player being a citizen of a specific nation
- Corrects Praefectus Gloves to give Evasion skill instead of Evasion
- Random fix to lower levels of mobs in Buburimu
- Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1729
- Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1847
- Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1951

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
