### PR TITLE
Fixed issue where Mob TP move would show KO instead of actual effect

### DIFF
--- a/scripts/globals/mobskills/stygian_flatus.lua
+++ b/scripts/globals/mobskills/stygian_flatus.lua
@@ -16,10 +16,10 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 30, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 30, 0, 120))
 
-    return typeEffect
+    return xi.effect.PARALYSIS
+
 end
 
 return mobskillObject

--- a/scripts/globals/mobskills/stygian_flatus.lua
+++ b/scripts/globals/mobskills/stygian_flatus.lua
@@ -16,7 +16,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 30, 0, 120))
+    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 30, 0, 120))
 
     return typeEffect
 end

--- a/scripts/globals/mobskills/stygian_vapor.lua
+++ b/scripts/globals/mobskills/stygian_vapor.lua
@@ -14,10 +14,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-
     local typeEffect = xi.effect.PLAGUE
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 5, 0, 120))
-
     return typeEffect
 end
 

--- a/scripts/globals/mobskills/stygian_vapor.lua
+++ b/scripts/globals/mobskills/stygian_vapor.lua
@@ -14,7 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 5, 0, 120))
+
+    local typeEffect = xi.effect.PLAGUE
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 5, 0, 120))
 
     return typeEffect
 end

--- a/scripts/globals/mobskills/stygian_vapor.lua
+++ b/scripts/globals/mobskills/stygian_vapor.lua
@@ -14,9 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PLAGUE
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 5, 0, 120))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 5, 0, 120))
+
+    return xi.effect.PLAGUE
 end
 
 return mobskillObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
fixes issue where promy bosses used specific TP move and would display KO message to players. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
