### PR TITLE
Fix potential guild point item syncing issues

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6675,7 +6675,7 @@ namespace charutils
         {
             PZone->ForEachChar([varName](CCharEntity* PChar)
             {
-                PChar->updateCharVarCache(varName, 0);
+                PChar->removeFromCharVarCache(varName);
             });
         });
         // clang-format on

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6675,7 +6675,7 @@ namespace charutils
         {
             PZone->ForEachChar([varName](CCharEntity* PChar)
             {
-                PChar->removeFromCharVarCache(varName);
+                PChar->updateCharVarCache(varName, 0);
             });
         });
         // clang-format on

--- a/src/map/utils/guildutils.cpp
+++ b/src/map/utils/guildutils.cpp
@@ -135,13 +135,13 @@ namespace guildutils
     {
         // TODO: This function can be faulty when dealing with multiple processes. Needs to be synchronized properly across servers.
 
-        bool doUpdate = static_cast<uint32>(serverutils::GetServerVar("[GUILD]pattern_update")) != CVanaTime::getInstance()->getSysYearDay();
+        bool doUpdate = static_cast<uint32>(serverutils::GetServerVar("[GUILD]pattern_update")) != CVanaTime::getInstance()->getJstYearDay();
 
         uint8 pattern = xirand::GetRandomNumber(8);
         if (doUpdate)
         {
             // write the new pattern and update time to try to prevent other servers from updating the pattern
-            serverutils::SetServerVar("[GUILD]pattern_update", CVanaTime::getInstance()->getSysYearDay());
+            serverutils::SetServerVar("[GUILD]pattern_update", CVanaTime::getInstance()->getJstYearDay());
             serverutils::SetServerVar("[GUILD]pattern", pattern);
             charutils::ClearCharVarFromAll("[GUILD]daily_points");
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
The PR changes guild system to use JST time for tracking guild point updates so this better aligns with JP midnight change of guild point items. 

I am pretty sure this was causing significant issues. Specifically, I think currently if a single server restarts between midnight server time (e.g., 0:00 MST in USA) and JP midnight (8:00 MST) then the server initialization (guildutils::Initialize) sees the day difference before the JP midnight trigger (that runs on all servers) and thus tries to change the guild item (though cannot because of hard coded client restrictions) and does reset chars [GUILD]daily_points (in the DB for all). 

However if not all servers are restarted at that time (i.e., only one crashes) then maybe some characters retain old charvarchaches that are then out of sync with the DB? Though I note that I am not an expert on how the charvarchache is working.

Overall this would not be a problem if the server timezone is set to JST, however this fix helps ensure that even if it is not the guild system should still be in sync.

When the fix is applied to an existing server (should be just after JP midnight triggers) the server variable [GUILD]pattern_update should be set to the day of the year (in JP) (UPDATE server_variables SET VALUE = X WHERE NAME = "[GUILD]pattern_update") and the char_vars for points should be reset (DELETE FROM char_vars WHERE varname = '[GUILD]daily_points'). This should occur before the server is restarted. This should align the sync going forward.

## Steps to test these changes
Potentially close https://github.com/AirSkyBoat/AirSkyBoat/issues/2405 , https://github.com/HorizonFFXI/HorizonXI-Issues/issues/754 , https://github.com/HorizonFFXI/HorizonXI-Issues/issues/744 , https://github.com/HorizonFFXI/HorizonXI-Issues/issues/831, https://github.com/HorizonFFXI/HorizonXI-Issues/issues/866, https://github.com/HorizonFFXI/HorizonXI-Issues/issues/871