### PR TITLE
Refactoring Uninvited Guests to fix a few issues

### DIFF
--- a/scripts/zones/Monarch_Linn/bcnms/uninvited_guests.lua
+++ b/scripts/zones/Monarch_Linn/bcnms/uninvited_guests.lua
@@ -6,37 +6,40 @@ local ID = require("scripts/zones/Monarch_Linn/IDs")
 require("scripts/globals/battlefield")
 require("scripts/globals/keyitems")
 -----------------------------------
-local battlefield_object = {}
+local battlefieldObject = {}
 
-battlefield_object.onBattlefieldTick = function(battlefield, tick)
+battlefieldObject.onBattlefieldTick = function(battlefield, tick)
     xi.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
-battlefield_object.onBattlefieldEnter = function(player, battlefield)
+battlefieldObject.onBattlefieldEnter = function(player, battlefield)
     player:messageSpecial(ID.text.KI_TORN, xi.ki.MONARCH_LINN_PATROL_PERMIT)
     player:delKeyItem(xi.ki.MONARCH_LINN_PATROL_PERMIT)
 end
 
-battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
-     if leavecode == xi.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
+    if leavecode == xi.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
         local _, clearTime, partySize = battlefield:getRecord()
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
         player:startEvent(32002)
-    elseif leavecode == xi.battlefield.leaveCode.EXIT or leavecode == xi.battlefield.leaveCode.WARPDC then
+    elseif
+        leavecode == xi.battlefield.leaveCode.EXIT or
+        leavecode == xi.battlefield.leaveCode.WARPDC
+    then
         -- However the player got out of the BCNM - they didnt win
-        player:setCharVar("UninvitedGuestsStatus", 2) -- update to failure state
+        player:setCharVar("UninvitedGuestsStatus", 3) -- update to failure state
     end
 end
 
-battlefield_object.onEventFinish = function(player, csid, option)
+battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 then
         -- Victory
-        player:setCharVar("UninvitedGuestsStatus", 1) -- update to victory state
+        player:setCharVar("UninvitedGuestsStatus", 2) -- update to victory state
     elseif csid == 32002 then
         -- Failure
-        player:setCharVar("UninvitedGuestsStatus", 2) -- update to failure state
+        player:setCharVar("UninvitedGuestsStatus", 3) -- update to failure state
     end
 end
 
-return battlefield_object
+return battlefieldObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Refactors Uninvited Guests to fix a few issues:
1. Double Rewards on first completion
2. Possibilty to get no reward and not have the reward persist to be given again
3. Possibility of not being able to re-flag the quest on the repeatable end.

## Steps to test these changes

1. Set Mission status to COP (6) The Savage (418) complete.
2. ensure quest is not flagged - !delquest 4 81
3. Interact with Justinius
4. Use !setPlayerVar <PlayerName> UninvitedGuestsStatus X to modify quest state (or go actually fight the bcnm)
```
0 is unset - no quest progress
1 is quest accepted, should mirror "has a permit" up until bcnm entry
2 is bcnm win
3 is bcnm loss
4 is post loss, talked to justin, waiting on conquest tally
```
5. UninvitedGuestsReset should update to the next conquest tally upon talking to justin post win or loss.