### PR TITLE
Bugfix for Conquest Logic

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1275,8 +1275,8 @@ local function canPurchaseItem(player, stock, pRank, guardNation, mOffset, optio
     if player:getCP() < price then
         if
             not (option <= 32933 and
-            option >= 32935 and
-            player:hasKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER))
+            option >= 32935) or
+            player:hasKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER)
         then
             player:messageSpecial(mOffset + 62, 0, 0, stock.item) -- "You do not have enough conquest points to purchase the <item>."
             return -1


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adjusts the conditional logic from previous PR so that players with conquest vouchers are still able to redeem and obtain their rings.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Talk to a Conquest Overseer with a conquest promotion voucher.
<!-- Clear and detailed steps to test your changes here -->
