### PR TITLE
Lokpix Dialogue fix

### DIFF
--- a/scripts/zones/Eastern_Altepa_Desert/DefaultActions.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/DefaultActions.lua
@@ -1,5 +1,5 @@
 local ID = require('scripts/zones/Eastern_Altepa_Desert/IDs')
 
 return {
-    ['Lokpix'] = { event = 24 },
+    -- ['Lokpix'] = { event = 24 }, -- Event 24 is out Abyssea era dialogue.
 }


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This change removes the calling of event 24, which is dialogue pertaining to the out of era quest "Open Sesame". This gave the illusion that players were receiving the quest.
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/2507
