### PR TITLE
Adjust Nightmare to allow mobs to wake up after taking damage

### DIFF
--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -775,7 +775,7 @@ void CStatusEffectContainer::DelStatusEffectsByType(uint16 Type)
 
 /************************************************************************
  *                                                                       *
- *  Удаляем все эффекты с указанными флагами                             *
+ *  Remove all effects with the specified flags                          *
  *                                                                       *
  ************************************************************************/
 
@@ -785,10 +785,25 @@ void CStatusEffectContainer::DelStatusEffectsByFlag(uint32 flag, bool silent)
     {
         if (PStatusEffect->GetFlag() & flag)
         {
-            // If this is a Nightmare effect flag, it needs to be removed explictly by a cure
+            // See if this is Nightmare
+            bool isNightmare = (PStatusEffect->GetStatusID() == EFFECT_SLEEP && PStatusEffect->GetSubID() == EFFECT_BIO) ? true : false;
 
-            if (!(flag & EFFECTFLAG_DAMAGE && PStatusEffect->GetStatusID() == EFFECT_SLEEP && PStatusEffect->GetSubID() == (uint32)EFFECT_BIO))
+            if (flag & EFFECTFLAG_DAMAGE && isNightmare)
+            {
+                // If it's a player, or player's pet, then taking damage should not wake the entity
+                if (this->m_POwner->objtype == TYPE_PC or this->m_POwner->objtype == TYPE_PET)
+                {
+                    continue;
+                }
+                else
+                {
+                    RemoveStatusEffect(PStatusEffect, silent);
+                }
+            }
+            else
+            {
                 RemoveStatusEffect(PStatusEffect, silent);
+            }
         }
     }
 }
@@ -1905,8 +1920,12 @@ void CStatusEffectContainer::TickRegen(time_point tick)
             {
                 DelStatusEffectSilent(EFFECT_HEALING);
                 m_POwner->takeDamage(damage);
-                if (!(m_POwner->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP) && m_POwner->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP)->GetSubID() == (uint32)EFFECT_BIO))
+
+                bool hasNightmare = (m_POwner->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP) && m_POwner->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP)->GetSubID() == (uint32)EFFECT_BIO);
+                if (!hasNightmare)
+                {
                     WakeUp(); // dots dont wake up from nightmare
+                }
             }
         }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adjusts pet Nightmare (Diabolos) so that slept mobs wake up on taking subsequent damage
- As with retail, any DoTs on the mob prior to Nightmare being applied will not wake the mob
- Any DoTs or other damage on the mob will wake it
- Nightmare effect given by Diabolos Prime against a player will not allow damage to wake the player (or pets)

## Steps to test these changes

- Fight Diabolos
- Use Diabolos to Nightmare other mobs
