### PR TITLE
Initial and Pet Enmity Update

### DIFF
--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -102,7 +102,7 @@ void CEnmityContainer::LogoutReset(uint32 EntityID)
 
 /************************************************************************
  *                                                                       *
- *  Минимальное (базовое) значение ненависти                             *
+ *  Minimum (base) hate value                                            *
  *                                                                       *
  ************************************************************************/
 
@@ -201,6 +201,7 @@ void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, 
         if (initial)
         {
             CE += 200;
+            VE += 900;
         }
 
         float bonus = CalculateEnmityBonus(PEntity);

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1520,6 +1520,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
                 }
                 PPet->PAI->MobSkill(PPetTarget, PAbility->getMobSkillID());
             }
+            state.ApplyEnmity();
         }
         // #TODO: make this generic enough to not require an if
         else if ((PAbility->isAoE() || (PAbility->getID() == ABILITY_LIEMENT && getMod(Mod::LIEMENT_EXTENDS_TO_AREA) > 0)) && this->PParty != nullptr)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- For all actions on a mob that generate any enmity, the initial hit will now generate CE 200 and VE 900. This includes summoner blood pacts and all pet actions.

Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1955

## Steps to test these changes
Use Bloodpact: Rage on a mob and see it have initial aggro on the summoner
<!-- Clear and detailed steps to test your changes here -->
