### PR TITLE
Fix Ancient Flames Beckon showing as complete for new chars

### DIFF
--- a/scripts/missions/cop/1_1_The_Rites_of_Life.lua
+++ b/scripts/missions/cop/1_1_The_Rites_of_Life.lua
@@ -28,7 +28,8 @@ mission.sections =
     -- 1. To start this mission, enter Lower Delkfutt's Tower for a cutscene after installing the Chains of Promathia expansion pack.
     {
         check = function(player, currentMission, missionStatus, vars)
-            return xi.settings.main.ENABLE_COP == 1 and currentMission < xi.mission.id.cop.THE_RITES_OF_LIFE
+            return xi.settings.main.ENABLE_COP == 1 and
+                currentMission < xi.mission.id.cop.THE_RITES_OF_LIFE
         end,
 
         [xi.zone.LOWER_DELKFUTTS_TOWER] =

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -160,9 +160,9 @@ CCharEntity::CCharEntity()
         m_missionLog[i].current = 0xFFFF;
     }
 
-    m_missionLog[4].current = 0;   // MISSION_TOAU
-    m_missionLog[5].current = 0;   // MISSION_WOTG
-    m_missionLog[6].current = 101; // MISSION_COP
+    m_missionLog[4].current = 0; // MISSION_TOAU
+    m_missionLog[5].current = 0; // MISSION_WOTG
+    m_missionLog[6].current = 0; // MISSION_COP
     for (auto& i : m_missionLog)
     {
         i.statusUpper = 0;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sets the starting CoP mission to 0 instead of 101 so that the mission doesn't show up until it's activated.
Still issues with showing current and completed quests together.  Maybe client side?

Closes  #1290 
## Steps to test these changes

Create a new char and check the mission log for CoP.
