### PR TITLE
When Angels Fall Fix

### DIFF
--- a/scripts/missions/cop/8_3_When_Angels_Fall.lua
+++ b/scripts/missions/cop/8_3_When_Angels_Fall.lua
@@ -98,7 +98,11 @@ mission.sections =
             ['_0z0'] = -- BCNM Entrance
             {
                 onTrigger = function(player, npc)
-                    if mission:getVar(player, 'Status') == 3 then
+                    if
+                        mission:getVar(player, 'Status') == 3 and
+                        player:hasKeyItem(xi.ki.BRAND_OF_TWILIGHT) and
+                        player:hasKeyItem(xi.ki.BRAND_OF_DAWN)
+                    then
                         return mission:progressEvent(203)
                     elseif mission:getVar(player, 'Status') == 5 then
                         return mission:progressEvent(205)
@@ -144,7 +148,6 @@ mission.sections =
                 [111] = function(player, csid, option)
                     if option == 1 then
                         player:addKeyItem(xi.ki.BRAND_OF_TWILIGHT)
-                        mission:setVar(player, "Status", mission:getVar(player, 'Status') + 1)
                         return mission:messageSpecial(zones[player:getZoneID()].text.KEYITEM_OBTAINED, xi.ki.BRAND_OF_TWILIGHT)
                     end
                 end,
@@ -152,7 +155,6 @@ mission.sections =
                 [110] = function(player, csid, option)
                     if option == 1 then
                         player:addKeyItem(xi.ki.BRAND_OF_DAWN)
-                        mission:setVar(player, "Status", mission:getVar(player, 'Status') + 1)
                         return mission:messageSpecial(zones[player:getZoneID()].text.KEYITEM_OBTAINED, xi.ki.BRAND_OF_DAWN)
                     end
                 end,


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixes players being unable to progress the mission "When Angels Fall".
- Closes HorizonFFXI/HorizonXI-Issues#976
Variables were being incorrectly incremented when players received each brand.
