### PR TITLE
Rent-A-Room Multi-Instance Zoning Fix

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3868,7 +3868,7 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
                                           (CharZone >= ZONE_WESTERN_ADOULIN && CharZone <= ZONE_EASTERN_ADOULIN);
                 // clang-format on
 
-                if ((PDestination->GetType() == ZONE_TYPE::CITY && (uint16)PDestination->GetID() == 0 && !RentExempt) &&
+                if ((PZoneLine->m_toZoneType == ZONE_TYPE::CITY && PZoneLine->m_toZone == 0 && !RentExempt) &&
                     (settings::get<bool>("map.RENT_A_ROOM") && settings::get<bool>("map.ERA_RENT_A_ROOM") ? !IsRentedCity : !IsInHomeNation && !IsRentedCity))
                 {
                     PChar->loc.p.rotation += 128;

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -360,7 +360,18 @@ zoneLine_t* CZone::GetZoneLine(uint32 zoneLineID)
 void CZone::LoadZoneLines()
 {
     TracyZoneScoped;
-    static const char fmtQuery[] = "SELECT zoneline, tozone, tox, toy, toz, rotation FROM zonelines WHERE fromzone = %u";
+    static const char fmtQuery[] =
+        "SELECT "
+        "zonelines.zoneline,"     // 0
+        "zonelines.tozone,"       // 1
+        "zonelines.tox,"          // 2
+        "zonelines.toy,"          // 3
+        "zonelines.toz,"          // 4
+        "zonelines.rotation,"     // 5
+        "zone_settings.zonetype " // 6
+        "FROM zonelines INNER JOIN zone_settings "
+        "ON zonelines.tozone = zone_settings.zoneid "
+        "WHERE zonelines.fromzone = %u;";
 
     int32 ret = sql->Query(fmtQuery, m_zoneID);
 
@@ -376,6 +387,7 @@ void CZone::LoadZoneLines()
             zl->m_toPos.y        = sql->GetFloatData(3);
             zl->m_toPos.z        = sql->GetFloatData(4);
             zl->m_toPos.rotation = (uint8)sql->GetIntData(5);
+            zl->m_toZoneType     = (ZONE_TYPE)sql->GetUIntData(6);
 
             m_zoneLineList.push_back(zl);
         }

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -493,6 +493,7 @@ struct zoneLine_t
     uint32     m_zoneLineID;
     uint16     m_toZone;
     position_t m_toPos;
+    ZONE_TYPE  m_toZoneType;
 };
 
 class CBasicPacket;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes an issue where zoning from one town to another town on different clusters would fail to send the player and crash the starting zone.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
