### PR TITLE
Fix conquest voucher usage without CP

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1274,9 +1274,9 @@ local function canPurchaseItem(player, stock, pRank, guardNation, mOffset, optio
 
     if player:getCP() < price then
         if
-            not (option <= 32933 and
-            option >= 32935) or
-            player:hasKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER)
+            not ((option >= 32933 and
+            option <= 32935) and
+            player:hasKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER))
         then
             player:messageSpecial(mOffset + 62, 0, 0, stock.item) -- "You do not have enough conquest points to purchase the <item>."
             return -1


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes conquest voucher usage without CP

## Steps to test these changes

* Have 10 CP. 
* !addkeyitem `CONQUEST_PROMOTION_VOUCHER`
* Have no EXP bands in inventory
* Purchase an exp band for 0 cp