### PR TITLE
Reset Dia/Dia II on recast

### DIFF
--- a/scripts/globals/spells/white/dia.lua
+++ b/scripts/globals/spells/white/dia.lua
@@ -45,10 +45,14 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
 
-    -- Check for Bio
+    -- Check for Bio/Dia
     local bio = target:getStatusEffect(xi.effect.BIO)
+    local dia = target:getStatusEffect(xi.effect.DIA)
 
-    if  bio == nil then -- if no bio, add dia dot
+    if dia ~= nil then -- reset dia timer if dia is already on target
+        target:delStatusEffectSilent(xi.effect.DIA)
+        target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 5, 1)
+    elseif  bio == nil then -- if no bio, add dia dot
         target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 5, 1)
     elseif  bio:getSubPower() == 10 and xi.settings.main.BIO_OVERWRITE == 1 then -- Try to kill same tier Bio (non-default behavior)
             target:delStatusEffect(xi.effect.BIO)

--- a/scripts/globals/spells/white/dia_ii.lua
+++ b/scripts/globals/spells/white/dia_ii.lua
@@ -44,10 +44,15 @@ spellObject.onSpellCast = function(caster, target, spell)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
     spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
-    -- Check for Bio
-    local bio = target:getStatusEffect(xi.effect.BIO)
 
-    if  bio == nil then -- if no bio, add dia dot
+    -- Check for Bio/Dia
+    local bio = target:getStatusEffect(xi.effect.BIO)
+    local dia = target:getStatusEffect(xi.effect.DIA)
+
+    if dia ~= nil then -- reset dia timer if dia is already on target
+        target:delStatusEffectSilent(xi.effect.DIA)
+        target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 10, 2)
+    elseif  bio == nil then -- if no bio, add dia dot
         target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 10, 2)
     elseif
         bio:getSubPower() == 10 or


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #2475 -- Dia will now override previous dia and restart timer

## Steps to test these changes
Cast dia, cast again when the spell is almost expired from target.   New dia effect & timer will restart
