### PR TITLE
Clear Mission Status After Failing A Testing Time

### DIFF
--- a/scripts/missions/windurst/2_2_A_Testing_Time.lua
+++ b/scripts/missions/windurst/2_2_A_Testing_Time.lua
@@ -105,12 +105,14 @@ local failMission = function(player, csid, option, npc)
     mission:setVar(player, "KillCount", 0)
     player:delKeyItem(xi.ki.CREATURE_COUNTER_MAGIC_DOLL)
     player:delMission(mission.areaId, mission.missionId)
+    player:setMissionStatus(mission.areaId, 0)
 end
 
 local clearMission = function(player, csid, option, npc)
     if mission:complete(player) then
         player:delKeyItem(xi.ki.CREATURE_COUNTER_MAGIC_DOLL)
     end
+    player:setMissionStatus(mission.areaId, 0)
 end
 
 mission.sections =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Players failing A Testing Time don't have their mission status cleared.

## Steps to test these changes

👀 