### PR TITLE
Fix memory receptacles so still works correctly when CFH

### DIFF
--- a/scripts/globals/promyvion.lua
+++ b/scripts/globals/promyvion.lua
@@ -97,7 +97,10 @@ xi.promyvion.receptacleOnFight = function(mob, target)
             local stray = GetMobByID(i)
             if stray:isSpawned() then
                 count = count + 1
-                if stray:getCurrentAction() == xi.act.ROAMING and mob:checkDistance(stray) < 8 then
+                if
+                    stray:getCurrentAction() == xi.act.ROAMING and
+                    mob:checkDistance(stray) < 8
+                then
                     stray:updateEnmity(target)
                 end
             end
@@ -153,7 +156,7 @@ xi.promyvion.receptacleIdle = function(mob)
 end
 
 xi.promyvion.receptacleOnDeath = function(mob, optParams)
-    if optParams.isKiller then
+    if mob:getLocalVar("deathLogic") == 0 then
         local mobId             = mob:getID()
         local zoneReceptacles   = zones[mob:getZoneID()].mob.MEMORY_RECEPTACLES
         local floor             = zoneReceptacles[mobId].group
@@ -198,6 +201,8 @@ xi.promyvion.receptacleOnDeath = function(mob, optParams)
                 end
             end
         end
+
+        mob:setLocalVar("deathLogic", 1)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue wherein a MR that is killed while CFH does not properly trigger death logic and thus never spawns portal and has incorrect respawn logic. MRs should be attackable by all players in zone but allowing CFH to work is a reasonable solution as well, thus this PR helps.

## Steps to test these changes