### PR TITLE
Fix Jeuno map vendors

### DIFF
--- a/scripts/globals/maps.lua
+++ b/scripts/globals/maps.lua
@@ -155,6 +155,10 @@ local mapVendors =
             xi.ki.MAP_OF_THE_ELDIEME_NECROPOLIS,
             xi.ki.MAP_OF_THE_GARLAIGE_CITADEL,
             xi.ki.MAP_OF_THE_ELSHIMO_REGIONS,
+            xi.ki.MAP_OF_THE_JEUNO_AREA,
+            xi.ki.MAP_OF_THE_SAN_DORIA_AREA,
+            xi.ki.MAP_OF_THE_BASTOK_AREA,
+            xi.ki.MAP_OF_THE_WINDURST_AREA
         },
     },
 
@@ -168,6 +172,10 @@ local mapVendors =
             xi.ki.MAP_OF_THE_ELDIEME_NECROPOLIS,
             xi.ki.MAP_OF_THE_GARLAIGE_CITADEL,
             xi.ki.MAP_OF_THE_ELSHIMO_REGIONS,
+            xi.ki.MAP_OF_THE_JEUNO_AREA,
+            xi.ki.MAP_OF_THE_SAN_DORIA_AREA,
+            xi.ki.MAP_OF_THE_BASTOK_AREA,
+            xi.ki.MAP_OF_THE_WINDURST_AREA
         },
     },
 
@@ -277,6 +285,7 @@ local function isMapOutOfEra(mapId)
     if era ~= "" then
         return eraData[era]
     end
+
     return false
 end
 
@@ -296,6 +305,7 @@ local function isMapFromVendor(npc, mapKeyItem)
             return true
         end
     end
+
     return false
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes Jeuno map vendors which should sell maps of Jeuno, and the three starter areas (see [here](https://web.archive.org/web/20051211110832/https://ffxi.allakhazam.com/db/bestiary.html?fmob=1650)). The era wiki page (see [here](https://ffxiclopedia.fandom.com/wiki/Promurouve?oldid=37859)) is wrong probably because the person that checked already had those maps.

## Steps to test these changes
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2318