### PR TITLE
Fix Calling Invalid Entity for Players with Hundred Fists

### DIFF
--- a/scripts/globals/effects/hundred_fists.lua
+++ b/scripts/globals/effects/hundred_fists.lua
@@ -10,8 +10,10 @@ effectObject.onEffectGain = function(target, effect)
     local jpLevel = target:getJobPointLevel(xi.jp.HUNDRED_FISTS_EFFECT)
     target:addMod(xi.mod.ACC, jpLevel * 2)
     -- Mobs do not TP or cast while hundred fists is active
-    target:setMobAbilityEnabled(false)
-    target:setMagicCastingEnabled(false)
+    if target:isMob() then
+        target:setMobAbilityEnabled(false)
+        target:setMagicCastingEnabled(false)
+    end
 end
 
 effectObject.onEffectTick = function(target, effect)
@@ -20,8 +22,10 @@ end
 effectObject.onEffectLose = function(target, effect)
     local jpLevel = target:getJobPointLevel(xi.jp.HUNDRED_FISTS_EFFECT)
     target:delMod(xi.mod.ACC, jpLevel * 2)
-    target:setMobAbilityEnabled(true)
-    target:setMagicCastingEnabled(true)
+    if target:isMob() then
+        target:setMobAbilityEnabled(true)
+        target:setMagicCastingEnabled(true)
+    end
 end
 
 return effectObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes an issue where when a player zones or activates hundred fists multiple calls to an invalid entity type are made.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
