### PR TITLE
Fix goblin wolfman delay issue

### DIFF
--- a/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Wolfman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Wolfman.lua
@@ -11,18 +11,21 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
     mob:addMod(xi.mod.ACC, 70) -- Very accurate
-    mob:setLocalVar("weaponOn", 0)
+end
+
+entity.onMobWeaponSkill = function(target, mob, skill)
+    if skill:getID() == xi.jsa.BLOOD_WEAPON then
+        mob:addMod(xi.mod.DELAY, 1500)
+        mob:addMod(xi.mod.ATTP, 160)
+        mob:setLocalVar("removeMods", 1)
+    end
 end
 
 entity.onMobFight = function(mob, target)
-    local weaponOn = mob:getLocalVar("weaponOn")
-    if mob:hasStatusEffect(xi.effect.BLOOD_WEAPON) and weaponOn == 0 then
-        mob:addMod(xi.mod.DELAY, 1500)
-        mob:addMod(xi.mod.ATTP, 160)
-        mob:setLocalVar("weaponOn", 1)
-    elseif not mob:hasStatusEffect(xi.effect.BLOOD_WEAPON) and weaponOn == 1 then
+    if not mob:hasStatusEffect(xi.effect.BLOOD_WEAPON) and mob:getLocalVar("removeMods") == 1 then
         mob:delMod(xi.mod.DELAY, 1500)
         mob:delMod(xi.mod.ATTP, 160)
+        mob:setLocalVar("removeMods", 0)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fix issue where goblin wolfman delay would very low for 10 sec after some spell casting, probably due to deleting the delay modifier every 3 secs after blood weapon wears off. Now the modifier methods are called only once.

## Steps to test these changes
