### PR TITLE
Fix entrance requirements of CoP three paths BCNMs

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -40,8 +40,8 @@ local battlefields =
         { 4,  676,    0 },   -- Totentanz (ENM)
         { 5,  677,    0 },   -- Tango with a Tracker (Quest)
         { 6,  678,    0 },   -- Requiem of Sin (Quest)
-     -- { 7,  679, 3454 },   -- Antagonistic Ambuscade (HKC30)
-     -- { 8,    ?,    0 },   -- *Head Wind (HTMBF)
+    --  { 7,  679, 3454 },   -- Antagonistic Ambuscade (HKC30)
+    --  { 8,    ?,    0 },   -- *Head Wind (HTMBF)
     },
 
     [xi.zone.THE_SHROUDED_MAW] =
@@ -59,35 +59,35 @@ local battlefields =
         { 2,  738,    0 },   -- Bionic Bug (ENM)
         { 3,  739,    0 },   -- Pulling the Strings (ENM)
         { 4,  740,    0 },   -- Automaton Assault (ENM)
-     -- { 5,  741, 3455 },   -- The Mobline Comedy (HKC50)
+    --  { 5,  741, 3455 },   -- The Mobline Comedy (HKC50)
     },
 
     [xi.zone.SPIRE_OF_HOLLA] =
     {
         { 0,  768,    0 },   -- Ancient Flames Beckon (PM1-3)
         { 1,  769,    0 },   -- Simulant (ENM)
-     -- { 2,  770, 3351 },   -- Empty Hopes (KC30)
+    --  { 2,  770, 3351 },   -- Empty Hopes (KC30)
     },
 
     [xi.zone.SPIRE_OF_DEM] =
     {
         { 0,  800,    0 },   -- Ancient Flames Beckon (PM1-3)
         { 1,  801,    0 },   -- You Are What You Eat (ENM)
-     -- { 2,  802, 3351 },   -- Empty Dreams (KC30)
+    --  { 2,  802, 3351 },   -- Empty Dreams (KC30)
     },
 
     [xi.zone.SPIRE_OF_MEA] =
     {
         { 0,  832,    0 },   -- Ancient Flames Beckon (PM1-3)
         { 1,  833,    0 },   -- Playing Host (ENM)
-     -- { 2,  834, 3351 },   -- Empty Desires (KC30)
+    --  { 2,  834, 3351 },   -- Empty Desires (KC30)
     },
 
     [xi.zone.SPIRE_OF_VAHZL] =
     {
         { 0,  864,    0 },   -- Desires of Emptiness (PM5-2)
         { 1,  865,    0 },   -- Pulling the Plug (ENM)
-     -- { 2,  866, 3352 },   -- Empty Aspirations (KC50)
+    --  { 2,  866, 3352 },   -- Empty Aspirations (KC50)
     },
 
     [xi.zone.RIVERNE_SITE_B01] =
@@ -110,8 +110,8 @@ local battlefields =
         { 4,  964,    0 },   -- Bugard in the Clouds (ENM)
         { 5,  965,    0 },   -- Beloved of the Atlantes (ENM)
         { 6,  966,    0 },   -- Uninvited Guests (Quest)
-     -- { 7,  967, 3455 },   -- Nest of Nightmares (HKC50)
-     -- { 8,    ?,    0 },   -- *The Savage (HTMBF)
+    --  { 7,  967, 3455 },   -- Nest of Nightmares (HKC50)
+    --  { 8,    ?,    0 },   -- *The Savage (HTMBF)
     },
 
     [xi.zone.SEALIONS_DEN] =
@@ -260,7 +260,7 @@ local battlefields =
         { 2,   34, 1551 },   -- Wings of Fury (BS20)
         { 3,   35, 1552 },   -- Petrifying Pair (BS30)
         { 4,   36, 1552 },   -- Toadal Recall (BS30)
-     -- { 5,   37,    0 },   -- Mirror, Mirror (Quest)
+    --  { 5,   37,    0 },   -- Mirror, Mirror (Quest)
     },
 
     [xi.zone.WAUGHROON_SHRINE] =
@@ -284,8 +284,8 @@ local battlefields =
         { 16,   80, 1175 },   -- Copycat (KS30)
         { 17,   81, 1178 },   -- Operation Desert Swarm (KS30)
         { 18,   82, 1180 },   -- Prehistoric Pigeons (KS30)
-     -- { 19,   83, 3351 },   -- The Palborough Project (KC30)
-     -- { 20,   84, 3352 },   -- Shell Shocked (KC50)
+    --  { 19,   83, 3351 },   -- The Palborough Project (KC30)
+    --  { 20,   84, 3352 },   -- Shell Shocked (KC50)
         { 21,   85,    0 },   -- Beyond Infinity (Quest)
     --  { 22,    ?, 4062 },   -- *The Worm's Tail (SKC10)
     --  { 23,    ?, 4063 },   -- *Grimshell Shocktroopers (SKC20)
@@ -316,8 +316,8 @@ local battlefields =
         { 15,  111, 1175 },   -- Seasons Greetings (KS30)
         { 16,  112, 1178 },   -- Royale Ramble (KS30)
         { 17,  113, 1180 },   -- Moa Constrictors (KS30)
-     -- { 18,  114, 3351 },   -- The V Formation (KC30)
-     -- { 19,  115, 3352 },   -- Avian Apostates (KC50)
+    --  { 18,  114, 3351 },   -- The V Formation (KC30)
+    --  { 19,  115, 3352 },   -- Avian Apostates (KC50)
         { 20,  116,    0 },   -- Beyond Infinity (Quest)
     --  { 21,    ?, 4062 },   -- *Steamed Sprouts (SKC10)
     --  { 22,    ?, 4063 },   -- *Divine Punishers (SKC20)
@@ -370,9 +370,9 @@ local battlefields =
         {  5,  197, 1175 },   -- Cactuar Suave (KS30)
         {  6,  198, 1178 },   -- Eye of the Storm (KS30)
         {  7,  199, 1180 },   -- The Scarlet King (KS30)
-     -- {  8,  200,    0 },   -- Roar! A Cat Burglar Bares Her Fangs (MKD10)
-     -- {  9,  201, 3352 },   -- Dragon Scales (KC50)
-     -- { 10,    ?, 4063 },   -- *Legion XI Comitatensis (SKC20)
+    --  {  8,  200,    0 },   -- Roar! A Cat Burglar Bares Her Fangs (MKD10)
+    --  {  9,  201, 3352 },   -- Dragon Scales (KC50)
+    --  { 10,    ?, 4063 },   -- *Legion XI Comitatensis (SKC20)
     },
 
     [xi.zone.FULL_MOON_FOUNTAIN] =
@@ -380,9 +380,9 @@ local battlefields =
         { 0,  224,    0 },   -- The Moonlit Path (Quest)
         { 1,  225,    0 },   -- Moon Reading (Windy 9-2)
         { 2,  226,    0 },   -- Waking the Beast (Quest)
-     -- { 3,  227,    0 },   -- Battaru Royale (ASA10)
-     -- { 4,    ?,    0 },   -- *The Moonlit Path (HTMBF)
-     -- { 5,    ?,    0 },   -- *Waking the Beast (HTMBF)
+    --  { 3,  227,    0 },   -- Battaru Royale (ASA10)
+    --  { 4,    ?,    0 },   -- *The Moonlit Path (HTMBF)
+    --  { 5,    ?,    0 },   -- *Waking the Beast (HTMBF)
     },
 
     [xi.zone.STELLAR_FULCRUM] =
@@ -478,7 +478,7 @@ local battlefields =
         { 14,  526, 1177 },   -- Idol Thoughts (BS50)
         { 15,  527, 1177 },   -- An Awful Autopsy (BS50)
         { 16,  528, 1130 },   -- Celery (BS60)
-     -- { 17,  529,    0 },   -- Mirror Images (Quest)
+    --  { 17,  529,    0 },   -- Mirror Images (Quest)
         { 18,  530, 2556 },   -- A Furious Finale (DNC LB5)
     --  { 19,  531,    0 },   -- Clash of the Comrades (Quest)
     --  { 20,  532,    0 },   -- Those Who Lurk in Shadows (ACP7)
@@ -1178,7 +1178,7 @@ local function checkReqs(player, npc, bfid, registrant)
 
         [640] = function() -- PM5-3 U3: Flames for the Dead
             return (player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THREE_PATHS) or
-            player:getMissionStatus(xi.mission.log_id.COP, xi.mission.status.COP.ULMIA) == 8) and
+            player:getMissionStatus(xi.mission.log_id.COP, xi.mission.status.COP.ULMIA) >= 8) and
             npcId == getEntranceOffset(0)
         end,
 
@@ -1200,7 +1200,7 @@ local function checkReqs(player, npc, bfid, registrant)
 
         [672] = function() -- PM5-3 U2: Head Wind
             return player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THREE_PATHS) or
-                player:getMissionStatus(xi.mission.log_id.COP, xi.mission.status.COP.ULMIA) == 7
+                player:getMissionStatus(xi.mission.log_id.COP, xi.mission.status.COP.ULMIA) >= 7
         end,
 
         [673] = function() -- ENM: Like the Wind
@@ -1230,6 +1230,11 @@ local function checkReqs(player, npc, bfid, registrant)
 
         [705] = function() -- ENM: Test Your Mite
             return player:hasKeyItem(xi.ki.ASTRAL_COVENANT)
+        end,
+
+        [736] = function() -- PM5-3 L3: A Century of Hardship
+            return player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THREE_PATHS) or
+                player:getMissionStatus(xi.mission.log_id.COP, xi.mission.status.COP.LOUVERANCE) >= 8
         end,
 
         [737] = function() -- Quest: Return to the Depths


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue where players that just completed a BCNM fight were not able to help additional players right afterwards (they would have to wait until after finishing three paths mission).

## Steps to test these changes