### PR TITLE
Cherrypick dual wield multiattack fix from LSB

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -184,7 +184,10 @@ local function getMultiAttacks(attacker, target, numHits, wsParams)
     end
 
     -- QA/TA/DA can only proc on the first hit of each weapon or each fist
-    if attacker:getWeaponSkillType(xi.slot.MAIN) == xi.skill.HAND_TO_HAND then
+    if
+        attacker:getOffhandDmg() > 0 or
+        attacker:getWeaponSkillType(xi.slot.MAIN) == xi.skill.HAND_TO_HAND
+    then
         multiChances = 2
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [X] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [X] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently on ASB only hand-to-hand can proc quadruple/triple/double etc attacks on the offhand during a WS. 
This PR cherry picks code from [LSB's weaponskill.lua](https://github.com/LandSandBoat/server/blob/base/scripts/globals/weaponskills.lua#L212) that resolves the issue of multihit procs never occurring on the offhand swing of a WS while dual wielding. 
 
## Steps to test these changes
Print the multiChances variable while using a WS and dual wielding and see that it is now properly set to 2.