### PR TITLE
Adding missing key item to 8-2 CS

### DIFF
--- a/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
+++ b/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
@@ -291,7 +291,7 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 0 then
-                        return mission:progressEvent(588)
+                        return mission:progressEvent(588, 0, xi.ki.MANUSTERY_RING)
                     elseif missionStatus == 2 then
                         return mission:progressEvent(601, 0, xi.ki.ORASTERY_RING)
                     elseif missionStatus == 6 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing key item to Apururu's cutscene for Windurst mission 8-2.
`Apururu: After learning this, I took the Manustery ring and set off for the Dark Dungeon...`
https://ffxiclopedia.fandom.com/wiki/The_Jester_Who%27d_Be_King/Plot_Details
Closes #1916

## Steps to test these changes

!cs 588 0 281