### PR TITLE
Fixed an issue where the quest For the Birds was unable to be completed

### DIFF
--- a/scripts/quests/otherAreas/For_the_Birds.lua
+++ b/scripts/quests/otherAreas/For_the_Birds.lua
@@ -61,10 +61,10 @@ quest.sections =
                         return quest:event(15, { [1] = xi.items.ARNICA_ROOT })
                     elseif prog == 1 and not player:hasKeyItem(xi.ki.GLITTERING_FRAGMENT) then
                         return quest:progressEvent(16, { [1] = xi.ki.GLITTERING_FRAGMENT })
-                    elseif player:hasKeyItem(xi.ki.GLITTERING_FRAGMENT) then
-                        return quest:event(17)
                     elseif prog == 4 then
                         return quest:progressEvent(18)
+                    elseif player:hasKeyItem(xi.ki.GLITTERING_FRAGMENT) then
+                        return quest:event(17)
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

This PR fixes an issue where the quest For the Birds could not be completed due to a bug caused by misordered logic in a block of else ifs. The logic was unable to ever reach the check for the var 'Prog' == 4 because it was falling into a section that checks if you have the KI first, which you always do until the quest is complete. The fix was to simply move the check for prog == 4 above the KI checking one. 
Fixes HorizonFFXI/HorizonXI-Issues#703

## Steps to test these changes

Reload the lua script for the quest after applying the fix and run through the quest quickly and see that it now completes fully.
<!-- Clear and detailed steps to test your changes here -->
