### PR TITLE
Fix Celphie regen mod

### DIFF
--- a/scripts/zones/Western_Altepa_Desert/mobs/Celphie.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/Celphie.lua
@@ -3,11 +3,12 @@
 --   NM: Celphie
 -----------------------------------
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
-entity.onMobFight = function(mob, target)
-    if mob:hasStatusEffect(xi.effect.HUNDRED_FISTS) then
+entity.onMobWeaponSkill = function(target, mob, skill)
+    if skill:getID() == xi.jsa.HUNDRED_FISTS then
         mob:addMod(xi.mod.REGEN, 20)
     end
 end

--- a/scripts/zones/Western_Altepa_Desert/mobs/Celphie.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/Celphie.lua
@@ -9,7 +9,7 @@ local entity = {}
 
 entity.onMobWeaponSkill = function(target, mob, skill)
     if skill:getID() == xi.jsa.HUNDRED_FISTS then
-        mob:addMod(xi.mod.REGEN, 20)
+        mob:setMod(xi.mod.REGEN, 20)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes the regen mod on Celphie that was erroneously being applied 15x during hundred fists (thus making it have a 300 HP a tick regen rather than 20)

## Steps to test these changes
Spawn and fight until it 2hrs and watch the regen difference