### PR TITLE
Fix fishing pirate chart fight items

### DIFF
--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -2245,6 +2245,12 @@ namespace fishingutils
                     }
                     else
                     {
+                        // ignore pirates chart items since not in pirates fight
+                        if (item->fishID == 5329 || item->fishID == 5330)
+                        {
+                            continue;
+                        }
+
                         if (!item->quest_only && FishingPools[PChar->getZone()].catchPools[area->areaId].stock[item->fishID].quantity == 0)
                         {
                             NoCatchList.insert(item->fishID);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Ignore pirates chart items during fishing if not in the pirates chart fight

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
