### PR TITLE
Fix Ichorous Ire Fossil Rock ID

### DIFF
--- a/scripts/quests/windurst/Blast_from_the_Past.lua
+++ b/scripts/quests/windurst/Blast_from_the_Past.lua
@@ -129,11 +129,7 @@ quest.sections =
             ['Fossil_Rock'] =
             {
                 onTrigger = function(player, npc)
-                    -- TODO: Break out Fossil Rock into multiple NPC names and update impacted
-                    -- quests and missions.
-                    local rockOffset = npc:getID() - shakhramiID.npc.FOSSIL_ROCK_OFFSET
-
-                    if rockOffset == 8 then
+                    if npc:getID() == shakhramiID.npc.ICHOROUS_IRE_FOSSIL_ROCK then
                         if
                             not GetMobByID(shakhramiID.mob.ICHOROUS_IRE):isSpawned() and
                             not player:hasItem(xi.items.BURNITE_SHELL_STONE)

--- a/scripts/zones/Maze_of_Shakhrami/IDs.lua
+++ b/scripts/zones/Maze_of_Shakhrami/IDs.lua
@@ -82,7 +82,8 @@ zones[xi.zone.MAZE_OF_SHAKHRAMI] =
             17588742,
             17588743,
         },
-        TREASURE_CHEST     = 17588773,
+        ICHOROUS_IRE_FOSSIL_ROCK = 17588745,
+        TREASURE_CHEST           = 17588773,
         EXCAVATION =
         {
             17588774,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where Ichorous Ire wasn't able to be spawned during Windurst quest Blast From The Past.

## Steps to test these changes

!addquest 2 11
!gotoid 17588745
Spawn Ichorous Ire

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/781