### PR TITLE
Fix Absorb Spell Effect Power

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1808,7 +1808,7 @@ xi.magic.doAbsorbSpell = function(caster, target, spell, params)
         target:addTP(-spellTable[isAbsorbTp].base)
     else
         caster:addStatusEffect(params.bonusEffect, spellTable[isAbsorbTp].base, 8, spellTable[isAbsorbTp].duration)
-        target:addStatusEffect(params.effect, -spellTable[isAbsorbTp].base, 8, spellTable[isAbsorbTp].duration)
+        target:addStatusEffect(params.effect, spellTable[isAbsorbTp].base, 8, spellTable[isAbsorbTp].duration)
     end
 
     return spellTable[isAbsorbTp].returnVal


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where Absorb spell effects were lowering the target's main stat by too much.

## Steps to test these changes

!getstats
absorb-str
!getstats