### PR TITLE
Normal CoP Fomors don't aggro low hate

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1260,6 +1260,15 @@ bool CMobController::CanAggroTarget(CBattleEntity* PTarget)
         return false;
     }
 
+    // Don't aggro, I'm a normal CoP Fomor and you have low hate
+    if (PMob->m_Family == 115 && !(PMob->m_Type & MOBTYPE_NOTORIOUS) && (PMob->getZone() >= 24 && PMob->getZone() <= 28) && PTarget->objtype == TYPE_PC)
+    {
+        if (((CCharEntity*)PTarget)->getCharVar("FOMOR_HATE") < 8)
+        {
+            return false;
+        }
+    }
+
     // Don't aggro I'm an underground worm
     if ((PMob->m_roamFlags & ROAMFLAG_WORM) && PMob->animationsub == 1)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Normal fomors in CoP zones will no longer agro players with level 1 fomor hate.

Closes #1890 

## Steps to test these changes

Stand next to a fomor with level 1 fomor hate, check for no agro.  Raise fomor hate to level 2 and check for aggro.
