### PR TITLE
Fix era crystal drop rate

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1631,7 +1631,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
 
         for (uint8 i = 0; i < crystalRolls; i++)
         {
-            if (xirand::GetRandomNumber(100) < 20 && AddItemToPool(4095 + m_Element, ++dropCount))
+            if (xirand::GetRandomNumber(100) < 50 && AddItemToPool(4095 + m_Element, ++dropCount))
             {
                 return;
             }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR brings the crystal drop rate more in line with actual era values (see data in https://github.com/AirSkyBoat/AirSkyBoat/issues/2634). Specifically, the rate changes from 20% (per player per mob) to 50% (per player per mob) as per the data. The original 20% rate was chosen in 2011 and no justification was provided for that choice (see https://github.com/LandSandBoat/server/commit/169570c55404cd6bb81e7023090d6e6b7b12c6dd) as far as I can tell. Thus the rate was probably meant to be changed or become tunable later on.

## Steps to test these changes
Kill mobs for crystals

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2634