### PR TITLE
More Magic Hit Rate Work For New Findings | Fix Elemental DOTs

### DIFF
--- a/scripts/globals/effects/barblind.lua
+++ b/scripts/globals/effects/barblind.lua
@@ -6,14 +6,14 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.BLINDRES, effect:getPower())
+    target:addMod(xi.mod.BLIND_MEVA, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.BLINDRES, effect:getPower())
+    target:delMod(xi.mod.BLIND_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/effects/barparalyze.lua
+++ b/scripts/globals/effects/barparalyze.lua
@@ -6,14 +6,14 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.PARALYZERES, effect:getPower())
+    target:addMod(xi.mod.PARALYZE_MEVA, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.PARALYZERES, effect:getPower())
+    target:delMod(xi.mod.PARALYZE_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/effects/barpetrify.lua
+++ b/scripts/globals/effects/barpetrify.lua
@@ -6,14 +6,14 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.PETRIFYRES, effect:getPower())
+    target:addMod(xi.mod.PETRIFY_MEVA, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.PETRIFYRES, effect:getPower())
+    target:delMod(xi.mod.PETRIFY_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/effects/barpoison.lua
+++ b/scripts/globals/effects/barpoison.lua
@@ -6,14 +6,14 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.POISONRES, effect:getPower())
+    target:addMod(xi.mod.POISON_MEVA, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.POISONRES, effect:getPower())
+    target:delMod(xi.mod.POISON_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/effects/barsilence.lua
+++ b/scripts/globals/effects/barsilence.lua
@@ -6,14 +6,14 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.SILENCERES, effect:getPower())
+    target:addMod(xi.mod.SILENCE_MEVA, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.SILENCERES, effect:getPower())
+    target:delMod(xi.mod.SILENCE_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/effects/barsleep.lua
+++ b/scripts/globals/effects/barsleep.lua
@@ -6,14 +6,14 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.SLEEPRES, effect:getPower())
+    target:addMod(xi.mod.SLEEP_MEVA, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.SLEEPRES, effect:getPower())
+    target:delMod(xi.mod.SLEEP_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/effects/barvirus.lua
+++ b/scripts/globals/effects/barvirus.lua
@@ -6,14 +6,14 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.VIRUSRES, effect:getPower())
+    target:addMod(xi.mod.VIRUS_MEVA, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.VIRUSRES, effect:getPower())
+    target:delMod(xi.mod.VIRUS_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/spells/enhancing_spell.lua
+++ b/scripts/globals/spells/enhancing_spell.lua
@@ -209,15 +209,7 @@ xi.spells.enhancing.calculateEnhancingBasePower = function(caster, target, spell
         (spellEffect >= xi.effect.BARSLEEP and
         spellEffect <= xi.effect.BARVIRUS)
     then
-        -- Works the same as Bar-Element spells. This is only out of 100
-        if skillLevel > 300 then
-            basePower = (25 + math.floor(skillLevel / 4)) / 10 -- 15 at 500
-        else
-            basePower = (40 + math.floor(skillLevel / 5)) / 10 -- 10 at 300
-        end
-
-        basePower = utils.clamp(basePower, 4, 15) -- Max is 15 and min is 4 a skill 0.
-
+        basePower = 20
     -- Boost-Stat / Gain-Stat
     elseif
         spellEffect >= xi.effect.STR_BOOST and

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1832,6 +1832,13 @@ xi.mod =
     CRITHITRATE_SLOT              = 1168, -- CRITHITRATE for slot
     ATT_SLOT                      = 1169, -- ATT for slot
     UDMG                          = 1170, -- Uncapped dmg taken (all types)
+    SLEEP_MEVA                    = 1171, -- Sleep MEVA from Barspells
+    POISON_MEVA                   = 1172, -- Poison MEVA from Barspells
+    PARALYZE_MEVA                 = 1173, -- Paralyze MEVA from Barspells
+    BLIND_MEVA                    = 1174, -- Blind MEVA from Barspells
+    SILENCE_MEVA                  = 1175, -- Silence MEVA from Barspells
+    VIRUS_MEVA                    = 1176, -- Virus MEVA from Barspells
+    PETRIFY_MEVA                  = 1177, -- Petrify MEVA from Barspells
 
     -- IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN src/map/modifier.h ASWELL!
 

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -962,6 +962,13 @@ enum class Mod
     CRITHITRATE_SLOT     = 1168, // CRITHITRATE for slot
     ATT_SLOT             = 1169, // ATT for slot
     UDMG                 = 1170, // Uncapped dmg taken (all types)
+    SLEEP_MEVA           = 1171, // Sleep MEVA from Barspells
+    POISON_MEVA          = 1172, // Poison MEVA from Barspells
+    PARALYZE_MEVA        = 1173, // Paralyze MEVA from Barspells
+    BLIND_MEVA           = 1174, // Blind MEVA from Barspells
+    SILENCE_MEVA         = 1175, // Silence MEVA from Barspells
+    VIRUS_MEVA           = 1176, // Virus MEVA from Barspells
+    PETRIFY_MEVA         = 1177, // Petrify MEVA from Barspells
 
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/globals/status.lua ASWELL!
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3139,7 +3139,7 @@ namespace charutils
 
         PChar->delModifier(Mod::MEVA, PChar->m_magicEvasion);
 
-        PChar->m_magicEvasion = battleutils::GetMaxSkill(SKILL_ELEMENTAL_MAGIC, JOB_RDM, PChar->GetMLevel());
+        PChar->m_magicEvasion = battleutils::GetMaxSkill(13, PChar->GetMLevel());
         PChar->addModifier(Mod::MEVA, PChar->m_magicEvasion);
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Implements status_meva values for barspells. These all default to 20 per Jimmayus' sources.
+ Moved EEM multiplication into the MEVA for the target per Jimmayus.
+ Forces a 50% minimum resist when EEM value is 150% per Jimmayus.
+ Changes player base MEVA skill to F per Jimmayus.
+ Fixes an issue with elemental DoTs.
+ Collapses some mirrored functions.

closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/473

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
