### PR TITLE
Additional Starlight Decor, Dream Hat +1 Edit

### DIFF
--- a/modules/custom/sql/starlight_celebrations.sql
+++ b/modules/custom/sql/starlight_celebrations.sql
@@ -10,8 +10,8 @@
 UPDATE zone_settings SET music_day=239 WHERE name='Port_Jeuno' AND zoneid='246';
 UPDATE zone_settings SET music_night=239 WHERE name='Port_Jeuno' AND zoneid='246';
 
-UPDATE npc_list SET pos_rot = 192, pos_x = -81.000, pos_y = 0.500, pos_z = 0.000, flag = 98305, namevis = 64, status = 0, entityFlags = 2075, look = 0x0000FF0200000000000000000000000000000000, name_prefix = 0, widescan = 0 WHERE npcid = 17784975 AND name = 'blank';
-UPDATE npc_list SET pos_rot = 192, pos_x = 7.250, pos_y = 0.500, pos_z = 0.000, flag = 98305, namevis = 64, status = 0, entityFlags = 2075, look = 0x0000FF0200000000000000000000000000000000, name_prefix = 0, widescan = 0 WHERE npcid = 17784976 AND name = 'blank';
+UPDATE npc_list SET pos_rot = 192, pos_x = -81.000, pos_y = 0.500, pos_z = 0.000, flag = 98305, namevis = 8, status = 0, entityFlags = 2075, look = 0x0000FF0200000000000000000000000000000000, name_prefix = 0, widescan = 0 WHERE npcid = 17784975 AND name = 'blank';
+UPDATE npc_list SET pos_rot = 192, pos_x = 7.250, pos_y = 0.500, pos_z = 0.000, flag = 98305, namevis = 8, status = 0, entityFlags = 2075, look = 0x0000FF0200000000000000000000000000000000, name_prefix = 0, widescan = 0 WHERE npcid = 17784976 AND name = 'blank';
 
 -- ------------------------------------------------------------
 -- Lower Jeuno (Zone 245)
@@ -20,17 +20,17 @@ UPDATE npc_list SET pos_rot = 192, pos_x = 7.250, pos_y = 0.500, pos_z = 0.000, 
 UPDATE zone_settings SET music_day=239 WHERE name='Lower_Jeuno' AND zoneid='245';
 UPDATE zone_settings SET music_night=239 WHERE name='Lower_Jeuno' AND zoneid='245';
 
-INSERT INTO `npc_list` VALUES (17781000,'blank','     ',57,-16.1250,0.675,5.4297,98305,40,40,0,0,64,0,2075,0x0000FC0200000000000000000000000000000000,34,NULL,0);
-INSERT INTO `npc_list` VALUES (17781001,'blank','     ',0,-18.3335,-0.100,-35.6341,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
-INSERT INTO `npc_list` VALUES (17781002,'blank','     ',0,-18.3405,-0.100,-35.6283,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
-INSERT INTO `npc_list` VALUES (17781003,'blank','     ',0,-28.0633,-0.100,-55.2038,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
-INSERT INTO `npc_list` VALUES (17781004,'blank','     ',0,-69.7005,-0.100,-127.3172,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
-INSERT INTO `npc_list` VALUES (17781005,'blank','     ',0,-86.1038,-0.100,-143.9980,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
-INSERT INTO `npc_list` VALUES (17781006,'blank','     ',0,-92.3048,-0.100,-155.1194,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
-INSERT INTO `npc_list` VALUES (17781007,'blank','     ',0,-90.9425,-0.100,-160.1327,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
-INSERT INTO `npc_list` VALUES (17781008,'blank','     ',0,-94.2040,-0.100,-184.0553,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
-INSERT INTO `npc_list` VALUES (17781009,'blank','     ',0,-53.2500,-6.000,-114.3925,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
-INSERT INTO `npc_list` VALUES (17781010,'blank','     ',0,-6.8849,-0.100,-15.2041,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781000,'blank','     ',57,-16.1250,0.675,5.4297,98305,40,40,0,0,8,0,2075,0x0000FC0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781001,'blank','     ',0,-18.3335,-0.100,-35.6341,98305,40,40,0,0,8,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781002,'blank','     ',0,-18.3405,-0.100,-35.6283,98305,40,40,0,0,8,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781003,'blank','     ',0,-28.0633,0.000,-55.2038,98305,40,40,0,0,8,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781004,'blank','     ',0,-69.7005,0.000,-127.3172,98305,40,40,0,0,8,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781005,'blank','     ',0,-86.1038,0.000,-143.9980,98305,40,40,0,0,8,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781006,'blank','     ',0,-92.3048,0.000,-155.1194,98305,40,40,0,0,8,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781007,'blank','     ',0,-90.9425,0.000,-160.1327,98305,40,40,0,0,8,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781008,'blank','     ',0,-94.2040,0.000,-184.0553,98305,40,40,0,0,8,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781009,'blank','     ',0,-53.2500,-6.000,-114.3925,98305,40,40,0,0,8,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781010,'blank','     ',0,-6.8849,-0.100,-15.2041,98305,40,40,0,0,8,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
 
 -- ------------------------------------------------------------
 -- Upper Jeuno (Zone 244)
@@ -39,7 +39,14 @@ INSERT INTO `npc_list` VALUES (17781010,'blank','     ',0,-6.8849,-0.100,-15.204
 UPDATE zone_settings SET music_day=239 WHERE name='Upper_Jeuno' AND zoneid='244';
 UPDATE zone_settings SET music_night=239 WHERE name='Upper_Jeuno' AND zoneid='244';
 
-UPDATE npc_list SET pos_rot = 18, pos_x = -50.000, pos_y = 0.675, pos_z = 109.253, flag = 98305, namevis = 64, status = 0, entityFlags = 98305, look = 0x0000FC0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776863 AND name = 'blank';
-UPDATE npc_list SET pos_rot = 185, pos_x = -44.364, pos_y = 8.000, pos_z = 104.674, flag = 98305, namevis = 64, status = 0, entityFlags = 98305, look = 0x0000FE0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776875 AND name = 'blank';
-UPDATE npc_list SET pos_rot = 42, pos_x = -37.256, pos_y = -0.500, pos_z = 27.000, flag = 98305, namevis = 64, status = 0, entityFlags = 98305, look = 0x0000FF0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776888 AND name = 'blank';
-UPDATE npc_list SET pos_rot = 94, pos_x = -66.605, pos_y = -0.200, pos_z = 65.117, flag = 98305, namevis = 64, status = 0, entityFlags = 98305, look = 0x0000FE0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776889 AND name = 'blank';
+UPDATE npc_list SET pos_rot = 18, pos_x = -50.000, pos_y = 0.675, pos_z = 109.253, flag = 98305, namevis = 8, status = 0, entityFlags = 98305, look = 0x0000FC0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776863 AND name = 'blank';
+UPDATE npc_list SET pos_rot = 185, pos_x = -44.364, pos_y = 8.000, pos_z = 104.674, flag = 98305, namevis = 8, status = 0, entityFlags = 98305, look = 0x0000FE0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776875 AND name = 'blank';
+UPDATE npc_list SET pos_rot = 42, pos_x = -37.256, pos_y = -0.500, pos_z = 27.000, flag = 98305, namevis = 8, status = 0, entityFlags = 98305, look = 0x0000FF0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776888 AND name = 'blank';
+UPDATE npc_list SET pos_rot = 94, pos_x = -66.605, pos_y = -0.200, pos_z = 65.117, flag = 98305, namevis = 8, status = 0, entityFlags = 98305, look = 0x0000FE0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776889 AND name = 'blank';
+
+-- ------------------------------------------------------------
+-- Valkurm Dunes (Zone 103)
+-- ------------------------------------------------------------
+
+UPDATE npc_list SET pos_rot = 139, pos_x = 136.2782, pos_y = -7.6649, pos_z = 96.8022, flag = 98305, namevis = 8, status = 0, entityFlags = 98305, look = 0x0000FE0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17199707 AND name = 'Moogle';
+UPDATE npc_list SET pos_rot = 139, pos_x = 142.2639, pos_y = -7.2481, pos_z = 103.2505, flag = 98305, namevis = 8, status = 0, entityFlags = 98305, look = 0x0000FE0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17199708 AND name = 'Moogle';

--- a/modules/custom/sql/starlight_celebrations.sql
+++ b/modules/custom/sql/starlight_celebrations.sql
@@ -10,6 +10,9 @@
 UPDATE zone_settings SET music_day=239 WHERE name='Port_Jeuno' AND zoneid='246';
 UPDATE zone_settings SET music_night=239 WHERE name='Port_Jeuno' AND zoneid='246';
 
+UPDATE npc_list SET pos_rot = 192, pos_x = -81.000, pos_y = 0.500, pos_z = 0.000, flag = 98305, namevis = 64, status = 0, entityFlags = 2075, look = 0x0000FF0200000000000000000000000000000000, name_prefix = 0, widescan = 0 WHERE npcid = 17784975 AND name = 'blank';
+UPDATE npc_list SET pos_rot = 192, pos_x = 7.250, pos_y = 0.500, pos_z = 0.000, flag = 98305, namevis = 64, status = 0, entityFlags = 2075, look = 0x0000FF0200000000000000000000000000000000, name_prefix = 0, widescan = 0 WHERE npcid = 17784976 AND name = 'blank';
+
 -- ------------------------------------------------------------
 -- Lower Jeuno (Zone 245)
 -- ------------------------------------------------------------
@@ -17,9 +20,26 @@ UPDATE zone_settings SET music_night=239 WHERE name='Port_Jeuno' AND zoneid='246
 UPDATE zone_settings SET music_day=239 WHERE name='Lower_Jeuno' AND zoneid='245';
 UPDATE zone_settings SET music_night=239 WHERE name='Lower_Jeuno' AND zoneid='245';
 
+INSERT INTO `npc_list` VALUES (17781000,'blank','     ',57,-16.1250,0.675,5.4297,98305,40,40,0,0,64,0,2075,0x0000FC0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781001,'blank','     ',0,-18.3335,-0.100,-35.6341,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781002,'blank','     ',0,-18.3405,-0.100,-35.6283,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781003,'blank','     ',0,-28.0633,-0.100,-55.2038,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781004,'blank','     ',0,-69.7005,-0.100,-127.3172,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781005,'blank','     ',0,-86.1038,-0.100,-143.9980,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781006,'blank','     ',0,-92.3048,-0.100,-155.1194,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781007,'blank','     ',0,-90.9425,-0.100,-160.1327,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781008,'blank','     ',0,-94.2040,-0.100,-184.0553,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781009,'blank','     ',0,-53.2500,-6.000,-114.3925,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+INSERT INTO `npc_list` VALUES (17781010,'blank','     ',0,-6.8849,-0.100,-15.2041,98305,40,40,0,0,64,0,2075,0x0000FE0200000000000000000000000000000000,34,NULL,0);
+
 -- ------------------------------------------------------------
 -- Upper Jeuno (Zone 244)
 -- ------------------------------------------------------------
 
 UPDATE zone_settings SET music_day=239 WHERE name='Upper_Jeuno' AND zoneid='244';
 UPDATE zone_settings SET music_night=239 WHERE name='Upper_Jeuno' AND zoneid='244';
+
+UPDATE npc_list SET pos_rot = 18, pos_x = -50.000, pos_y = 0.675, pos_z = 109.253, flag = 98305, namevis = 64, status = 0, entityFlags = 98305, look = 0x0000FC0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776863 AND name = 'blank';
+UPDATE npc_list SET pos_rot = 185, pos_x = -44.364, pos_y = 8.000, pos_z = 104.674, flag = 98305, namevis = 64, status = 0, entityFlags = 98305, look = 0x0000FE0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776875 AND name = 'blank';
+UPDATE npc_list SET pos_rot = 42, pos_x = -37.256, pos_y = -0.500, pos_z = 27.000, flag = 98305, namevis = 64, status = 0, entityFlags = 98305, look = 0x0000FF0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776888 AND name = 'blank';
+UPDATE npc_list SET pos_rot = 94, pos_x = -66.605, pos_y = -0.200, pos_z = 65.117, flag = 98305, namevis = 64, status = 0, entityFlags = 98305, look = 0x0000FE0200000000000000000000000000000000, name_prefix = 34, widescan = 0 WHERE npcid = 17776889 AND name = 'blank';

--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -115,11 +115,6 @@ xi.moghouse.moogleTrigger = function(player, npc)
                 local placedDay = player:getCharVar("[StarlightMisc]TreeTimePlaced")
                 local earnedReward = player:getCharVar("[StarlightMisc]DreamHatHQ")
                 local currentDay = VanadielUniqueDay()
-                local currentTime = os.time()
-                local currentMidnight = JstMidnight()
-
-                print(tostring(currentTime))
-                print(tostring(currentMidnight))
 
                 if (treePlaced ~= 0 and earnedReward ~= 1) then
                     local sandOrianTree = player:getCharVar("[StarlightMisc]SandOrianTree")

--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -116,7 +116,10 @@ xi.moghouse.moogleTrigger = function(player, npc)
                 local earnedReward = player:getCharVar("[StarlightMisc]DreamHatHQ")
                 local currentDay = VanadielUniqueDay()
                 local currentTime = os.time()
-                local currentMidnight = getVanaMidnight(placedDay)
+                local currentMidnight = JstMidnight()
+
+                print(tostring(currentTime))
+                print(tostring(currentMidnight))
 
                 if (treePlaced ~= 0 and earnedReward ~= 1) then
                     local sandOrianTree = player:getCharVar("[StarlightMisc]SandOrianTree")
@@ -125,7 +128,7 @@ xi.moghouse.moogleTrigger = function(player, npc)
                     local jeunoanTree = player:getCharVar("[StarlightMisc]JeunoanTree")
                     local holidayFame = player:getFameLevel(xi.quest.fame_area.HOLIDAY)
 
-                    if (placedDay < currentDay and currentTime > currentMidnight) then
+                    if (placedDay < currentDay) then
                         if holidayFame == 9 then
                             if sandOrianTree == 1 then
                                 player:startEvent(30017, 0, 0, 0, 86)

--- a/scripts/zones/Lower_Jeuno/IDs.lua
+++ b/scripts/zones/Lower_Jeuno/IDs.lua
@@ -78,20 +78,6 @@ zones[xi.zone.LOWER_JEUNO] =
     },
     npc =
     {
-        STARLIGHT_DECORATIONS =
-        {
-            [17781000] = 17781000, -- Big Jeuno Festive Tree
-            [17781001] = 17781001, -- Jeuno Festive Tree
-            [17781002] = 17781002, -- Jeuno Festive Tree
-            [17781003] = 17781003, -- Jeuno Festive Tree
-            [17781004] = 17781004, -- Jeuno Festive Tree
-            [17781005] = 17781005, -- Jeuno Festive Tree
-            [17781006] = 17781006, -- Jeuno Festive Tree
-            [17781007] = 17781007, -- Jeuno Festive Tree
-            [17781008] = 17781008, -- Jeuno Festive Tree
-            [17781009] = 17781009, -- Jeuno Festive Tree
-            [17781010] = 17781009, -- Jeuno Festive Tree
-        },
         CHULULU           = 17780771,
         VHANA_EHGAKLYWHA  = 17780880,
         STREETLAMP_OFFSET = 17780881,

--- a/scripts/zones/Lower_Jeuno/Zone.lua
+++ b/scripts/zones/Lower_Jeuno/Zone.lua
@@ -16,7 +16,6 @@ local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
     zone:registerTriggerArea(1, 23, 0, -43, 44, 7, -39) -- Inside Tenshodo HQ. TODO: Find out if this is used other than in ZM 17 (not anymore). Remove if not.
-    xi.events.starlightCelebration.applyStarlightDecorations(zone:getID())
     xi.chocobo.initZone(zone)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds additional celebration decor to select zones. Moved custom decor from npc_list to module. Changes dream hat +1 conditions. Additional decor has been added to starlight_celebrations.sql module in custom/sql.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Enable starlight_celebrations.sql in init.txt and check out the affected zones.
