### PR TITLE
Fix Apollyon NE crash when unlocking third floor

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -980,6 +980,18 @@ void CBattlefield::handleDeath(CBaseEntity* PEntity)
             {
                 ++group.deathCount;
 
+                break;
+            }
+        }
+    }
+
+    auto groups(m_groups);
+    for (auto& group : groups)
+    {
+        for (uint32 mobId : group.mobIds)
+        {
+            if (mobId == PEntity->id)
+            {
                 if (group.deathCallback.valid())
                 {
                     auto result = group.deathCallback(CLuaBattlefield(this), CLuaBaseEntity(PEntity), group.deathCount);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes an issue with the battlefield system when a death callback triggers mob spawns

Co-authored-by: jmcmorris <jasson@siegegames.com>

## Steps to test these changes

Enter Apollyon NE. Go to second floor and kill all the big birds
