### PR TITLE
Fixes Padfoot Spawn Conditions

### DIFF
--- a/scripts/zones/Lufaise_Meadows/Zone.lua
+++ b/scripts/zones/Lufaise_Meadows/Zone.lua
@@ -15,12 +15,18 @@ local zoneObject = {}
 zoneObject.onInitialize = function(zone)
     zone:registerTriggerArea(1, 179, -26, 327, 219, -18, 347)
 
+    local padfootRespawn = GetServerVariable("[Padfoot]Respawn")
     SetServerVariable("realPadfoot", math.random(1, 5))
     for _, v in pairs(ID.mob.PADFOOT) do
-        SpawnMob(v)
+        if os.time() > GetServerVariable("[Padfoot]Respawn") then
+            SpawnMob(v)
+        else
+            GetMobByID(v):setRespawnTime(padfootRespawn)
+        end
     end
+
     if xi.settings.main.ENABLE_WOTG == 1 then
-        GetMobByID(ID.mob.YALUN_EKE):setLocalVar("chooseYalun", math.random(1,2))
+        GetMobByID(ID.mob.YALUN_EKE):setLocalVar("chooseYalun", math.random(1, 2))
     end
 
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())

--- a/scripts/zones/Lufaise_Meadows/Zone.lua
+++ b/scripts/zones/Lufaise_Meadows/Zone.lua
@@ -15,13 +15,13 @@ local zoneObject = {}
 zoneObject.onInitialize = function(zone)
     zone:registerTriggerArea(1, 179, -26, 327, 219, -18, 347)
 
-    local padfootRespawn = GetServerVariable("[Padfoot]Respawn")
     SetServerVariable("realPadfoot", math.random(1, 5))
     for _, v in pairs(ID.mob.PADFOOT) do
-        if os.time() > GetServerVariable("[Padfoot]Respawn") then
+        local respawnP = GetServerVariable("\\[SPAWN\\]"..v)
+        if os.time() > respawnP then
             SpawnMob(v)
         else
-            GetMobByID(v):setRespawnTime(padfootRespawn)
+            GetMobByID(v):setRespawnTime(respawnP - os.time())
         end
     end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
@@ -26,7 +26,8 @@ entity.onMobDespawn = function(mob)
     local mobId = mob:getID()
 
     if mobId == ID.mob.PADFOOT[GetServerVariable("realPadfoot")] then
-        local respawn = 75600 + math.random(0, 6) * 1800 -- 21 - 24 hours with half hour windows
+        local respawn = os.time() + (75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
+        SetServerVariable("[Padfoot]Respawn", respawn)
 
         for _, v in pairs(ID.mob.PADFOOT) do
             if v ~= mobId and GetMobByID(v):isSpawned() then

--- a/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
@@ -26,15 +26,12 @@ entity.onMobDespawn = function(mob)
     local mobId = mob:getID()
 
     if mobId == ID.mob.PADFOOT[GetServerVariable("realPadfoot")] then
-        local respawn = os.time() + (75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
-        SetServerVariable("[Padfoot]Respawn", respawn)
-
         for _, v in pairs(ID.mob.PADFOOT) do
             if v ~= mobId and GetMobByID(v):isSpawned() then
                 DespawnMob(v)
             end
 
-            GetMobByID(v):setRespawnTime(respawn)
+            xi.mob.nmTODPersist(GetMobByID(v), 75600 + math.random(0, 6) * 1800) -- 21 to 24 hours with half hour windows
         end
 
         SetServerVariable("realPadfoot", math.random(1, 5))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixes an issue where Padfoot would instantly respawn on a crash/server restart
- Padfoots TOD now persists through crashes
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!goto 16875552
16875748
16875615
16875578
16875703

Kill every padfoot until you find the one that drops the ring (because we all know the earing does not drop)
Crash/restart server
See no padfoots
<!-- Clear and detailed steps to test your changes here -->
