### PR TITLE
Fix mercury synths to correct eras

### DIFF
--- a/modules/era/sql/synth_recipes_era.sql
+++ b/modules/era/sql/synth_recipes_era.sql
@@ -1373,6 +1373,7 @@ UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Melanzane' AND
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Windurst Taco' AND ID = 72002;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Salmon Roe' AND ID = 72005;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Rainbow Powder' AND ID = 63503;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Mercury' AND ID = 60515;
 
 -- ------------------------------------------------------------
 -- ToAU Synths
@@ -1748,6 +1749,7 @@ UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Fire Biscuit'
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Bloody Chocolate' AND ID = 71528;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Sutlac' AND ID = 71547;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Simit' AND ID = 72008;
+UPDATE `synth_recipes` SET ContentTag = 'ToAU' WHERE ResultName = 'Mercury' AND ID = 60519;
 
 -- ------------------------------------------------------------
 -- WotG Synths
@@ -1882,8 +1884,6 @@ UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Horn Trophy' 
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Trumpet Ring' AND ID = 54539;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Dark Ixion Ferrule' AND ID = 55009;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Winged Balance' AND ID = 55012;
-UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Mercury' AND ID = 60515;
-UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Mercury' AND ID = 60519;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Matka' AND ID = 60529;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Kodoku' AND ID = 60532;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Carbon Dioxide' AND ID = 61003;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fix mercury synths to correct eras

## Steps to test these changes
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/575