### PR TITLE
Wish Upon A Star Weather Check Fix

### DIFF
--- a/scripts/zones/Bastok_Markets/npcs/Enu.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Enu.lua
@@ -13,7 +13,7 @@ entity.onTrade = function(player, npc, trade)
     if trade:hasItemQty(1192, 1) and trade:getItemCount() == 1 then -- Quest: Wish Upon a Star - Trade Fallen Star
         if player:getCharVar("WishUponAStar_Status") == 3 then
             if
-                player:getWeather() == xi.weather.NONE and
+                (player:getWeather() == xi.weather.NONE or player:getWeather() == xi.weather.SUNSHINE) and
                 (VanadielTOTD() == xi.time.NIGHT or VanadielTOTD() == xi.time.MIDNIGHT)
             then
                 player:startEvent(334) -- Trade accepeted


### PR DESCRIPTION
-Bastok markets does not show WEATHER_NONE, only WEATHER_SUNSHINE

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #2660 .  Checks bastok markets for sunshine weather
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Complete quest normally, it should now work.
<!-- Clear and detailed steps to test your changes here -->
