### PR TITLE
Reassign Players to Battlefield on Disconnect

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -535,7 +535,7 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
 
         m_Zone->updateCharLevelRestriction(PChar);
 
-        if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_CONFRONTATION))
+        if (leavecode == BATTLEFIELD_LEAVE_CODE_EXIT && PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_CONFRONTATION))
         {
             PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD)->SetSubPower(0);
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Change the logic for RemoveEntity to only check if the player is leaving the battlefield. If the player disconnects, retain the battlefield subpower so players can reengage in the battle. If the player teleports or warps they will lose the battlefield debuff through various other checks.

## Steps to test these changes

Run battlefields with 2 players. Have one player !goto themselves to simulate a disconnect with and without this change.

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/268