### PR TITLE
Move Crafting Messages Off Linkshell 3

### DIFF
--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -486,7 +486,7 @@ xi.crafting.unionRepresentativeTriggerFinish = function(player, option, target, 
             else
                 player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6)
                 if ki.cost == 999999 then
-                    player:PrintToPlayer("This key item is out of era, no points have been deducted.", xi.msg.channel.NS_LINKSHELL3, "")
+                    player:PrintToPlayer("This key item is out of era, no points have been deducted.", xi.msg.channel.UNKNOWN_32, "")
                 end
             end
         end
@@ -514,7 +514,7 @@ xi.crafting.unionRepresentativeTriggerFinish = function(player, option, target, 
             else
                 player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6)
                 if cost == 999999 then
-                    player:PrintToPlayer("This item is out of era, no points have been deducted.", xi.msg.channel.NS_LINKSHELL3, "")
+                    player:PrintToPlayer("This item is out of era, no points have been deducted.", xi.msg.channel.UNKNOWN_32, "")
                 end
             end
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Moves crafting messages off of linkshell 3.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
