### PR TITLE
Add Missing Variable Increment To 8-3 For Brands

### DIFF
--- a/scripts/missions/cop/8_3_When_Angels_Fall.lua
+++ b/scripts/missions/cop/8_3_When_Angels_Fall.lua
@@ -109,7 +109,7 @@ mission.sections =
             ['_0zv'] = -- Particle Gate (Brand of Twilight)
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.BRAND_OF_TWILIGHT) and mission:getVar(player, 'Status') >= 3 then
+                    if not player:hasKeyItem(xi.ki.BRAND_OF_TWILIGHT) and mission:getVar(player, 'Status') >= 3 and mission:getVar(player, 'Status') <= 4 then
                         return mission:progressEvent(111)
                     else
                         return mission:messageSpecial(zones[npc:getZoneID()].text.NO_NEED_INVESTIGATE)
@@ -120,7 +120,7 @@ mission.sections =
             ['_0zu'] = -- Particle Gate (Brand of Dawn)
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.BRAND_OF_DAWN) and mission:getVar(player, 'Status') >= 3 then
+                    if not player:hasKeyItem(xi.ki.BRAND_OF_DAWN) and mission:getVar(player, 'Status') >= 3 and mission:getVar(player, 'Status') <= 4 then
                         return mission:progressEvent(110)
                     else
                         return mission:messageSpecial(zones[npc:getZoneID()].text.NO_NEED_INVESTIGATE)
@@ -144,6 +144,7 @@ mission.sections =
                 [111] = function(player, csid, option)
                     if option == 1 then
                         player:addKeyItem(xi.ki.BRAND_OF_TWILIGHT)
+                        mission:setVar(player, "Status", mission:getVar(player, 'Status') + 1)
                         return mission:messageSpecial(zones[player:getZoneID()].text.KEYITEM_OBTAINED, xi.ki.BRAND_OF_TWILIGHT)
                     end
                 end,
@@ -151,6 +152,7 @@ mission.sections =
                 [110] = function(player, csid, option)
                     if option == 1 then
                         player:addKeyItem(xi.ki.BRAND_OF_DAWN)
+                        mission:setVar(player, "Status", mission:getVar(player, 'Status') + 1)
                         return mission:messageSpecial(zones[player:getZoneID()].text.KEYITEM_OBTAINED, xi.ki.BRAND_OF_DAWN)
                     end
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Adds missing variable increment for COP 8-3 after obtaining the Brand of Twilight and Brand of Dawn.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1567

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
