### PR TITLE
Set Fixed Duration Cap for Maiden's Virelai Charm

### DIFF
--- a/scripts/globals/spells/songs/maidens_virelai.lua
+++ b/scripts/globals/spells/songs/maidens_virelai.lua
@@ -48,7 +48,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             target:addStatusEffect(xi.effect.CHARM_I, 0, 0, duration)
             caster:charm(target)
         else
-            caster:charmPet(target)
+            caster:charmDuration(target, duration)
         end
     else
         -- Resist

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11556,6 +11556,17 @@ void CLuaBaseEntity::charm(CLuaBaseEntity const* target)
 }
 
 /************************************************************************
+ *  Function: charmDuration()
+ *  Purpose : Charms an entity target for a duration
+ *  Example : mob:charm(target, duration)
+ ************************************************************************/
+
+void CLuaBaseEntity::charmDuration(CLuaBaseEntity const* target, uint32 duration)
+{
+    battleutils::applyCharm(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<CBattleEntity*>(target->GetBaseEntity()), std::chrono::seconds(duration));
+}
+
+/************************************************************************
  *  Function: uncharm()
  *  Purpose : Removes charm from an entity
  *  Example : target:uncharm()
@@ -15987,6 +15998,7 @@ void CLuaBaseEntity::Register()
 
     // BST
     SOL_REGISTER("charm", CLuaBaseEntity::charm);
+    SOL_REGISTER("charmDuration", CLuaBaseEntity::charmDuration);
     SOL_REGISTER("uncharm", CLuaBaseEntity::uncharm);
 
     // PUP

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -641,8 +641,9 @@ public:
     bool   addBardSong(CLuaBaseEntity* PEntity, uint16 effectID, uint16 power, uint16 tick,
                        uint16 duration, uint16 subID, uint16 subPower, uint16 tier); // Adds bard song effect
 
-    void charm(CLuaBaseEntity const* target); // applies charm on target
-    void uncharm();                           // removes charm on target
+    void charm(CLuaBaseEntity const* target);                          // applies charm on target
+    void charmDuration(CLuaBaseEntity const* target, uint32 duration); // applies charm on target for duration
+    void uncharm();                                                    // removes charm on target
 
     uint8 addBurden(uint8 element, uint8 burden);
     uint8 getOverloadChance(uint8 element);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the plumbing for a duration to be passed in to charm; this allows maiden's virelai to set its duration based off resist, etc. Breaks the duration calculation part out into its own function to be used in charm but not virelai

## Steps to test these changes

Check output for maiden's virelai and charm on various difficulty mobs

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/870