### PR TITLE
Fix Cryptonberry Assassins Using Wrong JSA

### DIFF
--- a/scripts/zones/Carpenters_Landing/mobs/Cryptonberry_Assassin.lua
+++ b/scripts/zones/Carpenters_Landing/mobs/Cryptonberry_Assassin.lua
@@ -8,6 +8,13 @@ mixins = { require("scripts/mixins/job_special") }
 -----------------------------------
 local entity = {}
 
+local cryptonberrySpecials =
+{
+    [xi.job.SMN] = xi.jsa.ASTRAL_FLOW,
+    [xi.job.BLM] = xi.jsa.MANAFONT,
+    [xi.job.THF] = xi.jsa.PERFECT_DODGE,
+}
+
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180) -- 3 minutes
 end
@@ -17,7 +24,7 @@ entity.onMobSpawn = function(mob)
         specials =
         {
             {
-                id = xi.jsa.MIJIN_GAKURE,
+                id = cryptonberrySpecials[mob:getMainJob()],
                 begCode = function(mobArg)
                     mobArg:messageText(mobArg, ID.text.CRYPTONBERRY_ASSASSIN_2HR)
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes an issue where cryptonberry assassins would use the wrong JSA for their job.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1819

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
