### PR TITLE
Fix Marble Bridge entry checks

### DIFF
--- a/scripts/zones/Upper_Jeuno/npcs/_6s1.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/_6s1.lua
@@ -33,13 +33,13 @@ local doorCheck =
     xi.job.PUP,
     xi.job.DNC,
     xi.job.SCH,
-    xi.race.HUME_M,
-    xi.race.ELVAAN_M,
-    xi.race.TARU_M,
+    xi.race.HUME_F,
+    xi.race.ELVAAN_F,
+    xi.race.TARU_F,
     xi.race.MITHRA,
     xi.race.GALKA,
-    0,
     1,
+    0,
 }
 
 local marbleEateryDoorCheck = function(player)
@@ -48,26 +48,35 @@ local marbleEateryDoorCheck = function(player)
     -- Rotation is based on https://ffxiclopedia.fandom.com/wiki/Marble_Bridge_Eatery removed by 3 days to match up with http://www.mithrapride.org/vana_time/
     for k, v in pairs(doorCheck) do
         if dayofthemonth == k then
-            if (k >= 1 or k <= 3) and player:getNation() == v then
-                player:startEvent(124, (dayofthemonth - 1), 1)
-            elseif (k >= 4 or k <= 23) and player:getMainJob() == v then
-                player:startEvent(124, (dayofthemonth - 1), 1)
+            if (k >= 1 and k <= 3) then
+                if player:getNation() == v then
+                    player:startEvent(124, (dayofthemonth - 1), 1)
+                else
+                    player:startEvent(124, (dayofthemonth - 1), 0)
+                end
+            elseif (k >= 4 and k <= 23) then
+                if player:getMainJob() == v then
+                    player:startEvent(124, (dayofthemonth - 1), 1)
+                else
+                    player:startEvent(124, (dayofthemonth - 1), 0)
+                end
+            -- The second argument to startevent() becomes dayofthemonth + 1 instead of - 1 from here, so that we skip over the RUN and GEO events.
             elseif k == 24 and player:getRace() > 0 and player:getRace() <= v then
-                player:startEvent(124, (dayofthemonth - 1), 1)
+                player:startEvent(124, (dayofthemonth + 1), 1)
             elseif k == 25 and player:getRace() > doorCheck[k - 1] and player:getRace() <= v then
-                player:startEvent(124, (dayofthemonth - 1), 1)
+                player:startEvent(124, (dayofthemonth + 1), 1)
             elseif k == 26 and player:getRace() > doorCheck[k - 1] and player:getRace() <= v then
-                player:startEvent(124, (dayofthemonth - 1), 1)
+                player:startEvent(124, (dayofthemonth + 1), 1)
             elseif k == 27 and player:getRace() > doorCheck[k - 1] and player:getRace() <= v then
-                player:startEvent(124, (dayofthemonth - 1), 1)
+                player:startEvent(124, (dayofthemonth + 1), 1)
             elseif k == 28 and player:getRace() > doorCheck[k - 1] and player:getRace() <= v then
-                player:startEvent(124, (dayofthemonth - 1), 1)
+                player:startEvent(124, (dayofthemonth + 1), 1)
             elseif k == 29 and player:getGender() == v then
-                player:startEvent(124, (dayofthemonth - 1), 1)
+                player:startEvent(124, (dayofthemonth + 1), 1)
             elseif k == 30 and player:getGender() == v then
-                player:startEvent(124, (dayofthemonth - 1), 1)
+                player:startEvent(124, (dayofthemonth + 1), 1)
             else
-                player:startEvent(124, (dayofthemonth - 1), 0)
+                player:startEvent(124, (dayofthemonth + 1), 0)
             end
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- Fixes RUN and GEO events unintentionally playing and causing the Marble Bridge entry event's first argument to become off-by-two.
- Fixes female characters never passing Hume, Elvaan, or Tarutaru race checks.
- Fixes entry requirements being swapped for gentlemen's day and ladies' day.

Fixes: #2602 
Fixes: #2302 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
- Change to !zone {Upper Jeuno}
- Interact with the 'Door: "Marble Bridge"'
- Add Vana'Diel time as necessary using the !time command
- Check that your character can properly enter the Marble Bridge when expected and cannot enter otherwise.
