### PR TITLE
Fix Charmed Mobs Casting Without Sic

### DIFF
--- a/scripts/globals/abilities/sic.lua
+++ b/scripts/globals/abilities/sic.lua
@@ -32,6 +32,7 @@ abilityObject.onUseAbility = function(player, target, ability)
         if mob:getTP() >= 1000 then
             mob:useMobAbility()
         elseif mob:hasSpellList() then
+            mob:setLocalVar("Sic", 1)
             mob:castSpell()
         else
             mob:queue(0, doSic)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -558,6 +558,17 @@ bool CMobController::CanCastSpells()
         }
     }
 
+    // Charmed BST pets don't passively cast spells
+    if (PMob->isCharmed && PMob->PMaster != nullptr && PMob->PMaster->objtype == TYPE_PC)
+    {
+        // Can cast spells if BST uses Sic while mob has less than 1000TP
+        if (PMob->GetLocalVar("Sic") != 1)
+        {
+            return false;
+        }
+        PMob->SetLocalVar("Sic", 0);
+    }
+
     return IsMagicCastingEnabled();
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Prevents charmed mobs from casting spells unless Beastmaster uses Sic and the mob can cast and it had less than 1000TP at the time of using Sic.

## Steps to test these changes

Get some charmed mobs, do some TP manipulation, do some Sic, do some reset, repeat.

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/1767
