### PR TITLE
Replace OoE woodworking guild item with CoP era item

### DIFF
--- a/modules/era/back_date_sqls/cop_era_guild_item_points.sql
+++ b/modules/era/back_date_sqls/cop_era_guild_item_points.sql
@@ -9,7 +9,7 @@ LOCK TABLES
     `guild_item_points` WRITE;
 
 -- remove non-CoP era items added by guild_item_points.sql in era/sql
-DELETE FROM `guild_item_points` WHERE `itemid` IN (5598, 5599, 5572, 5573, 5600, 5601);
+DELETE FROM `guild_item_points` WHERE `itemid` IN (5598, 5599, 5572, 5573, 5600, 5601, 358);
 
 -- add back original CoP era items
 INSERT INTO `guild_item_points` (`guildid`, `itemid`, `rank`, `points`, `max_points`, `pattern`) VALUES 
@@ -20,6 +20,8 @@ INSERT INTO `guild_item_points` (`guildid`, `itemid`, `rank`, `points`, `max_poi
     (8, 5147, 6, 375, 3680, 2),
     (8, 5155, 6, 875, 3680, 2),
     (8, 5147, 6, 375, 3680, 7),
-    (8, 5155, 6, 875, 3680, 7);
+    (8, 5155, 6, 875, 3680, 7),
+    (1, 16890, 8, 1200, 5120, 3),
+    (1, 16891, 8, 1300, 5120, 3);
 
 UNLOCK TABLES;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
The PR adds to the back date sql for CoP era guild point items by replacing Credenza (WoTG era) with Obelisk Lance and Obelisk Lance+1 (CoP era guild point items).

## Steps to test these changes

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/913