### PR TITLE
Add ability to clear trade container without taking items

### DIFF
--- a/modules/custom/lua/conquest_crystal_trade_fix.lua
+++ b/modules/custom/lua/conquest_crystal_trade_fix.lua
@@ -47,76 +47,78 @@ local expRings =
 
 m:addOverride("xi.conquest.overseerOnTrade", function(player, npc, trade, guardNation, guardType)
     -- Garrison Trade
-	if 
-		guardType == xi.conq.guard.OUTPOST and 
-		(trade:getItemId() >= 1528 and trade:getItemId() <= 1543) 
-	then
-		xi.garrison.onTrade(player, npc, trade, guardNation)
-	end
-	
-  if player:getNation() == guardNation or guardNation == xi.nation.OTHER then
-      local item = trade:getItemId()
-      local tradeConfirmed = false
-      local mOffset = zones[player:getZoneID()].text.CONQUEST
+    if 
+        guardType == xi.conq.guard.OUTPOST and 
+        (trade:getItemId() >= 1528 and trade:getItemId() <= 1543) 
+    then
+        xi.garrison.onTrade(player, npc, trade, guardNation)
+    end
 
-      -- DONATE CRYSTALS FOR RANK OR CONQUEST POINTS
-      if guardType <= xi.conquest.guard.FOREIGN and crystals[item] then
-          local pRank = player:getRank(player:getNation())
-          local pRankPoints = player:getRankPoints()
-          local addPoints = 0
+    if player:getNation() == guardNation or guardNation == xi.nation.OTHER then
+        local item = trade:getItemId()
+        local tradeConfirmed = false
+        local mOffset = zones[player:getZoneID()].text.CONQUEST
 
-          for crystalId, crystalWorth in pairs(crystals) do
-              local count = trade:getItemQty(crystalId)
+        -- DONATE CRYSTALS FOR RANK OR CONQUEST POINTS
+        if guardType <= xi.conquest.guard.FOREIGN and crystals[item] then
+            local pRank = player:getRank(player:getNation())
+            local pRankPoints = player:getRankPoints()
+            local addPoints = 0
 
-              if count > 0 then
-                  if pRank == 1 then
-                      player:showText(npc, mOffset - 7) -- "I cannot accept crystals from someone whose rank is still 1."
-                      break
-                  elseif pRankPoints == 4000 then
-                      player:showText(npc, mOffset + 43) -- "You do not need to donate any more crystals at your current rank."
-                      break
-                  else
-                      trade:confirmItem(crystalId, count)
-                      addPoints = addPoints + count * math.floor(4000 / (player:getRank(player:getNation()) * 12 - crystalWorth))
-                  end
-              end
-          end
+            for crystalId, crystalWorth in pairs(crystals) do
+                local count = trade:getItemQty(crystalId)
 
-          if addPoints > 0 and pRank ~= 1 and pRankPoints < 4000 then
-              if pRankPoints + addPoints >= 4000 then
-                  player:setRankPoints(4000)
-                  player:addCP((pRankPoints + (addPoints) - 4000)/14)
-                  player:showText(npc, mOffset + 44) -- "Your rank points are full. We've added the excess to your conquest points."
-              else
-                  player:addRankPoints(addPoints)
-                  player:showText(npc, mOffset + 45) -- "We've awarded you rank points for the crystals you've donated."
-              end
-              player:confirmTrade()
-              tradeConfirmed = true
-          end
-      end
+                if count > 0 then
+                    if pRank == 1 then
+                        player:showText(npc, mOffset - 7) -- "I cannot accept crystals from someone whose rank is still 1."
+                        break
+                    elseif pRankPoints == 4000 then
+                        player:showText(npc, mOffset + 43) -- "You do not need to donate any more crystals at your current rank."
+                        break
+                    else
+                        trade:confirmItem(crystalId, count)
+                        addPoints = addPoints + count * math.floor(4000 / (player:getRank(player:getNation()) * 12 - crystalWorth))
+                    end
+                end
+            end
 
-      -- RECHARGE EXP RING
-      if not tradeConfirmed and expRings[item] and npcUtil.tradeHas(trade, item) then
-          if xi.settings.BYPASS_EXP_RING_ONE_PER_WEEK == 1 or player:getCharVar("CONQUEST_RING_RECHARGE") < os.time() then
-              local ring = expRings[item]
+            if addPoints > 0 and pRank ~= 1 and pRankPoints < 4000 then
+                if pRankPoints + addPoints >= 4000 then
+                    player:setRankPoints(4000)
+                    player:addCP((pRankPoints + (addPoints) - 4000)/14)
+                    player:showText(npc, mOffset + 44) -- "Your rank points are full. We've added the excess to your conquest points."
+                else
+                    player:addRankPoints(addPoints)
+                    player:showText(npc, mOffset + 45) -- "We've awarded you rank points for the crystals you've donated."
+                end
+                player:confirmTrade()
+                tradeConfirmed = true
+            end
+        end
 
-              if player:getCP() >= ring.cp then
-                  player:delCP(ring.cp)
-                  player:confirmTrade()
-                  player:addItem(item)
-                  player:setCharVar("CONQUEST_RING_RECHARGE", getConquestTally())
-                  player:showText(npc, mOffset + 58, item, ring.cp, ring.charges) -- "Your ring is now fully recharged."
-              else
-                  player:showText(npc, mOffset + 55, item, ring.cp) -- "You do not have the required conquest points to recharge."
-              end
-           else
-              -- TODO: Verify that message is retail correct.
-              -- This gives feedback on a failure at least, and is grouped with the recharge messages.  Confident enough for a commit.
-              player:showText(npc, mOffset + 56, item) -- "Please be aware that you can only purchase or recharge <item> once during the period between each conquest results tally.
-          end
-      end
-  end
+        -- RECHARGE EXP RING
+        if not tradeConfirmed and expRings[item] and npcUtil.tradeHas(trade, item) then
+            if xi.settings.BYPASS_EXP_RING_ONE_PER_WEEK == 1 or player:getCharVar("CONQUEST_RING_RECHARGE") < os.time() then
+                local ring = expRings[item]
+
+                if player:getCP() >= ring.cp then
+                    player:delCP(ring.cp)
+                    player:confirmTrade()
+                    player:addItem(item)
+                    player:setCharVar("CONQUEST_RING_RECHARGE", getConquestTally())
+                    player:showText(npc, mOffset + 58, item, ring.cp, ring.charges) -- "Your ring is now fully recharged."
+                else
+                    player:tradeComplete(false)
+                    player:showText(npc, mOffset + 55, item, ring.cp) -- "You do not have the required conquest points to recharge."
+                end
+            else
+                -- TODO: Verify that message is retail correct.
+                -- This gives feedback on a failure at least, and is grouped with the recharge messages.  Confident enough for a commit.
+                player:tradeComplete(false)
+                player:showText(npc, mOffset + 56, item) -- "Please be aware that you can only purchase or recharge <item> once during the period between each conquest results tally.
+            end
+        end
+    end
 end)
 
 return m

--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1118,11 +1118,13 @@ xi.conquest.overseerOnTrade = function(player, npc, trade, guardNation, guardTyp
                     player:setCharVar("CONQUEST_RING_RECHARGE", getConquestTally())
                     player:showText(npc, mOffset + 58, item, ring.cp, ring.charges) -- "Your ring is now fully recharged."
                 else
+                    player:tradeComplete(false)
                     player:showText(npc, mOffset + 55, item, ring.cp) -- "You do not have the required conquest points to recharge."
                 end
             else
                 -- TODO: Verify that message is retail correct.
                 -- This gives feedback on a failure at least, and is grouped with the recharge messages.  Confident enough for a commit.
+                player:tradeComplete(false)
                 player:showText(npc, mOffset + 56, item) -- "Please be aware that you can only purchase or recharge <item> once during the period between each conquest results tally.
             end
         end

--- a/scripts/zones/Sea_Serpent_Grotto/npcs/_4w3.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/npcs/_4w3.lua
@@ -10,6 +10,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if npcUtil.tradeHas(trade, 749) then
+        player:tradeComplete(false)
         if player:getCharVar("SSG_MythrilDoor") == 7 then
             npc:openDoor(5) -- Open the door if a mythril beastcoin has been traded after checking the door the required number of times
         end

--- a/scripts/zones/Sea_Serpent_Grotto/npcs/_4w4.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/npcs/_4w4.lua
@@ -10,6 +10,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if npcUtil.tradeHas(trade, 748) then
+        player:tradeComplete(false)
         if player:getCharVar("SSG_GoldDoor") == 7 then
             npc:openDoor(5) -- Open the door if a gold beastcoin has been traded after checking the door the required number of times
         end

--- a/scripts/zones/Sea_Serpent_Grotto/npcs/_4w5.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/npcs/_4w5.lua
@@ -10,6 +10,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if npcUtil.tradeHas(trade, 750) then
+        player:tradeComplete(false)
         if player:getCharVar("SSG_SilverDoor") == 7 then
             npc:openDoor(5) -- Open the door if a silver beastcoin has been traded after checking the door the required number of times
         end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4106,15 +4106,16 @@ void CLuaBaseEntity::confirmTrade()
 
 /************************************************************************
  *  Function: tradeComplete()
- *  Purpose : Completes trade and removes all items in trade container
+ *  Purpose : Completes trade and removes all items in trade container (unless false is passed as parameter)
  *  Example : player:tradeComplete()
  ************************************************************************/
 
-void CLuaBaseEntity::tradeComplete()
+void CLuaBaseEntity::tradeComplete(sol::object const& shouldTakeItems)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    bool  takeItems = (shouldTakeItems != sol::lua_nil) ? shouldTakeItems.as<bool>() : true;
+    auto* PChar     = static_cast<CCharEntity*>(m_PBaseEntity);
 
     for (uint8 slotID = 0; slotID < TRADE_CONTAINER_SIZE; ++slotID)
     {
@@ -4126,7 +4127,10 @@ void CLuaBaseEntity::tradeComplete()
             if (PItem)
             {
                 PItem->setReserve(0);
-                charutils::UpdateItem(PChar, LOC_INVENTORY, invSlotID, -quantity);
+                if (takeItems)
+                {
+                    charutils::UpdateItem(PChar, LOC_INVENTORY, invSlotID, -quantity);
+                }
             }
         }
     }

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -233,7 +233,7 @@ public:
     void  changeContainerSize(uint8 locationID, int8 newSize); // Increase/Decreases container size
     uint8 getFreeSlotsCount(sol::object const& locID);         // Gets value of free slots in Entity inventory
     void  confirmTrade();                                      // Complete trade with an npc, only removing confirmed items
-    void  tradeComplete();                                     // Complete trade with an npc
+    void  tradeComplete(sol::object const& shouldTakeItems);   // Complete trade with an npc
     auto  getTrade() -> std::optional<CLuaTradeContainer>;
 
     // Equipping


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Finishes a trade without taking items from the inventory.  Allows players the ability to drop or move the items without the need to zone or logout after the trade.

Closes #800 
Closes #1657

## Steps to test these changes

Trade gold beastcoin to SSG door then drop it.
