### PR TITLE
Fix GTK bangles eva mod

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -906,13 +906,13 @@ INSERT INTO `item_latents` VALUES (14009,23,9,0,75);     -- Attack+9 when HP <=7
 -- Grand Temple Knight's Gauntlets
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES (14013,9,2,53,1);      -- DEX +2 in areas outside own nation's control
-INSERT INTO `item_latents` VALUES (14013,110,10,53,1);   -- DEX +2 in areas outside own nation's control
+INSERT INTO `item_latents` VALUES (14013,110,10,53,1);   -- PARRY +10 in areas outside own nation's control
 
 -- -------------------------------------------------------
 -- Grand Temple Knight's Bangles
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES (14014,11,2,53,1);     -- AGI +2 in areas outside own nation's control
-INSERT INTO `item_latents` VALUES (14014,68,7,53,1);     -- EVA +7 in areas outside own nation's control
+INSERT INTO `item_latents` VALUES (14014,108,7,53,1);     -- Evasion Skill +7 in areas outside own nation's control
 
 -- -------------------------------------------------------
 -- Praefectus's Gloves


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes GTK bangles which should give evasion skill mod rather than evasion mod (see [here](https://ffxiclopedia.fandom.com/wiki/Grand_Temple_Knight%27s_Bangles)).

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
