### PR TITLE
Fix luminous drape charm duration for JoL

### DIFF
--- a/scripts/globals/mobskills/luminous_drape.lua
+++ b/scripts/globals/mobskills/luminous_drape.lua
@@ -27,7 +27,13 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         return typeEffect
     end
 
-    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    local charmDuration = 60
+    if mob:getName() == "Jailer_of_Love" then
+        charmDuration = 10
+    end
+
+    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, charmDuration)
+
     if msg == xi.msg.basic.SKILL_ENFEEB_IS then
         mob:charm(target)
         mob:resetEnmity(target)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes the charm duration for luminous drape for JoL. See analogous [issue](https://github.com/EdenServer/community/issues/3302) from Eden for proof of short duration (~10 seconds).

## Steps to test these changes
Fight Jailer of Love (JoL) and wait for Luminous Drape
<!-- Clear and detailed steps to test your changes here -->
