### PR TITLE
2413 Talib Quest Revamp and Shady Business Quest CS fix

### DIFF
--- a/scripts/quests/bastok/Beauty_And_The_Galka.lua
+++ b/scripts/quests/bastok/Beauty_And_The_Galka.lua
@@ -69,12 +69,12 @@ quest.sections =
         },
     },
 
-    -- Quest Giver after Accepted
     {
         check = function(player, status, vars)
             return status == QUEST_ACCEPTED
         end,
 
+        -- Quest Giver after Accepted
         [xi.zone.PORT_BASTOK] =
         {
             ['Talib'] =
@@ -95,15 +95,9 @@ quest.sections =
                     npcUtil.giveKeyItem(player, xi.ki.PALBOROUGH_MINES_LOGS)
                 end,
             },
-        }
-    },
+        },
 
-    -- Quest Complete
-    {
-        check = function(player, status, vars)
-            return status == QUEST_ACCEPTED
-        end,
-
+        -- Quest Complete
         [xi.zone.BASTOK_MINES] =
         {
             ['Parraggoh'] =

--- a/scripts/quests/bastok/Beauty_And_The_Galka.lua
+++ b/scripts/quests/bastok/Beauty_And_The_Galka.lua
@@ -41,7 +41,6 @@ quest.sections =
                     else
                         quest:begin(player)
                     end
-
                 end,
             },
         },

--- a/scripts/quests/bastok/Beauty_And_The_Galka.lua
+++ b/scripts/quests/bastok/Beauty_And_The_Galka.lua
@@ -9,8 +9,6 @@ require("scripts/globals/keyitems")
 require("scripts/globals/npc_util")
 require('scripts/globals/quests')
 require('scripts/globals/zone')
-
-local portBastokIDs = require("scripts/zones/Port_Bastok/IDs")
 -----------------------------------
 local quest = Quest:new(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
 

--- a/scripts/quests/bastok/Beauty_And_The_Galka.lua
+++ b/scripts/quests/bastok/Beauty_And_The_Galka.lua
@@ -1,0 +1,149 @@
+-----------------------------------
+-- Beauty and the Galka
+-----------------------------------
+-- !addquest 1 1
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require("scripts/globals/items")
+require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
+require('scripts/globals/quests')
+require('scripts/globals/zone')
+
+local portBastokIDs = require("scripts/zones/Port_Bastok/IDs")
+-----------------------------------
+local quest = Quest:new(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
+
+quest.reward =
+{
+    fame = 75,
+    fameArea = xi.quest.fame_area.BASTOK,
+    item = xi.items.BRONZE_KNIFE
+}
+
+quest.sections =
+{
+    -- Quest Acceptance 1
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE
+        end,
+
+        [xi.zone.PORT_BASTOK] =
+        {
+            ['Talib'] = quest:progressEvent(2),
+
+            onEventFinish =
+            {
+                [2] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:setVar(player, 'Option', 1)
+                    else
+                        quest:begin(player)
+                    end
+
+                end,
+            },
+        },
+    },
+
+    -- Quest Acceptance 1a
+    {
+        check = function(player, status, vars)
+            return
+                status == QUEST_AVAILABLE and
+                quest:getVar(player, 'Option') == 1
+        end,
+
+        [xi.zone.BASTOK_MINES] =
+        {
+            ['Parraggoh'] = quest:progressEvent(7),
+
+            onEventFinish =
+            {
+                [7] = function(player, csid, option, npc)
+                    if option == 0 then
+                        quest:begin(player)
+                    end
+                end,
+            },
+        },
+    },
+
+    -- Quest Giver after Accepted
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.PORT_BASTOK] =
+        {
+            ['Talib'] =
+            {
+                onTrigger = quest:event(4),
+
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, { { xi.items.CHUNK_OF_ZINC_ORE, 1 } }) then
+                        return quest:progressEvent(3)
+                    end
+                end
+            },
+
+            onEventFinish =
+            {
+                [3] = function(player, csid, option, npc)
+                    player:tradeComplete()
+                    npcUtil.giveKeyItem(player, xi.ki.PALBOROUGH_MINES_LOGS)
+                end,
+            },
+        }
+    },
+
+    -- Quest Complete
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.BASTOK_MINES] =
+        {
+            ['Parraggoh'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.PALBOROUGH_MINES_LOGS) then
+                        return quest:progressEvent(10)
+                    end
+
+                    if math.random(1, 2) == 1 then
+                        return quest:event(8)
+                    end
+                    return quest:event(9)
+                end
+            },
+
+            onEventFinish =
+            {
+                [10] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:tradeComplete()
+                        player:delKeyItem(xi.ki.PALBOROUGH_MINES_LOGS)
+                    end
+                end
+            }
+        }
+    },
+
+    -- After Quest Complete
+    {
+        check = function(player, status, vars)
+            return status == QUEST_COMPLETED
+        end,
+
+        [xi.zone.BASTOK_MINES] =
+        {
+            ['Parraggoh'] = quest:event(12):replaceDefault()
+        }
+    },
+}
+
+return quest

--- a/scripts/quests/bastok/Shady_Business.lua
+++ b/scripts/quests/bastok/Shady_Business.lua
@@ -30,11 +30,11 @@ quest.sections =
 
         [xi.zone.PORT_BASTOK] =
         {
-            ['Talib'] = quest:progressEvent(2),
+            ['Talib'] = quest:progressEvent(90),
 
             onEventFinish =
             {
-                [2] = function(player, csid, option, npc)
+                [90] = function(player, csid, option, npc)
                     quest:begin(player)
                 end,
             },

--- a/scripts/zones/Bastok_Mines/npcs/Parraggoh.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Parraggoh.lua
@@ -3,55 +3,18 @@
 --  NPC: Parraggoh
 -- Finishes Quest: Beauty and the Galka
 -----------------------------------
-local ID = require("scripts/zones/Bastok_Mines/IDs")
-require("scripts/globals/quests")
-require("scripts/globals/keyitems")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local beautyAndTheGalka = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
-
-    -- Beauty and the Galka
-    if player:hasKeyItem(xi.ki.PALBOROUGH_MINES_LOGS) then
-        player:startEvent(10)
-
-    elseif beautyAndTheGalka == QUEST_ACCEPTED then
-        if math.random(1, 2) == 1 then
-            player:startEvent(8)
-        else
-            player:startEvent(9)
-        end
-
-    elseif player:getCharVar("BeautyAndTheGalkaDenied") == 1 then
-        player:startEvent(7)
-
-    elseif beautyAndTheGalka == QUEST_COMPLETED then
-        player:startEvent(12)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 7 and option == 0 then
-        player:addQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
-    elseif csid == 10 then
-        if player:getFreeSlotsCount() >= 1 then
-            player:completeQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
-            player:setCharVar("BeautyAndTheGalkaDenied", 0)
-            player:delKeyItem(xi.ki.PALBOROUGH_MINES_LOGS)
-            player:addFame(xi.quest.fame_area.BASTOK, 75)
-            player:addItem(16465)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 16465)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 16465)
-        end
-    end
 end
 
 return entity

--- a/scripts/zones/Port_Bastok/npcs/Talib.lua
+++ b/scripts/zones/Port_Bastok/npcs/Talib.lua
@@ -3,49 +3,18 @@
 --  NPC: Talib
 -- Starts Quest: Beauty and the Galka
 -----------------------------------
-require("scripts/globals/keyitems")
-require("scripts/globals/quests")
-local ID = require("scripts/zones/Port_Bastok/IDs")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA) == QUEST_ACCEPTED then
-        if trade:hasItemQty(642, 1) and trade:getItemCount() == 1 then
-            player:startEvent(3)
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    local beautyAndTheGalka = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
-    local shadyBusiness = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.SHADY_BUSINESS)
-
-    if
-        beautyAndTheGalka == QUEST_ACCEPTED or
-        player:getCharVar("BeautyAndTheGalkaDenied") >= 1
-    then
-        player:startEvent(4)
-    elseif shadyBusiness == QUEST_COMPLETED then
-        player:startEvent(90)
-    elseif beautyAndTheGalka == QUEST_AVAILABLE then
-        player:startEvent(2)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 2 and option == 0 then
-        player:addQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
-    elseif csid == 2 and option == 1 then
-        player:setCharVar("BeautyAndTheGalkaDenied", 1)
-    elseif csid == 3 then
-        player:tradeComplete()
-        player:addKeyItem(xi.ki.PALBOROUGH_MINES_LOGS)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.PALBOROUGH_MINES_LOGS)
-    end
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #2413   - Fixes the wrong CS being played.  Also revamps the previous quest into the new quest framework.

## Steps to test these changes

The Shady Business CS fix was a simple ID change.
To test the Beauty and the Galka change, follow the Wiki guide below https://ffxiclopedia.fandom.com/wiki/Beauty_and_the_Galka?so=search
or here for Classic: https://classicffxi.fandom.com/wiki/Beauty_and_the_Galka

(Both are identical)
