### PR TITLE
Fix visible gear latents

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -308,7 +308,7 @@ INSERT INTO `item_latents` VALUES (13143,368,25,13,193);
 -- -------------------------------------------------------
 -- Uggalepih Pendant
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES (13145,28,8,4,51);     -- "Magic Atk. Bonus" while MP <51%
+INSERT INTO `item_latents` VALUES (13145,28,8,45,51);     -- "Magic Atk. Bonus" while MP <51%
 
 -- Brisingamen+1 stats need to be found on retail so they can be corrected
 INSERT INTO `item_latents` VALUES (13162,2,10,26,0);     -- Daytime: HP +10 (needs HQ stats)
@@ -1625,7 +1625,7 @@ INSERT INTO `item_latents` VALUES (15504,25,3,53,0);     -- ACC +3 in areas insi
 -- -------------------------------------------------------
 -- Parade Gorget
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES (15506,369,1,1,85);    -- Refresh when HP >=85%
+INSERT INTO `item_latents` VALUES (15506,369,1,46,85);    -- Refresh when HP >=85%
 
 -- -------------------------------------------------------
 -- Diabolos's Torque

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -655,6 +655,23 @@ CItemEquipment* CCharEntity::getEquip(SLOTTYPE slot)
     return item;
 }
 
+std::vector<CItemEquipment*> CCharEntity::getVisibleEquip()
+{
+    std::vector<CItemEquipment*> visibleItems;
+    CItemEquipment* item = nullptr;
+
+    for (SLOTTYPE slot : {SLOT_HEAD, SLOT_BODY, SLOT_HANDS, SLOT_LEGS, SLOT_FEET})
+    {
+        item = getEquip(slot);
+        if (item != nullptr)
+        {
+            visibleItems.push_back(item);
+        }
+    }
+
+    return visibleItems;
+}
+
 void CCharEntity::ReloadPartyInc()
 {
     m_reloadParty = true;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -658,9 +658,9 @@ CItemEquipment* CCharEntity::getEquip(SLOTTYPE slot)
 std::vector<CItemEquipment*> CCharEntity::getVisibleEquip()
 {
     std::vector<CItemEquipment*> visibleItems;
-    CItemEquipment* item = nullptr;
+    CItemEquipment*              item = nullptr;
 
-    for (SLOTTYPE slot : {SLOT_HEAD, SLOT_BODY, SLOT_HANDS, SLOT_LEGS, SLOT_FEET})
+    for (SLOTTYPE slot : { SLOT_HEAD, SLOT_BODY, SLOT_HANDS, SLOT_LEGS, SLOT_FEET })
     {
         item = getEquip(slot);
         if (item != nullptr)

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -526,7 +526,7 @@ public:
     void   SetPlayTime(uint32 playTime);        // Set playtime
     uint32 GetPlayTime(bool needUpdate = true); // Get playtime
 
-    CItemEquipment* getEquip(SLOTTYPE slot);
+    CItemEquipment*              getEquip(SLOTTYPE slot);
     std::vector<CItemEquipment*> getVisibleEquip();
 
     CBasicPacket* PendingPositionPacket = nullptr;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -527,6 +527,7 @@ public:
     uint32 GetPlayTime(bool needUpdate = true); // Get playtime
 
     CItemEquipment* getEquip(SLOTTYPE slot);
+    std::vector<CItemEquipment*> getVisibleEquip();
 
     CBasicPacket* PendingPositionPacket = nullptr;
 

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -973,57 +973,36 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
             expression = m_POwner->health.hp < latentEffect.GetConditionsValue() && m_POwner->animation == ANIMATION_ATTACK;
             break;
         case LATENT::MP_UNDER_VISIBLE_GEAR:
-            // TODO: figure out if this is actually right
-            // CItemEquipment* head = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HEAD]));
-            // CItemEquipment* body = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_BODY]));
-            // CItemEquipment* hands = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HANDS]));
-            // CItemEquipment* legs = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_LEGS]));
-            // CItemEquipment* feet = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_FEET]));
+        {
+            // Since equipment is fairly specific to a player, don't put this visible calculation in battleentity
+            std::vector<CItemEquipment*> visibleEquip = m_POwner->getVisibleEquip();
 
-            // int32 visibleMp = 0;
-            // visibleMp += (head ? head->getModifier(Mod::MP) : 0);
-            // visibleMp += (body ? body->getModifier(Mod::MP) : 0);
-            // visibleMp += (hands ? hands->getModifier(Mod::MP) : 0);
-            // visibleMp += (legs ? legs->getModifier(Mod::MP) : 0);
-            // visibleMp += (feet ? feet->getModifier(Mod::MP) : 0);
+            int16 visibleMP = m_POwner->health.maxmp;
 
-            // TODO: add mp percent too
-            // if ((float)( mp / ((m_POwner->health.mp - m_POwner->health.modmp) + (m_POwner->PMeritPoints->GetMerit(MERIT_MAX_MP)->count * 10 ) +
-            //    visibleMp) ) <= m_LatentEffectList.at(i)->GetConditionsValue())
-            //{
-            //    m_LatentEffectList.at(i)->Activate();
-            //}
-            // else
-            //{
-            //    m_LatentEffectList.at(i)->Deactivate();
-            //}
+            for (auto equip: visibleEquip)
+            {
+                visibleMP += equip->getModifier(Mod::MP);
+            }
+
+            // there is evidence that 0/0 (e.g., 0/20 with uggalepih pendant) does not trigger this latent
+            expression = visibleMP > 0 && (uint8)floor(((float)m_POwner->health.mp / (float)visibleMP) * 100) <= latentEffect.GetConditionsValue();
             break;
+        }
         case LATENT::HP_OVER_VISIBLE_GEAR:
-            // TODO: figure out if this is actually right
-            // CItemEquipment* head = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HEAD]));
-            // CItemEquipment* body = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_BODY]));
-            // CItemEquipment* hands = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HANDS]));
-            // CItemEquipment* legs = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_LEGS]));
-            // CItemEquipment* feet = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_FEET]));
+        {
+            // Since equipment is fairly specific to a player, don't put this visible calculation in battleentity
+            std::vector<CItemEquipment*> visibleEquip = m_POwner->getVisibleEquip();
 
-            // int32 visibleHp = 0;
-            // visibleHp += (head ? head->getModifier(Mod::HP) : 0);
-            // visibleHp += (body ? body->getModifier(Mod::HP) : 0);
-            // visibleHp += (hands ? hands->getModifier(Mod::HP) : 0);
-            // visibleHp += (legs ? legs->getModifier(Mod::HP) : 0);
-            // visibleHp += (feet ? feet->getModifier(Mod::HP) : 0);
+            int16 visibleHP = m_POwner->health.maxhp;
 
-            // TODO: add mp percent too
-            // if ((float)( hp / ((m_POwner->health.hp - m_POwner->health.modhp) + (m_POwner->PMeritPoints->GetMerit(MERIT_MAX_HP)->count * 10 ) +
-            //    visibleHp) ) <= m_LatentEffectList.at(i)->GetConditionsValue())
-            //{
-            //    m_LatentEffectList.at(i)->Activate();
-            //}
-            // else
-            //{
-            //    m_LatentEffectList.at(i)->Deactivate();
-            //}
+            for (auto equip: visibleEquip)
+            {
+                visibleHP += equip->getModifier(Mod::HP);
+            }
+
+            expression = (uint8)floor(((float)m_POwner->health.hp / (float)visibleHP) * 100) >= latentEffect.GetConditionsValue();
             break;
+        }
         case LATENT::WEAPON_BROKEN:
         {
             auto  slot = latentEffect.GetSlot();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Fixes latents that are based off of visible gear only
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Closes #1658 (Herc. Ring was fixed in a previous latent PR)

## Steps to test these changes
* Go grab a parade gorget and an uggalepih pendant
* For uggalepih pendant, recommended testing with ninja for easy mp calculations (what I did) and visible damage increase
* For parade gorget, mp refresh is easy to see based on hp values
<!-- Clear and detailed steps to test your changes here -->

As is tradition, here's retail numbers from uggalepih pendant testing to determine what visible gear means:\

Naked values:
![image](https://user-images.githubusercontent.com/5553731/206410156-a9546281-abff-4475-bf4a-c9575bef9dcc.png)

Damage values we're comparing:
![image](https://user-images.githubusercontent.com/5553731/206410267-92a0cbba-f0f3-4941-94f5-84787cdb0fb5.png)

Wow, uggalepih pendant works!
![image](https://user-images.githubusercontent.com/5553731/206410579-3d6e53ac-e2d4-4d9e-97ce-9750646dfb8e.png)

MP+% gear does not affect (Nares Trews)
![image](https://user-images.githubusercontent.com/5553731/206410722-cdbe757e-82c4-4ca5-9ea0-a7909ff55fcb.png)

Some tests on when uggalepih pendant triggers:
![image](https://user-images.githubusercontent.com/5553731/206410812-58e7b72e-1808-42b0-8f02-21b50407feae.png)


Hooray, so we've determined that visible gear means literally head/body/hands/legs/feet, and is only `Mod::HP` values. Let's look at the two items in question on localdev:

Base naked ninja damage
![image](https://user-images.githubusercontent.com/5553731/206410989-6ceb08b6-f8b8-43c9-b245-2a5ddbefa7ee.png)

uggalepih pendant alone won't do it (0/0 = ???)
![image](https://user-images.githubusercontent.com/5553731/206411059-3757b33c-e07f-4db1-850d-9f2fc7113fd5.png)

add a walahra turban and voila
![image](https://user-images.githubusercontent.com/5553731/206411172-c729b998-9dd5-4817-b4d8-902ce7262c17.png)


Parade gorget time, you'll have to believe me with tick values though

Base refresh:
![image](https://user-images.githubusercontent.com/5553731/206411260-cd7739f0-b6eb-4e0b-9fee-1c847acc7275.png)

Parade gorget triggers:
![image](https://user-images.githubusercontent.com/5553731/206411401-0189e859-679d-44c1-9e6a-2f6c45230530.png)

Parade gorget _also_ triggers, ignoring accessories all over the place that bring literal HPP under the latent threshold
![image](https://user-images.githubusercontent.com/5553731/206411457-c5bb4f27-2089-4a09-97c3-a08b2c193b82.png)
