### PR TITLE
Move Dhalmel Hair Synthesis to Correct Expansion

### DIFF
--- a/modules/era/sql/synth_recipes_era.sql
+++ b/modules/era/sql/synth_recipes_era.sql
@@ -674,7 +674,6 @@ UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ID = 41027;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Dhalmel Mantle' AND ID = 41028;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Noct Brais' AND ID = 41029;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Studded Boots' AND ID = 41030;
-UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Dhalmel Hair' AND ID = 41031;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Sandals' AND ID = 41032;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ID = 41033;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Breath Mantle' AND ID = 41035;
@@ -1951,6 +1950,7 @@ UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Marinara Pizz
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Marinara Slice' AND ID = 71545;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Pizza Dough' AND ID = 72004;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Cherry Muffin' AND ID = 72011;
+UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Dhalmel Hair' AND ID = 41031;
 
 -- ------------------------------------------------------------
 -- ACP


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where the Dhalmel Hair synthesis was available before its correct expansion.

## Steps to test these changes

👀 

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2512