### PR TITLE
Reassign Players to BCNM on Disconnect

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -207,6 +207,9 @@ xi.settings.map =
     -- Enable/disable level cap of mission battlefields stored in database.
     LV_CAP_MISSION_BCNM = 1,
 
+    -- Prevent players from reentering a battlefield after choosing to run away. Retail allows reentry of battlefields.
+    PREVENT_BATTLEFIELD_REENTRY = true,
+
     -- Max allowed merits points players can hold
     --  10 classic
     --  30 abyssea

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -537,7 +537,15 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
 
         if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_CONFRONTATION))
         {
-            PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD)->SetSubPower(0);
+            if (leavecode == BATTLEFIELD_LEAVE_CODE_LOSE || leavecode == BATTLEFIELD_LEAVE_CODE_WIN)
+            {
+                PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD)->SetSubPower(0);
+            }
+            else if (settings::get<bool>("map.PREVENT_BATTLEFIELD_REENTRY") && leavecode == BATTLEFIELD_LEAVE_CODE_EXIT)
+            {
+                PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
+                PChar->StatusEffectContainer->DelStatusEffect(EFFECT_LEVEL_RESTRICTION);
+            }
         }
 
         if (PChar->isDead())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Reassigns a player when they've disconnected from a BCNM.

## Steps to test these changes

Run a BCNM with two players, have one disconnect and come back. Should be able to participate as expected.
