### PR TITLE
Add setWallhackAllowed() to Disable Wallhack Flag Addition

### DIFF
--- a/scripts/zones/The_Shrouded_Maw/mobs/Diremite.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diremite.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- Area: The Shrouded Maw
+-- Mob: Diremite
+-- Mission: Darkness Named
+-----------------------------------
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setWallhackAllowed(false)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+return entity

--- a/scripts/zones/The_Shrouded_Maw/mobs/Pasuk.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Pasuk.lua
@@ -10,7 +10,7 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.TP_DRAIN, { chance = 100, power = math.random(200,260) })
+    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.TP_DRAIN, { chance = 100, power = math.random(200, 260) })
 end
 
 entity.onMobSpawn = function(mob)
@@ -34,14 +34,14 @@ entity.onMobFight = function(mob, target)
         if mob:checkDistance(target) > 14 then
             mob:timer(2000, function(mobArg)
                 local pos = target:getPos()
-                mobArg:setPos(pos.x+1, pos.y, pos.z+1)
+                mobArg:setPos(pos.x + 1, pos.y, pos.z + 1)
                 mobArg:setLocalVar("timer", os.time() + 30)
             end)
         end
     end
 end
 
-entity.onMobDead = function(mob, player, optParams)
+entity.onMobDeath = function(mob, player, optParams)
 end
 
 return entity

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -190,14 +190,14 @@ bool CPathFind::PathInRange(const position_t& point, float range, uint8 pathFlag
     {
         auto PEntity = dynamic_cast<CBattleEntity*>(m_POwner)->GetBattleTarget();
 
-        if (PEntity)
+        if (PEntity && !m_POwner->m_ignoreWallhack)
         {
             result           = abs(m_POwner->loc.p.y - PEntity->loc.p.y) < m_POwner->loc.zone->m_navMesh->GetVerticalLimit() ? ValidPosition(PEntity->loc.p) : true;
             m_carefulPathing = result ? true : false;
         }
     }
 
-    if (!result) // If I failed to path successfully, then I should wallhack to reach my destination.
+    if (!result && !m_POwner->m_ignoreWallhack) // If I failed to path successfully, then I should wallhack to reach my destination.
     {
         pathFlags |= PATHFLAG_WALLHACK;
         PathTo(point, pathFlags, false);

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -308,6 +308,8 @@ public:
     ALLEGIANCE_TYPE allegiance; // what types of targets the entity can fight
     uint8           updatemask; // what to update next server tick to players nearby
 
+    bool m_ignoreWallhack = false; // Flag to ignore wallhack if set to true.
+
     uint32 animBegin; // Animation start time
     uint8  animPath;  // Which animation Path
     bool   animStart; // Is this starting an animation?

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15533,7 +15533,7 @@ void CLuaBaseEntity::setWallhackAllowed(bool allowed)
 
     XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr || m_PBaseEntity->objtype == TYPE_PC);
 
-    m_PBaseEntity->m_ignoreWallhack = !allowed ? true : false;
+    m_PBaseEntity->m_ignoreWallhack = !allowed;
 }
 
 //==========================================================//

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15527,6 +15527,15 @@ uint8 CLuaBaseEntity::getMannequinPose(uint16 itemID)
     return 0;
 }
 
+void CLuaBaseEntity::setWallhackAllowed(bool allowed)
+{
+    TracyZoneScoped;
+
+    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr || m_PBaseEntity->objtype == TYPE_PC);
+
+    m_PBaseEntity->m_ignoreWallhack = !allowed ? true : false;
+}
+
 //==========================================================//
 
 void CLuaBaseEntity::Register()
@@ -16349,6 +16358,7 @@ void CLuaBaseEntity::Register()
     // Mannequins
     SOL_REGISTER("setMannequinPose", CLuaBaseEntity::setMannequinPose);
     SOL_REGISTER("getMannequinPose", CLuaBaseEntity::getMannequinPose);
+    SOL_REGISTER("setWallhackAllowed", CLuaBaseEntity::setWallhackAllowed);
 }
 
 std::ostream& operator<<(std::ostream& os, const CLuaBaseEntity& entity)

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -879,6 +879,7 @@ public:
 
     uint8 getMannequinPose(uint16 itemID);
     void  setMannequinPose(uint16 itemID, uint8 race, uint8 pose);
+    void  setWallhackAllowed(bool allowed); // Sets whether an entity should ignore wallhack flags in pathfind.
 
     static void Register();
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Adds entity:setWallhackAllowed(bool) to allow for wallhack to be disallowed or universally allowed during pathfind calculations for a specific entity.
+ Adds the function to the initialize for the diremites in shrouded maw.
+ Fixes a typo for an ENM in shrouded maw for onMobDeath.

This should fix https://github.com/AirSkyBoat/AirSkyBoat/issues/1448 when combined with a new mesh.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
