### PR TITLE
Tagged and added setting for Explorer Moogles

### DIFF
--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -72,6 +72,9 @@ xi.settings.main =
     MAGIAN_TRIALS_MOBKILL_MULTIPLIER = 1,
     MAGIAN_TRIALS_TRADE_MULTIPLIER   = 1,
 
+    -- Explorer Moogles
+    ENABLE_EXPLORERMOOGLE = false,
+
     -- VoidWalker
     ENABLE_VOIDWALKER = 0,
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Explorer Moogles were hidden through status instead of content tag (One in Jeuno had a different status and was still visible). I added a new content tag and associated setting to settings/main.lua. Status was fixed and all Explorer Moogles were tagged. Tested in game with both settings.

```lua
    -- Explorer Moogles
    ENABLE_EXPLORERMOOGLE = true,
```

Tag was shortened to this (From EXPLORER_MOOGLES) due to content_tags being truncated at 14 chars.

Closes #1421

## Steps to test these changes

```
Selbina
!gotoid 17793131

Mhaura
!gotoid 17797253

Northern San d'Oria
!gotoid 17723648

Bastok Mines
!gotoid 17735856

Port Windurst
!gotoid 17760450

Ru'Lude Gardens
!gotoid 17772773
```
