### PR TITLE
Charmed Players Bug Fix

### DIFF
--- a/scripts/globals/effects/lullaby.lua
+++ b/scripts/globals/effects/lullaby.lua
@@ -10,9 +10,6 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    if target:hasStatusEffect(xi.effect.CHARM_I) or target:hasStatusEffect(xi.effect.CHARM_II) then
-        target:resetAI()
-    end
 end
 
 return effectObject

--- a/scripts/globals/effects/petrification.lua
+++ b/scripts/globals/effects/petrification.lua
@@ -10,9 +10,6 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    if target:hasStatusEffect(xi.effect.CHARM_I) or target:hasStatusEffect(xi.effect.CHARM_II) then
-        target:resetAI()
-    end
 end
 
 return effectObject

--- a/scripts/globals/effects/sleep.lua
+++ b/scripts/globals/effects/sleep.lua
@@ -17,9 +17,6 @@ effectObject.onEffectLose = function(target, effect)
     if effect:getSubType() == xi.effect.BIO then
         -- Nightmare
         target:delMod(xi.mod.REGEN_DOWN, effect:getSubPower())
-
-    elseif target:hasStatusEffect(xi.effect.CHARM_I) or target:hasStatusEffect(xi.effect.CHARM_II) then
-        target:resetAI()
     end
 end
 

--- a/scripts/globals/effects/stun.lua
+++ b/scripts/globals/effects/stun.lua
@@ -10,9 +10,6 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    if target:hasStatusEffect(xi.effect.CHARM_I) or target:hasStatusEffect(xi.effect.CHARM_II) then
-        target:resetAI()
-    end
 end
 
 return effectObject

--- a/scripts/globals/effects/terror.lua
+++ b/scripts/globals/effects/terror.lua
@@ -10,9 +10,6 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    if target:hasStatusEffect(xi.effect.CHARM_I) or target:hasStatusEffect(xi.effect.CHARM_II) then
-        target:resetAI()
-    end
 end
 
 return effectObject


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Remove stale fix that ended up causing more errors. Original resetAI() fix was made to cause players to re-engage the mob after waking up while still being charmed. This resetAI was causing players to not properly disengage.

Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1283