### PR TITLE
Add ninja AF mob enagakure to pirate ship route

### DIFF
--- a/scripts/zones/Ship_bound_for_Selbina_Pirates/mobs/Enagakure.lua
+++ b/scripts/zones/Ship_bound_for_Selbina_Pirates/mobs/Enagakure.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- Area: Ship bound for Selbina Pirates
+--  Mob: Enagakure
+-- Involved in Quest: I'll Take the Big Box
+-----------------------------------
+require("scripts/globals/keyitems")
+-----------------------------------
+local entity = {}
+
+entity.onMobDeath = function(mob, player, optParams)
+    if
+        player:hasKeyItem(xi.ki.SEANCE_STAFF) and
+        player:getCharVar("Enagakure_Killed") == 0
+    then
+        player:setCharVar("Enagakure_Killed", 1)
+    end
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds ninja AF mob enagakure to the pirate ship route so players can complete the quest even on that route. Currently enagakure spawns on the route but killing it does not actually count as killing and thus player gets no CS.

## Steps to test these changes
