### PR TITLE
Clear trade container on mission / quest completion

### DIFF
--- a/scripts/globals/interaction/mission.lua
+++ b/scripts/globals/interaction/mission.lua
@@ -47,5 +47,20 @@ function Mission:complete(player)
         self:cleanup(player)
     end
 
+    -- Clear trade container if needed
+    -- This avoids issues with quest lua files not properly
+    -- calling `tradeComplete()` on fail
+    self:tradeComplete(player, didComplete)
+
     return didComplete
+end
+
+-- Called from quest or mission system to clean up player trade container
+-- TODO: Put in common location
+function Mission:tradeComplete(player, takeItems)
+    if takeItems then
+        player:confirmTrade()
+    else
+        player:tradeComplete(false)
+    end
 end

--- a/scripts/globals/interaction/quest.lua
+++ b/scripts/globals/interaction/quest.lua
@@ -42,5 +42,20 @@ function Quest:complete(player)
         self:cleanup(player)
     end
 
+    -- Clear trade container if needed
+    -- This avoids issues with quest lua files not properly
+    -- calling `tradeComplete()` on fail
+    self:tradeComplete(player, didComplete)
+
     return didComplete
+end
+
+-- Called from quest or mission system to clean up player trade container
+-- TODO: Put in common location
+function Quest:tradeComplete(player, takeItems)
+    if takeItems then
+        player:confirmTrade()
+    else
+        player:tradeComplete(false)
+    end
 end

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1772,6 +1772,11 @@ void SmallPacket0x034(map_session_data_t* const PSession, CCharEntity* const PCh
             PChar->UContainer->UnLock();
             PTarget->UContainer->UnLock();
         }
+        else
+        {
+            ShowError("SmallPacket0x034: Player %s trying to trade invalid item. [Item: %i | Trade Slot: %i | Inv Slot: %i | Quantity: %i] ",
+                        PChar->GetName(), itemID, tradeSlotID, invSlotID, quantity);
+        }
     }
 }
 


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a few quests that use the new quest system by automatically clearing trade container on completion

## Steps to test these changes

Complete a quest using the quest wrapper lua. (i.e: Groceries.lua)