### PR TITLE
Jug & Mob Base Damage Fix

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -409,6 +409,11 @@ int16 CBattleEntity::GetAmmoDelay()
 uint16 CBattleEntity::GetMainWeaponDmg()
 {
     TracyZoneScoped;
+    if (objtype == TYPE_PET || objtype == TYPE_MOB)
+    {
+        return mobutils::GetWeaponDamage(static_cast<CMobEntity*>(this), SLOT_MAIN);
+    }
+
     if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
     {
         if ((weapon->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -63,7 +63,13 @@ namespace mobutils
         {
             bonus = 5;
         }
+
         if (lvl == 1)
+        {
+            bonus = 0;
+        }
+
+        if (PMob->objtype == TYPE_PET)
         {
             bonus = 0;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ Fixed an issue where Mobs were using the wrong base weapon damage formula.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Should see minimal changes to both damage types.
Can compare damage a mob does on you before/after the change
<!-- Clear and detailed steps to test your changes here -->
