### PR TITLE
Final Sting damage reduction + other fixes

### DIFF
--- a/scripts/globals/items/chaosbringer.lua
+++ b/scripts/globals/items/chaosbringer.lua
@@ -28,7 +28,7 @@ itemObject.onItemEquip = function(player, item)
 end
 
 itemObject.onItemUnequip = function(player, item)
-    player:removeListener('CHAOSBRINGER_KILLS')
+    player:removeListener("CHAOSBRINGER_KILLS")
 end
 
 return itemObject

--- a/scripts/globals/mobskills/final_sting.lua
+++ b/scripts/globals/mobskills/final_sting.lua
@@ -15,7 +15,7 @@ local mobskillObject = {}
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     local param = skill:getParam()
     if param == 0 then
-        param = 50
+        param = 34
     end
 
     if mob:getHPP() <= param then

--- a/scripts/globals/mobskills/final_sting.lua
+++ b/scripts/globals/mobskills/final_sting.lua
@@ -31,7 +31,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
 
     local hpMod = skill:getMobHPP() / 100
-    dmgmod = dmgmod + hpMod * math.random(5, 10)
+    dmgmod = dmgmod + hpMod * math.random(5, 8)
 
     if mob:isMobType(xi.mobskills.mobType.NOTORIOUS) then
         dmgmod = dmgmod * 5

--- a/scripts/globals/mobskills/final_sting.lua
+++ b/scripts/globals/mobskills/final_sting.lua
@@ -31,7 +31,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
 
     local hpMod = skill:getMobHPP() / 100
-    dmgmod = dmgmod + hpMod * 14 + math.random(2, 6)
+    dmgmod = dmgmod + hpMod * math.random(5, 10)
 
     if mob:isMobType(xi.mobskills.mobType.NOTORIOUS) then
         dmgmod = dmgmod * 5

--- a/scripts/globals/mobskills/final_sting.lua
+++ b/scripts/globals/mobskills/final_sting.lua
@@ -15,7 +15,7 @@ local mobskillObject = {}
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     local param = skill:getParam()
     if param == 0 then
-        param = 34
+        param = 35
     end
 
     if mob:getHPP() <= param then

--- a/scripts/globals/mobskills/final_sting.lua
+++ b/scripts/globals/mobskills/final_sting.lua
@@ -31,7 +31,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
 
     local hpMod = skill:getMobHPP() / 100
-    dmgmod = dmgmod + hpMod * math.random(5, 8)
+    dmgmod = dmgmod + hpMod * 5 + math.random(1, 3)
 
     if mob:isMobType(xi.mobskills.mobType.NOTORIOUS) then
         dmgmod = dmgmod * 5

--- a/scripts/zones/Inner_Horutoto_Ruins/DefaultActions.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/DefaultActions.lua
@@ -1,7 +1,7 @@
 local ID = require("scripts/zones/Inner_Horutoto_Ruins/IDs")
 
 return {
-    ['_5ca'] = { event = 44 },
+    ['_5ca'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
     ['_5cb'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
     ['_5ci'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
     ['_5c5'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixes players requiring to click the door twice to complete Making Headlines quest
- Tones down final sting to not be so overpowered. Previously final sting could achieve a dmgMod of around 2 - 20 (reflected in HP). Which is around ~20x more powerful than any regular mob ability. The proposed changes bring that dmgMod range to be around 1.5 - 8 (reflected in HP)

Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1009
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/820
