### PR TITLE
Add Periodic Save State Permanence for Players | Fix CP Reporting

### DIFF
--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -58,6 +58,9 @@ xi.settings.main =
     CAP_CURRENCY_SPARKS    = 99999,
     CAP_CURRENCY_VALOR     = 50000,
 
+    -- Player Data Sync/Save
+    PLAYER_DATA_SAVE = 120, -- Default time period to save player position, stats, and status effects in seconds.
+
     -- PL EXP Nerf
     PL_PENALTY = 0,
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -252,6 +252,8 @@ CCharEntity::CCharEntity()
     m_mentorUnlocked   = false;
     m_jobMasterDisplay = false;
     m_EffectsChanged   = false;
+
+    m_nextDataSave = std::chrono::system_clock::now() + std::chrono::seconds(settings::get<uint16>("main.PLAYER_DATA_SAVE") > 0 ? settings::get<uint16>("main.PLAYER_DATA_SAVE") : 120);
 }
 
 CCharEntity::~CCharEntity()

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -365,6 +365,7 @@ public:
     bool              shouldPetPersistThroughZoning(); // if true, zoning should not cause a currently active pet to despawn
     uint8             m_SetBlueSpells[20];             // The 0x200 offsetted blue magic spell IDs which the user has set. (1 byte per spell)
     uint32            m_FieldChocobo;
+    time_point        m_nextDataSave; // Sets the next point to save to the DB.
 
     UnlockedAttachments_t m_unlockedAttachments; // Unlocked Automaton Attachments (1 bit per attachment)
     CAutomatonEntity*     PAutomaton;            // Automaton statistics

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -692,6 +692,14 @@ void SmallPacket0x015(map_session_data_t* const PSession, CCharEntity* const PCh
                 PChar->PWideScanTarget = nullptr;
             }
         }
+
+        if (std::chrono::system_clock::now() > PChar->m_nextDataSave)
+        {
+            charutils::SaveCharStats(PChar);
+            charutils::SaveCharPosition(PChar);
+            PChar->StatusEffectContainer->SaveStatusEffects();
+            PChar->m_nextDataSave = std::chrono::system_clock::now() + std::chrono::seconds(settings::get<uint16>("main.PLAYER_DATA_SAVE") > 0 ? settings::get<uint16>("main.PLAYER_DATA_SAVE") : 120);
+        }
     }
 }
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6414,6 +6414,11 @@ namespace charutils
         {
             PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
         }
+
+        if (type == charutils::GetConquestPointsName(PChar).c_str())
+        {
+            PChar->pushPacket(new CConquestPacket(PChar));
+        }
     }
 
     void SetPoints(CCharEntity* PChar, const char* type, int32 amount)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Adds a save state for players defaulting to 120s and is adjustable in main.lua.
+ Adds an extra packet send to the player when points are added to ensure the conquest map is up to date with the player's conquest points.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/784
closes https://github.com/AirSkyBoat/AirSkyBoat/issues/715

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
