### PR TITLE
Fixed issue in getBarSpellDefBonus, should return Power not Sub Power

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -127,7 +127,7 @@ end
 local function getBarSpellDefBonus(mob, target, spellElement)
     if spellElement >= xi.magic.element.FIRE and spellElement <= xi.magic.element.WATER then
         if target:hasStatusEffect(xi.magic.barSpell[spellElement]) then -- bar- spell magic defense bonus
-            return target:getStatusEffect(xi.magic.barSpell[spellElement]):getSubPower()
+            return target:getStatusEffect(xi.magic.barSpell[spellElement]):getPower()
         end
     end
 end


### PR DESCRIPTION
Bar Spells don't have sub power.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This adds Bar Spell resistances properly to mob skills.  Previously calling `getSubPower()`, but this does not return a value for bar spells. 

## Steps to test these changes

1. Grab a LIzard, Remove all other skills except fireball from mob skill list 
2. Get hit by Fireball, Record the number 
3. Apply Barfira to yourself, should have a power of 68, can also be done via `!addeffect 100 68 10000`
4. Get hit by Fireball Again, Number should be reduced 