### PR TITLE
Zine ores eating singles

### DIFF
--- a/scripts/quests/bastok/Beauty_And_The_Galka.lua
+++ b/scripts/quests/bastok/Beauty_And_The_Galka.lua
@@ -80,7 +80,10 @@ quest.sections =
                 onTrigger = quest:event(4),
 
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, { { xi.items.CHUNK_OF_ZINC_ORE, 1 } }) then
+                    if
+                        npcUtil.tradeHasExactly(trade, { { xi.items.CHUNK_OF_ZINC_ORE, 1 } }) and
+                        not player:hasKeyItem(xi.ki.PALBOROUGH_MINES_LOGS)
+                    then
                         return quest:progressEvent(3)
                     end
                 end
@@ -108,6 +111,7 @@ quest.sections =
                     if math.random(1, 2) == 1 then
                         return quest:event(8)
                     end
+
                     return quest:event(9)
                 end
             },


### PR DESCRIPTION
Inputs checks for next stage and if has KI will not accept any ores as a trade.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Addresses issue where player can trade a single zinc ore to NPC and NPC will eat them. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Addresses issue https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1041
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
![image](https://user-images.githubusercontent.com/16403542/217980878-8d56ded9-bca3-4842-96a6-456ac095b86d.png)
