### PR TITLE
Consortium Fix

### DIFF
--- a/scripts/quests/sandoria/A_Job_for_the_Consortium.lua
+++ b/scripts/quests/sandoria/A_Job_for_the_Consortium.lua
@@ -97,7 +97,7 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if player:hasKeyItem(xi.ki.BRUGAIRE_GOODS) then
-                        if math.random() > 0.25 or (VanadielHour() > 6 and VanadielHour() < 18) then
+                        if math.random() > 0.25 or (VanadielHour() < 6 and VanadielHour() > 18) then
                             quest:setVar(player, 'Option', 0)
                             return quest:progressEvent(54)
                         else


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixed players from being stopped in customs during the "A Job for the Consortium" quest during "safe" hours
Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/815
