### PR TITLE
Remove Mount Misc Flag from Unmountable Era Zones

### DIFF
--- a/modules/era/sql/era_zone_settings.sql
+++ b/modules/era/sql/era_zone_settings.sql
@@ -24,4 +24,17 @@ UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `z
 UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 139;
 UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 128;
 
+-- Remove mount flag from zones that cannot have Chocobos prior to mounts being added
+UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 5;   -- Uleguerand Range
+UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 7;   -- Attohwa Chasm
+UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 24;  -- Lufaise Meadows
+UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 25;  -- Misareaux Coast
+UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 111; -- Beaucedine Glacier
+UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 112; -- Xarcabard
+UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 113; -- Cape Teriggan
+UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 122; -- Ro'Maeve
+UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 126; -- Qufim Island
+UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 127; -- Behemoth's Dominion
+UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 128; -- Valley of Sorrows
+
 UNLOCK TABLES;

--- a/sql/zone_settings.sql
+++ b/sql/zone_settings.sql
@@ -163,7 +163,7 @@ INSERT INTO `zone_settings` VALUES (118,2,'127.0.0.1',54230,'Buburimu_Peninsula'
 INSERT INTO `zone_settings` VALUES (119,2,'127.0.0.1',54230,'Meriphataud_Mountains',0,0,101,103,0,0.00,2204);
 INSERT INTO `zone_settings` VALUES (120,2,'127.0.0.1',54230,'Sauromugue_Champaign',158,158,101,103,0,0.00,2204);
 INSERT INTO `zone_settings` VALUES (121,2,'127.0.0.1',54230,'The_Sanctuary_of_ZiTah',190,190,101,191,0,0.00,2204);
-INSERT INTO `zone_settings` VALUES (122,2,'127.0.0.1',54230,'RoMaeve',211,211,101,191,0,0.00,2200);
+INSERT INTO `zone_settings` VALUES (122,2,'127.0.0.1',54230,'RoMaeve',211,211,101,191,0,0.00,2204);
 INSERT INTO `zone_settings` VALUES (123,2,'127.0.0.1',54230,'Yuhtunga_Jungle',134,134,101,191,0,0.00,2204);
 INSERT INTO `zone_settings` VALUES (124,2,'127.0.0.1',54230,'Yhoator_Jungle',134,134,101,191,0,0.00,2204);
 INSERT INTO `zone_settings` VALUES (125,2,'127.0.0.1',54230,'Western_Altepa_Desert',171,171,101,191,0,0.00,2204);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Update era module to remove the ability to mount in various zones where Chocobos were not allowed. This fixes an issue where existing servers don't pull in the recent change to remove Ro'Maeve's ability to ride Chocobos.

## Steps to test these changes

Pull changes
Run dbtool.py
!zone ZiTah
!addeffect mounted
Try to mount into Ro'Maeve