### PR TITLE
Fix Incorrect Traverser Stones Appearing in Currency Tab

### DIFF
--- a/scripts/globals/player.lua
+++ b/scripts/globals/player.lua
@@ -187,7 +187,8 @@ xi.player.onGameIn = function(player, firstLogin, zoning)
     -- This is for migration safety only, and should be removed at a later date
     if
         player:hasCompletedQuest(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.A_JOURNEY_BEGINS) and
-        player:getTraverserEpoch() == 0
+        player:getTraverserEpoch() == 0 and
+        xi.settings.main.ENABLE_ABYSSEA == 1
     then
         player:setTraverserEpoch()
     end

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6869,7 +6869,10 @@ namespace charutils
             }
         }
 
-        return floor((std::time(nullptr) - traverserEpoch) / (stoneWaitHours * 3600)) - traverserClaimed;
+        uint32 traverserStones = floor((std::time(nullptr) - traverserEpoch) / (stoneWaitHours * 3600)) - traverserClaimed;
+        traverserStones        = settings::get<uint8>("main.ENABLE_ABYSSEA") == 1 ? traverserStones : 0;
+
+        return traverserStones;
     }
 
     void ReadHistory(CCharEntity* PChar)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Removes showing Traverser Stones while Abyssea is not enabled.
+ Stops the generation of Traverser Stones while Abyssea is not enabled.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/877

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
