### PR TITLE
Fix Broken Interaction in The Missing Piece

### DIFF
--- a/scripts/zones/Northern_San_dOria/npcs/Charlaimagnat.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Charlaimagnat.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Area: Northern San d'Oria
 --  NPC: Charlaimagnat
+-- !pos 125 6 111 231
 -----------------------------------
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
 require("scripts/globals/keyitems")

--- a/scripts/zones/Quicksand_Caves/npcs/qm5.lua
+++ b/scripts/zones/Quicksand_Caves/npcs/qm5.lua
@@ -3,12 +3,12 @@
 --  NPC: ??? (qm5)
 -- Involved in Quest: The Missing Piece
 -- positions:
--- 1: !pos 770 0 -419
--- 2: !pos 657 0 -537
--- 3: !pos 749 0 -573
--- 4: !pos 451 -16 -739
--- 5: !pos 787 -16 -819
--- spawn in npc_list is 770 0 -419
+-- 1: !pos 770 0 -419 208
+-- 2: !pos 657 0 -537 208
+-- 3: !pos 749 0 -573 208
+-- 4: !pos 451 -16 -739 208
+-- 5: !pos 787 -16 -819 208
+-- spawn in npc_list is 770 0 -419 208
 -----------------------------------
 local ID = require("scripts/zones/Quicksand_Caves/IDs")
 require("scripts/globals/keyitems")
@@ -27,7 +27,7 @@ entity.onTrigger = function(player, npc)
         theMissingPiece == QUEST_ACCEPTED and
         not hasAncientTablet and
         not hasAncientFragment and
-        not player:getTitle() == xi.title.ACQUIRER_OF_ANCIENT_ARCANUM
+        player:getTitle() ~= xi.title.ACQUIRER_OF_ANCIENT_ARCANUM
     then
         player:addKeyItem(xi.ki.ANCIENT_TABLET_FRAGMENT)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.ANCIENT_TABLET_FRAGMENT)

--- a/scripts/zones/Rabao/npcs/Alfesar.lua
+++ b/scripts/zones/Rabao/npcs/Alfesar.lua
@@ -1,7 +1,9 @@
 -----------------------------------
 -- Area: Rabao
 --  NPC: Alfesar
---Starts The Missing Piece
+-- Starts The Missing Piece
+-- !addquest 5 193
+-- !pos 22 8 40 247
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/keyitems")
@@ -19,25 +21,27 @@ entity.onTrigger = function(player, npc)
     local fame = player:getFameLevel(xi.quest.fame_area.SELBINA_RABAO)
 
     if theMissingPiece == QUEST_AVAILABLE and fame >= 4 then -- start quest
-        player:startEvent(6)
+        player:startEvent(6, xi.ki.ANCIENT_TABLET_FRAGMENT)
     elseif
         theMissingPiece == QUEST_ACCEPTED and
-        not player:hasKeyItem(xi.ki.ANCIENT_TABLET_FRAGMENT)
+        not player:hasKeyItem(xi.ki.ANCIENT_TABLET_FRAGMENT) and
+        not player:hasKeyItem(xi.ki.TABLET_OF_ANCIENT_MAGIC)
     then
         -- talk to again with quest activated
-        player:startEvent(7)
+        player:startEvent(7, xi.ki.ANCIENT_TABLET_FRAGMENT)
     elseif
         theMissingPiece == QUEST_ACCEPTED and
-        player:hasKeyItem(xi.ki.ANCIENT_TABLET_FRAGMENT)
+        player:hasKeyItem(xi.ki.ANCIENT_TABLET_FRAGMENT) and
+        not player:hasKeyItem(xi.ki.TABLET_OF_ANCIENT_MAGIC)
     then
         -- successfully retrieve key item
-        player:startEvent(8)
+        player:startEvent(8, xi.ki.ANCIENT_TABLET_FRAGMENT)
     elseif
         theMissingPiece == QUEST_ACCEPTED and
         player:hasKeyItem(xi.ki.TABLET_OF_ANCIENT_MAGIC)
     then
         -- They got their Key items. tell them to goto sandy
-        player:startEvent(9)
+        player:startEvent(9, 0, xi.ki.ANCIENT_TABLET_FRAGMENT)
     else
         player:startEvent(52) -- standard dialogue
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes broken interaction preventing players from getting the ancient tablet fragment.

## Steps to test these changes

Rabao, Quicksand, Rabao, San d'Oria

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2332
