### PR TITLE
Prevent players being automatically jailed for crafting on airships

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3593,7 +3593,7 @@ void SmallPacket0x059(map_session_data_t* const PSession, CCharEntity* const PCh
     TracyZoneScoped;
     if (PChar->animation == ANIMATION_SYNTH)
     {
-        synthutils::sendSynthDone(PChar);
+        synthutils::sendSynthDone(PChar, false);
     }
 }
 

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -903,12 +903,21 @@ namespace synthutils
      *                                                                       *
      ************************************************************************/
 
-    int32 doSynthResult(CCharEntity* PChar)
+    int32 doSynthResult(CCharEntity* PChar, bool forced = false)
     {
         uint8 m_synthResult = PChar->CraftContainer->getQuantity(0);
         PChar->SetLocalVar("InSynth", 0);
         if (settings::get<bool>("map.ANTICHEAT_ENABLED"))
         {
+            // If player was forced to end synthesis early due to zone (eg. Airship/Boat)
+            if (forced)
+            {
+                PChar->CraftContainer->setQuantity(0, synthutils::SYNTHESIS_FAIL);
+                m_synthResult = SYNTHESIS_FAIL;
+                doSynthFail(PChar);
+                return 0;
+            }
+
             std::chrono::duration animationDuration = server_clock::now() - PChar->m_LastSynthTime;
             if (animationDuration < 10s)
             {
@@ -1042,9 +1051,9 @@ namespace synthutils
      *                                                                       *
      ************************************************************************/
 
-    int32 sendSynthDone(CCharEntity* PChar)
+    int32 sendSynthDone(CCharEntity* PChar, bool forced = false)
     {
-        doSynthResult(PChar);
+        doSynthResult(PChar, forced);
 
         PChar->animation = ANIMATION_NONE;
         PChar->updatemask |= UPDATE_HP;

--- a/src/map/utils/synthutils.h
+++ b/src/map/utils/synthutils.h
@@ -56,7 +56,7 @@ namespace synthutils
     };
 
     int32 startSynth(CCharEntity* PChar);
-    int32 sendSynthDone(CCharEntity* PChar);
+    int32 sendSynthDone(CCharEntity* PChar, bool forced);
     int32 doSynthFail(CCharEntity* PChar);
 }; // namespace synthutils
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -433,7 +433,7 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
     if (PChar->animation == ANIMATION_SYNTH)
     {
         PChar->CraftContainer->setQuantity(0, synthutils::SYNTHESIS_FAIL);
-        synthutils::sendSynthDone(PChar);
+        synthutils::sendSynthDone(PChar, true);
     }
 
     // TODO: могут возникать проблемы с переходом между одной и той же зоной (zone == prevzone)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Players are automatically jailed if synthesis ends prematurely due to fast synth exploit detection. Unfortunately this is also being triggered by zoning while in synthesis due to airships/boats and would probably happen if a player was warped or teleported too.

I added an extra parameter to bypass when synthesis is forcibly terminated by the server (zoning) and not due to a premature packet from the player.

## Steps to test these changes

Craft while an airship is landing