### PR TITLE
Added weather conditions to Yhoator harvesting and fixed positions

### DIFF
--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -52,7 +52,7 @@ zoneObject.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
 end
 
-function updateRainHarvesting(status)
+local function updateRainHarvesting(status)
     for point = 1, #ID.npc.HARVESTING do
         GetNPCByID(ID.npc.HARVESTING[point]):setStatus(status)
     end

--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -13,6 +13,12 @@ require('scripts/missions/amk/helpers')
 -----------------------------------
 local zoneObject = {}
 
+local function updateRainHarvesting(status)
+    for point = 1, #ID.npc.HARVESTING do
+        GetNPCByID(ID.npc.HARVESTING[point]):setStatus(status)
+    end
+end
+
 zoneObject.onChocoboDig = function(player, precheck)
     return xi.chocoboDig.start(player, precheck)
 end
@@ -50,12 +56,6 @@ end
 
 zoneObject.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
-end
-
-local function updateRainHarvesting(status)
-    for point = 1, #ID.npc.HARVESTING do
-        GetNPCByID(ID.npc.HARVESTING[point]):setStatus(status)
-    end
 end
 
 zoneObject.onZoneWeatherChange = function(weatherType)

--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -33,9 +33,10 @@ zoneObject.onInitialize = function(zone)
 
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
 
-    xi.helm.initZone(zone, xi.helm.type.HARVESTING)
-    xi.helm.initZone(zone, xi.helm.type.LOGGING)
     xi.chocobo.initZone(zone)
+    xi.helm.initZone(zone, xi.helm.type.LOGGING)
+    xi.helm.initZone(zone, xi.helm.type.HARVESTING)
+    updateRainHarvesting(xi.status.DISAPPEAR)
 
     xi.bmt.updatePeddlestox(xi.zone.YUHTUNGA_JUNGLE, ID.npc.PEDDLESTOX)
 end
@@ -49,6 +50,20 @@ end
 
 zoneObject.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+end
+
+function updateRainHarvesting(status)
+    for point = 1, #ID.npc.HARVESTING do
+        GetNPCByID(ID.npc.HARVESTING[point]):setStatus(status)
+    end
+end
+
+zoneObject.onZoneWeatherChange = function(weatherType)
+    if weatherType == xi.weather.RAIN or weatherType == xi.weather.SQUALL then
+        updateRainHarvesting(xi.status.NORMAL)
+    else
+        updateRainHarvesting(xi.status.DISAPPEAR)
+    end
 end
 
 zoneObject.onZoneIn = function(player, prevZone)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Added rain weather conditions for Yhoator Jungle Harvesting Points
- 2nd and 3rd Harvesting Points were stacked, so I moved 3rd to correct location
- **Should be added before HXI release** to prevent items from being too abundant if obtainable in all weather conditions

Closes #1054

## Steps to test these changes

Clear (No weather): !setweather 0
Rain (Single water): !setweather 6
Squall (Double water): !setweather 7

!gotoid 17285681
!gotoid 17285682
!gotoid 17285683
