### PR TITLE
Fix onRegionEnter

### DIFF
--- a/scripts/quests/jeuno/Apocalypse_Nigh.lua
+++ b/scripts/quests/jeuno/Apocalypse_Nigh.lua
@@ -70,7 +70,7 @@ quest.sections =
 
         [xi.zone.RULUDE_GARDENS] =
         {
-            onRegionEnter =
+            onTriggerAreaEnter =
             {
                 [1] = function(player, region)
                     return quest:progressEvent(123)

--- a/scripts/quests/jeuno/Storms_of_Fate.lua
+++ b/scripts/quests/jeuno/Storms_of_Fate.lua
@@ -25,7 +25,7 @@ quest.sections =
 
         [xi.zone.RULUDE_GARDENS] =
         {
-            onRegionEnter =
+            onTriggerAreaEnter =
             {
                 [1] = function(player, region)
                     if player:getCharVar("Mission[6][840]Status") == 8 then
@@ -88,7 +88,7 @@ quest.sections =
 
         [xi.zone.RULUDE_GARDENS] =
         {
-            onRegionEnter =
+            onTriggerAreaEnter =
             {
                 [1] = function(player, region)
                     if quest:getVar(player, 'Status') == 3 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

onRegion isn't real, unlike the one piece

## Steps to test these changes

👀 
