### PR TITLE
Converts Faded Promises & Adjust typo in Selbina Global Var & adjusts…

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -4220,6 +4220,7 @@ xi.items =
     ANJU                            = 17771,
     ZUSHIO                          = 17772,
     KODACHI_OF_TRIALS               = 17773,
+    FUKURO                          = 17775,
     GANKO                           = 17786,
     OHAGURO                         = 17787,
     SAIREN                          = 17788,

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -184,7 +184,7 @@ xi.treasure.treasureInfo =
                     {
                         test = function(player)
                             return player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.FADED_PROMISES) == QUEST_ACCEPTED and
-                                player:getCharVar("FadedPromises") == 2 and not player:hasKeyItem(xi.ki.DIARY_OF_MUKUNDA)
+                                player:getCharVar("Quest[1][73]Prog") == 2 and not player:hasKeyItem(xi.ki.DIARY_OF_MUKUNDA)
                         end,
 
                         code = function(player)

--- a/scripts/quests/bastok/Faded_Promises.lua
+++ b/scripts/quests/bastok/Faded_Promises.lua
@@ -17,9 +17,6 @@ require('scripts/globals/titles')
 require('scripts/globals/zone')
 require('scripts/globals/interaction/quest')
 -----------------------------------
-local bastokMarketsID = zones[xi.zone.METALWORKS]
------------------------------------
-
 local quest = Quest:new(xi.quest.log_id.BASTOK, xi.quest.id.bastok.FADED_PROMISES)
 
 quest.reward =
@@ -107,9 +104,7 @@ quest.sections =
             ['Kagetora'] =
             {
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 2 and
-                    player:hasKeyItem(xi.ki.DIARY_OF_MUKUNDA)
-                    then
+                    if quest:getVar(player, 'Prog') == 2 and player:hasKeyItem(xi.ki.DIARY_OF_MUKUNDA) then
                         return quest:progressEvent(296)
                     else
                         return quest:event(23)

--- a/scripts/quests/bastok/Faded_Promises.lua
+++ b/scripts/quests/bastok/Faded_Promises.lua
@@ -54,7 +54,7 @@ quest.sections =
 
     {
         check = function(player, status, vars)
-            return status >= QUEST_ACCEPTED
+            return status == QUEST_ACCEPTED
         end,
 
         [xi.zone.METALWORKS] =
@@ -83,7 +83,7 @@ quest.sections =
             {
                 [803] = function(player, csid, option, npc)
                     if option == 0 then
-                    quest:setVar(player, 'Prog', 2)
+                        quest:setVar(player, 'Prog', 2)
                     end
                 end,
 

--- a/scripts/quests/bastok/Faded_Promises.lua
+++ b/scripts/quests/bastok/Faded_Promises.lua
@@ -1,0 +1,130 @@
+-----------------------------------
+-- Faded Promises
+-----------------------------------
+-- Log ID: 1, Quest ID: 73
+-- Romualdo : !gotoid 17748022
+-- Ayame : !gotoid 17748015
+-- Palborough_Mines chest: !gotoid 17363374
+-- Kagetora : !gotoid 17743879
+-- Alois : !gotoid 17747997
+
+-----------------------------------
+require('scripts/globals/items')
+require('scripts/globals/keyitems')
+require('scripts/globals/npc_util')
+require('scripts/globals/quests')
+require('scripts/globals/titles')
+require('scripts/globals/zone')
+require('scripts/globals/interaction/quest')
+-----------------------------------
+local bastokMarketsID = zones[xi.zone.METALWORKS]
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.BASTOK, xi.quest.id.bastok.FADED_PROMISES)
+
+quest.reward =
+{
+    fame     = 10,
+    fameArea = xi.quest.fame_area.BASTOK,
+    item     = xi.items.FUKURO,
+    title    = xi.title.ASSASSIN_REJECT,
+
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE and
+            player:getMainJob() == xi.job.NIN and
+            player:getMainLvl() >= 20 and
+            player:getFameLevel(xi.quest.fame_area.NORG) >= 1
+        end,
+
+        [xi.zone.METALWORKS] =
+        {
+            ['Romualdo'] = quest:progressEvent(802),
+
+            onEventFinish =
+            {
+                [802] = function(player, csid, option, npc)
+                    quest:begin(player)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status >= QUEST_ACCEPTED
+        end,
+
+        [xi.zone.METALWORKS] =
+        {
+            ['Ayame'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return quest:progressEvent(803)
+                    elseif quest:getVar(player, 'Prog') == 3 then
+                        return quest:progressEvent(804)
+                    end
+                end,
+            },
+
+            ['Alois'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 4 then
+                        return quest:progressEvent(805)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [803] = function(player, csid, option, npc)
+                    if option == 0 then
+                    quest:setVar(player, 'Prog', 2)
+                    end
+                end,
+
+                [804] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 4)
+                end,
+
+                [805] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:delKeyItem(xi.ki.DIARY_OF_MUKUNDA)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.PORT_BASTOK] =
+        {
+            ['Kagetora'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 2 and
+                    player:hasKeyItem(xi.ki.DIARY_OF_MUKUNDA)
+                    then
+                        return quest:progressEvent(296)
+                    else
+                        return quest:event(23)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [296] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 3)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/bastok/Faded_Promises.lua
+++ b/scripts/quests/bastok/Faded_Promises.lua
@@ -38,7 +38,7 @@ quest.sections =
             return status == QUEST_AVAILABLE and
             player:getMainJob() == xi.job.NIN and
             player:getMainLvl() >= 20 and
-            player:getFameLevel(xi.quest.fame_area.NORG) >= 1
+            player:getFameLevel(xi.quest.fame_area.NORG) >= 4
         end,
 
         [xi.zone.METALWORKS] =

--- a/scripts/zones/Metalworks/npcs/Alois.lua
+++ b/scripts/zones/Metalworks/npcs/Alois.lua
@@ -13,27 +13,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getCharVar("FadedPromises") == 4 then
-        player:startEvent(805)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 805 then
-        if
-            npcUtil.completeQuest(
-                player,
-                xi.quest.log_id.BASTOK,
-                xi.quest.id.bastok.FADED_PROMISES,
-                { item = 17775, xi.title.ASSASSIN_REJECT, var = { "FadedPromises" }, fame = 10 }
-            )
-        then
-            player:delKeyItem(xi.ki.DIARY_OF_MUKUNDA)
-        end
-    end
 end
 
 return entity

--- a/scripts/zones/Metalworks/npcs/Ayame.lua
+++ b/scripts/zones/Metalworks/npcs/Ayame.lua
@@ -9,22 +9,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getCharVar("FadedPromises") == 1 then
-        player:startEvent(803)
-    elseif player:getCharVar("FadedPromises") == 3 then
-        player:startEvent(804)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 803 and option == 1 then
-        player:setCharVar("FadedPromises", 2)
-    elseif csid == 804 then
-        player:setCharVar("FadedPromises", 4)
-    end
 end
 
 return entity

--- a/scripts/zones/Metalworks/npcs/Romualdo.lua
+++ b/scripts/zones/Metalworks/npcs/Romualdo.lua
@@ -11,26 +11,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local fadedPromises = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.FADED_PROMISES)
-
-    if
-        fadedPromises == QUEST_AVAILABLE and
-        player:getMainJob() == xi.job.NIN and
-        player:getMainLvl() >= 20 and
-        player:getFameLevel(xi.quest.fame_area.NORG) >= 4
-    then
-        player:startEvent(802)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 802 then
-        player:addQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.FADED_PROMISES)
-        player:setCharVar("FadedPromises", 1)
-    end
 end
 
 return entity

--- a/scripts/zones/Port_Bastok/npcs/Kagetora.lua
+++ b/scripts/zones/Port_Bastok/npcs/Kagetora.lua
@@ -25,11 +25,6 @@ entity.onTrigger = function(player, npc)
         end
     elseif player:getCharVar("twentyInPirateYearsCS") == 1 then
         player:startEvent(261)
-    elseif
-        player:getCharVar("FadedPromises") == 2 and
-        player:hasKeyItem(xi.ki.DIARY_OF_MUKUNDA)
-    then
-        player:startEvent(296)
     else
         player:startEvent(23)
     end
@@ -43,8 +38,6 @@ entity.onEventFinish = function(player, csid, option)
         player:setCharVar("AyameAndKaede_Event", 1)
     elseif csid == 261 then
         player:setCharVar("twentyInPirateYearsCS", 2)
-    elseif csid == 296 then
-        player:setCharVar("FadedPromises", 3)
     end
 end
 

--- a/scripts/zones/Selbina/Zone.lua
+++ b/scripts/zones/Selbina/Zone.lua
@@ -16,7 +16,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onGameHour = function(zone)
-    SetServerVariable("Selbina_Deastination", math.random(1, 100))
+    SetServerVariable("Selbina_Destination", math.random(1, 100))
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Meww_the_Turtlerider.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Meww_the_Turtlerider.lua
@@ -49,7 +49,7 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.nmTODPersist(mob, math.random(126, 144) * 60) -- 21 to 24 hours, 10 minute windows
+    xi.mob.nmTODPersist(mob, math.random(126, 144) * 600) -- 21 to 24 hours, 10 minute windows
     DespawnMob(ID.mob.MEWW_THE_TURTLERIDER + 1)
     DespawnMob(ID.mob.MEWW_THE_TURTLERIDER + 2)
 end


### PR DESCRIPTION
… Meww Turtlerider timer

https://github.com/HorizonFFXI/HorizonXI-Issues/issues/826

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Converts Faded Promises
Adjusts Meww the turtlerider to appropriate respawn time.
Changes typo in Seblina/Zone.lua for pirates variable.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
