### PR TITLE
Fix prereqs rubbish day quest

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
@@ -172,7 +172,7 @@ entity.onEventFinish = function(player, csid, option)
         player:tradeComplete()
         player:completeQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.COLLECT_TARUT_CARDS)
 
-    elseif csid == 199 and option == 0 then
+    elseif csid == 199 and option == 1 then
         local valid = player:getLocalVar("validFortune")
         if valid == 1 then
             player:setLocalVar("validFortune", 0)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes the prereqs for getting the rubbish day quest, specifically there was a mistake with checking of an option flag and from all sources I have seen the partner for compatibility check only needs to be in the same zone (if there is capture showing otherwise I can remove that change)

## Steps to test these changes
!pos -13 -6 -42 245
!setfamelevel 3 3 name
!completequest 3 10 name
Talk to Chululu and do compatibility test with actual player in same zone
Repeat on three diff in-game days
Get rubbish day quest

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/917