### PR TITLE
Fix Mission Text for Windurst 2-2

### DIFF
--- a/scripts/missions/windurst/2_2_A_Testing_Time.lua
+++ b/scripts/missions/windurst/2_2_A_Testing_Time.lua
@@ -91,9 +91,9 @@ local assessment = function(player, npc)
         end
 
         if completed then
-            return mission:progressEvent(204, 0, 0, 0, 0, 0, VanadielHour(), 48 - hoursPassed, 0)
+            return mission:progressEvent(204, 0, 0, 0, 0, 0, killCount, 48 - hoursPassed, 0)
         else
-            return mission:progressEvent(183, 0, VanadielHour(), 24 - hoursPassed)
+            return mission:progressEvent(183, 0, killCount, 24 - hoursPassed)
         end
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fix Windurst 2-2 text mission dialogue since it was incorrectly reporting the hour of the day instead of number of mobs killed.

## Steps to test these changes

Do 2-2, it's terrible.
