### PR TITLE
Add check to MH zoning to turn off RentaRoom if both false.

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3912,6 +3912,7 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
                 // clang-format on
 
                 if ((PZoneLine->m_toZoneType == ZONE_TYPE::CITY && PZoneLine->m_toZone == 0 && !RentExempt) &&
+                    (settings::get<bool>("map.RENT_A_ROOM") || settings::get<bool>("map.ERA_RENT_A_ROOM")) &&
                     (settings::get<bool>("map.RENT_A_ROOM") && settings::get<bool>("map.ERA_RENT_A_ROOM") ? !IsRentedCity : !IsInHomeNation && !IsRentedCity))
                 {
                     PChar->loc.p.rotation += 128;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently, if `RENT_A_ROOM` and `ERA_RENT_A_ROOM` are both set to `false` the packet_system will still turn a player around if the room isn't rented since there is no check (or in the case of rulude gardens, send them to the shadow realm). This adds that check, letting player into mog house if both settings are `false`

## Steps to test these changes

Set both `RENT_A_ROOM` and `ERA_RENT_A_ROOM` to false and enter an unrented mog house, it will let you. Set one of these settings to `true` and it will not. 
