### PR TITLE
Promy Boss Bug Fix

### DIFF
--- a/scripts/zones/Spire_of_Holla/mobs/Wreaker.lua
+++ b/scripts/zones/Spire_of_Holla/mobs/Wreaker.lua
@@ -20,4 +20,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
+entity.onMobDeath = function(mob, player, optParams)
+end
+
 return entity

--- a/scripts/zones/Spire_of_Mea/mobs/Delver.lua
+++ b/scripts/zones/Spire_of_Mea/mobs/Delver.lua
@@ -18,4 +18,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
+entity.onMobDeath = function(mob, player, optParams)
+end
+
 return entity


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixes an issue where if promy bosses died with listeners applied to them, they weren't being removed and would respawn stuck in a "terrored" state. This was being caused due to not having the onMobDeath function which removes listeners from said mob.
