### PR TITLE
Tagged Tutorial NPCs (WOTG) as 'TUTORIAL' and added setting to main.lua

### DIFF
--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -250,6 +250,7 @@ xi.settings.main =
     FORCE_SPAWN_QM_RESET_TIME    = 900,  -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.
     GOBBIE_BOX_MIN_AGE           = 45,   -- Minimum character age in days before a character can sign up for Gobbie Mystery Box
     MAP_VENDORS_ALL_MAPS         = false, -- If true, all map vendors can sell all vendorable maps
+    ENABLE_TUTORIAL              = false, -- If true, enable Tutorial NPCs (WotG): Alaune (17719618), Gulldago (17739939), Selele (17764600)
 
     -- Synergy
     ENABLE_SYNERGY = 0, -- Default to off as Synergy is not coded


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Tutorial NPCs were added during WOTG and shouldn't be there if WOTG is disabled.
https://ffxiclopedia.fandom.com/wiki/Tutorial_NPC
https://ffxiclopedia.fandom.com/wiki/Tutorial_NPC?action=history

DAT mod needed for Adventurer Coupon NPCs who reference the Tutorial NPCs by name after receiving the Coupon. Example:

```
Ailevia: You will find a guardswoman named Alaune at the Westgate, south west from here. She has further information that should prove useful in your adventuring.
```

Closes #2166

## Steps to test these changes

settings/main.lua
```
    RESTRICT_CONTENT = 1,
    ENABLE_WOTG      = 0,
```

Should not work with WOTG off:
```
Alaune
!gotoid 17719618

Gulldago
!gotoid 17739939

Selele
!gotoid 17764600
```