### PR TITLE
Fix bomb core and related non-skill weapons

### DIFF
--- a/modules/era/sql/item_mods.sql
+++ b/modules/era/sql/item_mods.sql
@@ -26,6 +26,7 @@ WHERE itemId IN (
     SELECT itemId
     FROM item_weapon
     WHERE skill < 25
+    AND skill != 0
     )
 AND modId = 165;
 
@@ -35,6 +36,7 @@ WHERE itemId IN (
     SELECT itemId
     FROM item_weapon
     WHERE skill < 25
+    AND skill != 0
     )
 AND modId = 23;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes bomb core and related weapons so that their attack mod is not changed from ATT to ATT_SLOT (which is a mod that is used for main and offhand weapon only). Without this fix bomb core does not give any attack. This also fixes this issue for any other special weapons that have skill of 0 (no specific skill) and have attack or crit hit mods. 

## Steps to test these changes
Equip bomb core with the attack mod set to 23 (ATT)
Compare to equipping bomb core with the attack mod set to 1169 (ATT_SLOT)