### PR TITLE
Fix Error in WS Lua | Fix Certain Families Not Consistently Linking

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -1160,7 +1160,7 @@ local function calculateRawfSTR(dSTR, divisor)
 end
 
 -- Given the attacker's str and the mob's vit, fSTR is calculated (for melee WS)
-xi.weaponskills.fSTR = function(atk_str, def_vit, weapon_rank)
+xi.weaponskills.fSTR = function(atk_str, def_vit, weaponRank)
     local dSTR = atk_str - def_vit
     local fSTR = calculateRawfSTR(dSTR, 4)
 
@@ -1176,7 +1176,7 @@ xi.weaponskills.fSTR = function(atk_str, def_vit, weapon_rank)
 end
 
 -- Given the attacker's str and the mob's vit, fSTR2 is calculated (for ranged WS)
-xi.weaponskills.fSTR2 = function(atk_str, def_vit, weapon_rank)
+xi.weaponskills.fSTR2 = function(atk_str, def_vit, weaponRank)
     local dSTR = atk_str - def_vit
     local fSTR2 = calculateRawfSTR(dSTR, 2)
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -238,7 +238,7 @@ void CZoneEntities::FindPartyForMob(CBaseEntity* PEntity)
             int16 sublink = PMob->getMobMod(MOBMOD_SUBLINK);
 
             if (PCurrentMob->allegiance == PMob->allegiance &&
-                (forceLink || PCurrentMob->m_Family == PMob->m_Family || (sublink && sublink == PCurrentMob->getMobMod(MOBMOD_SUBLINK))))
+                (forceLink || PCurrentMob->m_SuperFamily == PMob->m_SuperFamily || PCurrentMob->m_Family == PMob->m_Family || (sublink && sublink == PCurrentMob->getMobMod(MOBMOD_SUBLINK))))
             {
                 if (PCurrentMob->PMaster == nullptr || PCurrentMob->PMaster->objtype == TYPE_MOB)
                 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes an error in FSTR2 in weaponskills.lua which had an underscored variable name.
+ Adds in super family link capabilities to mob aggro attempts.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1376

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
