### PR TITLE
Fix MP and TP drain-based mob skills on undead

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -718,49 +718,41 @@ end
 -- end
 
 xi.mobskills.mobDrainMove = function(mob, target, drainType, drain, attackType, damageType)
-    if not target:isUndead() then
-        if drainType == xi.mobskills.drainType.MP then
-            -- can't go over limited mp
-            if target:getMP() < drain then
-                drain = target:getMP()
-            end
-
-            target:delMP(drain)
-            mob:addMP(drain)
-
-            return xi.msg.basic.SKILL_DRAIN_MP
-        elseif drainType == xi.mobskills.drainType.TP then
-            -- can't go over limited tp
-            if target:getTP() < drain then
-                drain = target:getTP()
-            end
-
-            target:delTP(drain)
-            mob:addTP(drain)
-
-            return xi.msg.basic.SKILL_DRAIN_TP
-        elseif drainType == xi.mobskills.drainType.HP then
-            -- can't go over limited hp
-            if target:getHP() < drain then
-                drain = target:getHP()
-            end
-
-            target:takeDamage(drain, mob, attackType, damageType)
-            mob:addHP(drain)
-
-            return xi.msg.basic.SKILL_DRAIN_HP
+    if drainType == xi.mobskills.drainType.MP then
+        -- can't go over limited mp
+        if target:getMP() < drain then
+            drain = target:getMP()
         end
-    else
-        -- it's undead so just deal damage
+
+        target:delMP(drain)
+        mob:addMP(drain)
+
+        return xi.msg.basic.SKILL_DRAIN_MP
+    elseif drainType == xi.mobskills.drainType.TP then
+        -- can't go over limited tp
+        if target:getTP() < drain then
+            drain = target:getTP()
+        end
+
+        target:delTP(drain)
+        mob:addTP(drain)
+
+        return xi.msg.basic.SKILL_DRAIN_TP
+    elseif drainType == xi.mobskills.drainType.HP then
         -- can't go over limited hp
         if target:getHP() < drain then
             drain = target:getHP()
         end
 
         target:takeDamage(drain, mob, attackType, damageType)
-        return xi.msg.basic.DAMAGE
+        -- if not undead then drain else just do damage
+        if not target:isUndead() then
+            mob:addHP(drain)
+            return xi.msg.basic.SKILL_DRAIN_HP
+        else
+            return xi.msg.basic.DAMAGE
+        end
     end
-
     return xi.msg.basic.SKILL_NO_EFFECT
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR removes code that applies damage to undead from TP and MP drain-based mob skills. This will fix corner cases such as a pet leech using TP drainkiss and doing 800+ damage (when should have been TP) to an undead. Note that TP and MP drain working on undead and HP drain doing damage (but not drain) on undead was validated on retail.

## Steps to test these changes
Go to Bostaunieux Oubliette
Charm a leech mob and fight it against a ghost mob
Spam sic and give leech 1000 TP then wait for TP drainkiss or MP drainkiss (should not do damage anymore)
Also can fight leech against non-undead mob to see normal drain skills
And can fight leech as player to see the drain skills as well