### PR TITLE
Fix several issues with in a pickle quest

### DIFF
--- a/scripts/quests/windurst/In_a_Pickle.lua
+++ b/scripts/quests/windurst/In_a_Pickle.lua
@@ -2,7 +2,7 @@
 -- In a Pickle
 -----------------------------------
 -- !addquest 2 5
--- Hariga-Origa : !pos -70.244,-3.800,-4.439
+-- Hariga-Origa : !pos -70.244, -3.800, -4.439
 -----------------------------------
 require('scripts/globals/interaction/quest')
 require('scripts/globals/npc_util')
@@ -14,9 +14,10 @@ local quest = Quest:new(xi.quest.log_id.WINDURST, xi.quest.id.windurst.IN_A_PICK
 
 quest.reward =
 {
-    gil = 200,
-    fame = 8,
+    fame = 75,
     fameArea = xi.quest.fame_area.WINDURST,
+    item = xi.items.BONE_HAIRPIN,
+    itemParams = { fromTrade = true, }
 }
 
 quest.sections =
@@ -54,6 +55,7 @@ quest.sections =
                     if npcUtil.tradeHasExactly(trade, xi.items.SMOOTH_STONE) then
                         local rand = math.random(1, 4)
                         if rand <= 2 then
+                            player:confirmTrade()
                             return quest:progressEvent(659)
                         elseif rand == 3 then
                             player:confirmTrade()
@@ -74,10 +76,7 @@ quest.sections =
             {
                 [659] = function(player, csid, option, npc)
                     if quest:complete(player) then
-                        player:confirmTrade()
                         player:needToZone(true)
-                        npcUtil.giveItem(player, xi.items.BONE_HAIRPIN)
-                        player:addFame(xi.quest.fame_area.WINDURST, 75)
                     end
                 end,
             },
@@ -94,16 +93,19 @@ quest.sections =
             ['Chamama'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.items.SMOOTH_STONE) then
-                        local rand = math.random(1, 4)
-                        if rand <= 2 then
-                            return quest:progressEvent(662, 200)
-                        elseif rand == 3 then
-                            player:confirmTrade()
-                            return quest:progressEvent(657) -- IN A PICKLE: Too Light
-                        elseif rand == 4 then
-                            player:confirmTrade()
-                            return quest:progressEvent(658) -- IN A PICKLE: Too Small
+                    if quest:getVar(player, 'repeat') == 1 then
+                        if npcUtil.tradeHasExactly(trade, xi.items.SMOOTH_STONE) then
+                            local rand = math.random(1, 4)
+                            if rand <= 2 then
+                                player:confirmTrade()
+                                return quest:progressEvent(662, 200)
+                            elseif rand == 3 then
+                                player:confirmTrade()
+                                return quest:progressEvent(657) -- IN A PICKLE: Too Light
+                            elseif rand == 4 then
+                                player:confirmTrade()
+                                return quest:progressEvent(658) -- IN A PICKLE: Too Small
+                            end
                         end
                     end
                 end,
@@ -127,10 +129,10 @@ quest.sections =
                 end,
 
                 [662] = function(player, csid, option, npc)
-                    player:confirmTrade()
                     player:needToZone(true)
                     quest:setVar(player, 'repeat', 0)
                     player:addFame(xi.quest.fame_area.WINDURST, 8)
+                    player:addGil(200)
                 end,
             },
         },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes the following issues with quest
- gives the correct rewards the first time the quest is completed
- confirms the trade before giving the hairpin so no issue with inventory space if inventory is full when trading (otherwise players could get inventory full message and then when they trade again the stone is too small or too large which does not make sense)
- actually give the gil for repeating the quest
- make the the player accepts the quest each repeated time before npc accepts a trade

## Steps to test these changes