### PR TITLE
Fixed Shantotto quest reward

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -4078,6 +4078,7 @@ xi.items =
     MAPLE_WAND                      = 17049,
     CADUCEUS                        = 17058,
     EARTH_WAND                      = 17076,
+    BRASS_ROD                       = 17081,
     MISERY_STAFF                    = 17116,
     HYPNO_STAFF                     = 17117,
     SHORTBOW                        = 17152,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

BRASS_ROD was missing from globals, preventing the quest reward from being given for Curses, Foiled Again!

Closes #1246

## Steps to test these changes
!delquest 2 32
(If needed)

!additem bone_chip 2
!additem pinch_of_bomb_ash
!addquest 2 32
Shantotto : !pos 122 -2 112 239