### PR TITLE
Fix Overwriting Same Tier of Stat Potency Enfeebles

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -561,6 +561,17 @@ xi.magic.applyResistance = function(caster, target, spell, params)
     return xi.magic.applyResistanceEffect(caster, target, spell, params)
 end
 
+xi.magic.differentEffect = function(caster, target, spell, params)
+    if
+        target:hasStatusEffect(params.effect) and
+        utils.ternary(target:getStatusEffect(params.effect):getSubPower() > 0, target:getStatusEffect(params.effect):getSubPower(), 3) >= params.tier
+    then
+        return false
+    end
+
+    return true
+end
+
 -- USED FOR Status Effect Enfeebs (blind, slow, para, etc.)
 -- Output:
 -- The factor to multiply down duration (1/2 1/4 1/8 1/16)

--- a/scripts/globals/spells/black/blind.lua
+++ b/scripts/globals/spells/black/blind.lua
@@ -30,6 +30,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.BLINDNESS
+    params.tier = 1
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
@@ -39,7 +46,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, potency, 0, resduration) then
+        elseif target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/blind_ii.lua
+++ b/scripts/globals/spells/black/blind_ii.lua
@@ -31,6 +31,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.BLINDNESS
+    params.tier = 2
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
@@ -40,7 +47,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, potency, 0, resduration) then
+        elseif target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/burn.lua
+++ b/scripts/globals/spells/black/burn.lua
@@ -24,6 +24,13 @@ spellObject.onSpellCast = function(caster, target, spell)
         params.skillType = xi.skill.ELEMENTAL_MAGIC
         params.bonus = 0
         params.effect = nil
+        params.tier = 1
+
+        if not xi.magic.differentEffect(caster, target, spell, params) then
+            spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+            return params.effect
+        end
+
         local resist = xi.magic.applyResistance(caster, target, spell, params)
         if resist <= 0.125 then
             spell:setMsg(xi.msg.basic.MAGIC_RESIST)
@@ -56,7 +63,7 @@ spellObject.onSpellCast = function(caster, target, spell)
                 local mbonus = caster:getMerit(xi.merit.ELEMENTAL_DEBUFF_EFFECT)
                 DOT = DOT + mbonus / 2 -- Damage
 
-                target:addStatusEffect(xi.effect.BURN, DOT, 3, duration)
+                target:addStatusEffect(xi.effect.BURN, DOT, 3, duration, 0, params.tier)
             end
         end
     end

--- a/scripts/globals/spells/black/choke.lua
+++ b/scripts/globals/spells/black/choke.lua
@@ -24,6 +24,13 @@ spellObject.onSpellCast = function(caster, target, spell)
         params.skillType = xi.skill.ELEMENTAL_MAGIC
         params.bonus = 0
         params.effect = nil
+        params.tier = 1
+
+        if not xi.magic.differentEffect(caster, target, spell, params) then
+            spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+            return params.effect
+        end
+
         local resist = xi.magic.applyResistance(caster, target, spell, params)
         if resist <= 0.125 then
             spell:setMsg(xi.msg.basic.MAGIC_RESIST)
@@ -56,7 +63,7 @@ spellObject.onSpellCast = function(caster, target, spell)
                 local mbonus = caster:getMerit(xi.merit.ELEMENTAL_DEBUFF_EFFECT)
                 DOT = DOT + mbonus / 2 -- Damage
 
-                target:addStatusEffect(xi.effect.CHOKE, DOT, 3, duration)
+                target:addStatusEffect(xi.effect.CHOKE, DOT, 3, duration, 0, params.tier)
             end
         end
     end

--- a/scripts/globals/spells/black/drown.lua
+++ b/scripts/globals/spells/black/drown.lua
@@ -24,6 +24,13 @@ spellObject.onSpellCast = function(caster, target, spell)
         params.skillType = xi.skill.ELEMENTAL_MAGIC
         params.bonus = 0
         params.effect = nil
+        params.tier = 1
+
+        if not xi.magic.differentEffect(caster, target, spell, params) then
+            spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+            return params.effect
+        end
+
         local resist = xi.magic.applyResistance(caster, target, spell, params)
         if resist <= 0.125 then
             spell:setMsg(xi.msg.basic.MAGIC_RESIST)
@@ -56,7 +63,7 @@ spellObject.onSpellCast = function(caster, target, spell)
                 local mbonus = caster:getMerit(xi.merit.ELEMENTAL_DEBUFF_EFFECT)
                 DOT = DOT + mbonus / 2 -- Damage
 
-                target:addStatusEffect(xi.effect.DROWN, DOT, 3, duration)
+                target:addStatusEffect(xi.effect.DROWN, DOT, 3, duration, 0, params.tier)
             end
         end
     end

--- a/scripts/globals/spells/black/frost.lua
+++ b/scripts/globals/spells/black/frost.lua
@@ -24,6 +24,13 @@ spellObject.onSpellCast = function(caster, target, spell)
         params.skillType = xi.skill.ELEMENTAL_MAGIC
         params.bonus = 0
         params.effect = nil
+        params.tier = 1
+
+        if not xi.magic.differentEffect(caster, target, spell, params) then
+            spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+            return params.effect
+        end
+
         local resist = xi.magic.applyResistance(caster, target, spell, params)
         if resist <= 0.125 then
             spell:setMsg(xi.msg.basic.MAGIC_RESIST)
@@ -55,7 +62,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
                 local mbonus = caster:getMerit(xi.merit.ELEMENTAL_DEBUFF_EFFECT)
                 DOT = DOT + mbonus / 2 -- Damage
-                target:addStatusEffect(xi.effect.FROST, DOT, 3, duration)
+                target:addStatusEffect(xi.effect.FROST, DOT, 3, duration, 0, params.effect)
             end
         end
     end

--- a/scripts/globals/spells/black/gravity.lua
+++ b/scripts/globals/spells/black/gravity.lua
@@ -25,6 +25,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.WEIGHT
+    params.tier = 1
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
@@ -34,7 +41,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 0, resduration) then
+        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/gravity_ii.lua
+++ b/scripts/globals/spells/black/gravity_ii.lua
@@ -25,6 +25,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.WEIGHT
+    params.tier = 2
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
@@ -34,7 +41,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 0, resduration) then
+        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison.lua
+++ b/scripts/globals/spells/black/poison.lua
@@ -21,6 +21,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.POISON
+    params.tier = 1
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- effect taken
@@ -30,7 +37,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 3, resduration) then
+        elseif target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison_ii.lua
+++ b/scripts/globals/spells/black/poison_ii.lua
@@ -21,6 +21,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.POISON
+    params.tier = 2
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- effect taken
@@ -30,7 +37,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 3, resduration) then
+        elseif target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison_iii.lua
+++ b/scripts/globals/spells/black/poison_iii.lua
@@ -24,6 +24,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.POISON
+    params.tier = 3
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+       spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+       return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- effect taken
@@ -33,7 +40,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 3, resduration) then
+        elseif target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poisonga.lua
+++ b/scripts/globals/spells/black/poisonga.lua
@@ -21,6 +21,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.POISON
+    params.tier = 1
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- effect taken
@@ -30,7 +37,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 3, resduration) then
+        elseif target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poisonga_ii.lua
+++ b/scripts/globals/spells/black/poisonga_ii.lua
@@ -21,6 +21,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.POISON
+    params.tier = 2
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- effect taken
@@ -30,7 +37,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 3, resduration) then
+        elseif target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poisonga_iii.lua
+++ b/scripts/globals/spells/black/poisonga_iii.lua
@@ -32,6 +32,12 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus     = 0
     params.effect    = effect
+    params.tier = 3
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
 
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
     if resist == 1 or resist == 0.5 then -- effect taken
@@ -41,7 +47,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(effect, power, 3, resduration) then
+        elseif target:addStatusEffect(effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/rasp.lua
+++ b/scripts/globals/spells/black/rasp.lua
@@ -24,6 +24,13 @@ spellObject.onSpellCast = function(caster, target, spell)
         params.skillType = xi.skill.ELEMENTAL_MAGIC
         params.bonus = 0
         params.effect = nil
+        params.tier = 1
+
+        if not xi.magic.differentEffect(caster, target, spell, params) then
+            spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+            return params.effect
+        end
+
         local resist = xi.magic.applyResistance(caster, target, spell, params)
         if resist <= 0.125 then
             spell:setMsg(xi.msg.basic.MAGIC_RESIST)
@@ -56,7 +63,7 @@ spellObject.onSpellCast = function(caster, target, spell)
                 local mbonus = caster:getMerit(xi.merit.ELEMENTAL_DEBUFF_EFFECT)
                 DOT = DOT + mbonus / 2 -- Damage
 
-                target:addStatusEffect(xi.effect.RASP, DOT, 3, duration)
+                target:addStatusEffect(xi.effect.RASP, DOT, 3, duration, 0, params.tier)
             end
         end
     end

--- a/scripts/globals/spells/black/shock.lua
+++ b/scripts/globals/spells/black/shock.lua
@@ -24,6 +24,13 @@ spellObject.onSpellCast = function(caster, target, spell)
         params.skillType = xi.skill.ELEMENTAL_MAGIC
         params.bonus = 0
         params.effect = nil
+        params.tier = 1
+
+        if not xi.magic.differentEffect(caster, target, spell, params) then
+            spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+            return params.effect
+        end
+
         local resist = xi.magic.applyResistance(caster, target, spell, params)
         if resist <= 0.125 then
             spell:setMsg(xi.msg.basic.MAGIC_RESIST)
@@ -56,7 +63,7 @@ spellObject.onSpellCast = function(caster, target, spell)
                 local mbonus = caster:getMerit(xi.merit.ELEMENTAL_DEBUFF_EFFECT)
                 DOT = DOT + mbonus / 2 -- Damage
 
-                target:addStatusEffect(xi.effect.SHOCK, DOT, 3, duration)
+                target:addStatusEffect(xi.effect.SHOCK, DOT, 3, duration, 0, params.tier)
             end
         end
     end

--- a/scripts/globals/spells/white/paralyze.lua
+++ b/scripts/globals/spells/white/paralyze.lua
@@ -28,6 +28,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.PARALYSIS
+    params.tier = 1
+
+    if not xi.magic.hasEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then -- There are no quarter or less hits, if target resists more than .5 spell is resisted completely
@@ -37,7 +44,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, potency, 0, duration * resist) then
+        elseif target:addStatusEffect(params.effect, potency, 0, duration * resist, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             -- no effect

--- a/scripts/globals/spells/white/paralyze_ii.lua
+++ b/scripts/globals/spells/white/paralyze_ii.lua
@@ -28,6 +28,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.PARALYSIS
+    params.tier = 2
+
+    if not xi.magic.hasEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then
@@ -37,7 +44,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, potency, 0, resduration) then
+        elseif target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/slow.lua
+++ b/scripts/globals/spells/white/slow.lua
@@ -34,6 +34,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.SLOW
+    params.tier = 1
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
@@ -43,7 +50,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, 1) then
+        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/slow_ii.lua
+++ b/scripts/globals/spells/white/slow_ii.lua
@@ -28,6 +28,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.SLOW
+    params.tier = 1
+
+    if not xi.magic.differentEffect(caster, target, spell, params) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
+    end
+
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then --Do it!
@@ -37,7 +44,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 0, resduration) then
+        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Removes the ability to overwrite an enfeeble of the same tier while having higher potency due to stats.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/901

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
