### PR TITLE
Fix draw-in for simurgh and roc

### DIFF
--- a/scripts/zones/Rolanberry_Fields/mobs/Simurgh.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Simurgh.lua
@@ -13,21 +13,12 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:addMod(xi.mod.SLEEPRES, 100)
+end
+
+entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.DRAW_IN, 1)
-end
-
-entity.onMobEngaged = function(mob, target)
-    mob:setLocalVar("drawInTime", os.time() + 20)
-end
-
-entity.onMobFight = function(mob, target)
-    -- Draws in targeted member every 8 to 20 seconds
-    local drawInTime = mob:getLocalVar("drawInTime")
-
-    if os.time() > drawInTime then
-        mob:triggerDrawIn(mob, false, 1, 35, target)
-        mob:setLocalVar("drawInTime", os.time() + math.random(8, 20))
-    end
+    -- custom distance from retail capture
+    mob:setMobMod(xi.mobMod.DRAW_IN_CUSTOM_RANGE, 34)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Sauromugue_Champaign/mobs/Roc.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Roc.lua
@@ -11,8 +11,10 @@ require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
-entity.onMobInitialize = function(mob)
+entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    -- custom distance from retail capture
+    mob:setMobMod(xi.mobMod.DRAW_IN_CUSTOM_RANGE, 34)
 end
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fix simurgh and roc draw-in mechanism to be in line with retail capture and era videos

## Steps to test these changes
