### PR TITLE
Save Food and Dedication effects on use to persist crashes

### DIFF
--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -553,6 +553,11 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
         }
         m_POwner->updatemask |= UPDATE_HP;
 
+        if (statusId == EFFECT_FOOD || statusId == EFFECT_DEDICATION)
+        {
+            m_POwner->StatusEffectContainer->SaveStatusEffects();
+        }
+
         return true;
     }
     else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Save status effects for Dedication (EXP) and Food to prevent them being wiped on sudden server outage.

Closes #2400

## Steps to test these changes

!additem chariot_band
Use it and wait for buff to apply
Alt+F4 your server
Restart everything
