### PR TITLE
Fix everyones grudge and rancor

### DIFF
--- a/scripts/globals/mobskills/everyones_grudge.lua
+++ b/scripts/globals/mobskills/everyones_grudge.lua
@@ -11,20 +11,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local realDmg = 0
-    local power = 5
-
-    if target:getID() > 100000 then
-        realDmg = power * math.random(30, 100)
-    else
-        realDmg = power * target:getCharVar("EVERYONES_GRUDGE_KILLS") -- Damage is 5 times the amount you have killed
-        if mob:isNM() then
-            realDmg = realDmg * 10 -- sets the multiplier to 50 for NM's
-        end
-    end
-
+    local realDmg = 5 * target:getCharVar("EVERYONES_GRUDGE_KILLS") -- Damage is 5 times the amount you have killed
     target:takeDamage(realDmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)
-
     return realDmg
 end
 

--- a/scripts/globals/mobskills/everyones_rancor.lua
+++ b/scripts/globals/mobskills/everyones_rancor.lua
@@ -27,16 +27,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local realDmg = 0
-
-    if target:getID() > 100000 then
-        realDmg = 50 * math.random(50, 100)
-    else
-        realDmg = 10 * target:getCharVar("EVERYONES_GRUDGE_KILLS")
-    end
-
+    local realDmg = 50 * target:getCharVar("EVERYONES_GRUDGE_KILLS")
     target:takeDamage(realDmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)
-
     return realDmg
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes Everyone's Grudge to only use the 5x multiplier (and never 50x) and Everyone's Rancor to always use the 50x multiplier (see [here](https://ffxiclopedia.fandom.com/wiki/Everyone's_Rancor) and [here](https://web.archive.org/web/20070109022313/http://wiki.ffo.jp/html/5469.html))

## Steps to test these changes
Feed tp to normal tonberries and tonberry NMs under 25% HP