### PR TITLE
Clean trade container on event finish

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -83,6 +83,7 @@
 #include "spell.h"
 #include "status_effect_container.h"
 #include "timetriggers.h"
+#include "trade_container.h"
 #include "transport.h"
 #include "utils/battleutils.h"
 #include "utils/charutils.h"
@@ -2235,6 +2236,17 @@ namespace luautils
             PChar->animation = ANIMATION_DEATH;
             PChar->pushPacket(new CRaiseTractorMenuPacket(PChar, TYPE_HOMEPOINT));
             PChar->updatemask |= UPDATE_HP;
+        }
+
+        if (PChar->TradeContainer->getItemsCount() > 0)
+        {
+            ShowDebug("Event [%d] finished without trade cleaned up. "
+                      "Call player:tradeComplete(false) or player:confirmTrade onEventFinish.",
+                      eventID);
+
+            // Because we can't guarantee that a trade is cleaned up after a quest or event is complete,
+            // we clean up the trade container here to avoid having items in reserve.
+            PChar->TradeContainer->Clean();
         }
 
         return 0;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1772,6 +1772,11 @@ void SmallPacket0x034(map_session_data_t* const PSession, CCharEntity* const PCh
             PChar->UContainer->UnLock();
             PTarget->UContainer->UnLock();
         }
+        else
+        {
+            ShowError("SmallPacket0x034: Player %s trying to trade invalid item. [Item: %i | Trade Slot: %i | Inv Slot: %i | Quantity: %i] ",
+                      PChar->GetName(), itemID, tradeSlotID, invSlotID, quantity);
+        }
     }
 }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes issues with items being locked in reserve after quests not fully cleaned up
- Adds logging for some instances of trading invalid items

## Steps to test these changes

Finish groceries with full inventory by trading meat jerky
Put jerky up on AH. Should not error out or allow dupe
