### PR TITLE
remove the ability for crit to go negative because of ddex/dagi and clamp crit at 1%

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2758,7 +2758,7 @@ namespace battleutils
                 }
             }
 
-            critHitRate = std::clamp(critHitRate, 0, 100);
+            critHitRate = std::clamp(critHitRate, 1, 100);
         }
         return (uint8)critHitRate;
     }
@@ -2770,13 +2770,6 @@ namespace battleutils
         int32 defenderAgi = PDefender->AGI();
         int32 dDex        = attackerDex - defenderAgi;
         int32 dDexAbs     = std::abs(dDex);
-        int32 sign        = 1;
-
-        if (dDex < 0)
-        {
-            // Target has higher AGI so this will be a decrease to crit rate
-            sign = -1;
-        }
 
         // Default to +0 crit rate for a delta of 0-6
         int32 critRate = 0;
@@ -2806,7 +2799,7 @@ namespace battleutils
         }
 
         // Crit rate delta from stats caps at +-15
-        return std::min(critRate, 15) * sign;
+        return std::min(critRate, 15);
     }
 
     /************************************************************************
@@ -2844,7 +2837,7 @@ namespace battleutils
         critHitRate += GetAGICritBonus(PAttacker, PDefender);
         critHitRate += PAttacker->getMod(Mod::CRITHITRATE);
         critHitRate += PDefender->getMod(Mod::ENEMYCRITRATE);
-        critHitRate = std::clamp(critHitRate, 0, 100);
+        critHitRate = std::clamp(critHitRate, 1, 100);
 
         return (uint8)critHitRate;
     }
@@ -2856,20 +2849,13 @@ namespace battleutils
         int32 defenderAgi = PDefender->AGI();
         int32 dAGI        = attackerAgi - defenderAgi;
         int32 dAgiAbs     = std::abs(dAGI);
-        int32 sign        = 1;
-
-        if (dAGI < 0)
-        {
-            // Target has higher AGI so this will be a decrease to crit rate
-            sign = -1;
-        }
 
         // Default to +0 crit rate
         int32 critRate = 0;
 
         critRate = dAgiAbs / 10;
 
-        return std::min(critRate, 15) * sign;
+        return std::min(critRate, 15);
     }
 
     /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* floor dDex crit at 0 instead of -15
* floor dAgi crit at 0 instead of -15
* clamp overall crit at 1 instead of 0
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go whack some mobs with way less dex than them. Get whacked on by some mobs.

The initial change that allowed for negative dCrit values did not have a lot of justification -- https://github.com/LandSandBoat/server/commit/56474c8f31577827b5870f8a8d7a36d583075697 -- really just "I did some testing and have some numbers, these are some formulae, enjoy.

Unfortunately, I haven't been able to find anything that corroborates two main claims of the previous commit:
1) dDex/dAgi can go negative
* The wiki page linked to in the comments state 0 as a floor
* Old posts that say nothing about negative d* values:
https://www.bluegartr.com/threads/68786-Dexterity-s-impact-on-critical-hits
https://www.bluegartr.com/threads/68786-Dexterity-s-impact-on-critical-hits?p=3225612&viewfull=1#post3225612 specifically
2) Critical hit can hit 0%
https://www.bg-wiki.com/ffxi/Enemy_Critical_Hit_Rate debunks this, the lowest crit you can go against a mob is 1%

So, this PR removes those assumptions and puts into place the thinking offered by the wiki page and corresponding BG threads.
