### PR TITLE
2334 starfall tear quest revamp

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -2781,6 +2781,7 @@ xi.items =
     PARANA_SHIELD                   = 12298,
     ASPIS                           = 12299,
     TARGE                           = 12300,
+    FISH_SCALE_SHIELD               = 12316,
     FLAME_SHIELD                    = 12317,
     TOWER_SHIELD                    = 12324,
     MASTER_SHIELD                   = 12344,

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -168,7 +168,7 @@ xi.quest.id =
     [xi.quest.area[xi.quest.log_id.BASTOK]] =
     {
         THE_SIRENS_TEAR                 = 0,  -- ± Converted
-        BEAUTY_AND_THE_GALKA            = 1,  -- ±
+        BEAUTY_AND_THE_GALKA            = 1,  -- ± Converted
         WELCOME_TO_BASTOK               = 2,  -- + Converted
         GUEST_OF_HAUTEUR                = 3,  -- + Converted
         THE_QUADAVS_CURSE               = 4,  -- ± Converted
@@ -319,7 +319,7 @@ xi.quest.id =
         SAY_IT_WITH_FLOWERS             = 50, -- +
         HOIST_THE_JELLY_ROGER           = 51, -- +
         SOMETHING_FISHY                 = 52, -- +
-        TO_CATCH_A_FALLING_STAR         = 53, -- +
+        TO_CATCH_A_FALLING_STAR         = 53, -- + Converted
         PAYING_LIP_SERVICE              = 60, -- +
         THE_AMAZIN_SCORPIO              = 61, -- +
         TWINSTONE_BONDING               = 62, -- +

--- a/scripts/quests/windurst/To_Catch_A_Falling_Star.lua
+++ b/scripts/quests/windurst/To_Catch_A_Falling_Star.lua
@@ -1,0 +1,144 @@
+-----------------------------------
+-- To Catch A Falling Star
+-----------------------------------
+-- !addquest 2 53
+-- Sigismund : !pos -110 -9 80 206
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require("scripts/globals/items")
+require("scripts/globals/npc_util")
+require('scripts/globals/quests')
+require('scripts/globals/zone')
+
+local westSaruIDs = require("scripts/zones/West_Sarutabaruta/IDs")
+-----------------------------------
+local quest = Quest:new(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_CATCH_A_FALLING_STAR)
+
+quest.reward =
+{
+    fame = 75,
+    fameArea = xi.quest.fame_area.WINDURST,
+    item = xi.items.FISH_SCALE_SHIELD
+}
+
+quest.sections =
+{
+    -- Quest Acceptance
+    {
+        check = function(player, status, vars)
+           return status == QUEST_AVAILABLE
+        end,
+
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Sigismund'] = quest:progressEvent(196, 0, xi.items.STARFALL_TEAR),
+
+            onEventFinish =
+            {
+                [196] = function(player, csid, option, npc)
+                    quest:begin(player)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        -- Supporting Character dialogue after Accepted
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Tohopka'] = quest:event(198, 0, xi.items.STARFALL_TEAR, xi.items.HANDFUL_OF_PUGIL_SCALES)
+        },
+
+        -- Twinkle Tree in West Saru.
+        [xi.zone.WEST_SARUTABARUTA] =
+        {
+            ['Twinkle_Tree'] =
+            {
+                onTrigger = function(player, npc)
+                    if VanadielHour() <= 3 then
+                        player:messageSpecial(westSaruIDs.text.FROST_DEPOSIT_TWINKLES)
+                        return quest:messageSpecial(westSaruIDs.text.MELT_BARE_HANDS)
+                    end
+                    return quest:messageSpecial(westSaruIDs.text.NOTHING_OUT_OF_ORDINARY)
+                end,
+
+                onTrade = function(player, npc, trade)
+                    if VanadielHour() > 3 then
+                        return quest:messageSpecial(westSaruIDs.text.NOTHING_OUT_OF_ORDINARY)
+                    end
+
+                    if npcUtil.tradeHasExactly(trade, { { xi.items.HANDFUL_OF_PUGIL_SCALES, 1 } }) then
+                        if npcUtil.giveItem(player, xi.items.STARFALL_TEAR) then
+                            player:confirmTrade()
+                            if quest:getVar(player, 'Prog') == 0 then
+                                quest:setVar(player, 'Prog', 1)
+                            end
+                            player:messageSpecial(westSaruIDs.text.FROST_DEPOSIT_TWINKLES)
+                            return quest:messageSpecial(westSaruIDs.text.MELT_BARE_HANDS)
+                        end
+                    end
+                end
+            }
+        }
+    },
+
+    -- Quest Complete
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Sigismund'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(197, 0, xi.items.STARFALL_TEAR)
+                end,
+
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, { { xi.items.STARFALL_TEAR, 1 } }) then
+                        return quest:progressEvent(199)
+                    end
+                end
+            },
+
+            onEventFinish =
+            {
+                [199] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:tradeComplete()
+                        quest:setVar(player, 'Prog', 2)
+                    end
+                end
+            }
+        }
+    },
+
+    -- After Quest Complete
+    {
+        check = function(player, status, vars)
+            return
+                status == QUEST_COMPLETED and
+                vars.Prog > 0
+        end,
+
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Sigismund'] = quest:progressEvent(200),
+
+            onEventFinish =
+            {
+                [200] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 0)
+                end
+            }
+        }
+    },
+}
+
+return quest

--- a/scripts/quests/windurst/To_Catch_A_Falling_Star.lua
+++ b/scripts/quests/windurst/To_Catch_A_Falling_Star.lua
@@ -47,7 +47,6 @@ quest.sections =
             return status == QUEST_ACCEPTED
         end,
 
-
         [xi.zone.PORT_WINDURST] =
         {
             -- Supporting Character dialogue after Accepted
@@ -105,8 +104,6 @@ quest.sections =
                         player:messageSpecial(westSaruIDs.text.FROST_DEPOSIT_TWINKLES)
                         return quest:messageSpecial(westSaruIDs.text.MELT_BARE_HANDS)
                     end
-
-
                 end
             }
         },

--- a/scripts/quests/windurst/Toraimarai_Turmoil.lua
+++ b/scripts/quests/windurst/Toraimarai_Turmoil.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Water Way to Go
+-- Toraimarai Turmoil
 -----------------------------------
 -- !addquest 2 16
 -- Ohbiru-Dohbiru : !pos 23 -5 -193 238

--- a/scripts/zones/Port_Windurst/DefaultActions.lua
+++ b/scripts/zones/Port_Windurst/DefaultActions.lua
@@ -13,6 +13,8 @@ return {
     ['Pichichi']        = { event = 364 },
     ['Pyo_Nzon']        = { event = 366 },
     ['Shanruru']        = { event = 367 },
+    ['Sigismund']       = { event = 357 },
+    ['Tohopka']         = { event = 358 },
     ['Tokaka']          = { event = 207 },
     ['Yafa_Yaa']        = { event = 365 },
 }

--- a/scripts/zones/Port_Windurst/npcs/Sigismund.lua
+++ b/scripts/zones/Port_Windurst/npcs/Sigismund.lua
@@ -13,48 +13,15 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local starstatus = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_CATCH_A_FALLING_STAR)
-    if
-        starstatus == 1 and
-        trade:hasItemQty(546, 1) and
-        trade:getItemCount() == 1 and
-        trade:getGil() == 0
-    then
-        player:startEvent(199) -- Quest Finish
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    local starstatus = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_CATCH_A_FALLING_STAR)
-    if starstatus == QUEST_AVAILABLE then
-        player:startEvent(196, 0, 546) -- Quest Start
-    elseif starstatus == QUEST_ACCEPTED then
-        player:startEvent(197, 0, 546) -- Quest Reminder
-    elseif
-        starstatus == QUEST_COMPLETED and
-        player:getCharVar("QuestCatchAFallingStar_prog") > 0
-    then
-        player:startEvent(200) -- After Quest
-        player:setCharVar("QuestCatchAFallingStar_prog", 0)
-    else
-        player:startEvent(357)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 196 then
-        player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_CATCH_A_FALLING_STAR)
-    elseif csid == 199 then
-        player:tradeComplete()
-        player:completeQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_CATCH_A_FALLING_STAR)
-        player:addFame(xi.quest.fame_area.WINDURST, 75)
-        player:addItem(12316)
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 12316)
-        player:setCharVar("QuestCatchAFallingStar_prog", 2)
-    end
 end
 
 return entity

--- a/scripts/zones/Port_Windurst/npcs/Sigismund.lua
+++ b/scripts/zones/Port_Windurst/npcs/Sigismund.lua
@@ -4,12 +4,6 @@
 -- Starts and Finishes Quest: To Catch a Falling Star
 -- !pos -110 -10 82 240
 -----------------------------------
-local ID = require("scripts/zones/Port_Windurst/IDs")
-require("scripts/globals/settings")
-require("scripts/globals/quests")
-require("scripts/globals/titles")
-require("scripts/globals/status")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)

--- a/scripts/zones/Port_Windurst/npcs/Tohopka.lua
+++ b/scripts/zones/Port_Windurst/npcs/Tohopka.lua
@@ -12,13 +12,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local starStatus = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_CATCH_A_FALLING_STAR)
-
-    if starStatus == QUEST_ACCEPTED then
-        player:startEvent(198, 0, 546, 868)
-    else
-        player:startEvent(358)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Port_Windurst/npcs/Tohopka.lua
+++ b/scripts/zones/Port_Windurst/npcs/Tohopka.lua
@@ -4,8 +4,6 @@
 -- Type: Standard NPC
 -- !pos -105.723 -10 83.813 240
 -----------------------------------
-require("scripts/globals/quests")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)

--- a/scripts/zones/West_Sarutabaruta/DefaultActions.lua
+++ b/scripts/zones/West_Sarutabaruta/DefaultActions.lua
@@ -3,4 +3,5 @@ local ID = require("scripts/zones/West_Sarutabaruta/IDs")
 return {
     ['Ipupu']        = { text = ID.text.IPUPU_DIALOG },
     ['Maata-Ulaata'] = { text = ID.text.MAATA_ULAATA },
+    ['Twinkle_Tree'] = { text = ID.text.NOTHING_OUT_OF_ORDINARY }
 }

--- a/scripts/zones/West_Sarutabaruta/npcs/Twinkle_Tree.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Twinkle_Tree.lua
@@ -5,11 +5,6 @@
 --  Note: EventID for Twinkle Tree is unknown. Quest funtions but the full event is not played.
 -- !pos 156.003 -40.753 333.742 115
 -----------------------------------
-local ID = require("scripts/zones/West_Sarutabaruta/IDs")
-require("scripts/globals/items")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)

--- a/scripts/zones/West_Sarutabaruta/npcs/Twinkle_Tree.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Twinkle_Tree.lua
@@ -13,34 +13,9 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if
-        player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_CATCH_A_FALLING_STAR) == QUEST_ACCEPTED and
-        VanadielHour() <= 3
-    then
-        if
-            npcUtil.tradeHas(trade, xi.items.HANDFUL_OF_PUGIL_SCALES) and
-            player:getCharVar("QuestCatchAFallingStar_prog") == 0
-        then
-            player:messageSpecial(ID.text.FROST_DEPOSIT_TWINKLES)
-            player:messageSpecial(ID.text.MELT_BARE_HANDS)
-            if npcUtil.giveItem(player, xi.items.STARFALL_TEAR) then
-                player:confirmTrade()
-                player:setCharVar("QuestCatchAFallingStar_prog", 1)
-            end
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    if
-        VanadielHour() <= 3 and
-        player:getCharVar("QuestCatchAFallingStar_prog") == 0
-    then
-        player:messageSpecial(ID.text.FROST_DEPOSIT_TWINKLES)
-        player:messageSpecial(ID.text.MELT_BARE_HANDS)
-    else
-        player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Starfall Tear can now be obtained as many times as the player wants until they complete the quest.

PR also revamps this quest into the new framework.

Closes #2334 

## Steps to test these changes

Trade a Handful of Pugil Scales for a Starfall Tear
Drop the Tear
Trade again and receive another Tear
