### PR TITLE
Tredecim Scythe Hidden Effect

### DIFF
--- a/scripts/globals/items/tredecim_scythe.lua
+++ b/scripts/globals/items/tredecim_scythe.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- ID: 18052
+-- Tredecim Scythe
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemDrop = function(player, item)
+    player:setLocalVar('TREDECIM_COUNTER', 0)
+end
+
+itemObject.onItemEquip = function(player, item)
+    player:addListener("ATTACK", "TREDECIM_ATTACK", function(playerArg, mob)
+        -- Setting of critical attack is handled in battleentity.cpp
+        playerArg:setLocalVar("TREDECIM_COUNTER", playerArg:getLocalVar("TREDECIM_COUNTER") + 1)
+    end)
+end
+
+itemObject.onItemUnequip = function(player, item)
+    player:removeListener("TREDECIM_ATTACK")
+end
+
+return itemObject

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2147,6 +2147,13 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
 
                 actionTarget.reaction = REACTION::HIT;
 
+                if (this->GetLocalVar("TREDECIM_COUNTER") == 13 && weaponSlot == SLOT_MAIN)
+                {
+                    // Ensure critical is only set to main weapon slot
+                    attack.SetCritical(true, weaponSlot, attack.IsGuarded());
+                    this->SetLocalVar("TREDECIM_COUNTER", -1);
+                }
+
                 // Critical hit.
                 if (attack.IsCritical())
                 {


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Implements Tredecim's Scythe to crit every 13th hit. This counter increments even when the player misses, is saved when they log off, zone, etc. Moreover, it only increments when attacking with the scythe. https://ffxiclopedia.fandom.com/wiki/Tredecim_Scythe

Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1778
