### PR TITLE
Lucky Roll Npcs Implementation and more

### DIFF
--- a/scripts/globals/events/starlight_celebrations.lua
+++ b/scripts/globals/events/starlight_celebrations.lua
@@ -224,6 +224,8 @@ function xi.events.starlightCelebration.tokenMoogleOnFinish(player, id, csid, op
                 {
                     5552,   -- Black Pudding
                     18863,  -- Dream Bell
+                    10382,  -- Dream Mittens
+                    10383,  -- Dream Mittens +1
                     5542,   -- Gateau Aux Fraises
                     5616,   -- Lebkuchen House
                     5622,   -- Candy Cane

--- a/scripts/zones/Norg/IDs.lua
+++ b/scripts/zones/Norg/IDs.lua
@@ -47,12 +47,16 @@ zones[xi.zone.NORG] =
         RETRIEVE_DIALOG_ID            = 11287, -- You retrieve <item> from the porter moogle's care.
         COMMON_SENSE_SURVIVAL         = 12297, -- It appears that you have arrived at a new survival guide provided by the Adventurers' Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
         DIDYA_GET_BUMPED              = 12325, -- Didya get bumped about by the waves on yer way here, <name>? No matter. The boss be waitin' inside fer ya.
+        LUCKY_ROLL_GAMEOVER           = 10763, -- I'm sorry, but that's it for today's game of Lucky Roll. Come by tomorrow, and maybe Lady Luck will be waiting for you!
+        LUCKY_ROLL_EXACT              = 10761, -- And because your roll put the running total at exactly 400, you receive a bonus prize!
+        LUCKY_ROLL_CLOSE              = 10762, -- And for bringing the total so close to 400, here is your extra prize!
     },
     mob =
     {
     },
     npc =
     {
+        REPAT                         = 17809505, -- Lucky Roll Npc
     },
 }
 

--- a/scripts/zones/Norg/npcs/Repat.lua
+++ b/scripts/zones/Norg/npcs/Repat.lua
@@ -1,17 +1,17 @@
 -----------------------------------
--- Area: Rabao
---  NPC: Mileon
+-- Area: Norg
+--  NPC: Repat
 -- Type: Lucky Roll Gambler
--- !pos 26.080 8.201 65.297 247
+-- !pos -15.29 1.09 146.00 252
 -----------------------------------
-local ID = require("scripts/zones/Rabao/IDs")
+local ID = require("scripts/zones/Norg/IDs")
 require("scripts/globals/npc_util")
 -----------------------------------
 
 local entity = {}
 
 entity.onSpawn = function(npc)
-    npc:setLocalVar("[LuckyRoll]Rabao", math.random (150, 250)) -- ~observed range from retail
+    npc:setLocalVar("[LuckyRoll]Norg", math.random (150, 250)) -- ~observed range from retail
 end
 
 entity.onTrade = function(player, npc, trade)
@@ -20,10 +20,10 @@ end
 entity.onTrigger = function(player, npc)
     local gil = player:getGil()
     local playCheck = player:getCharVar("[LuckyRoll]Played")
-    local winCheck = npc:getLocalVar("[LuckyRoll]RabaoLastWon")
+    local winCheck = npc:getLocalVar("[LuckyRoll]NorgLastWon")
 
     if playCheck ~= vanaDay() and winCheck ~= vanaDay() then
-        player:startEvent(100, gil)
+        player:startEvent(174, gil)
     else
         player:showText(npc, ID.text.LUCKY_ROLL_GAMEOVER)
     end
@@ -31,22 +31,22 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
-    if csid == 100 and option == 0 then
+    if csid == 174 and option == 0 then
 
-        local npc = GetNPCByID(ID.npc.MILEON)
-        local currentTotal = npc:getLocalVar("[LuckyRoll]Rabao")
+        local npc = GetNPCByID(ID.npc.REPAT)
+        local currentTotal = npc:getLocalVar("[LuckyRoll]Norg")
         local roll = math.random(1, 1)
         local newTotal = currentTotal + roll
 
         player:updateEvent(4, roll, 0, newTotal)
-        npc:setLocalVar("[LuckyRoll]Rabao", newTotal)
+        npc:setLocalVar("[LuckyRoll]Norg", newTotal)
     end
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 100 and option == 0 then
-        local npc = GetNPCByID(ID.npc.MILEON)
-        local newTotal = npc:getLocalVar("[LuckyRoll]Rabao")
+    if csid == 174 and option == 0 then
+        local npc = GetNPCByID(ID.npc.REPAT)
+        local newTotal = npc:getLocalVar("[LuckyRoll]Norg")
 
         if newTotal >= 400 then
 
@@ -58,8 +58,8 @@ entity.onEventFinish = function(player, csid, option)
                 npcUtil.giveItem(player, math.random(769, 776))
             end
 
-            npc:setLocalVar("[LuckyRoll]Rabao", math.random(150, 250))
-            npc:setLocalVar("[LuckyRoll]RabaoLastWon", VanadielUniqueDay())
+            npc:setLocalVar("[LuckyRoll]Norg", math.random(150, 250))  -- observed range from retail
+            npc:setLocalVar("[LuckyRoll]NorgLastWon", VanadielUniqueDay())
             player:addGil(10000)
         end
 

--- a/scripts/zones/Norg/npcs/Repat.lua
+++ b/scripts/zones/Norg/npcs/Repat.lua
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
     local playCheck = player:getCharVar("[LuckyRoll]Played")
     local winCheck = npc:getLocalVar("[LuckyRoll]NorgLastWon")
 
-    if playCheck ~= vanaDay() and winCheck ~= vanaDay() then
+    if playCheck ~= VanadielUniqueDay() and winCheck ~= VanadielUniqueDay() then
         player:startEvent(174, gil)
     else
         player:showText(npc, ID.text.LUCKY_ROLL_GAMEOVER)
@@ -35,7 +35,7 @@ entity.onEventUpdate = function(player, csid, option)
 
         local npc = GetNPCByID(ID.npc.REPAT)
         local currentTotal = npc:getLocalVar("[LuckyRoll]Norg")
-        local roll = math.random(1, 1)
+        local roll = math.random(1, 6)
         local newTotal = currentTotal + roll
 
         player:updateEvent(4, roll, 0, newTotal)

--- a/scripts/zones/Rabao/IDs.lua
+++ b/scripts/zones/Rabao/IDs.lua
@@ -39,12 +39,16 @@ zones[xi.zone.RABAO] =
         GENEROIT_SHOP_DIALOG          = 10308, -- Ho there! I am called Generoit. I have everything here for the chocobo enthusiast, and other rare items galore.
         RETRIEVE_DIALOG_ID            = 10764, -- You retrieve <item> from the porter moogle's care.
         COMMON_SENSE_SURVIVAL         = 11842, -- It appears that you have arrived at a new survival guide provided by the Adventurers' Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
+        LUCKY_ROLL_GAMEOVER           = 10324, -- I'm sorry, but that's it for today's game of Lucky Roll. Come by tomorrow, and maybe Lady Luck will be waiting for you!
+        LUCKY_ROLL_EXACT              = 10322, -- And because your roll put the running total at exactly 400, you receive a bonus prize!
+        LUCKY_ROLL_CLOSE              = 10323, -- And for bringing the total so close to 400, here is your extra prize!
     },
     mob =
     {
     },
     npc =
     {
+        MILEON                        = 17788987, -- Lucky Roll Npc
     },
 }
 

--- a/scripts/zones/Rabao/npcs/Mileon.lua
+++ b/scripts/zones/Rabao/npcs/Mileon.lua
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
     local playCheck = player:getCharVar("[LuckyRoll]Played")
     local winCheck = npc:getLocalVar("[LuckyRoll]RabaoLastWon")
 
-    if playCheck ~= vanaDay() and winCheck ~= vanaDay() then
+    if playCheck ~= VanadielUniqueDay() and winCheck ~= VanadielUniqueDay() then
         player:startEvent(100, gil)
     else
         player:showText(npc, ID.text.LUCKY_ROLL_GAMEOVER)
@@ -35,7 +35,7 @@ entity.onEventUpdate = function(player, csid, option)
 
         local npc = GetNPCByID(ID.npc.MILEON)
         local currentTotal = npc:getLocalVar("[LuckyRoll]Rabao")
-        local roll = math.random(1, 1)
+        local roll = math.random(1, 6)
         local newTotal = currentTotal + roll
 
         player:updateEvent(4, roll, 0, newTotal)

--- a/scripts/zones/Tavnazian_Safehold/npcs/Quelveuiat.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Quelveuiat.lua
@@ -5,6 +5,18 @@
 -----------------------------------
 local entity = {}
 
+local pathNodes =
+{
+    { x = -3.177, y = -22.750, z = -25.970, rotation = 132, wait = 35000 },
+    { x = 3.177, y = -22.750, z = -25.970, rotation = 0, wait = 35000 },
+}
+
+entity.onSpawn = function(npc)
+    npc:initNpcAi()
+    npc:setPos(xi.path.first(pathNodes))
+    npc:pathThrough(pathNodes, xi.path.flag.PATROL)
+end
+
 entity.onTrade = function(player, npc, trade)
 end
 


### PR DESCRIPTION
Adds logic to Lucky Roll Npcs Mileon in Rabao, Repat in Norg. Also a quick update to starlight_celebrations to include dream mittens within reward tables.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Implements Lucky Roll NPC logic
- Mileon (Rabao) Closes #939 
- Repat (Norg) Closes #1089

Adds Pathing logic for Quelveuiat in Tavnazian Safehold Closes #1768

Adds Dream Mittens/+1 to rewards tables for Starlight Celebration.

## Steps to test these changes
Go talk to affected NPCs, get lucky with token redemption during Starlight Celebration.

<!-- Clear and detailed steps to test your changes here -->
