### PR TITLE
Fix Mob Ranged Attack misses and Viscid Secretion

### DIFF
--- a/scripts/globals/mobskills/viscid_secretion.lua
+++ b/scripts/globals/mobskills/viscid_secretion.lua
@@ -9,7 +9,14 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    return 0
+    if
+        mob:getName() == "Pasuk" or
+        mob:getName() == "Gnyan"
+    then
+        return 0
+    end
+
+    return 1
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
@@ -17,8 +24,16 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local gravity = xi.effect.WEIGHT
     local duration = math.random(120, 180)
 
-    xi.mobskills.mobStatusEffectMove(mob, target, gravity, 50, 0, duration)
+    local gravityMessage = xi.mobskills.mobStatusEffectMove(mob, target, gravity, 50, 0, duration)
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, slow, 5000, 0, duration))
+
+    if
+        skill:getMsg() == xi.msg.basic.SKILL_MISS or
+        skill:getMsg() == xi.msg.basic.SKILL_NO_EFFECT
+    then
+        skill:setMsg(gravityMessage)
+        return gravity
+    end
 
     return slow
 end

--- a/scripts/quests/sandoria/Spice_Gals.lua
+++ b/scripts/quests/sandoria/Spice_Gals.lua
@@ -79,7 +79,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if not player:hasKeyItem(xi.ki.RIVERNEWORT) then
                         player:addKeyItem(xi.ki.RIVERNEWORT)
-                        return quest:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RIVERNWORT)
+                        return quest:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RIVERNEWORT)
                     end
                 end,
             },
@@ -92,7 +92,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if not player:hasKeyItem(xi.ki.RIVERNEWORT) then
                         player:addKeyItem(xi.ki.RIVERNEWORT)
-                        return quest:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RIVERNWORT)
+                        return quest:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RIVERNEWORT)
                     end
                 end,
             },

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1259,7 +1259,7 @@ INSERT INTO `mob_skills` VALUES (1357,1008,'tidal_dive',1,15.0,2000,1000,4,0,0,0
 INSERT INTO `mob_skills` VALUES (1358,1009,'plasma_charge',0,7.0,2000,1000,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1359,855,'chthonian_ray',4,27.0,2000,5000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1360,855,'apocalyptic_ray',4,7.0,2000,5000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1361,827,'viscid_secretion',4,12.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1361,832,'viscid_secretion',4,12.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1362,37,'wild_ginseng',0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1363,822,'hungry_crunch',0,7.0,2000,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1364,848,'mighty_snort',0,7.0,2000,1500,4,0,0,0,0,0,0);

--- a/src/map/mobskill.cpp
+++ b/src/map/mobskill.cpp
@@ -46,7 +46,7 @@ CMobSkill::CMobSkill(uint16 id)
 
 bool CMobSkill::hasMissMsg() const
 {
-    return m_Message == 158 || m_Message == 188 || m_Message == 31 || m_Message == 30;
+    return m_Message == 158 || m_Message == 188 || m_Message == 31 || m_Message == 30 || m_Message == 354;
 }
 
 bool CMobSkill::isAoE() const


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Three unrelated fixes here.
1) Fixes mob ranged attacks not animating misses correctly.  Tested with all mob ranged attacks except Dynamis Demons and Dynamis Quadavs.

2) Fixes a few issues with Viscid Secretion.  
All Diremites were using this, only specific NMs should.   Normal Diremites would pretzel themselves unpon usage.  
Messaging was incorrect for the skill, only showing the effect of if the slow had landed.  This led to scenarios where the skill said it missed but applied a gravity effect.
Fixed animation - per capture from capture disco it is the same animation ID as filamented hold - 832
![image](https://user-images.githubusercontent.com/105882290/219512305-41fd505e-ca98-4fbb-8aea-7135076dfc9a.png)
Interesting to me that this was cast on an automatron - and the spec react is miss hit guard

3) Fixes a typo in the messaging for Spice Gals at the QM.
![image](https://user-images.githubusercontent.com/105882290/219801012-965dfbfe-3377-408a-8071-efbda9bfde3c.png)

## Steps to test these changes
1) Get ranged attack by a beastmen mob.  A miss should show as a miss.  !setmod racc 0 can assist in forcing a miss.

2) Two fold.  Find a normal diremite in say pso xja - !setmod regain 3000 and ensure it does not use viscid.
Step 2 - enter the ENM Test Your Mite and give Pasuk regain.  Verify the status messaging is correct for: 
all effects miss  
Only slow lands
Only grav lands
Both slow and grav land.
Note: Gnyan is not implmented (yet) so it is not available to test with.

3) Was a typo - very easy fix.  To test run quest up to the ??? in riverne A and B.  
Closes Horizon [#699](https://github.com/HorizonFFXI/HorizonXI-Issues/issues/699)