### PR TITLE
Fix promy boss blackscreen issue for helpers

### DIFF
--- a/scripts/missions/cop/helpers.lua
+++ b/scripts/missions/cop/helpers.lua
@@ -181,7 +181,6 @@ xi.cop.helpers.spireEventFinish = function(mission, player, csid, option, npc)
         if numCompletedPromyvions == 3 then
             -- We need to make sure the fallthrough does not trigger an overriding
             -- teleport.
-            player:setLocalVar('toLufaise', 1)
             teleportLocation = xi.teleport.id.LUFAISE
         end
 

--- a/scripts/zones/Spire_of_Dem/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Dem/bcnms/ancient_flames_beckon.lua
@@ -52,7 +52,7 @@ battlefieldObject.onEventFinish = function(player, csid, option)
         player:addExp(1500)
         xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)
     end
-    player:setLocalVar('promyLeaveCode',0)
+    player:setLocalVar('promyLeaveCode', 0)
     player:setLocalVar('newPromy', 0)
 end
 

--- a/scripts/zones/Spire_of_Dem/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Dem/bcnms/ancient_flames_beckon.lua
@@ -23,6 +23,7 @@ battlefieldObject.onBattlefieldEnter = function(player, battlefield)
 end
 
 battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
+    player:setLocalVar('promyLeaveCode', leavecode)
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
         local arg8 = xi.cop.helpers.numPromyvionCompleted(player, xi.cop.helpers.promyvionCrags.DEM) + 1
@@ -47,13 +48,12 @@ battlefieldObject.onEventUpdate = function(player, csid, option)
 end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
-    if
-        player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.THE_MOTHERCRYSTALS and
-        not player:getLocalVar('toLufaise') == 1
-    then
+    if player:getLocalVar('newPromy') ~= 1 and player:getLocalVar('promyLeaveCode') == xi.battlefield.leaveCode.WON then
         player:addExp(1500)
         xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)
     end
+    player:setLocalVar('promyLeaveCode',0)
+    player:setLocalVar('newPromy', 0)
 end
 
 return battlefieldObject

--- a/scripts/zones/Spire_of_Holla/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Holla/bcnms/ancient_flames_beckon.lua
@@ -52,7 +52,7 @@ battlefieldObject.onEventFinish = function(player, csid, option)
         player:addExp(1500)
         xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)
     end
-    player:setLocalVar('promyLeaveCode',0)
+    player:setLocalVar('promyLeaveCode', 0)
     player:setLocalVar('newPromy', 0)
 end
 

--- a/scripts/zones/Spire_of_Holla/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Holla/bcnms/ancient_flames_beckon.lua
@@ -23,6 +23,7 @@ battlefieldObject.onBattlefieldEnter = function(player, battlefield)
 end
 
 battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
+    player:setLocalVar('promyLeaveCode', leavecode)
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
         local arg8 = xi.cop.helpers.numPromyvionCompleted(player, xi.cop.helpers.promyvionCrags.HOLLA) + 1
@@ -47,13 +48,12 @@ battlefieldObject.onEventUpdate = function(player, csid, option)
 end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
-    if
-        player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.THE_MOTHERCRYSTALS and
-        not player:getLocalVar('toLufaise') == 1
-    then
+    if player:getLocalVar('newPromy') ~= 1 and player:getLocalVar('promyLeaveCode') == xi.battlefield.leaveCode.WON then
         player:addExp(1500)
         xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)
     end
+    player:setLocalVar('promyLeaveCode',0)
+    player:setLocalVar('newPromy', 0)
 end
 
 return battlefieldObject

--- a/scripts/zones/Spire_of_Mea/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Mea/bcnms/ancient_flames_beckon.lua
@@ -52,7 +52,7 @@ battlefieldObject.onEventFinish = function(player, csid, option)
         player:addExp(1500)
         xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)
     end
-    player:setLocalVar('promyLeaveCode',0)
+    player:setLocalVar('promyLeaveCode', 0)
     player:setLocalVar('newPromy', 0)
 end
 

--- a/scripts/zones/Spire_of_Mea/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Mea/bcnms/ancient_flames_beckon.lua
@@ -23,6 +23,7 @@ battlefieldObject.onBattlefieldEnter = function(player, battlefield)
 end
 
 battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
+    player:setLocalVar('promyLeaveCode', leavecode)
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
         local arg8 = xi.cop.helpers.numPromyvionCompleted(player, xi.cop.helpers.promyvionCrags.MEA) + 1
@@ -47,13 +48,12 @@ battlefieldObject.onEventUpdate = function(player, csid, option)
 end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
-    if
-        player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.THE_MOTHERCRYSTALS and
-        not player:getLocalVar('toLufaise') == 1
-    then
+    if player:getLocalVar('newPromy') ~= 1 and player:getLocalVar('promyLeaveCode') == xi.battlefield.leaveCode.WON then
         player:addExp(1500)
         xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)
     end
+    player:setLocalVar('promyLeaveCode',0)
+    player:setLocalVar('newPromy', 0)
 end
 
 return battlefieldObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR prevents players that already completed a promy from blackscreening after helping with that same promy boss fight.

## Steps to test these changes
- Fight a promy boss with at least one player that has already completed that promy (i.e., has light of dem)

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/666