### PR TITLE
Fix Everyones Grudge and Rancor for pets and Uggalepih Necklace

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -2940,6 +2940,7 @@ xi.items =
     SPIDER_TORQUE                   = 13137,
     YINYANG_LORGNETTE               = 13139,
     OPO_OPO_NECKLACE                = 13143,
+    UGGALEPIH_NECKLACE              = 13147,
     EVASION_TORQUE                  = 13148,
     PARRYING_TORQUE                 = 13149,
     SHIELD_TORQUE                   = 13150,

--- a/scripts/globals/mobskills/everyones_grudge.lua
+++ b/scripts/globals/mobskills/everyones_grudge.lua
@@ -4,6 +4,7 @@
 --  Notes: Invokes collective hatred to spite a single target.
 --   Damage done is 5x the amount of tonberries you have killed! For NM's using this it is 50 x damage.
 -----------------------------------
+require("scripts/globals/items")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
@@ -11,7 +12,27 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local realDmg = 5 * target:getCharVar("EVERYONES_GRUDGE_KILLS") -- Damage is 5 times the amount you have killed
+    local grudgeKills = 0
+    local player = nil
+
+    if target:isPC() then
+        grudgeKills = target:getCharVar("EVERYONES_GRUDGE_KILLS")
+        player = target
+    elseif target:isPet() then
+        grudgeKills = target:getMaster():getCharVar("EVERYONES_GRUDGE_KILLS")
+        player = target:getMaster()
+    end
+
+    local realDmg = 5 * grudgeKills -- Damage is 5 times the amount you have killed
+
+    if
+        player and
+        player:getEquipID(xi.slot.NECK) == xi.items.UGGALEPIH_NECKLACE
+    then
+        realDmg = math.floor(realDmg * (1 - (player:getTP() / 3000)))
+        player:setTP(0)
+    end
+
     target:takeDamage(realDmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)
     return realDmg
 end

--- a/scripts/globals/mobskills/everyones_rancor.lua
+++ b/scripts/globals/mobskills/everyones_rancor.lua
@@ -10,6 +10,7 @@
 -----------------------------------
 require("scripts/globals/mobskills")
 require("scripts/globals/status")
+require("scripts/globals/items")
 -----------------------------------
 local mobskillObject = {}
 
@@ -27,7 +28,27 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local realDmg = 50 * target:getCharVar("EVERYONES_GRUDGE_KILLS")
+    local grudgeKills = 0
+    local player = nil
+
+    if target:isPC() then
+        grudgeKills = target:getCharVar("EVERYONES_GRUDGE_KILLS")
+        player = target
+    elseif target:isPet() then
+        grudgeKills = target:getMaster():getCharVar("EVERYONES_GRUDGE_KILLS")
+        player = target:getMaster()
+    end
+
+    local realDmg = 50 * grudgeKills -- Damage is 50 times the amount you have killed
+
+    if
+        player and
+        player:getEquipID(xi.slot.NECK) == xi.items.UGGALEPIH_NECKLACE
+    then
+        realDmg = math.floor(realDmg * (1 - (player:getTP() / 3000)))
+        player:setTP(0)
+    end
+
     target:takeDamage(realDmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)
     return realDmg
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR implements the Uggalepih Necklace hidden effect (see [here](https://ffxiclopedia.fandom.com/wiki/Uggalepih_Necklace) and [here](https://ffxi.allakhazam.com/db/item.html?fitem=4785)) and fixes Everyones Grudge and Rancor to deal with situations where the moves are used on pets and thus needs to reference the masters hate to calculate damage.

## Steps to test these changes
