### PR TITLE
add main/sub/ranged/ammo to visible gear latents as per testing

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -660,7 +660,7 @@ std::vector<CItemEquipment*> CCharEntity::getVisibleEquip()
     std::vector<CItemEquipment*> visibleItems;
     CItemEquipment*              item = nullptr;
 
-    for (SLOTTYPE slot : { SLOT_HEAD, SLOT_BODY, SLOT_HANDS, SLOT_LEGS, SLOT_FEET })
+    for (SLOTTYPE slot : { SLOT_MAIN, SLOT_SUB, SLOT_RANGED, SLOT_AMMO, SLOT_BODY, SLOT_HANDS, SLOT_LEGS, SLOT_FEET })
     {
         item = getEquip(slot);
         if (item != nullptr)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Add the above gear as visible gear for latents to process

## Steps to test these changes
* validation of what constitutes visible gear done by WinterSolstice
<!-- Clear and detailed steps to test your changes here -->
