### PR TITLE
[map] Moved check for nullptr up to prevent errors accessing ptr fields

### DIFF
--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -151,12 +151,14 @@ void CTransportHandler::InitializeTransport()
 
             zoneTown.npcDoor  = zoneutils::GetEntity(sql->GetUIntData(2), TYPE_NPC);
             zoneTown.ship.npc = zoneutils::GetEntity(sql->GetUIntData(1), TYPE_SHIP);
+
             // Moved here, you can't access the npcDoor or .ship.npc if they're nullptr, so the following lines cause a read access error
             if (zoneTown.npcDoor == nullptr || zoneTown.ship.npc == nullptr)
             {
                 ShowError("Transport <%u>: transport or door not found", (uint8)sql->GetIntData(0));
                 continue;
             }
+
             zoneTown.ship.npc->name.resize(8);
             zoneTown.ship.npc->manualConfig = true;
 
@@ -176,7 +178,6 @@ void CTransportHandler::InitializeTransport()
             zoneTown.ship.setVisible(false);
             zoneTown.closeDoor(false);
 
-            
             if (zoneTown.ship.timeArriveDock < 10)
             {
                 ShowError("Transport <%u>: time_anim_arrive must be > 10", (uint8)sql->GetIntData(0));

--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -151,14 +151,12 @@ void CTransportHandler::InitializeTransport()
 
             zoneTown.npcDoor  = zoneutils::GetEntity(sql->GetUIntData(2), TYPE_NPC);
             zoneTown.ship.npc = zoneutils::GetEntity(sql->GetUIntData(1), TYPE_SHIP);
-
             // Moved here, you can't access the npcDoor or .ship.npc if they're nullptr, so the following lines cause a read access error
             if (zoneTown.npcDoor == nullptr || zoneTown.ship.npc == nullptr)
             {
                 ShowError("Transport <%u>: transport or door not found", (uint8)sql->GetIntData(0));
                 continue;
             }
-
             zoneTown.ship.npc->name.resize(8);
             zoneTown.ship.npc->manualConfig = true;
 

--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -151,6 +151,14 @@ void CTransportHandler::InitializeTransport()
 
             zoneTown.npcDoor  = zoneutils::GetEntity(sql->GetUIntData(2), TYPE_NPC);
             zoneTown.ship.npc = zoneutils::GetEntity(sql->GetUIntData(1), TYPE_SHIP);
+
+            // Moved here, you can't access the npcDoor or .ship.npc if they're nullptr, so the following lines cause a read access error
+            if (zoneTown.npcDoor == nullptr || zoneTown.ship.npc == nullptr)
+            {
+                ShowError("Transport <%u>: transport or door not found", (uint8)sql->GetIntData(0));
+                continue;
+            }
+
             zoneTown.ship.npc->name.resize(8);
             zoneTown.ship.npc->manualConfig = true;
 
@@ -170,11 +178,7 @@ void CTransportHandler::InitializeTransport()
             zoneTown.ship.setVisible(false);
             zoneTown.closeDoor(false);
 
-            if (zoneTown.npcDoor == nullptr || zoneTown.ship.npc == nullptr)
-            {
-                ShowError("Transport <%u>: transport or door not found", (uint8)sql->GetIntData(0));
-                continue;
-            }
+            
             if (zoneTown.ship.timeArriveDock < 10)
             {
                 ShowError("Transport <%u>: time_anim_arrive must be > 10", (uint8)sql->GetIntData(0));


### PR DESCRIPTION
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes hard crash on map server start-up due to nullptr values being accessed.

## Steps to test these changes

Edit global settings:
1. Enable `RESTRICT_CONTENT = 1`
2. Disable CoP `ENABLE_COP = 0`

Start the server.  Shouldn't crash anymore.
