### PR TITLE
Fix double reward in Waking Dreams quest

### DIFF
--- a/scripts/quests/windurst/Waking_Dreams.lua
+++ b/scripts/quests/windurst/Waking_Dreams.lua
@@ -72,6 +72,9 @@ quest.sections =
             onEventFinish =
             {
                 [920] = function(player, csid, option, npc)
+                    quest.reward.item = nil
+                    quest.reward.gil = nil
+
                     if option == 1 and not player:hasItem(xi.items.DIABOLOSS_POLE) then
                         quest.reward.item = xi.items.DIABOLOSS_POLE
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue where if a previous player chooses an item or gil reward, and then the current player chooses a summon reward, the current player will get both the summon and the previously chosen item or gil reward. This is because quest.reward.item and quest.reward.gil were not reset for the current player and thus carried over from the previous player.

## Steps to test these changes
!addquest 2 93
!addkeyitem WHISPER_OF_DREAMS
Talk to Kerutoto and choose an item
!addquest 2 93
!addkeyitem WHISPER_OF_DREAMS
Talk to Kerutoto again and choose the summon (you should not get the item again as well)