### PR TITLE
Fix EEM Bonus for MEVA

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -246,14 +246,16 @@ xi.magic.calculateMagicHitRate = function(magicacc, magiceva, target, element, s
     local eemTier = 0
     local resBuild = 0
     local mevaMult = 1
+    local eemBonus = 0
 
     if target and element and element ~= xi.magic.ele.NONE and target:isMob() then
         eemTier = xi.magic.calculateEEMTier(target, element, skillchainCount)
         resBuild = utils.ternary(target:isNM() and isDamageSpell, xi.magic.tryBuildResistance(target, xi.magic.resistMod[element], false, caster), 0)
         mevaMult = xi.magic.calculateMEVAMult(utils.clamp(eemTier + resBuild, -3, 11))
+        eemBonus = (target:getMod(xi.mod.MEVA) * mevaMult) - target:getMod(xi.mod.MEVA)
     end
 
-    local magicAccDiff = magicacc - math.floor((magiceva * mevaMult) + 0.5) -- Rounds to the nearest integer. LuaJIT does not have a math.round so this is a workaround.
+    local magicAccDiff = magicacc - math.floor(magiceva + eemBonus + 0.5) -- Rounds to the nearest integer. LuaJIT does not have a math.round so this is a workaround.
 
     if magicAccDiff < 0 then
         p = utils.clamp(((50 + math.floor(magicAccDiff / 2))), 5, 95)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixes an issue where EEM was multiplying the entire magiceva value after dstat and level correction rather than base modifier. 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
