### PR TITLE
Fix garrison npc levels and loot tables

### DIFF
--- a/modules/era/sql/era_mob_droplist.sql
+++ b/modules/era/sql/era_mob_droplist.sql
@@ -26323,8 +26323,8 @@ INSERT INTO `mob_droplist` VALUES (3222,2,0,1000,1452,0);         -- Ordelle Bro
 INSERT INTO `mob_droplist` VALUES (3222,2,0,1000,1455,0);         -- One Byne Bill (Steal)
 
 -- Garrison Drops
-INSERT INTO `mob_droplist` VALUES (3226,1,1,@UNCOMMON,1604,500); -- (Garrison) Mannequin Legs (Group 1 - Uncommon, 10% * 50%)
-INSERT INTO `mob_droplist` VALUES (3226,1,1,@UNCOMMON,1605,500); -- (Garrison) Mannequin Feet (Group 1 - Uncommon, 10% * 50%)
+INSERT INTO `mob_droplist` VALUES (3226,1,1,@RARE,1604,500); -- (Garrison) Mannequin Legs (Group 1 - Rare, 5% * 50%)
+INSERT INTO `mob_droplist` VALUES (3226,1,1,@RARE,1605,500); -- (Garrison) Mannequin Feet (Group 1 - Rare, 5% * 50%)
 
 -- ZoneID: 115 - Crawler (Starfall Hillock)
 INSERT INTO `mob_droplist` VALUES (3227,0,0,1000,816,@UNCOMMON);  -- Spool Of Silk Thread (Uncommon, 10%)

--- a/modules/era/sql/era_mob_elemental_evasion.sql
+++ b/modules/era/sql/era_mob_elemental_evasion.sql
@@ -971,6 +971,7 @@ UPDATE `mob_pools` SET `ele_eva_id` = 146 WHERE `poolid` = 5008; -- Frenzied Man
 UPDATE `mob_pools` SET `ele_eva_id` = 43 WHERE `poolid` = 6424; -- Funnel Bats
 UPDATE `mob_pools` SET `ele_eva_id` = 176 WHERE `poolid` = 1462; -- Gargouille
 UPDATE `mob_pools` SET `ele_eva_id` = 250 WHERE `poolid` = 1463; -- Gargoyle
+UPDATE `mob_pools` SET `ele_eva_id` = 164 WHERE `poolid` = 20001; -- Garrison allies
 UPDATE `mob_pools` SET `ele_eva_id` = 365 WHERE `poolid` = 1473; -- Garuda Prime
 UPDATE `mob_pools` SET `ele_eva_id` = 345 WHERE `poolid` = 4647; -- Garuda Prime
 UPDATE `mob_pools` SET `ele_eva_id` = 103 WHERE `poolid` = 5179; -- Gasha

--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -95,6 +95,7 @@ xi.garrison.aggroGroups = function(group1, group2)
             if entity1 == nil or entity2 == nil then
                 printf("[warning] Could not apply aggro because either %i or %i are not valid entities", entityId1, entityId2)
             else
+                debugLogf("Applying enmity: %i <-> %i", entityId1, entityId2)
                 entity1:addEnmity(entity2, math.random(1, 5), math.random(1, 5))
                 entity2:addEnmity(entity1, math.random(1, 5), math.random(1, 5))
             end
@@ -104,7 +105,7 @@ end
 
 -- Spawns and npc for the given zone and with the given name, look, pose
 -- Uses dynamic entities
-xi.garrison.spawnNPC = function(zone, zoneData, x, y, z, rot, name, look)
+xi.garrison.spawnNPC = function(zone, zoneData, x, y, z, rot, name, groupId, look)
     local mob = zone:insertDynamicEntity({
         objtype = xi.objType.MOB,
         allegiance = xi.allegiance.PLAYER,
@@ -115,7 +116,7 @@ xi.garrison.spawnNPC = function(zone, zoneData, x, y, z, rot, name, look)
         rotation = rot,
         look = look,
 
-        groupId = 1,
+        groupId = groupId,
         groupZoneId = xi.zone.GM_HOME,
 
         releaseIdOnDeath = true,
@@ -156,11 +157,16 @@ xi.garrison.spawnNPCs = function(zone, zoneData)
     local regionIndex = GetRegionOwner(zone:getRegionID()) + 1
     local allyName    = xi.garrison.allyNames[zoneData.levelCap][regionIndex]
     local allyLooks   = xi.garrison.allyLooks[zoneData.levelCap][regionIndex]
+    local allyGroupId = xi.garrison.allyGroupIds[zoneData.levelCap]
+    debugLogf("Spawning %d npcs. GroupId: %d", #zoneData.players, allyGroupId)
 
     -- Spawn 1 npc per player in alliance
     for i = 1, #zoneData.players do
-        local mob = xi.garrison.spawnNPC(zone, zoneData, xPos, yPos, zPos, rot, allyName, utils.randomEntry(allyLooks))
-        mob:setMobLevel(zoneData.levelCap - math.floor(zoneData.levelCap / 5))
+        local mob = xi.garrison.spawnNPC(zone, zoneData, xPos, yPos, zPos, rot, allyName, allyGroupId, utils.randomEntry(allyLooks))
+        -- Note: This does change the mob level because ally npcs are of type mob, and
+        -- level_restriction is only applied to PCs. However, we need the status to validate that the
+        -- npcs are part of the garrison.
+        -- Because the npcs are not level capped, group ids should be used to define min / max level.
         xi.garrison.addLevelCap(mob, zoneData.levelCap)
         table.insert(zoneData.npcs, mob:getID())
 
@@ -603,7 +609,8 @@ xi.garrison.getSpawnSchedule = function(player)
     local spawnSchedule = xi.garrison.waves.spawnSchedule[numParties]
 
     if spawnSchedule == nil then
-        printf("[warning] Spawn schedule not found for number of parties: %d", numParties)
+        -- Leave the log there even if valid most times, because it may help us cause bad use cases
+        debugLogf("[warning] Spawn schedule not found for number of parties: %d. Ignore if player has no party.", numParties)
         spawnSchedule = xi.garrison.waves.spawnSchedule[1]
     end
 

--- a/scripts/globals/garrison_data.lua
+++ b/scripts/globals/garrison_data.lua
@@ -19,6 +19,18 @@ xi.garrison.allyNames =
     [75] = { "MilitaryAttache", "MilitaryAttache", "MilitaryAttache" },
 }
 
+-- Group Ids are different per cap due to min / max level requirements
+-- They all use the same pool at the moment, but we could also change families
+-- based on cap, which would change base stats
+xi.garrison.allyGroupIds =
+{
+    [20] = 1,
+    [30] = 2,
+    [40] = 3,
+    [50] = 4,
+    [75] = 5,
+}
+
 -- Look is Determined by Nation and LevelCap (Appears to be 4 for each outpost need more data though)
 xi.garrison.allyLooks =
 {

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -13297,8 +13297,13 @@ INSERT INTO `mob_groups` VALUES (7,6954,209,'Titan_Prime_HTBF',0,128,0,0,0,99,99
 -- GM Zone (Zone 210)
 -- ------------------------------------------------------------
 
--- Garrison npc
-INSERT INTO `mob_groups` VALUES (1,20001,210,'Garrison',0,129,0,0,0,30,35,1); -- we need 1 base model
+-- Garrison npcs (1 per cap). These are inserted dynamically. Only min/max level matters.
+-- Consider adding a dynamic entitiy spawn param for min / max level so we only need 1 base mob group.
+INSERT INTO `mob_groups` VALUES (1,20001,210,'Garrison_20',0,129,0,0,0,15,20,1);
+INSERT INTO `mob_groups` VALUES (2,20001,210,'Garrison_30',0,129,0,0,0,25,30,1);
+INSERT INTO `mob_groups` VALUES (3,20001,210,'Garrison_40',0,129,0,0,0,35,40,1);
+INSERT INTO `mob_groups` VALUES (4,20001,210,'Garrison_50',0,129,0,0,0,45,50,1);
+INSERT INTO `mob_groups` VALUES (5,20001,210,'Garrison_75',0,129,0,0,0,70,75,1);
 
 -- ------------------------------------------------------------
 -- Cloister_of_Tides (Zone 211)

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1573,6 +1573,11 @@ Usage:
                 mobutils::InitializeMob(PMob, zoneutils::GetZone(targetZoneId));
             }
         }
+        else
+        {
+            ShowError("Unable to find entity with groupId: %d, zoneId: %d. Check that mob_pools.ele_eva_id, group and zoneid match.", groupid, groupZoneId);
+        }
+
         return PMob;
     }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes garrison npc levels so they can be adjusted with group ids
- Reduces mannequin drop rates to 5%
- Adds logging when dynamic entity cannot be found

## Steps to test these changes

Play garrison in different areas and use !getstats to check the npc level
