### PR TITLE
Updated NQ Behemoth Thunderbolt

### DIFF
--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -158,7 +158,7 @@ INSERT INTO `mob_skill_lists` VALUES ('Beetle',49,343);
 INSERT INTO `mob_skill_lists` VALUES ('Gloom_Eye',50,548);
 INSERT INTO `mob_skill_lists` VALUES ('Gloom_Eye',50,549);
 INSERT INTO `mob_skill_lists` VALUES ('Behemoth',51,628);
-INSERT INTO `mob_skill_lists` VALUES ('Behemoth',51,629);
+INSERT INTO `mob_skill_lists` VALUES ('Behemoth',51,1686);
 INSERT INTO `mob_skill_lists` VALUES ('Behemoth',51,630);
 INSERT INTO `mob_skill_lists` VALUES ('Behemoth',51,631);
 INSERT INTO `mob_skill_lists` VALUES ('Behemoth',51,632);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1584,7 +1584,7 @@ INSERT INTO `mob_skills` VALUES (1671,202,'ink_jet_alt',0,7.0,2000,0,4,4,0,3,0,0
 -- INSERT INTO `mob_skills` VALUES (1683,1427,'#1427',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1684,120,'foul_breath',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1685,1429,'frost_breath',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1686,1430,'thunderbolt',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1686,1430,'thunderbolt',1,30.0,2000,1500,4,0,0,0,0,0,0); -- Behemoth non aoe to bystanders.
 -- INSERT INTO `mob_skills` VALUES (1687,123,'chomp_rush',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1688,124,'scythe_tail',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1689,1433,'double_claw',0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
Updated NQ Behemoth usage of thunderbolt to not hit outside party/alliance members, unlike KB whose usage of thunderbolt DOES hit ALL players. https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1034

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adjusts NQ Behemoth usage of Thunderbolt to not hit outside party/alliance. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1034
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
