### PR TITLE
Adjust Mob TPs moves to not apply slow if target has haste

### DIFF
--- a/scripts/globals/mobskills/demonic_howl.lua
+++ b/scripts/globals/mobskills/demonic_howl.lua
@@ -13,7 +13,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, 240))
+    if target:hasStatusEffect(xi.effect.HASTE) then
+        skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
+        return
+    else
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, 240))
+    end
 
     return xi.effect.SLOW
 end

--- a/scripts/globals/mobskills/horror_cloud.lua
+++ b/scripts/globals/mobskills/horror_cloud.lua
@@ -21,7 +21,12 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local noResist = 1
 
     -- 2 minute unresisted duration.
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, 120, 0, 0, noResist))
+    if target:hasStatusEffect(xi.effect.HASTE) then
+        skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
+        return
+    else
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, 120, 0, 0, noResist))
+    end
 
     return xi.effect.SLOW
 end

--- a/scripts/globals/mobskills/intimidate.lua
+++ b/scripts/globals/mobskills/intimidate.lua
@@ -13,7 +13,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.SLOW, 2500, 0, 120))
+    if target:hasStatusEffect(xi.effect.HASTE) then
+        skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
+        return
+    else
+        skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.SLOW, 2500, 0, 120))
+    end
 
     return xi.effect.SLOW
 end

--- a/scripts/globals/mobskills/murk.lua
+++ b/scripts/globals/mobskills/murk.lua
@@ -20,7 +20,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local weight = false
     local typeEffect
 
-    slowed = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 8500, 0, math.random(45, 90))
+    if not target:hasStatusEffect(xi.effect.HASTE) then
+        slowed = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 8500, 0, math.random(45, 90))
+    end
     weight = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 44, 0, 60)
 
     skill:setMsg(xi.msg.basic.SKILL_ENFEEB_IS)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Added a check to block slow from being applied if the target already has haste on, per Jimmayus's mob TP move testing.