### PR TITLE
Tri Bat and Goblin Mobskill tweaks

### DIFF
--- a/scripts/globals/mobskills/bomb_toss.lua
+++ b/scripts/globals/mobskills/bomb_toss.lua
@@ -9,6 +9,12 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    local suicideCheck = math.random(0, 100)
+    if suicideCheck <= 15 then -- 15% chance to use bomb_toss_suicide if bomb_toss is picked (50%)
+        mob:useMobAbility(592)
+        return 1
+    end
+
     return 0
 end
 

--- a/scripts/globals/mobskills/slipstream.lua
+++ b/scripts/globals/mobskills/slipstream.lua
@@ -13,7 +13,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 25, 0, 180))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 25, 0, math.random(120, 180)))
 
     return xi.effect.ACCURACY_DOWN
 end

--- a/scripts/globals/mobskills/sonic_boom.lua
+++ b/scripts/globals/mobskills/sonic_boom.lua
@@ -14,7 +14,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 25, 0, math.random(120, 180)))
-ws
+
     return xi.effect.ATTACK_DOWN
 end
 

--- a/scripts/globals/mobskills/sonic_boom.lua
+++ b/scripts/globals/mobskills/sonic_boom.lua
@@ -13,8 +13,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 50, 0, 180))
-
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 25, 0, math.random(120, 180)))
+ws
     return xi.effect.ATTACK_DOWN
 end
 

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -514,7 +514,6 @@ INSERT INTO `mob_skill_lists` VALUES ('Gnole',132,2175);
 INSERT INTO `mob_skill_lists` VALUES ('Gnole',132,2176);
 INSERT INTO `mob_skill_lists` VALUES ('Goblin',133,590);
 INSERT INTO `mob_skill_lists` VALUES ('Goblin',133,591);
-INSERT INTO `mob_skill_lists` VALUES ('Goblin',133,592);
 INSERT INTO `mob_skill_lists` VALUES ('God',134,1491);
 INSERT INTO `mob_skill_lists` VALUES ('God',134,1492);
 INSERT INTO `mob_skill_lists` VALUES ('God',134,1493);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Bomb toss suicide will now only have a 15% chance to be used upon picking the skill bomb_toss
- Attack down change from 50% to 25% on sonic_boom
- Duration changes to Tri Bats
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
