### PR TITLE
Fix Ru'Lude Gardens Moghouse

### DIFF
--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -351,3 +351,22 @@ xi.moghouse.onEventFinishRentARoom = function(player, csid, option)
         end
     end
 end
+
+xi.moghouse.isRented = function(player)
+    local playerzone = player:getZoneID()
+    local isrentexempt = (playerzone >= xi.zone.SOUTHERN_SAN_DORIA_S and playerzone <= xi.zone.WINDURST_WATERS_S) or (playerzone >= xi.zone.WESTERN_ADOULIN and playerzone <= xi.zone.EASTERN_ADOULIN)
+
+    if isrentexempt or not xi.settings.map.RENT_A_ROOM then
+        return true
+    end
+
+    local playerregion = player:getZone():getRegionID()
+    local ishomenation = playerregion == xi.moghouse.nationRegionBits[player:getNation()]
+    local isrentedcity = playerregion == player:getCharVar("[Moghouse]Rent-a-room")
+
+    if xi.settings.map.RENT_A_ROOM and utils.ternary(xi.settings.map.ERA_RENT_A_ROOM, isrentedcity, ishomenation or isrentedcity) then
+        return true
+    end
+
+    return false
+end

--- a/scripts/zones/RuLude_Gardens/npcs/Elevator_Button.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Elevator_Button.lua
@@ -9,7 +9,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(75)
+    if xi.moghouse.isRented(player) then
+        player:startEvent(75)
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes Ru'Lude Gardens moghouse allowing players without changing their rent-a-room location from getting into the moghouse.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
