### PR TITLE
Chaosbringer count fix

### DIFF
--- a/scripts/globals/items/chaosbringer.lua
+++ b/scripts/globals/items/chaosbringer.lua
@@ -14,8 +14,7 @@ itemObject.onItemEquip = function(player, item)
             mob:addListener("TAKE_DAMAGE", "VALID_KILL", function(mobArg, amount, attacker, attackType, damageType)
                 mob:setLocalVar("listenerApplied", 1)
                 if
-                    (attacker:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DARKNESS) == QUEST_ACCEPTED or
-                    attacker:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DEATH) == QUEST_ACCEPTED) and
+                    attacker:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DARKNESS) >= QUEST_ACCEPTED and
                     attacker:getEquipID(xi.slot.MAIN) == xi.items.CHAOSBRINGER and
                     attackType == xi.attackType.PHYSICAL and
                     amount > mobArg:getHP()


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Chaosbringer will now continue tracking kills after completing the quest "Blade of Darkness".
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/2645