### PR TITLE
HELM Claim System (Module)

### DIFF
--- a/modules/custom/lua/helm_claim.lua
+++ b/modules/custom/lua/helm_claim.lua
@@ -16,10 +16,10 @@ local claimSettings = {
 }
 
 local helmTools = {
-    [xi.helm.type.HARVESTING] = 1020,
-    [xi.helm.type.EXCAVATION] = 605,
-    [xi.helm.type.LOGGING] = 1021,
-    [xi.helm.type.MINING] = 605,
+    [xi.helm.type.HARVESTING] = 1020, -- Sickle
+    [xi.helm.type.EXCAVATION] = 605,  -- Pickaxe
+    [xi.helm.type.LOGGING] = 1021,    -- Hatchet
+    [xi.helm.type.MINING] = 605,      -- Pickaxe
 }
 
 if xi.settings[m.name] then
@@ -38,7 +38,7 @@ m:addOverride("xi.helm.onTrade", function(player, npc, trade, helmType, csid, fu
         return
     end
 
-    if trade:hasItemQty(helmTools[helmType], 1) and trade:getItemCount() == 1 then
+    if npcUtil.tradeHasExactly(trade, helmTools[helmType]) then
         local lastTrade = player:getLocalVar("[HELM]Last_Trade")
 
         if os.time() > lastTrade + 4 then

--- a/modules/custom/lua/helm_claim.lua
+++ b/modules/custom/lua/helm_claim.lua
@@ -9,7 +9,7 @@ require("modules/module_utils")
 local m = Module:new("helm_claim")
 
 local claimSettings = {
-    MESSAGE = "Another player is currently using that.",
+    MESSAGE = "Another player is currently using this.",
     CLAIM_DURATION = 10, -- Seconds
     POINT_AVAILABLE = "POINT_AVAILABLE",
     POINT_CLAIMED = "POINT_CLAIMED"

--- a/modules/custom/lua/helm_claim.lua
+++ b/modules/custom/lua/helm_claim.lua
@@ -5,6 +5,8 @@
 -- Prevents players from "stealing" a point currently in use
 -----------------------------------
 require("modules/module_utils")
+require("scripts/globals/items")
+require("scripts/globals/npc_util")
 -----------------------------------
 local m = Module:new("helm_claim")
 
@@ -16,10 +18,10 @@ local claimSettings = {
 }
 
 local helmTools = {
-    [xi.helm.type.HARVESTING] = 1020, -- Sickle
-    [xi.helm.type.EXCAVATION] = 605,  -- Pickaxe
-    [xi.helm.type.LOGGING] = 1021,    -- Hatchet
-    [xi.helm.type.MINING] = 605,      -- Pickaxe
+    [xi.helm.type.HARVESTING] = xi.items.SICKLE,
+    [xi.helm.type.EXCAVATION] = xi.items.PICKAXE,
+    [xi.helm.type.LOGGING]    = xi.items.HATCHET,
+    [xi.helm.type.MINING]     = xi.items.PICKAXE,
 }
 
 if xi.settings[m.name] then

--- a/modules/custom/lua/helm_claim.lua
+++ b/modules/custom/lua/helm_claim.lua
@@ -1,0 +1,60 @@
+-----------------------------------
+-- HELM Claim
+-----------------------------------
+-- Gathering Points are "claimed" for x seconds upon use
+-- Prevents players from "stealing" a point currently in use
+-----------------------------------
+require("modules/module_utils")
+-----------------------------------
+local m = Module:new("helm_claim")
+
+local claimSettings = {
+    MESSAGE = "Another player is currently using that.",
+    CLAIM_DURATION = 10, -- Seconds
+    POINT_AVAILABLE = "POINT_AVAILABLE",
+    POINT_CLAIMED = "POINT_CLAIMED"
+}
+
+local helmTools = {
+    [xi.helm.type.HARVESTING] = 1020,
+    [xi.helm.type.EXCAVATION] = 605,
+    [xi.helm.type.LOGGING] = 1021,
+    [xi.helm.type.MINING] = 605,
+}
+
+if xi.settings[m.name] then
+    if xi.settings[m.name].MESSAGE then
+        claimSettings.MESSAGE = xi.settings[m.name].MESSAGE
+    end
+
+    if xi.settings[m.name].CLAIM_DURATION then
+        claimSettings.CLAIM_DURATION = xi.settings[m.name].CLAIM_DURATION
+    end
+end
+
+m:addOverride("xi.helm.onTrade", function(player, npc, trade, helmType, csid, func)
+    if os.time() < npc:getLocalVar(claimSettings.POINT_AVAILABLE) and player:getID() ~= npc:getLocalVar(claimSettings.POINT_CLAIMED) then
+        player:PrintToPlayer(claimSettings.MESSAGE, xi.msg.channel.SYSTEM_3)
+        return
+    end
+
+    if trade:hasItemQty(helmTools[helmType], 1) and trade:getItemCount() == 1 then
+        local lastTrade = player:getLocalVar("[HELM]Last_Trade")
+
+        if os.time() > lastTrade + 4 then
+            npc:setLocalVar(claimSettings.POINT_AVAILABLE, os.time() + claimSettings.CLAIM_DURATION)
+            npc:setLocalVar(claimSettings.POINT_CLAIMED, player:getID())
+        end
+    end
+
+    super(player, npc, trade, helmType, csid, func)
+end)
+
+m:addOverride("xi.helm.movePoint", function(target, zoneId, helmType)
+    target:setLocalVar(claimSettings.POINT_AVAILABLE, 0)
+    target:setLocalVar(claimSettings.POINT_CLAIMED, 0)
+
+    super(target, zoneId, helmType)
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

### HELM (Harvesting, Excavation, Logging, Mining) Claim System

Prevents unnecessary player disputes while preserving the accepted gathering etiquette.

Point will be claimed to the first player who uses it and freed up when no longer in use. The default value (10 seconds) gives players just enough time to hold a point if they continue to use a macro, without slowing down the redistribution.

Optional settings to adjust message and duration (eg. in `settings/map.lua`)
```lua
xi.settings.helm_claim = {
    MESSAGE = "Another player is currently using this.",
    CLAIM_DURATION = 10,
}
```

## Steps to test these changes

Add module to `modules/init.txt`
```
custom/lua/helm_claim.lua
```

Take two characters to a Mining Point or other gathering point.
Take turns trading tools (Or use a macro) and observe the results.

```
/targetnpc
/item "Pickaxe" <t>
```