### PR TITLE
Disable Unity Checks for Non-ROE Servers

### DIFF
--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -687,6 +687,11 @@ namespace roeutils
     void CycleUnityRankings()
     {
         TracyZoneScoped;
+        if (!settings::get<bool>("main.ENABLE_ROE"))
+        {
+            return;
+        }
+
         const char* rankingQuery = "UPDATE unity_system SET members_prev = members_current, points_prev = points_current, members_current = 0, points_current = 0;";
         sql->Query(rankingQuery);
 
@@ -696,6 +701,11 @@ namespace roeutils
     void UpdateUnityRankings()
     {
         TracyZoneScoped;
+        if (!settings::get<bool>("main.ENABLE_ROE"))
+        {
+            return;
+        }
+
         const char* memberQuery = "UPDATE unity_system JOIN (SELECT unity_leader, COUNT(*) AS members FROM char_profile GROUP BY unity_leader) TMP ON unity_system.leader = unity_leader SET unity_system.members_current = members;";
         sql->Query(memberQuery);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

These updates are called into directly from time_server.cpp and query the database even if Records of Eminence is not enabled for a server.

## Steps to test these changes

👀 