### PR TITLE
Prevent NMs From Using Suicide Bomb Toss

### DIFF
--- a/scripts/globals/mobskills/bomb_toss.lua
+++ b/scripts/globals/mobskills/bomb_toss.lua
@@ -10,7 +10,12 @@ local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     local suicideCheck = math.random(0, 100)
-    if suicideCheck <= 15 then -- 15% chance to use bomb_toss_suicide if bomb_toss is picked (50%)
+
+    if
+        not mob:isNM() and
+        not mob:isInDynamis() and
+        suicideCheck <= 15 -- 15% chance to use bomb_toss_suicide if bomb_toss is picked (50%)
+    then
         mob:useMobAbility(592)
         return 1
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

New method of suicide bomb toss can have NMs and dynamis mobs killing themselves since they bypass the 592 onMobSkillCheck. Don't let them do that.

## Steps to test these changes

!spawnmob 17649693
!gotoid 17649693
!tp 3000

@Frankie-hz 