### PR TITLE
Reset dia/dia2 timers on subsequent dia casts

### DIFF
--- a/scripts/globals/spells/white/dia.lua
+++ b/scripts/globals/spells/white/dia.lua
@@ -47,8 +47,12 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
+    local dia = target:getStatusEffect(xi.effect.DIA)
 
-    if  bio == nil then -- if no bio, add dia dot
+    if dia ~= nil then -- reset dia timer if dia is already on target
+        target:delStatusEffectSilent(xi.effect.DIA)
+        target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 5, 1)
+    elseif  bio == nil then -- if no bio, add dia dot
         target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 5, 1)
     elseif  bio:getSubPower() == 10 and xi.settings.main.BIO_OVERWRITE == 1 then -- Try to kill same tier Bio (non-default behavior)
             target:delStatusEffect(xi.effect.BIO)

--- a/scripts/globals/spells/white/dia_ii.lua
+++ b/scripts/globals/spells/white/dia_ii.lua
@@ -46,8 +46,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
+    local dia = target:getStatusEffect(xi.effect.DIA)
 
-    if  bio == nil then -- if no bio, add dia dot
+    if dia ~= nil then -- reset dia timer if dia is already on target
+        target:delStatusEffectSilent(xi.effect.DIA)
+        target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 10, 2)
+    elseif  bio == nil then -- if no bio, add dia dot
+
         target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 10, 2)
     elseif
         bio:getSubPower() == 10 or


### PR DESCRIPTION
Reset dia/dia ii timers on subsequent dia casts

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #2475 - Dia and dia ii will now overwrite themselves and add time

## Steps to test these changes
Cast dia, wait approximately 10 seconds before it should wear off, recast dia.   Repeat the same steps for dia ii.

