### PR TITLE
Remove Slendix from pre-abyssea era

### DIFF
--- a/scripts/zones/Inner_Horutoto_Ruins/mobs/Goblin_Leecher.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/mobs/Goblin_Leecher.lua
@@ -12,7 +12,9 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.SLENDLIX_SPINDLETHUMB_PH, 10, 3600) -- 1 hour
+    if xi.settings.main.ENABLE_ABYSSEA then
+        xi.mob.phOnDespawn(mob, ID.mob.SLENDLIX_SPINDLETHUMB_PH, 10, 3600) -- 1 hour
+    end
 end
 
 return entity


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixed out of era NM Slendix Spindlethumb from spawning.
