### PR TITLE
Update navmesh submodule to utilize new navmesh repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "navmeshes"]
 	path = navmeshes
-	url = https://github.com/LandSandBoat/xiNavmeshes.git
+	url = https://github.com/AirSkyBoat/xiNavmeshes.git
 [submodule "documentation/wiki"]
 	path = documentation/wiki
 	url = https://github.com/LandSandBoat/server.wiki.git

--- a/modules/era/sql/era_zone_settings.sql
+++ b/modules/era/sql/era_zone_settings.sql
@@ -4,4 +4,18 @@ ALTER TABLE `zone_settings`
     ADD COLUMN IF NOT EXISTS `updatedmesh` tinyint(1) unsigned NOT NULL DEFAULT '0' AFTER `misc`,
     ADD COLUMN IF NOT EXISTS `forcecarefulpathing` tinyint(1) unsigned NOT NULL DEFAULT '0' AFTER `updatedmesh`;
 
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 146;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 149;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 185;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 188;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 100;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 101;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 106;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 107;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 115;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 116;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 10;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 139;
+UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 128;
+
 UNLOCK TABLES;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Updates the navmesh submodule to point to new ASB navmesh repository
- Cleaned up and corrected navmesh for the following zones:
  - Balgas_Dais
  - Davoi
  - Dynamis-Jeuno
  - Dynamis-San_dOria
  - East_Ronfaure
  - East_Sarutabaruta
  - Horlais_Peak
  - North_Gustaberg
  - South_Gustaberg
  - The_Shrouded_Maw
  - Valley_of_Sorrows
  - West_Ronfaure
  - West_Sarutabaruta
- Updated era_zone_settings.sql to enable settings to utilize the new navmeshes properly

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
