### PR TITLE
Fix fishermans belt effect duration and skill boost

### DIFF
--- a/scripts/globals/items/fishermans_belt.lua
+++ b/scripts/globals/items/fishermans_belt.lua
@@ -5,8 +5,8 @@
 -- 2Min, All Races
 -----------------------------------
 -- Enchantment: Synthesis image support
--- Duration: 2Min
--- Fishing Skill +3
+-- Duration: 2 Earth Hours
+-- Fishing Skill +2
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
@@ -37,7 +37,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.FISHING_IMAGERY, 3, 0, 120)
+    target:addStatusEffect(xi.effect.FISHING_IMAGERY, 2, 0, 7200)
 end
 
 itemObject.onEffectGain = function(target, effect)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fishing has different advanced support that lasts for 2 hours and raises skill by 2 points (rather than 3), see [here](https://ffxiclopedia.fandom.com/wiki/Synthesis_Image_Support), [here](https://ffxi.allakhazam.com/db/item.html?fitem=9203)(suggesting duration was longer than 2 mins in era), and also notice the lack of any updates in SE patch notes after 2005.

## Steps to test these changes
Use the item
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2614