### PR TITLE
Add module for 2002 Viper Bite

### DIFF
--- a/modules/era/back_date_sqls/2002_viper_bite.sql
+++ b/modules/era/back_date_sqls/2002_viper_bite.sql
@@ -1,6 +1,6 @@
 -- Sep. 12th, 2002: "The skill levels required to learn Viper Bite and Gust Slash were switched."
 -- https://www.bg-wiki.com/ffxi/The_History_of_Final_Fantasy_XI/2002
--- (This reverses the change)
+-- (This reverses the change, so Viper Bite is learned earlier)
 REPLACE INTO `weapon_skills` (`weaponskillid`, `name`, `jobs`, `type`, `skilllevel`, `element`, `animation`, `animationTime`, `range`, `aoe`, `primary_sc`, `secondary_sc`, `tertiary_sc`, `main_only`, `unlock_id`) VALUES
     (17,'viper_bite',0x00000000020200000002020002000000000002000000,2,40,0,32,2000,5,1,4,0,0,0,0),
     (19,'gust_slash',0x02000002020202020202020202020200020202020000,2,100,16,34,2000,15,1,6,0,0,0,0);

--- a/modules/era/back_date_sqls/2002_viper_bite.sql
+++ b/modules/era/back_date_sqls/2002_viper_bite.sql
@@ -1,0 +1,6 @@
+-- Sep. 12th, 2002: "The skill levels required to learn Viper Bite and Gust Slash were switched."
+-- https://www.bg-wiki.com/ffxi/The_History_of_Final_Fantasy_XI/2002
+-- (This reverses the change)
+REPLACE INTO `weapon_skills` (`weaponskillid`, `name`, `jobs`, `type`, `skilllevel`, `element`, `animation`, `animationTime`, `range`, `aoe`, `primary_sc`, `secondary_sc`, `tertiary_sc`, `main_only`, `unlock_id`) VALUES
+    (17,'viper_bite',0x00000000020200000002020002000000000002000000,2,40,0,32,2000,5,1,4,0,0,0,0),
+    (19,'gust_slash',0x02000002020202020202020202020200020202020000,2,100,16,34,2000,15,1,6,0,0,0,0);

--- a/modules/era/back_date_sqls/2002_viper_bite.sql
+++ b/modules/era/back_date_sqls/2002_viper_bite.sql
@@ -1,6 +1,5 @@
 -- Sep. 12th, 2002: "The skill levels required to learn Viper Bite and Gust Slash were switched."
 -- https://www.bg-wiki.com/ffxi/The_History_of_Final_Fantasy_XI/2002
 -- (This reverses the change, so Viper Bite is learned earlier)
-REPLACE INTO `weapon_skills` (`weaponskillid`, `name`, `jobs`, `type`, `skilllevel`, `element`, `animation`, `animationTime`, `range`, `aoe`, `primary_sc`, `secondary_sc`, `tertiary_sc`, `main_only`, `unlock_id`) VALUES
-    (17,'viper_bite',0x00000000020200000002020002000000000002000000,2,40,0,32,2000,5,1,4,0,0,0,0),
-    (19,'gust_slash',0x02000002020202020202020202020200020202020000,2,100,16,34,2000,15,1,6,0,0,0,0);
+UPDATE `weapon_skills` SET skilllevel = 40 WHERE name = 'viper_bite';
+UPDATE `weapon_skills` SET skilllevel = 100 WHERE name = 'gust_slash';


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Before September 2002, Viper Bite was learned at 40 Dagger Skill (Lv13 Thief). It was the direct successor Wasp Sting, the way Gust Slash "upgrades" into Cyclone. The IDs still reflect this.

Unfortunately, this change was never reverted despite Dagger being considered very weak, especially in the early game where it's lacking a decent Weapon Skill.

This module reverses that change to the original 2002 implementation, for servers that choose to enable it.

`The skill levels required to learn Viper Bite and Gust Slash were switched.` (Sep. 12th, 2002)
https://www.bg-wiki.com/ffxi/The_History_of_Final_Fantasy_XI/2002

## Steps to test these changes
- Add module to modules/init.txt: `era/back_date_sqls/2002_viper_bite.sql`
- Run `dbtool.py`

- In game:
```
!changejob thf 15
!capallskills
```