### PR TITLE
Fix healing breath to ignore dead party members

### DIFF
--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -69,7 +69,7 @@ local function doHealingBreath(player, threshold)
     else
         local party = player:getPartyWithTrusts()
         for _, member in pairs(party) do
-            if member:getHPP() <= threshold and inBreathRange(member) then
+            if member:getHPP() <= threshold and inBreathRange(member) and not member:isDead() then
                 player:getPet():useJobAbility(healingbreath, member)
                 break
             end
@@ -189,7 +189,6 @@ entity.onMobDeath = function(mob, player)
 end
 
 entity.onPetLevelRestriction = function(pet)
-    removeWyvernLevels(pet)
     pet:setLocalVar("wyvern_exp", 0)
     pet:setLocalVar("level_Ups", 0)
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fix healing breath to ignore dead party members

## Steps to test these changes
Still need to test with more players on test server
