### PR TITLE
Fix item issue in The Promise quest 

### DIFF
--- a/scripts/quests/windurst/SOB7_The_Promise.lua
+++ b/scripts/quests/windurst/SOB7_The_Promise.lua
@@ -204,16 +204,16 @@ quest.sections =
                     if player:hasKeyItem(xi.ki.INVISIBLE_MAN_STICKER) then
                         return quest:event(800)
                     elseif quest:getVar(player, 'Chamama') > 0 then
-                        return quest:event(798, 0, xi.items.SHOALWEED, xi.ki.INVISIBLE_MAN_STICKER)
+                        return quest:event(798, 0, xi.items.CLUMP_OF_SHOALWEED, xi.ki.INVISIBLE_MAN_STICKER)
                     else
-                        return quest:progressEvent(797, 0, xi.items.SHOALWEED, xi.ki.INVISIBLE_MAN_STICKER)
+                        return quest:progressEvent(797, 0, xi.items.CLUMP_OF_SHOALWEED, xi.ki.INVISIBLE_MAN_STICKER)
                     end
                 end,
 
                 onTrade = function(player, npc, trade)
                     if
                         quest:getVar(player, 'Chamama') == 1 and
-                        npcUtil.tradeHasExactly(trade, xi.items.SHOALWEED) and
+                        npcUtil.tradeHasExactly(trade, xi.items.CLUMP_OF_SHOALWEED) and
                         not player:hasKeyItem(xi.ki.INVISIBLE_MAN_STICKER)
                     then
                         return quest:progressEvent(799, 0, 0, xi.ki.INVISIBLE_MAN_STICKER)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue preventing progress in The Promise quest due to incorrect label for shoalweed item.

## Steps to test these changes
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/899