### PR TITLE
Removed aggressive status for Oldton Stirge's.

### DIFF
--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -475,7 +475,7 @@ INSERT INTO `mob_groups` VALUES (15,2687,11,'Moblin_Chapman',792,0,1705,0,0,33,3
 INSERT INTO `mob_groups` VALUES (16,565,11,'Bugbear_Servingman',720,0,377,0,0,32,35,0);
 INSERT INTO `mob_groups` VALUES (17,1160,11,'Earth_Elemental',924,4,6044,0,0,45,50,0);
 INSERT INTO `mob_groups` VALUES (18,563,11,'Bugbear_Muscleman',5700,0,376,4700,0,52,52,0);
-INSERT INTO `mob_groups` VALUES (19,3776,11,'Stirge',792,0,2338,0,0,33,36,0);
+INSERT INTO `mob_groups` VALUES (19,7071,11,'Stirge',792,0,2338,0,0,33,36,0);
 INSERT INTO `mob_groups` VALUES (20,121,11,'Ancient_Bomb',924,0,83,0,0,40,45,0);
 INSERT INTO `mob_groups` VALUES (21,3912,11,'Thunder_Elemental',924,4,2412,0,0,45,50,0);
 INSERT INTO `mob_groups` VALUES (22,2703,11,'Moblin_Rodman',924,0,1718,0,0,41,43,0);

--- a/sql/mob_pools.sql
+++ b/sql/mob_pools.sql
@@ -7139,6 +7139,9 @@ INSERT INTO `mob_pools` VALUES (7068,'Mystic_Avatar','Mystic_Avatar',321,0x00001
 INSERT INTO `mob_pools` VALUES (7069,'Mystic_Avatar','Mystic_Avatar',320,0x00001E0300000000000000000000000000000000,1,1,12,240,100,0,1,1,1,18,759,0,0,131,0,0,0,0,256,320,320);
 INSERT INTO `mob_pools` VALUES (7070,'Mystic_Avatar','Mystic_Avatar',323,0x00001B0300000000000000000000000000000000,1,1,8,240,100,0,1,1,1,18,759,0,0,131,0,0,0,0,256,323,323);
 
+-- Oldton Movapolos 
+INSERT INTO `mob_pools` VALUES (7071,'Stirge_Oldton','Stirge_Oldton',46,0x0000000100000000000000000000000000000000,1,1,11,240,100,0,0,0,1,0,0,0,397,643,8,0,0,0,0,46,46);
+
 -- ------------------------------------------------------------
 -- Start of AirSkyBoat section
 


### PR DESCRIPTION
No longer aggro.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixed earlier boo-boo when I made all 3x zones of Stirge's non-aggressive. This creates a separate pool and assigns Oldton ones as non-aggressive while the other zones remain aggressive. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
![image](https://user-images.githubusercontent.com/16403542/217105399-83c2a7bb-2b5f-4d53-8cd7-e893ab2447a7.png)
