### PR TITLE
Fixes Yagudo Avatar spawn conditions

### DIFF
--- a/scripts/zones/Castle_Oztroja/mobs/Tzee_Xicu_the_Manifest.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Tzee_Xicu_the_Manifest.lua
@@ -35,6 +35,7 @@ entity.onMobDespawn = function(mob)
     local nqMob = GetMobByID(mob:getID() - 3)
     SetServerVariable("[POP]Tzee_Xicu_the_Manifest", os.time() + 259200) -- 3 days
     SetServerVariable("[PH]Tzee_Xicu_the_Manifest", 0)
+    SetServerVariable("[POPNUM]Tzee_Xicu_the_Manifest", 0)
     DisallowRespawn(mob:getID(), true)
     DisallowRespawn(nqID, false)
     xi.mob.nmTODPersist(nqMob, math.random(75600, 86400)) -- 21 to 24 hours

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Avatar.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Avatar.lua
@@ -21,21 +21,22 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    local nqID = mob:getID()
+    local nqId = mob:getID()
 
-    if nqID == ID.mob.YAGUDO_AVATAR then
-        local hqMob       = GetMobByID(ID.mobs.TZEE_XICU_THE_MANIFEST)
-        local hqID        = hqMob():getID()
+    -- the quest version of this NM doesn't respawn or count toward hq nm
+    if nqId == ID.mob.YAGUDO_AVATAR then
+        SetServerVariable("[POPNUM]Tzee_Xicu_the_Manifest", math.random(1, 5))
+        local hqId        = mob:getID() + 3
         local timeOfDeath = GetServerVariable("[POP]Tzee_Xicu_the_Manifest")
         local kills       = GetServerVariable("[PH]Tzee_Xicu_the_Manifest")
-        local popNow      = (math.random(1, 5) == 3 or kills > 6)
+        local popNow      = GetServerVariable("[POPNUM]Tzee_Xicu_the_Manifest") == 3 or kills > 6
 
         if os.time() > timeOfDeath and popNow then
-            DisallowRespawn(nqID, true)
-            DisallowRespawn(hqID, false)
-            xi.mob.nmTODPersist(hqMob, math.random(75600, 86400)) -- 21 to 24 hours
+            DisallowRespawn(nqId, true)
+            DisallowRespawn(hqId, false)
+            xi.mob.nmTODPersist(GetMobByID(hqId), math.random(75600, 86400))
         else
-            xi.mob.nmTODPersist(mob, math.random(75600, 86400)) -- 21 to 24 hours
+            xi.mob.nmTODPersist(GetMobByID(nqId), math.random(75600, 86400))
             SetServerVariable("[PH]Tzee_Xicu_the_Manifest", kills + 1)
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixes an issue where Yagudo Avatar would instantly respawn over and over due to the ID being wrong
- Added persistence so that if Tzee is up and the zone crashes it will respawn instead of the avatar
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!gotoid 17396134
Kill Yagudo Avatar and see it not instantly respawn
<!-- Clear and detailed steps to test your changes here -->
