### PR TITLE
Foe Requiem Message

### DIFF
--- a/scripts/globals/spells/songs/foe_requiem.lua
+++ b/scripts/globals/spells/songs/foe_requiem.lua
@@ -57,7 +57,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Try to overwrite weaker slow / haste
     if xi.magic.canOverwrite(target, effect, power) then
         -- overwrite them
-        target:delStatusEffect(effect)
+        target:delStatusEffectSilent(effect)
         target:addStatusEffect(effect, power, 3, duration)
         spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
     else

--- a/scripts/globals/spells/songs/foe_requiem_ii.lua
+++ b/scripts/globals/spells/songs/foe_requiem_ii.lua
@@ -57,7 +57,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Try to overwrite weaker slow / haste
     if xi.magic.canOverwrite(target, effect, power) then
         -- overwrite them
-        target:delStatusEffect(effect)
+        target:delStatusEffectSilent(effect)
         target:addStatusEffect(effect, power, 3, duration)
         spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
     else

--- a/scripts/globals/spells/songs/foe_requiem_iii.lua
+++ b/scripts/globals/spells/songs/foe_requiem_iii.lua
@@ -57,7 +57,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Try to overwrite weaker slow / haste
     if xi.magic.canOverwrite(target, effect, power) then
         -- overwrite them
-        target:delStatusEffect(effect)
+        target:delStatusEffectSilent(effect)
         target:addStatusEffect(effect, power, 3, duration)
         spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
     else

--- a/scripts/globals/spells/songs/foe_requiem_iv.lua
+++ b/scripts/globals/spells/songs/foe_requiem_iv.lua
@@ -57,7 +57,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Try to overwrite weaker slow / haste
     if xi.magic.canOverwrite(target, effect, power) then
         -- overwrite them
-        target:delStatusEffect(effect)
+        target:delStatusEffectSilent(effect)
         target:addStatusEffect(effect, power, 3, duration)
         spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
     else

--- a/scripts/globals/spells/songs/foe_requiem_v.lua
+++ b/scripts/globals/spells/songs/foe_requiem_v.lua
@@ -57,7 +57,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Try to overwrite weaker slow / haste
     if xi.magic.canOverwrite(target, effect, power) then
         -- overwrite them
-        target:delStatusEffect(effect)
+        target:delStatusEffectSilent(effect)
         target:addStatusEffect(effect, power, 3, duration)
         spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
     else

--- a/scripts/globals/spells/songs/foe_requiem_vi.lua
+++ b/scripts/globals/spells/songs/foe_requiem_vi.lua
@@ -62,7 +62,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Try to overwrite weaker slow / haste
     if xi.magic.canOverwrite(target, effect, power) then
         -- overwrite them
-        target:delStatusEffect(effect)
+        target:delStatusEffectSilent(effect)
         target:addStatusEffect(effect, power, 3, duration)
         spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
     else


### PR DESCRIPTION
If foe requiem overwrites other spells, the chat log should not show the old spell has worn off.   This is the correct behavior -- I just verified on retail.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
On retail, when this spell is overwritten by the same or higher tier spell, it does not have the effect wear off message. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Cast foe requiem to overwrite other same/lower level requiems.   The "Requiem effect wears off" should no longer be shown, only the new effect.
<!-- Clear and detailed steps to test your changes here -->
