### PR TITLE
Updated MobController to handle scenarios where mob is stuck.

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -733,7 +733,7 @@ void CMobController::UpdateLastKnownPosition()
     // 3. Mob is not bound or asleep
     m_Stuck =
         PMob->CanMove() &&
-        !PMob->isAsleep() &&
+        !PMob->StatusEffectContainer->IsAsleep() &&
         distanceSquared(m_LastPos, PMob->loc.p) <= 1.5f &&
         distanceSquared(PMob->loc.p, PTarget->loc.p) > PMob->GetMeleeRange();
 

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -732,11 +732,11 @@ void CMobController::UpdateLastKnownPosition()
     // 2. Distance to Target > Melee Range
     // 3. Mob is not bound or asleep
     m_Stuck =
+        PMob->CanMove() &&
+        !PMob->isAsleep() &&
         distanceSquared(m_LastPos, PMob->loc.p) <= 1.5f &&
-        distanceSquared(PMob->loc.p, PTarget->loc.p) > PMob->GetMeleeRange() &&
-        PMob->StatusEffectContainer->GetStatusEffect(EFFECT_BIND) == nullptr &&
-        PMob->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP) == nullptr &&
-        PMob->StatusEffectContainer->GetStatusEffect(EFFECT_SLEEP_II) == nullptr;
+        distanceSquared(PMob->loc.p, PTarget->loc.p) > PMob->GetMeleeRange();
+
     m_LastPos = PMob->loc.p;
 }
 

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -737,7 +737,7 @@ void CMobController::UpdateLastKnownPosition()
         distanceSquared(PMob->loc.p, m_LastTargetPos) > PMob->GetMeleeRange();
 
     m_LastTargetPos = PTarget->loc.p;
-    m_LastPos = PMob->loc.p;
+    m_LastPos       = PMob->loc.p;
 }
 
 void CMobController::Move()

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -728,7 +728,7 @@ bool CMobController::IsStuck()
 void CMobController::UpdateLastKnownPosition()
 {
     // Mob is considered "Stuck" if:
-    // 1. Current Pos - Last Pos is <= 2.5 
+    // 1. Current Pos - Last Pos is <= 2.5
     // 2. Distance to Target's Last Pos > Melee Range
     // 3. Mob is not bound or asleep
     m_Stuck =

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -728,15 +728,15 @@ bool CMobController::IsStuck()
 void CMobController::UpdateLastKnownPosition()
 {
     // Mob is considered "Stuck" if:
-    // 1. Last Pos && Current Pos are <= 1.5
-    // 2. Distance to Target > Melee Range
+    // 1. Current Pos - Last Pos is <= 2.5 
+    // 2. Distance to Target's Last Pos > Melee Range
     // 3. Mob is not bound or asleep
     m_Stuck =
         PMob->CanMove() &&
-        !PMob->StatusEffectContainer->IsAsleep() &&
-        distanceSquared(m_LastPos, PMob->loc.p) <= 1.5f &&
-        distanceSquared(PMob->loc.p, PTarget->loc.p) > PMob->GetMeleeRange();
+        distanceSquared(m_LastPos, PMob->loc.p) <= 2.5f &&
+        distanceSquared(PMob->loc.p, m_LastTargetPos) > PMob->GetMeleeRange();
 
+    m_LastTargetPos = PTarget->loc.p;
     m_LastPos = PMob->loc.p;
 }
 

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -84,6 +84,7 @@ private:
 
     bool       m_Stuck = false;
     position_t m_LastPos;
+    position_t m_LastTargetPos;
 
     time_point m_LastActionTime;
     time_point m_LastMagicTime;

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -62,7 +62,9 @@ protected:
     bool         CanSeePoint(position_t pos);
     virtual bool CanCastSpells();
     void         CastSpell(SpellID spellid);
+    bool         IsStuck();
     virtual void Move();
+    virtual void UpdateLastKnownPosition();
 
     virtual void DoCombatTick(time_point tick);
     void         FaceTarget(uint16 targid = 0);
@@ -80,6 +82,9 @@ protected:
 private:
     CMobEntity* const PMob;
 
+    bool       m_Stuck = false;
+    position_t m_LastPos;
+
     time_point m_LastActionTime;
     time_point m_LastMagicTime;
     time_point m_LastMobSkillTime;
@@ -89,6 +94,7 @@ private:
     time_point m_NeutralTime;
     time_point m_WaitTime;
     time_point m_ResetTick;
+    time_point m_StuckTick;
 
     bool       m_firstSpell{ true };
     time_point m_LastRoamScript{ time_point::min() };

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1640,7 +1640,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
 
 bool CMobEntity::CanMove()
 {
-    return !StatusEffectContainer->HasStatusEffect({EFFECT_BIND, EFFECT_PETRIFICATION, EFFECT_TERROR, EFFECT_STUN});
+    return !StatusEffectContainer->IsAsleep() && !StatusEffectContainer->HasStatusEffect({EFFECT_BIND, EFFECT_PETRIFICATION, EFFECT_TERROR, EFFECT_STUN});
 }
 
 bool CMobEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg)

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -1636,6 +1636,11 @@ void CMobEntity::DropItems(CCharEntity* PChar)
             }
         }
     }
+}
+
+bool CMobEntity::CanMove()
+{
+    return !StatusEffectContainer->HasStatusEffect({EFFECT_BIND, EFFECT_PETRIFICATION, EFFECT_TERROR, EFFECT_STUN});
 }
 
 bool CMobEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg)

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -179,6 +179,8 @@ public:
     virtual void Spawn() override;
     virtual void FadeOut() override;
 
+    virtual bool CanMove();
+
     bool   m_AllowRespawn; // if true, allow respawn
     uint32 m_RespawnTime;  // respawn time
     uint32 m_DropItemTime; // time until monster death animation


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR introduces a method to track a mob's movement and determine if it's stuck in the game world.

This addresses common exploits where the mob would be Aggro'd and trying to pathfind to the player.  While pathfinding, the mob would effectively do nothing if it couldn't move.

These edits introduce introduce methods to check if the mob is stuck. During the `Move()` function, it checks whether the mob is stuck AFTER all the pathfind attempts have been made.  If the mob is stuck and not in a bound/slept state and should be able to move, this will force the mob to step toward the player.


## Steps to test these changes

Go to the mountain outside Bastok Markets in South Gustaberg.
There is a wasp at the base of the winding path, go up the path, cast a spell.
The behavior without these fixes is the mob will get stuck at the base of the path unable to find a path up the mountain.
The behavior with these fixes is the bee will path directly up to the player.

You can also test this by using Project Tako to set a waypoint at the top of a spine at Dem/Mea/Holla.  
Aggro a mob, then teleport up to the spot.  One of two things should happen: 
1. The mob will deaggro because it can't find a path to you and/or you've left the leash range
2. The mob will path up to you despite not having an appropriate nav mesh path to you.
