### PR TITLE
Fix reward for Twinstone Bonding

### DIFF
--- a/scripts/quests/windurst/Twinstone_Bonding.lua
+++ b/scripts/quests/windurst/Twinstone_Bonding.lua
@@ -14,14 +14,6 @@ require('scripts/globals/zone')
 -----------------------------------
 local quest = Quest:new(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TWINSTONE_BONDING)
 
-quest.reward =
-{
-    fame = 80,
-    fameArea = xi.quest.fame_area.WINDURST,
-    item = xi.items.WRAPPED_BOW,
-    title = xi.title.BOND_FIXER
-}
-
 quest.sections =
 {
     -- Quest Acceptance
@@ -83,11 +75,21 @@ quest.sections =
 
                 [490] = function(player, csid, option, npc)
                     if player:getQuestStatus(quest.areaId, quest.questId) == QUEST_COMPLETED then
+                        -- rewards for repeat completion
                         quest.reward =
                         {
                             fame = 10,
                             fameArea = xi.quest.fame_area.WINDURST,
                             gil = 900 * xi.settings.main.GIL_RATE
+                        }
+                    else
+                        -- rewards for first completion
+                        quest.reward =
+                        {
+                            fame = 80,
+                            fameArea = xi.quest.fame_area.WINDURST,
+                            item = xi.items.WRAPPED_BOW,
+                            title = xi.title.BOND_FIXER
                         }
                     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This fixes the reward for Twinstone Bonding by always providing the correct reward for first time completion and subsequent completion. Previously, if another player repeated the quest all subsequent first time completion players would get just the repeat reward (because quest.reward was never set back to the first time completion rewards).

## Steps to test these changes
Talk to Gioh Ajihri
!additem 13360
Trade to Gioh Ajihri
!goto PlayerName
!additem 13360
Trade to Gioh Ajihri
!delquest 2 62
Repeat quest steps and see that you get first time completion reward when you should