### PR TITLE
Various fixes

### DIFF
--- a/scripts/zones/Waughroon_Shrine/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Waughroon_Shrine/npcs/Armoury_Crate.lua
@@ -616,7 +616,7 @@ local loot =
         },
         {
             { itemid = xi.items.FUMA_SUNE_ATE,       droprate = 550 },
-            { itemid = xi.items.CHUNK_OF_ADAMAN_ORE, droprate = 200 },
+            { itemid = xi.items.ADAMAN_INGOT, droprate = 200 },
             { itemid = xi.items.ORICHALCUM_INGOT,    droprate = 250 },
         },
         {

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -581,7 +581,7 @@ INSERT INTO `item_latents` VALUES (13557,13,3,53,0);     -- MND +3 in areas insi
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES (13558,1,4,53,0);      -- DEF +4 in areas inside own nation's control
 INSERT INTO `item_latents` VALUES (13558,11,2,53,0);     -- AGI +2 in areas inside own nation's control
-INSERT INTO `item_latents` VALUES (13558,10,2,53,0);     -- VIT +3 in areas inside own nation's control
+INSERT INTO `item_latents` VALUES (13558,10,3,53,0);     -- VIT +3 in areas inside own nation's control
 
 -- -------------------------------------------------------
 -- Patriarch Protector's Ring

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -357,6 +357,8 @@ INSERT INTO `mob_pool_mods` VALUES (2748,370,5,0); -- REGEN: 5
 INSERT INTO `mob_pool_mods` VALUES (2790,168,50,0); -- SPELLINTERRUPT: 50
 INSERT INTO `mob_pool_mods` VALUES (2790,240,7,0);  -- SLEEPRES: 7
 INSERT INTO `mob_pool_mods` VALUES (2790,244,7,0);  -- SILENCERES: 7
+INSERT INTO `mob_pool_mods` VALUES (2790,1,3000,1); -- GIL_MIN: 3000
+INSERT INTO `mob_pool_mods` VALUES (2790,2,5000,1); -- GIL_MAX: 5000 (~9000 with max gilfinder)
 
 -- Mythril Golem
 INSERT INTO `mob_pool_mods` VALUES (2793,4,4,1); -- SIGHT_RANGE: 4


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes four small issues:
- KS30 copycat should drop adaman ingot rather than adaman ore (see [here](https://ffxiclopedia.fandom.com/wiki/Copycat))
- Mysticmaker Profblix should drop between 3000-9000 gil (see [here](https://ffxiclopedia.fandom.com/wiki/Mysticmaker_Profblix))
- Gold Musketeer's Ring should have +3 VIT rather than +2 VIT (see [here](https://ffxiclopedia.fandom.com/wiki/Gold_Musketeer%27s_Ring))
- Fix Even More Gullibles Travels quest CS (currently blocking the quest) by renaming the Magriffon NPC from the CS so that the NPC does not call the onspawn lua script for the Magriffon NPC that gives the quest.

## Steps to test these changes
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/173
