### PR TITLE
Quality Assurance Bug Fixes

### DIFF
--- a/scripts/globals/mobskills/stasis.lua
+++ b/scripts/globals/mobskills/stasis.lua
@@ -18,18 +18,20 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local shadows = xi.mobskills.shadowBehavior.NUMSHADOWS_1
-    -- local dmg = xi.mobskills.mobFinalAdjustments(10, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, shadows)
+    local numhits = 1
+    local accmod = 1
+    local dmgmod = 2
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 1.0, 1.25, 1.5)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
+
     local typeEffect = xi.effect.PARALYSIS
 
     mob:resetEnmity(target)
 
-    if xi.mobskills.mobPhysicalHit(skill) then
-        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 40, 0, 60))
-        return typeEffect
-    end
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 40, 0, 60)
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
-    return shadows
+    return dmg
 end
 
 return mobskillObject

--- a/scripts/zones/Bearclaw_Pinnacle/mobs/Snoll_Tzar.lua
+++ b/scripts/zones/Bearclaw_Pinnacle/mobs/Snoll_Tzar.lua
@@ -32,7 +32,6 @@ entity.onMobFight = function(mob, player, target)
         mob:setLocalVar("salty", 0)
     end
 
-
     -- big
     if
         delay < os.time() and

--- a/scripts/zones/Bearclaw_Pinnacle/mobs/Snoll_Tzar.lua
+++ b/scripts/zones/Bearclaw_Pinnacle/mobs/Snoll_Tzar.lua
@@ -20,6 +20,19 @@ entity.onMobFight = function(mob, player, target)
 
     mob:setDamage(130)
 
+    -- handle salt usage
+    if mob:getLocalVar("melt") == 1 then
+        player:messageText(player, ID.text.BEGINS_TO_MELT)
+        mob:setLocalVar("melt", 0)
+    end
+
+    -- salt cooldown time reset
+    if (mob:getLocalVar("cooldown") < os.time() and mob:getLocalVar("salty") == 1) then
+        player:messageText(player, ID.text.SHOOK_SALT)
+        mob:setLocalVar("salty", 0)
+    end
+
+
     -- big
     if
         delay < os.time() and

--- a/scripts/zones/Mhaura/npcs/Pikini-Mikini.lua
+++ b/scripts/zones/Mhaura/npcs/Pikini-Mikini.lua
@@ -20,9 +20,11 @@ entity.onTrigger = function(player, npc)
         4151,  720,    -- Echo Drops
         4112,  819,    -- Potion
         4509,   10,    -- Distilled Water
-        917,  1821,    -- Parchment
         17395,   9,    -- Lugworm
         1021,  450,    -- Hatchet
+        xi.items.SCROLL_OF_REGEN,     3974,
+        xi.items.SCROLL_OF_REGEN_II,  7203,
+        xi.items.SCROLL_OF_SLEEPGA,  10304,
         4376,  108,    -- Meat Jerky
         5299,  133,    -- Salsa
         2867, 9000,    -- Mhaura Waystone

--- a/scripts/zones/Northern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Northern_San_dOria/DefaultActions.lua
@@ -24,7 +24,6 @@ return {
     },
     ['Guilerme']   = { text = ID.text.GUILERME_DIALOG },
     ['Helaku']     = { event = 541 },
-    ['Hinaree']    = { event = 580 },
     ['Kasaroro']   = { event = 548 },
     ['Maurinne']   = { text = ID.text.MAURINNE_DIALOG },
     ['Miageau']    = { event = 517 },

--- a/scripts/zones/Port_Bastok/DefaultActions.lua
+++ b/scripts/zones/Port_Bastok/DefaultActions.lua
@@ -11,7 +11,7 @@ return {
     ['Evi']          = { event = 21 },
     ['Gudav']        = { event = 31 },
     ['Hilda']        = { event = 48 },
-    ['Juroro']       = { event = 253 },
+    -- ['Juroro']       = { event = 253 },
     ['Kurando']      = { event = 28 },
     ['Latifah']      = { event = 13 },
     ['Mine_Konte']   = { event = 42 },

--- a/scripts/zones/Port_Bastok/npcs/Juroro.lua
+++ b/scripts/zones/Port_Bastok/npcs/Juroro.lua
@@ -55,6 +55,8 @@ entity.onTrigger = function(player, npc)
         end  -- Ability to summon Titan
 
         player:startEvent(252, 0, xi.ki.TUNING_FORK_OF_EARTH, 1, 0, numitem)
+    else
+        player:startEvent(253)
     end
 end
 

--- a/scripts/zones/Port_Jeuno/npcs/Shami.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Shami.lua
@@ -127,10 +127,8 @@ entity.onTrigger = function(player, npc)
         player:startEvent(317)
     elseif beastmensSeal + kindredsSeal + kindredsCrest + highKindredsCrest + sacredKindredsCrest == 0 then
         player:startEvent(23) -- Standard dialog ?
-    elseif xi.settings.main.ENABLE_ABYSSEA == 1 then
-        player:startEvent(322, (kindredsSeal * 65536) + beastmensSeal, (highKindredsCrest * 65536) + kindredsCrest, 0, 0, 1, 0, 0) -- Standard dialog with menu
     else
-        player:startEvent(322, (kindredsSeal * 65536) + beastmensSeal, 0, 0, 0, 1, 0, 0) -- WoTG Era Dialogue
+        player:startEvent(322, (kindredsSeal * 65536) + beastmensSeal, 0, 0, 0, 1, 0, 0)
     end
 end
 

--- a/scripts/zones/Port_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Port_San_dOria/DefaultActions.lua
@@ -21,6 +21,7 @@ return {
     ['Noquerelle']   = { event = 583 },
     ['Parcarin']     = { event = 566 },
     ['Phersula']     = { event = 545 },
+    ['Portaure']     = { event = 649 },
     ['Rielle']       = { event = 564 },
     ['Sheridan']     = { event = 572 },
     ['Solgierte']    = { event = 567 },

--- a/scripts/zones/Southern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Southern_San_dOria/DefaultActions.lua
@@ -4,6 +4,7 @@ return {
     ['Amaura']      = { event = 642 },
     ['Atelloune']   = { event = 884 },
     ['Hae_Jakhya']  = { event = 610 },
+    -- ['Hinaree']     = { event = 0 }, -- Needs new data
     ['Rosel']       = { text = ID.text.ROSEL_GREETINGS },
     ['Sobane']      = { text = ID.text.SOBANE_DIALOG },
     ['Valderotaux'] = { event = 58 },

--- a/scripts/zones/Southern_San_dOria/npcs/Hinaree.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Hinaree.lua
@@ -12,6 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
+    player:startEvent(580)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Southern_San_dOria/npcs/Hinaree.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Hinaree.lua
@@ -12,7 +12,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(580)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/sql/mob_family_system.sql
+++ b/sql/mob_family_system.sql
@@ -110,7 +110,7 @@ INSERT INTO `mob_family_system` VALUES (57,'Buffalo',33,'Buffalo',6,'Beast',2,40
 INSERT INTO `mob_family_system` VALUES (58,'Bugard',34,'Bugard',14,'Lizard',1,40,115,110,4,4,4,4,4,4,4,1,3,1,3,1,2,0);
 INSERT INTO `mob_family_system` VALUES (59,'Bugbear',35,'Bugbear',7,'Beastmen',1,40,125,90,3,2,5,2,6,4,5,1,2,1,3,5,1,0);
 INSERT INTO `mob_family_system` VALUES (60,'CaitSith',36,'CaitSith',5,'Avatar',0,40,100,120,3,3,3,3,3,3,3,1,3,1,3,0,1,0);
-INSERT INTO `mob_family_system` VALUES (61,'Cardian',37,'Cardian',3,'Arcana',0,40,109,140,1,3,4,5,4,4,3,1,3,1,3,6,34,0);
+INSERT INTO `mob_family_system` VALUES (61,'Cardian',37,'Cardian',3,'Arcana',0,40,109,140,1,3,4,5,4,4,3,1,3,1,3,7,34,0);
 INSERT INTO `mob_family_system` VALUES (62,'Cerberus',38,'Cerberus',6,'Beast',3,80,100,90,1,1,3,1,1,1,2,1,3,1,3,1,2,0);
 INSERT INTO `mob_family_system` VALUES (63,'Chariot',39,'Chariot',4,'ArchaicMachine',3,40,90,90,1,3,4,3,6,6,5,1,3,1,3,0,34,0);
 INSERT INTO `mob_family_system` VALUES (64,'Chigoe',40,'Chigoe',20,'Vermin',0,40,120,90,3,2,1,6,6,4,5,1,3,1,3,4,3,0);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1424,7 +1424,7 @@ INSERT INTO `mob_skills` VALUES (1522,1082,'energy_screen',0,10,2000,1500,1,0,0,
 INSERT INTO `mob_skills` VALUES (1523,1083,'mana_screen',0,10,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1524,1084,'dissipation',2,20.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1525,1090,'guided_missile_ii',2,5.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1526,1085,'colossal_blow',0,10.0,2000,3000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1526,1085,'colossal_blow',0,10.0,2000,3000,4,0,0,10,0,0,0);
 INSERT INTO `mob_skills` VALUES (1527,1086,'laser_shower',4,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1528,1087,'floodlight',2,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1529,1089,'hyper_pulse',1,10.0,2000,1500,4,0,0,0,0,0,0); -- Proto-Omega


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Shu'Meyo salt wasn't affecting Snoll Tzar
- Gives Portaure correct default dialogue
- Shami lua clean up
- Fixes cardians to properly drop light crystals instead of water
- Fixes Serket's Stasis abliity to be blocked by shadows
- Gives Proto-Omega's Colossal Blow knockback
- Fixes Jack of Spades spawn point
- Temporarily prevents players needing to talk to Juroro twice Fixes out of era vendor inventory: https://www.bg-wiki.com/index.php?title=Pikini-Mikini&oldid=133111

Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/787
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1026
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1162
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1208
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1216
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1275
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1442
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/1633
