### PR TITLE
Refactoring Uninvited Guests to fix a few issues

### DIFF
--- a/scripts/quests/otherAreas/Uninvited_Guests.lua
+++ b/scripts/quests/otherAreas/Uninvited_Guests.lua
@@ -15,6 +15,14 @@ require('scripts/globals/zone')
 require('scripts/globals/interaction/quest')
 -----------------------------------
 
+--[[
+    UninvitedGuestsStatus
+    1 = Accepted
+    2 = Won
+    3 = Lost
+    4 = On Cooldown Due to Loss
+]]
+
 local quest = Quest:new(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.UNINVITED_GUESTS)
 
 local rewards =
@@ -120,10 +128,9 @@ quest.sections =
             },
         },
     },
-
     {
         check = function(player, status, vars)
-            return status == QUEST_ACCEPTED
+            return (status == QUEST_ACCEPTED) or (status == QUEST_COMPLETED)
         end,
 
         [xi.zone.TAVNAZIAN_SAFEHOLD] =
@@ -131,22 +138,24 @@ quest.sections =
             ['Justinius'] =
             {
                 onTrigger = function(player, npc)
-                    local uninvitedGuests =  player:getCharVar("UninvitedGuestsStatus")
-
-                    if uninvitedGuests == 0 then
-                        if not player:hasKeyItem(xi.ki.MONARCH_LINN_PATROL_PERMIT) then
-                            npcUtil.giveKeyItem(player, xi.ki.MONARCH_LINN_PATROL_PERMIT)
-                        end
+                    local uninvitedGuests = player:getCharVar("UninvitedGuestsStatus")
+                    local questStatus = player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.UNINVITED_GUESTS)
+                    
+                    -- Reminder to go to Monarch Linn
+                    if uninvitedGuests == 1 and questStatus == QUEST_ACCEPTED then
                         return quest:progressEvent(571)
                     -- Player won, give reward
-                    elseif uninvitedGuests == 1 then
+                    elseif uninvitedGuests == 2 then
                         return quest:progressEvent(572)
-                    -- Uninvited Guests Failure - mocks player until conquest tally
-                    elseif uninvitedGuests == 2 or (uninvitedGuests == 3 and player:getCharVar("UninvitedGuestsReset")) >= os.time() then
-                        return quest:progressEvent(575)
                     -- Reissues permit post failure
-                    elseif uninvitedGuests == 3 and player:getCharVar("UninvitedGuestsReset") <= os.time() then
+                    elseif uninvitedGuests == 4 and (player:getCharVar("UninvitedGuestsReset") <= os.time()) then
                         return quest:progressEvent(574)
+                    -- Uninvited Guests Failure - mocks player until conquest tally
+                    elseif uninvitedGuests == 3 or (uninvitedGuests == 4 and player:getCharVar("UninvitedGuestsReset") >= os.time()) then
+                        return quest:progressEvent(575)
+                    -- The repeat quest kick off
+                    elseif player:getCharVar("UninvitedGuestsReset") <= os.time() and not player:hasKeyItem(xi.ki.MONARCH_LINN_PATROL_PERMIT) then
+                        return quest:progressEvent(573)
                     end
                 end,
             },
@@ -161,94 +170,33 @@ quest.sections =
                     end
 
                     if rewardId == 1 and quest:complete(player) then -- special case for Gil
-                        updateUninvitedGuests(player, true)
-                        npcUtil.giveCurrency(player, "gil", 10000)
+                        if npcUtil.giveCurrency(player, "gil", 10000) then
+                            updateUninvitedGuests(player, true)
+                        end
                     elseif quest:complete(player) then -- Reward item
-                        updateUninvitedGuests(player, true)
-                        npcUtil.giveItem(player, rewardId)
-                    end
-                end,
-
-                [574] = function(player, csid, option, npc)
-                    npcUtil.giveKeyItem(player, xi.ki.MONARCH_LINN_PATROL_PERMIT)
-                    player:setCharVar("UninvitedGuestsStatus", 0)
-                end,
-
-                [575] = function(player, csid, option, npc)
-                    -- Player has failed and must wait until conquest to retry
-                    if player:getCharVar("UninvitedGuestsStatus") == 2 then
-                        updateUninvitedGuests(player, false)
-                        player:setCharVar("UninvitedGuestsStatus", 3)
-                    end
-                end,
-            },
-        },
-    },
-    {
-        check = function(player, status, vars)
-            return status == QUEST_COMPLETED
-        end,
-
-        [xi.zone.TAVNAZIAN_SAFEHOLD] =
-        {
-            ['Justinius'] =
-            {
-                onTrigger = function(player, npc)
-                    local uninvitedGuests =  player:getCharVar("UninvitedGuestsStatus")
-
-                    -- Restart quest after conquest tally
-                    if player:getCharVar("UninvitedGuestsReset") <= os.time() and
-                    not player:hasKeyItem(xi.ki.MONARCH_LINN_PATROL_PERMIT) then
-                        return quest:progressEvent(573)
-                    -- Player won, give reward
-                    elseif uninvitedGuests == 1 then
-                        return quest:progressEvent(572)
-                    -- Uninvited Guests Failure - mocks player until conquest tally
-                    elseif uninvitedGuests == 2 or (uninvitedGuests == 3 and
-                    player:getCharVar("UninvitedGuestsReset")) >= os.time() then
-                        return quest:progressEvent(575)
-                    -- Reissues permit post failure
-                    elseif uninvitedGuests == 3 and
-                    player:getCharVar("UninvitedGuestsReset") <= os.time() then
-                        return quest:progressEvent(574)
-                    end
-                end,
-            },
-            onEventFinish =
-            {
-                [572] = function(player, csid, option, npc)
-                    -- Determine Reward (or check if a reward is pending)
-                    local rewardId = player:getCharVar("UninvitedGuestsReward") -- Done to prevent ppl holding the r/ex xp page and forcing a recalculation
-                    if rewardId == 0 then
-                        rewardId = generateUninvitedGuestsReward(player)
-                    end
-
-                    if rewardId == 1 then -- special case for Gil
-                        updateUninvitedGuests(player, true)
-                        npcUtil.giveCurrency(player, "gil", 10000)
-                    else -- Reward item
-                        updateUninvitedGuests(player, true)
-                        npcUtil.giveItem(player, rewardId)
+                        if npcUtil.giveItem(player, rewardId) then
+                           updateUninvitedGuests(player, true)
+                        end
                     end
                 end,
 
                 [573] = function(player, csid, option, npc)
                     if option == 1 then
                         npcUtil.giveKeyItem(player, xi.ki.MONARCH_LINN_PATROL_PERMIT)
-                        player:setCharVar("UninvitedGuestsStatus", 0) -- accepted
+                        player:setCharVar("UninvitedGuestsStatus", 1) -- accepted
                     end
                 end,
 
                 [574] = function(player, csid, option, npc)
                     npcUtil.giveKeyItem(player, xi.ki.MONARCH_LINN_PATROL_PERMIT)
-                    player:setCharVar("UninvitedGuestsStatus", 0)
+                    player:setCharVar("UninvitedGuestsStatus", 1) -- accepted
                 end,
 
                 [575] = function(player, csid, option, npc)
                     -- Player has failed and must wait until conquest to retry
-                    if player:getCharVar("UninvitedGuestsStatus") == 2 then
+                    if player:getCharVar("UninvitedGuestsStatus") == 3 then
                         updateUninvitedGuests(player, false)
-                        player:setCharVar("UninvitedGuestsStatus", 3)
+                        player:setCharVar("UninvitedGuestsStatus", 4)
                     end
                 end,
             },

--- a/scripts/zones/Monarch_Linn/bcnms/uninvited_guests.lua
+++ b/scripts/zones/Monarch_Linn/bcnms/uninvited_guests.lua
@@ -25,17 +25,17 @@ battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
         player:startEvent(32002)
     elseif leavecode == xi.battlefield.leaveCode.EXIT or leavecode == xi.battlefield.leaveCode.WARPDC then
         -- However the player got out of the BCNM - they didnt win
-        player:setCharVar("UninvitedGuestsStatus", 2) -- update to failure state
+        player:setCharVar("UninvitedGuestsStatus", 3) -- update to failure state
     end
 end
 
 battlefield_object.onEventFinish = function(player, csid, option)
     if csid == 32001 then
         -- Victory
-        player:setCharVar("UninvitedGuestsStatus", 1) -- update to victory state
+        player:setCharVar("UninvitedGuestsStatus", 2) -- update to victory state
     elseif csid == 32002 then
         -- Failure
-        player:setCharVar("UninvitedGuestsStatus", 2) -- update to failure state
+        player:setCharVar("UninvitedGuestsStatus", 3) -- update to failure state
     end
 end
 

--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -1096,7 +1096,7 @@ INSERT INTO `synth_recipes` VALUES (14519,0,0,0,92,0,0,0,0,0,0,4099,4241,1359,91
 INSERT INTO `synth_recipes` VALUES (14520,0,1995,0,92,0,0,0,0,0,0,4096,4238,1711,1711,1711,1711,1711,1711,2144,0,669,669,669,669,6,6,6,6,'Mlbd. Sheet');
 INSERT INTO `synth_recipes` VALUES (14521,0,0,0,92,0,0,0,0,0,0,4096,4238,1286,16470,0,0,0,0,0,0,17625,17625,17625,17625,1,1,1,1,'Ponderous Gully');
 INSERT INTO `synth_recipes` VALUES (14522,0,0,20,93,0,0,0,0,59,0,4096,4238,652,654,654,654,713,824,924,0,16777,16791,16791,16791,1,1,1,1,'Death Scythe');  -- JPWiki/ffxiclopedia  Discrepancies between pages, but highest value used.
--- INSERT INTO `synth_recipes` VALUES (14523,0,0,0,93,0,255,0,0,0,0,4098,4240,664,682,1764,1764,0,0,0,0,12490,15192,15192,15192,1,1,1,1,'Yasha Jinpachi');  -- JPWiki data 93SM, 58CL, subs/mats unconfirmed elsewhere
+INSERT INTO `synth_recipes` VALUES (14523,0,0,0,93,0,58,0,0,0,0,4098,4240,664,682,1764,1764,0,0,0,0,12490,15192,15192,15192,1,1,1,1,'Yasha Jinpachi');  -- JPWiki data 93SM, 58CL, subs/mats unconfirmed elsewhere
 INSERT INTO `synth_recipes` VALUES (14524,0,0,0,93,40,0,25,0,0,0,4096,4238,2001,2001,2275,2823,12698,0,0,0,12189,12189,12189,12189,1,1,1,1,'Ebon Gauntlets');  -- JPWiki data, ffxiclopedia agree since 07/2019 revision,subs unconfirmed elsewhere
 INSERT INTO `synth_recipes` VALUES (14525,0,0,0,93,0,0,0,0,0,0,4096,4238,3918,3918,3918,3918,0,0,0,0,3919,3919,3919,3919,1,1,1,1,'Midrium Ingot');
 -- INSERT INTO `synth_recipes` VALUES (14526,0,0,0,93,255,0,0,0,0,0,4096,4238,655,716,745,914,0,0,0,0,16653,16685,16685,16685,1,1,1,1,'Nadziak');  -- JPWiki data 93SM, 49GS, 13WW, subs/mats unconfirmed elsewhere

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1303,6 +1303,10 @@ namespace fishingutils
 
     fishingarea_t* GetFishingArea(CCharEntity* PChar)
     {
+        // We should not be here. Caller is responsible for acting on a player that
+        // is attempting to fish in MH
+        XI_DEBUG_BREAK_IF(PChar->m_moghouseID > 0)
+
         int16        zoneId = PChar->getZone();
         position_t   p      = PChar->loc.p;
         areavector_t loc    = { p.x, p.y, p.z };
@@ -1926,6 +1930,12 @@ namespace fishingutils
             ShowWarning("Fishing is currently disabled");
             PChar->pushPacket(new CChatMessagePacket(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Fishing is currently disabled"));
             PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
+            return;
+        }
+
+        if (PChar->m_moghouseID > 0)
+        {
+            ShowError(fmt::format("Player {} attempting to fish inside Mog House", PChar->GetName()));
             return;
         }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [ x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Refactors Uninvited Guests to fix a few issues:
1. Double Rewards on first completion
2. Possibilty to get no reward and not have the reward persist to be given again
3. Possibility of not being able to re-flag the quest on the repeatable end.

## Steps to test these changes

1. Set Mission status to COP (6) The Savage (418) complete.
2. ensure quest is not flagged - !delquest 4 81
3. Interact with Justinius
4. Use !setPlayerVar <PlayerName> UninvitedGuestsStatus X to modify quest state (or go actually fight the bcnm)
 1. 0 is unset - no quest progress
 1. 1 is quest accepted, should mirror "has a permit" up until bcnm entry
 1. 2 is bcnm win
 1. 3 is bcnm loss
 1. 4 is post loss, talked to justin, waiting on conquest tally
5. UninvitedGuestsReset should update to the next conquest tally upon talking to justin post win or loss.