### PR TITLE
Fixed Full Moon conditions for RNG AF1

### DIFF
--- a/scripts/zones/Jugner_Forest/npcs/qm2.lua
+++ b/scripts/zones/Jugner_Forest/npcs/qm2.lua
@@ -12,8 +12,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local phase = VanadielMoonPhase()
-    local direction = VanadielMoonDirection()
     if player:getCharVar("sinHunting") == 4 and IsMoonFull() then
         player:startEvent(13, 0, 1107)
     else

--- a/scripts/zones/Jugner_Forest/npcs/qm2.lua
+++ b/scripts/zones/Jugner_Forest/npcs/qm2.lua
@@ -4,6 +4,8 @@
 -- Involved in Quest: Sin Hunting - RNG AF1
 -- !pos -10.946 -1.000 313.810 104
 -----------------------------------
+local ID = require('scripts/zones/Jugner_Forest/IDs')
+-----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
@@ -12,9 +14,10 @@ end
 entity.onTrigger = function(player, npc)
     local phase = VanadielMoonPhase()
     local direction = VanadielMoonDirection()
-    if player:getCharVar("sinHunting") == 4 and
-    ((phase <= 90 and direction == 2) or (phase <= 95 and direction == 1)) then
+    if player:getCharVar("sinHunting") == 4 and IsMoonFull() then
         player:startEvent(13, 0, 1107)
+    else
+       player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Full Moon should be required to use the ??? (qm) https://ffxiclopedia.fandom.com/wiki/Sin_Hunting?oldid=142571
- Replaced incorrect conditions with IsMoonFull()
- Added fallback message when not Full Moon

Closes #1121

## Steps to test these changes

!pos -10.946 -1.000 313.810 104