### PR TITLE
Fix kuftal tunnel fished up devil manta respawn time

### DIFF
--- a/scripts/zones/Kuftal_Tunnel/mobs/Devil_Manta.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Devil_Manta.lua
@@ -1,0 +1,11 @@
+-----------------------------------
+-- Area: Kuftal Tunnel
+--  Mob: Devil Manta (Fished)
+-----------------------------------
+local entity = {}
+
+entity.onMobDeath = function(mob, player, optParams)
+    mob:setLocalVar("lastTOD", os.time())
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR sets the local ToD variable on death of the fished up devil manta in kuftal tunnel so the fishing code has something to check against.

## Steps to test these changes
Fish up devil manta in kuftal tunnel and kill
Try to fish another within 10 mins
After 10 mins should be able to fish up another