### PR TITLE
Fix invincible and physical/ranged mob skills

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -690,6 +690,14 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
 
     dmg = utils.stoneskin(target, dmg)
 
+    if
+        (attackType == xi.attackType.PHYSICAL or
+        attackType == xi.attackType.RANGED) and
+        target:hasStatusEffect(xi.effect.INVINCIBLE)
+    then
+        return 0
+    end
+
     if dmg > 0 then
         target:updateEnmityFromDamage(mob, dmg)
         target:handleAfflatusMiseryDamage(dmg)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes the ability invincible so that physical and ranged mob skills do not do damage to PLD player. I am not sure this is correct place in the code for this check but other abilities like PD are processed in the same place so maybe.

## Steps to test these changes
Fight mobs with different types of mob skills (for example gobs have bomb toss (magical) and goblin rush (physical))