### PR TITLE
Add dupe guards for AH / Dbox

### DIFF
--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -112,6 +112,7 @@ namespace charutils
     uint8  AddItem(CCharEntity* PChar, uint8 LocationID, CItem* PItem, bool silence = false);
     uint8  AddItem(CCharEntity* PChar, uint8 LocationID, uint16 itemID, uint32 quantity = 1, bool silence = false);
     uint8  MoveItem(CCharEntity* PChar, uint8 LocationID, uint8 SlotID, uint8 NewSlotID);
+    bool   ValidateUpdateItem(CCharEntity* PChar, uint8 locationID, uint8 slotID, int32 quantity, bool force = false);
     uint32 UpdateItem(CCharEntity* PChar, uint8 LocationID, uint8 slotID, int32 quantity, bool force = false);
     void   DropItem(CCharEntity* PChar, uint8 container, uint8 slotID, int32 quantity, uint16 ItemID);
     void   CheckValidEquipment(CCharEntity* PChar);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Prevents item dupes in case of item being locked

## Steps to test these changes

- Have full inventory
- Talk to Tami
- Read the temp key item (note)
- !zone {Zeruhn Mines}
- !gotoname Zel%
- talk to npc
- Trade jerky to Tami
- AH Jerky

Item should NOT be posted in AH.
