### PR TITLE
Fix reraise gorget synth era to COP

### DIFF
--- a/modules/era/sql/synth_recipes_era.sql
+++ b/modules/era/sql/synth_recipes_era.sql
@@ -1374,6 +1374,7 @@ UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Honey' AND ID 
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Mercury' AND ID = 60515;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Himantes' AND ID = 42503;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Beast Horn' AND ID = 53025;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Reraise Gorget' AND ID = 54007;
 
 -- ------------------------------------------------------------
 -- ToAU Synths
@@ -1605,7 +1606,6 @@ UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Marid Tusk Ar
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Marid Tusk Arrowheads' AND ID = 53526;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Darksteel Shield' AND ID = 54001;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Marid Ring' AND ID = 54002;
-UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Reraise Gorget' AND ID = 54007;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Lamia Garland' AND ID = 54009;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Mega Fan' AND ID = 54011;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Hellish Bugle' AND ID = 54020;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This fixes the era of reraise gorget since the synth was around in CoP era (see posts near bottom of [here](https://ffxi.allakhazam.com/db/item.html?fitem=5591)), thus allowing the synth.

## Steps to test these changes
