### PR TITLE
Fixed mission list to require 1-2 for 1-3

### DIFF
--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -757,6 +757,12 @@ xi.mission.getMissionMask = function(player)
 
         -- All repeatable missions are skippable as well, so track the required
         -- missions, and only add to mask if rank and required are met
+
+        -- If 1-3 (mId 2), require 1-2 (mId 1)
+        if missionId == 2 and not player:hasCompletedMission(nation, 1) then
+            break
+        end
+
         if
             missionId >= lastRequiredMission and
             (


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Rank 1 mission list was showing 1-3 before 1-2 was completed, so I fixed it. It was very difficult to fit this into the existing condition (Which has 6 different comparisons) so I created one separate for Rank 1, as it is a special case.

I've tested several variations but this probably needs more thorough attention as it is such core functionality. Either way, it would suck to miss this for Horizon release and have everyone skipping missions that shouldn't be skipped.

Closes #2170

## Steps to test these changes

Area: Northern San d'Oria
NPC: Grilau
!pos -241.987 6.999 57.887 231
!reloadglobal missions

Mission list should read:
```
Orcish Scouts (1-1)
```

Complete mission 1-1:
```
!addmission 0 1 <name>
!completemission 0 1 <name>
```

Mission list should now read:
```
Orcish Scouts (1-1)
Bat Hunt (1-2)
```

Complete mission 1-2:
```
!addmission 1 1 <name>
!completemission 1 1 <name>
```

Mission list should now read:
```
Orcish Scouts (1-1)
Bat Hunt (1-2)
Save the Children (1-3) 
```