### PR TITLE
Stop Players from Interacting with Event Menus and Teleporters when Damaged

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1156,7 +1156,7 @@ xi.conquest.overseerOnTrigger = function(player, npc, guardNation, guardType, gu
         local a6 = getArg6(player)
         local a7 = player:getCP()
 
-        player:startEvent(guardEvent, a1, 0, a3, 0, 0, a6, a7, 0)
+        player:startMenuEvent(guardEvent, a1, 0, a3, 0, 0, a6, a7, 0)
 
     -- CITY AND FOREIGN OVERSEERS
     elseif guardType <= xi.conquest.guard.FOREIGN then
@@ -1169,15 +1169,15 @@ xi.conquest.overseerOnTrigger = function(player, npc, guardNation, guardType, gu
         local a7 = player:getCP()
         local a8 = getExForceReward(player, guardNation)
 
-        player:startEvent(guardEvent, a1, a2, a3, a4, a5, a6, a7, a8)
+        player:startMenuEvent(guardEvent, a1, a2, a3, a4, a5, a6, a7, a8)
 
     -- OUTPOST AND BORDER OVERSEERS
     elseif guardType >= xi.conquest.guard.OUTPOST then
         local a1 = getArg1(player, guardNation, guardType)
         if a1 == 1808 then -- non-allied nation
-            player:startEvent(guardEvent, a1, 0, 0, 0, 0, player:getRank(player:getNation()), 0, 0)
+            player:startMenuEvent(guardEvent, a1, 0, 0, 0, 0, player:getRank(player:getNation()), 0, 0)
         else
-            player:startEvent(guardEvent, a1, 0, 0x3F0000, 0, 0, getArg6(player), 0, 0)
+            player:startMenuEvent(guardEvent, a1, 0, 0x3F0000, 0, 0, getArg6(player), 0, 0)
         end
     end
 end
@@ -1404,7 +1404,7 @@ xi.conquest.vendorOnTrigger = function(player, vendorRegion, vendorEvent)
     end
 
     local fee = xi.conquest.outpostFee(player, vendorRegion)
-    player:startEvent(vendorEvent, nation, fee, 0, fee, player:getCP(), 0, 0, 0)
+    player:startMenuEvent(vendorEvent, nation, fee, 0, fee, player:getCP(), 0, 0, 0)
 end
 
 xi.conquest.vendorOnEventUpdate = function(player, vendorRegion)

--- a/scripts/zones/Riverne-Site_A01/globals.lua
+++ b/scripts/zones/Riverne-Site_A01/globals.lua
@@ -25,7 +25,7 @@ local riverneA01Global =
         ..............................................................................................]]
     unstableDisplacementTrigger = function(player, npc, event)
         if npc:getAnimation() == xi.anim.OPEN_DOOR then
-            player:startEvent(event)
+            player:startMenuEvent(event)
         else
             player:messageSpecial(ID.text.SD_VERY_SMALL)
         end

--- a/scripts/zones/Riverne-Site_B01/globals.lua
+++ b/scripts/zones/Riverne-Site_B01/globals.lua
@@ -25,7 +25,7 @@ local riverneB01Global =
         ..............................................................................................]]
     unstableDisplacementTrigger = function(player, npc, event)
         if npc:getAnimation() == xi.anim.OPEN_DOOR then
-            player:startEvent(event)
+            player:startMenuEvent(event)
         else
             player:messageSpecial(ID.text.SD_VERY_SMALL)
         end

--- a/scripts/zones/RuAun_Gardens/Zone.lua
+++ b/scripts/zones/RuAun_Gardens/Zone.lua
@@ -59,7 +59,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 
     if p["green"] ~= nil then -- green portal
         if player:getCharVar("skyShortcut") == 1 then
-            player:startEvent(42)
+            player:startMenuEvent(42)
         else
             local title = player:getTitle()
 
@@ -72,15 +72,15 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 
     elseif p["portal"] ~= nil then -- blue portal
         if GetNPCByID(p["portal"]):getAnimation() == xi.anim.OPEN_DOOR then
-            player:startOptionalCutscene(p["event"])
+            player:startMenuEvent(p["event"])
         end
 
     elseif type(p["event"]) == "table" then -- portal with random destination
         local events = p["event"]
-        player:startOptionalCutscene(events[math.random(1, #events)])
+        player:startMenuEvent(events[math.random(1, #events)])
 
     else -- portal with static destination
-        player:startOptionalCutscene(p["event"])
+        player:startMenuEvent(p["event"])
     end
 end
 

--- a/scripts/zones/The_Shrine_of_RuAvitau/Zone.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/Zone.lua
@@ -84,7 +84,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     local areaId = triggerArea:GetTriggerAreaID()
 
     if teleportEventsByArea[areaId] then
-        player:startOptionalCutscene(teleportEventsByArea[areaId])
+        player:startMenuEvent(teleportEventsByArea[areaId])
     end
 end
 

--- a/src/map/event_info.h
+++ b/src/map/event_info.h
@@ -49,6 +49,7 @@ enum EVENT_TYPE : uint8
     NORMAL,
     CUTSCENE,
     OPTIONAL_CUTSCENE,
+    MENU,
 };
 
 struct EventInfo : EventPrep

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -977,6 +977,18 @@ void CLuaBaseEntity::startOptionalCutscene(int32 EventID, sol::variadic_args va)
 }
 
 /************************************************************************
+ *  Function: startMenuEvent()
+ *  Purpose : Starts an event which is closable due to an attack.
+ *  Example : player:startMenuEvent(4)
+ *  Notes   : Event ID must be associated with the zone.
+ ************************************************************************/
+
+void CLuaBaseEntity::startMenuEvent(int32 EventID, sol::variadic_args va)
+{
+    StartEventHelper(EventID, va, EVENT_TYPE::MENU);
+}
+
+/************************************************************************
  *  Function: updateEvent()
  *  Purpose : Sends new arguments to an event
  *  Example : player:updateEvent(ring[1],ring[2],ring[3])
@@ -1094,25 +1106,13 @@ void CLuaBaseEntity::release(sol::object const& p0)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    auto* PChar       = static_cast<CCharEntity*>(m_PBaseEntity);
+    uint8 stopMessage = (p0 != sol::lua_nil) ? p0.as<uint8>() : 0;
 
-    RELEASE_TYPE releaseType = RELEASE_TYPE::STANDARD;
-    uint8        stopMessage = (p0 != sol::lua_nil) ? p0.as<uint8>() : 0;
-
-    if (PChar->isInEvent())
+    if (PChar)
     {
-        // Message: Event skipped
-        releaseType = RELEASE_TYPE::SKIPPING;
-        if (stopMessage == 0)
-        {
-            PChar->pushPacket(new CMessageSystemPacket(0, 0, 117));
-        }
+        charutils::releaseEvent(PChar, stopMessage != 0);
     }
-
-    PChar->inSequence = false;
-    PChar->pushPacket(new CReleasePacket(PChar, releaseType));
-    PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::EVENT));
-    PChar->endCurrentEvent();
 }
 
 /************************************************************************
@@ -15509,6 +15509,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("startEvent", CLuaBaseEntity::startEvent);
     SOL_REGISTER("startCutscene", CLuaBaseEntity::startCutscene);
     SOL_REGISTER("startOptionalCutscene", CLuaBaseEntity::startOptionalCutscene);
+    SOL_REGISTER("startMenuEvent", CLuaBaseEntity::startMenuEvent);
     SOL_REGISTER("startEventString", CLuaBaseEntity::startEventString);
     SOL_REGISTER("updateEvent", CLuaBaseEntity::updateEvent);
     SOL_REGISTER("updateEventString", CLuaBaseEntity::updateEventString);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -89,6 +89,7 @@ public:
     void       startEventString(int32 EventID, sol::variadic_args va);      // Begins Event with string param (0x33 packet)
     void       startCutscene(int32 EventID, sol::variadic_args va);         // Begins cutscene which locks the character
     void       startOptionalCutscene(int32 EventID, sol::variadic_args va); // Begins an event that can turn into a cutscene
+    void       startMenuEvent(int32 EventID, sol::variadic_args va);        // Begins an event that can be interrupted.
 
     void updateEvent(sol::variadic_args va);       // Updates event
     void updateEventString(sol::variadic_args va); // (string, string, string, string, uint32, ...)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -63,9 +63,11 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../packets/message_combat.h"
 #include "../packets/message_special.h"
 #include "../packets/message_standard.h"
+#include "../packets/message_system.h"
 #include "../packets/monipulator1.h"
 #include "../packets/monipulator2.h"
 #include "../packets/quest_mission_log.h"
+#include "../packets/release.h"
 #include "../packets/roe_sparkupdate.h"
 #include "../packets/server_ip.h"
 #include "../packets/timer_bar_util.h"
@@ -7188,6 +7190,30 @@ namespace charutils
             return sql->GetUIntData(0);
         }
         return 0;
+    }
+
+    void releaseEvent(CCharEntity* PChar, bool skipMessage)
+    {
+        if (!PChar)
+        {
+            return;
+        }
+
+        RELEASE_TYPE releaseType = RELEASE_TYPE::STANDARD;
+
+        if (PChar->isInEvent())
+        {
+            releaseType = RELEASE_TYPE::SKIPPING;
+            if (!skipMessage)
+            {
+                PChar->pushPacket(new CMessageSystemPacket(0, 0, 117));
+            }
+        }
+
+        PChar->inSequence = false;
+        PChar->pushPacket(new CReleasePacket(PChar, releaseType));
+        PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::EVENT));
+        PChar->endCurrentEvent();
     }
 
 }; // namespace charutils

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -272,6 +272,7 @@ namespace charutils
     bool hasEntitySpawned(CCharEntity* PChar, CBaseEntity* entity);
 
     uint32 getCharIdFromName(std::string const& name);
+    void   releaseEvent(CCharEntity* PChar, bool skipMessage = false);
 }; // namespace charutils
 
 #endif // _CHARUTILS_H


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Forces the player to skip an event (only menu based and teleporters) when damaged from an attack.

closes https://github.com/AirSkyBoat/AirSkyBoat/issues/930

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
