### PR TITLE
Adjusted fame reward values for Gourmet quest

### DIFF
--- a/scripts/quests/bastok/Gourmet.lua
+++ b/scripts/quests/bastok/Gourmet.lua
@@ -15,7 +15,7 @@ local quest = Quest:new(xi.quest.log_id.BASTOK, xi.quest.id.bastok.GOURMET)
 
 quest.reward =
 {
-    fame     = 30,
+    fame     = 10,
     fameArea = xi.quest.fame_area.BASTOK,
     title    = xi.title.MOMMYS_HELPER,
 }
@@ -103,11 +103,11 @@ quest.sections =
             onEventFinish =
             {
                 [201] = function(player, csid, option, npc)
-                    tradeEventFinish(player, 200, 30)
+                    tradeEventFinish(player, 200, 0) -- Original: 30
                 end,
 
                 [202] = function(player, csid, option, npc)
-                    tradeEventFinish(player, 350, 90)
+                    tradeEventFinish(player, 350, 0) -- Original: 90
                 end,
 
                 [203] = function(player, csid, option, npc)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Nullifies the fame bonus for completing the quest repeatedly.  Only base fame gets applied each time.

## Steps to test these changes
