### PR TITLE
Adds 2hr to Kirin's summoned pets

### DIFF
--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Byakko.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Byakko.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: The Shrine of Ru'Avitau
---   NM: Seiryu (Pet)
+--   NM: Byakko (Pet)
 -----------------------------------
 mixins = { require("scripts/mixins/job_special") }
 -----------------------------------

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Genbu.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Genbu.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: The Shrine of Ru'Avitau
---   NM: Seiryu (Pet)
+--   NM: Byakko (Pet)
 -----------------------------------
 mixins = { require("scripts/mixins/job_special") }
 -----------------------------------

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Suzaku.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Suzaku.lua
@@ -1,27 +1,12 @@
 -----------------------------------
 -- Area: The Shrine of Ru'Avitau
---  Mob: Suzaku (Pet version)
+--   NM: Suzaku (Pet)
+-----------------------------------
+mixins = { require("scripts/mixins/job_special") }
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-end
-
--- Return the selected spell ID.
-entity.onMobMagicPrepare = function(mob, target, spellId)
-    -- Suzaku uses     Burn, Fire IV, Firaga III, Flare
-    -- Let's give -ga3 a higher distribution than the others.
-    local rnd = math.random()
-
-    if rnd < 0.5 then
-        return 176 -- firaga 3
-    elseif rnd < 0.7 then
-        return 147 -- fire 4
-    elseif rnd < 0.9 then
-        return 204 -- flare
-    else
-        return 235 -- burn
-    end
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Adds the ability for Byakko, Genbu, Seiryu, and Suzaku to 2hr when summoned by Kirin

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
