### PR TITLE
Add Additional Error Checking to weaponskills.lua

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -239,7 +239,11 @@ xi.weaponskills.getRangedHitRate = function(attacker, target, capHitRate, bonus,
         bonus = 0
     end
 
-    if wsParams and wsParams.acc100 ~= 0 then
+    local acc100 = wsParams.acc100 or 0
+    local acc200 = wsParams.acc200 or 0
+    local acc300 = wsParams.acc300 or 0
+
+    if acc100 ~= 0 and acc200 ~= 0 and acc300 ~= 0 then
         if calcParams.tp >= 3000 then
             accVarryTP = (wsParams.acc300 - 1) * 100
         elseif calcParams.tp >= 2000 then
@@ -1006,7 +1010,11 @@ xi.weaponskills.getHitRate = function(attacker, target, capHitRate, bonus, isSub
     local flourisheffect = attacker:getStatusEffect(xi.effect.BUILDING_FLOURISH)
     local accVarryTP = 0
 
-    if wsParams and wsParams.acc100 ~= 0 then
+    local acc100 = wsParams.acc100 or 0
+    local acc200 = wsParams.acc200 or 0
+    local acc300 = wsParams.acc300 or 0
+
+    if acc100 ~= 0 and acc200 ~= 0 and acc300 ~= 0 then
         if calcParams.tp >= 3000 then
             accVarryTP = wsParams.acc300 - 1
         elseif calcParams.tp >= 2000 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Add additional error checking to weaponskills.lua for nil acc or acc 0 values.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
