### PR TITLE
Allow Mog House Exit quest completion during event

### DIFF
--- a/scripts/zones/Northern_San_dOria/npcs/Kuu_Mohzolhi.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Kuu_Mohzolhi.lua
@@ -6,18 +6,21 @@
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/quests")
+require("scripts/globals/items")
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
 require("scripts/globals/events/starlight_celebrations")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if xi.events.starlightCelebration.isStarlightEnabled() ~= 0 then
-        xi.events.starlightCelebration.onStarlightSmilebringersTrade(player, trade, npc)
+    if not trade:hasItemQty(xi.items.MARGUERITE, 1) then            -- Marguerite
+        if xi.events.starlightCelebration.isStarlightEnabled() ~= 0 then
+            xi.events.starlightCelebration.onStarlightSmilebringersTrade(player, trade, npc)
 
-        return
+            return
+        end
+        local itemQuality = 0
     end
-    local itemQuality = 0
 
     if trade:getItemCount() == 1 and trade:getGil() == 0 then
         if trade:hasItemQty(958, 1) then            -- Marguerite

--- a/scripts/zones/Northern_San_dOria/npcs/Kuu_Mohzolhi.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Kuu_Mohzolhi.lua
@@ -13,14 +13,12 @@ require("scripts/globals/events/starlight_celebrations")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if not trade:hasItemQty(xi.items.MARGUERITE, 1) then            -- Marguerite
-        if xi.events.starlightCelebration.isStarlightEnabled() ~= 0 then
-            xi.events.starlightCelebration.onStarlightSmilebringersTrade(player, trade, npc)
+    if xi.events.starlightCelebration.isStarlightEnabled() ~= 0 and not trade:hasItemQty(xi.items.MARGUERITE, 1) then
+        xi.events.starlightCelebration.onStarlightSmilebringersTrade(player, trade, npc)
 
-            return
-        end
-        local itemQuality = 0
+        return
     end
+    local itemQuality = 0
 
     if trade:getItemCount() == 1 and trade:getGil() == 0 then
         if trade:hasItemQty(958, 1) then            -- Marguerite


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This file needs to be completely refactored using a table and shared between the different Mog House Exit quest NPCs, there are a many dialog outcomes to be considered.

**However, to avoid introducing a bunch of potential issues, I just did a quick fix so players are still able to trade the required flower during the event, as this is blocking important functionality for new players.**

I'll come back to this in a future PR if nobody else picks up.

https://ffxiclopedia.fandom.com/wiki/Growing_Flowers

I checked the Bastok and Windust equivalents and they do not have the Starlight Celebration condition blocking their quests.

This can be hotfixed on live server.

Closes #2228 

## Steps to test these changes

!pos -123 0 80 231
!additem marguerite