### PR TITLE
Bard songs replace own status effect

### DIFF
--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -969,6 +969,7 @@ bool CStatusEffectContainer::ApplyBardEffect(CStatusEffect* PStatusEffect, uint8
 
     uint8          numOfEffects = 0;
     CStatusEffect* oldestSong   = nullptr;
+    uint8           overwrite   = false;    // are we overwriting the same song effect?
     for (CStatusEffect* ExistingStatusEffect : m_StatusEffectSet)
     {
         if (ExistingStatusEffect->GetStatusID() >= EFFECT_REQUIEM && ExistingStatusEffect->GetStatusID() <= EFFECT_NOCTURNE) // is an active brd effect
@@ -978,6 +979,8 @@ bool CStatusEffectContainer::ApplyBardEffect(CStatusEffect* PStatusEffect, uint8
                 // OVERWRITE
                 PStatusEffect->SetSlot(ExistingStatusEffect->GetSlot()); // use same slot as the one it replaces
                 DelStatusEffectByTier(PStatusEffect->GetStatusID(), PStatusEffect->GetTier());
+                oldestSong = ExistingStatusEffect;
+                overwrite = true;
             }
             if (ExistingStatusEffect->GetSubID() == PStatusEffect->GetSubID())
             { // YOUR BRD effect
@@ -986,7 +989,8 @@ bool CStatusEffectContainer::ApplyBardEffect(CStatusEffect* PStatusEffect, uint8
                 {
                     oldestSong = ExistingStatusEffect;
                 }
-                else if (std::chrono::milliseconds(ExistingStatusEffect->GetDuration()) + ExistingStatusEffect->GetStartTime() <
+                else if (!overwrite &&
+                         std::chrono::milliseconds(ExistingStatusEffect->GetDuration()) + ExistingStatusEffect->GetStartTime() <
                          std::chrono::milliseconds(oldestSong->GetDuration()) + oldestSong->GetStartTime())
                 {
                     oldestSong = ExistingStatusEffect;


### PR DESCRIPTION
If applicable, bard songs replace own status effect in preference to song effect with shortest remaining duration.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #2395 
This PR addresses the issue by ensuring that when a bard song buff is cast and the same song buff status effect is already present on a player, then only that status effect is replaced. Previously the effect with the lowest remaining duration was replaced, which could result in the loss of a status effect.

## Steps to test these changes
1. On a character with main job bard, equip an instrument with no song enhancements (e.g. Maple Harp).
2. Play Valor Minuet.
3. Play Sword Madrigal.
4. [At this point the player has two status effects, Minuet and Madrigal, with Minuet having a lesser remaining duration since it was cast first.]
5. Play Sword Madrigal again.
Result: the player has both a Minuet and a Madrigal effect. The Minuet effect duration is unaffected and the Madrigal effect duration is reset to full. (Before this PR the player would have only Madrigal at this point as the Minuet effect, having a lesser remaining duration, would have been deleted in addition to the Madrigal effect being replaced.)
