### PR TITLE
Fixed toolbag (hiraishin) being unusable

### DIFF
--- a/modules/era/sql/item_basic.sql
+++ b/modules/era/sql/item_basic.sql
@@ -970,7 +970,7 @@ REPLACE INTO `item_basic` (`itemid`, `subid`, `name`, `sortname`, `stackSize`, `
     (5230, 0, 'love_chocolate', 'love_chocolate', 1, 1580, 57, 0, 582),
     (5231, 0, 'truelove_chocolate', 'truelove_choco.', 1, 1580, 57, 0, 955),
     (5306, 0, 'bottle_of_hallowed_water', 'hallowed_water', 12, 1540, 33, 0, 424),
-    (5312, 0, 'toolbag_(hiraishin)', 'toolbag_(hira)', 12, 1540, 49, 0, 920),
+    (5312, 0, 'toolbag_hiraishin', 'toolbag_(hira)', 12, 1540, 49, 0, 920),
     (5335, 0, 'acid_bolt_quiver', 'ac._bolt_quiver', 12, 1540, 15, 0, 615),
     (5340, 0, 'silver_bullet_pouch', 'silv._bul._pouch', 12, 1540, 15, 0, 250),
     (5359, 0, 'bronze_bullet_pouch', 'brz._bull._pouch', 12, 1540, 15, 0, 15),


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Toolbag (Hiraishin) had the wrong item name in the era database which was preventing the item from being usable

Closes #1441

## Steps to test these changes

- `!additem toolbag_hiraishin`
- Use the toolbag
- Should create Hiraishin x99
