### PR TITLE
Final ASB fixes before launch

### DIFF
--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -736,15 +736,24 @@ xi.job_utils.dragoon.pickAndUseDamageBreath = function(player, target)
     }
 
     local lowest = resistances[1]
-    local breath = breathList[1]
+    local breath = breathList[math.random(#breathList)]
+    local head = player:getEquippedItem(xi.slot.HEAD)
 
-    -- https://www.bg-wiki.com/ffxi/Wyvern_(Dragoon_Pet)#Elemental_Breath
-    -- The wyvern simply picks the lowest resistance breath and no longer relies on Drachen Armet et al
-    -- if all resistances are equal, Flame Breath is picked first.
-    for i, v in ipairs(breathList) do
-        if resistances[i] < lowest then
-            lowest = resistances[i]
-            breath = v
+    -- https://ffxiclopedia.fandom.com/wiki/Drachen_Armet?oldid=965925
+    -- https://ffxiclopedia.fandom.com/wiki/Elemental_Breath?oldid=738854
+    -- The wyvern picks breath based on the lowest resistance if the player has Drachen Armet equipped.
+    -- If all resistances are equal, a random breath is used.
+    -- However there innately exists a chance where wyvern use breath based on weakness.
+    if
+        head == xi.items.DRACHEN_ARMET or
+        head == xi.items.DRACHEN_ARMET_P1 or
+        math.random() < 0.5
+    then
+        for i, v in ipairs(breathList) do
+            if resistances[i] < lowest then
+                lowest = resistances[i]
+                breath = v
+            end
         end
     end
 

--- a/scripts/quests/crystalWar/Message_on_the_Winds.lua
+++ b/scripts/quests/crystalWar/Message_on_the_Winds.lua
@@ -27,6 +27,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == QUEST_AVAILABLE and
+                xi.settings.main.ENABLE_WOTG and
                 player:getMainLvl() >= 20
         end,
 

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -4013,7 +4013,7 @@ INSERT INTO `mob_skill_lists` VALUES ('Boggelman',4046,384);
 INSERT INTO `mob_skill_lists` VALUES ('Boggelman',4046,385);
 INSERT INTO `mob_skill_lists` VALUES ('Boggelman',4046,386);
 INSERT INTO `mob_skill_lists` VALUES ('Boggelman',4046,387);
-INSERT INTO `mob_skill_lists` VALUES ('Boggelman',4046,822);
+INSERT INTO `mob_skill_lists` VALUES ('Boggelman',4046,1363);
 
 INSERT INTO `mob_skill_lists` VALUES ('JailerOfTemperance',4047,1463);
 INSERT INTO `mob_skill_lists` VALUES ('JailerOfTemperance',4047,1465);


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Boggelman was using Chaos breath instead of Hungry Crunch
- Players were triggering quests from WOTG and blocking them from other quests
- Fixes out of era wyvern breath behavior. Wyvern's elemental breath will target mobs weakness 50% of the time, and random otherwise as estimated by wiki. However if players have drachen armet equipped, the wyvern will use a breath attacked based from mob's weaknesses.

Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/444
Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/468
Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/491
