### PR TITLE
Update healing_spell.lua

### DIFF
--- a/scripts/globals/spells/healing_spell.lua
+++ b/scripts/globals/spells/healing_spell.lua
@@ -17,8 +17,8 @@ xi.spells.healing = xi.spells.healing or {}
 
 xi.spells.healing.healingTable =
 {
-    [xi.magic.spell.CURE]           = { { power = 60,  maxCap = 20,  rate = 1,      constant = -10, minCap = 10  }, { power = 100, maxCap = 20,  rate = 2, constant = 5,    minCap = 10  }, { power = 999, maxCap = 30,  rate = 57,      constant = 29.125,   minCap = 10  } },
-    [xi.magic.spell.CURE_II]        = { { power = 110, maxCap = 75,  rate = 1,      constant = 20,  minCap = 60  }, { power = 170, maxCap = 75,  rate = 2, constant = 47.5, minCap = 60  }, { power = 999, maxCap = 90,  rate = 35.6666, constant = 87.62,    minCap = 60  } },
+    [xi.magic.spell.CURE]           = { { power = 60,  maxCap = 20,  rate = 1,      constant = -10, minCap = 10  }, { power = 100, maxCap = 30,  rate = 2,  constant = 5,    minCap = 10  }, { power = 999, maxCap = 30,  rate = 57, constant = 29.125,   minCap = 10  } },
+    [xi.magic.spell.CURE_II]        = { { power = 110, maxCap = 75,  rate = 1,      constant = 20,  minCap = 60  }, { power = 170, maxCap = 90,  rate = 2,  constant = 47.5, minCap = 60  }, { power = 999, maxCap = 90,  rate = 35.6666, constant = 87.62,    minCap = 60  } },
     [xi.magic.spell.CURE_III]       = { { power = 180, maxCap = 160, rate = 1,      constant = 70,  minCap = 130 }, { power = 300, maxCap = 160, rate = 2, constant = 115,  minCap = 130 }, { power = 999, maxCap = 190, rate = 15.6666, constant = 180.43,   minCap = 130 } },
     [xi.magic.spell.CURE_IV]        = { { power = 220, maxCap = 330, rate = 0.6666, constant = 165, minCap = 270 }, { power = 460, maxCap = 330, rate = 2, constant = 275,  minCap = 270 }, { power = 999, maxCap = 390, rate = 6.5,     constant = 354.6666, minCap = 270 } },
     [xi.magic.spell.CURE_V]         = { { power = 320, maxCap = 570, rate = 0.6666, constant = 330, minCap = 450 }, { power = 560, maxCap = 570, rate = 1, constant = 410,  minCap = 450 }, { power = 999, maxCap = 690, rate = 2.8333,  constant = 591.2,    minCap = 450 } },
@@ -35,9 +35,8 @@ xi.spells.healing.healingTable =
 
 xi.spells.healing.calculatePower = function(player)
     if player then
-        return 3 * player:getStat(xi.mod.MND) + player:getStat(xi.mod.VIT) + 3 * (player:getSkillLevel(xi.skill.HEALING_MAGIC) / 5)
+        return 3 * player:getStat(xi.mod.MND) + player:getStat(xi.mod.VIT) + 3 * (math.floor(player:getSkillLevel(xi.skill.HEALING_MAGIC) / 5))
     end
-
     return 0
 end
 
@@ -121,7 +120,6 @@ xi.spells.healing.applyCasterBonuses = function(caster, final, element, isWhiteM
     local equipBonuses = xi.spells.healing.getEquipBonuses(caster)
     local dwBonus = xi.spells.healing.getDayWeatherBonus(caster, element)
     local abilityBonus = xi.spells.healing.getAbilityBonus(caster, isWhiteMagic)
-
     return math.floor(((final * equipBonuses) * dwBonus) * abilityBonus)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The current formula for healing magic is incorrectly tiering / capping healing magic spells.  For instance, the 2nd tier Cure 1 cap was set to 20, when it should be 30.

The data used for this PR can be located here:
https://web.archive.org/web/20080528034331/http://members.shaw.ca/pizza_steve/cure/Index.html

You can test the healing values using this healing calculator: 
https://web.archive.org/web/20080528091305/http://members.shaw.ca/pizza_steve/cure/Cure_Calculator.html

## Steps to test these changes

1. Change job to White Mage (any level / range)
2. Plug in Mnd / Vit / Skill values on the Cure Calculator
3. Cure another player
