### PR TITLE
Fix SaveAllStatusEffects From Removing Effects During Persist State

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -745,7 +745,7 @@ bool CCharEntity::PersistData()
 
     if (dataToPersist & CHAR_PERSIST::EFFECTS)
     {
-        StatusEffectContainer->SaveStatusEffects(true);
+        StatusEffectContainer->SaveStatusEffects(true, false);
     }
 
     /* TODO

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -973,7 +973,7 @@ int32 map_close_session(time_point tick, map_session_data_t* map_session_data)
         uint64 ipp    = map_session_data->client_addr;
         ipp |= port64 << 32;
 
-        map_session_data->PChar->StatusEffectContainer->SaveStatusEffects(map_session_data->shuttingDown == 1);
+        map_session_data->PChar->StatusEffectContainer->SaveStatusEffects(map_session_data->shuttingDown == 1, false);
 
         delete[] map_session_data->server_packet_data;
         delete map_session_data->PChar;
@@ -1046,7 +1046,7 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
                             petutils::DespawnPet(PChar);
                         }
 
-                        PChar->StatusEffectContainer->SaveStatusEffects(true);
+                        PChar->StatusEffectContainer->SaveStatusEffects(true, false);
                         charutils::SaveCharPosition(PChar);
 
                         ShowDebug("map_cleanup: %s timed out, closing session", PChar->GetName());
@@ -1056,7 +1056,7 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
                     }
                     else
                     {
-                        map_session_data->PChar->StatusEffectContainer->SaveStatusEffects(true);
+                        map_session_data->PChar->StatusEffectContainer->SaveStatusEffects(true, false);
                         sql->Query("DELETE FROM accounts_sessions WHERE charid = %u;", map_session_data->PChar->id);
 
                         delete[] map_session_data->server_packet_data;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -697,7 +697,7 @@ void SmallPacket0x015(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             charutils::SaveCharStats(PChar);
             charutils::SaveCharPosition(PChar);
-            PChar->StatusEffectContainer->SaveStatusEffects();
+            PChar->StatusEffectContainer->SaveStatusEffects(false, true);
             PChar->m_nextDataSave = std::chrono::system_clock::now() + std::chrono::seconds(settings::get<uint16>("main.PLAYER_DATA_SAVE") > 0 ? settings::get<uint16>("main.PLAYER_DATA_SAVE") : 120);
         }
     }

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1632,7 +1632,7 @@ void CStatusEffectContainer::LoadStatusEffects()
  *                                                                       *
  ************************************************************************/
 
-void CStatusEffectContainer::SaveStatusEffects(bool logout)
+void CStatusEffectContainer::SaveStatusEffects(bool logout, bool skipRemove)
 {
     XI_DEBUG_BREAK_IF(m_POwner->objtype != TYPE_PC);
 
@@ -1640,7 +1640,7 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
 
     for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
     {
-        if ((logout && PStatusEffect->GetFlag() & EFFECTFLAG_LOGOUT) || (!logout && PStatusEffect->GetFlag() & EFFECTFLAG_ON_ZONE))
+        if (!skipRemove && ((logout && PStatusEffect->GetFlag() & EFFECTFLAG_LOGOUT) || (!logout && PStatusEffect->GetFlag() & EFFECTFLAG_ON_ZONE)))
         {
             RemoveStatusEffect(PStatusEffect, true);
             continue;
@@ -1700,7 +1700,11 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
                        std::chrono::duration_cast<std::chrono::seconds>(PStatusEffect->GetStartTime().time_since_epoch()).count());
         }
     }
-    DeleteStatusEffects();
+
+    if (!skipRemove)
+    {
+        DeleteStatusEffects();
+    }
 }
 
 /************************************************************************

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -83,8 +83,8 @@ public:
     void TickEffects(time_point tick);
     void TickRegen(time_point tick);
 
-    void LoadStatusEffects();                    // загружаем эффекты персонажа
-    void SaveStatusEffects(bool logout = false); // сохраняем эффекты персонажа
+    void LoadStatusEffects();                                             // загружаем эффекты персонажа
+    void SaveStatusEffects(bool logout = false, bool skipRemove = false); // сохраняем эффекты персонажа
 
     uint8 GetEffectsCount(EFFECT ID); // получаем количество эффектов с указанным id
     uint8 GetLowestFreeSlot();        // returns the lowest free slot for songs/rolls


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Adds an additional overloaded bool to SaveAllStatusEffects which stops the function from removing any status effects.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
