### PR TITLE
Adds Quest Secrets of Ovens Lost

### DIFF
--- a/scripts/quests/otherAreas/Secrets_of_Ovens_Lost.lua
+++ b/scripts/quests/otherAreas/Secrets_of_Ovens_Lost.lua
@@ -1,0 +1,146 @@
+-----------------------------------
+-- Secrets of Ovens Lost
+-- Despachiaire: !pos 109 -40 -86
+-- Jonette: !pos -71 -11 9
+-- Phomiuna Aqueducts qm_tavnazian_cookbook: !pos varies   ID: 16888123
+-- Sacrarium qm_tavnazian_cookbook: !pos varies   ID: 16892184
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/keyitems')
+require('scripts/globals/npc_util')
+require('scripts/globals/quests')
+require('scripts/globals/status')
+require('scripts/globals/items')
+-----------------------------------
+local ID = require('scripts/zones/Sacrarium/IDs')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.SECRETS_OF_OVENS_LOST)
+
+quest.reward =
+{
+    item = xi.items.MIRATETES_MEMOIRS,
+}
+
+quest.sections =
+{
+    {
+        -- Pre Quest CS with Despachiaire
+        check = function(player, status, vars)
+            return
+                status == QUEST_AVAILABLE and
+                quest:getVar(player, 'Prog') == 0 and
+                player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.SPICE_GALS) == QUEST_COMPLETED
+        end,
+
+        [xi.zone.TAVNAZIAN_SAFEHOLD] =
+        {
+            ['Despachiaire'] = quest:progressEvent(505),
+
+            onEventFinish =
+            {
+                [505] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+            },
+        },
+    },
+    {
+        -- Initial Quest Start with Jonette
+        check = function(player, status, vars)
+            return
+                status == QUEST_AVAILABLE and
+                quest:getVar(player, 'Prog') == 1
+        end,
+
+        [xi.zone.TAVNAZIAN_SAFEHOLD] =
+        {
+            ['Jonette'] = quest:progressEvent(506),
+
+            onEventFinish =
+            {
+                [506] = function(player, csid, option, npc)
+                    quest:begin(player)
+                end,
+            },
+        },
+    },
+    {
+        -- Mid Quest, reused for the repeat as well
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.TAVNAZIAN_SAFEHOLD] =
+        {
+            ['Jonette'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.TAVNAZIAN_COOKBOOK) then
+                        return quest:progressEvent(508)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [508] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:delKeyItem(xi.ki.TAVNAZIAN_COOKBOOK)
+                        quest:setVar(player, 'Option', getConquestTally())
+                    end
+                end,
+            },
+        },
+        [xi.zone.PHOMIUNA_AQUEDUCTS] =
+        {
+            ['qm_tavnazian_cookbook'] =
+            {
+                onTrigger = function(player, npc)
+                    if not player:hasKeyItem(xi.ki.TAVNAZIAN_COOKBOOK) then
+                        player:addKeyItem(xi.ki.TAVNAZIAN_COOKBOOK)
+                        return quest:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.TAVNAZIAN_COOKBOOK)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.SACRARIUM] =
+        {
+            ['qm_tavnazian_cookbook'] =
+            {
+                onTrigger = function(player, npc)
+                    if not player:hasKeyItem(xi.ki.TAVNAZIAN_COOKBOOK) then
+                        player:addKeyItem(xi.ki.TAVNAZIAN_COOKBOOK)
+                        return quest:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.TAVNAZIAN_COOKBOOK)
+                    end
+                end,
+            },
+        },
+    },
+    {
+        -- Quest Repeat
+        check = function(player, status, vars)
+            return
+                status == QUEST_COMPLETED and
+                quest:getVar(player, 'Option') < getConquestTally()
+        end,
+
+        [xi.zone.TAVNAZIAN_SAFEHOLD] =
+        {
+            ['Jonette'] = quest:progressEvent(507),
+
+            onEventFinish =
+            {
+                [507] = function(player, csid, option, npc)
+                    -- This quest specifically has wiki notes that it shows back up in the quest log for repeats
+                    -- To achieve this, we delete it from the players log then accept it
+                    player:delQuest(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.SECRETS_OF_OVENS_LOST)
+                    quest:begin(player)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Phomiuna_Aqueducts/IDs.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/IDs.lua
@@ -55,7 +55,8 @@ zones[xi.zone.PHOMIUNA_AQUEDUCTS] =
     },
     npc =
     {
-        LADDER_KNOCKING = 16888096,
+        LADDER_KNOCKING       = 16888096,
+        QM_TAVNAZIAN_COOKBOOK = 16888123,
     },
 }
 

--- a/scripts/zones/Phomiuna_Aqueducts/Zone.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/Zone.lua
@@ -16,6 +16,9 @@ zoneObject.onInitialize = function(zone)
     else
         xi.mob.nmTODPersistCache(zone, ID.mob.EBA)
     end
+
+    -- FFXI wiki has some info stating ~10mins realtime for Phomiuna Aqueducts
+    GetNPCByID(ID.npc.QM_TAVNAZIAN_COOKBOOK):addPeriodicTrigger(0, 250, 0)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype)

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/qm_tavnazian_cookbook.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/qm_tavnazian_cookbook.lua
@@ -1,0 +1,40 @@
+-----------------------------------
+-- Area: Phomiuna Aqueducts
+--  NPC: ??? for Tavnazian Cookbook
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/npc_util")
+local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
+-----------------------------------
+local entity = {}
+
+local points =
+{
+    [1]  = { 83.219, -25.047, 8.010 },   -- J-9 on some vases
+    [2]  = { -62.6, -26.000, 107.965 },  -- F-7 on a shelf
+    [3]  = { -47.454, -26.000, 11.535 }, -- F-9 on a shelf
+    [4]  = { 84.827, -26.000, 108.299 }  -- J-7 on a shelf
+}
+
+entity.onTrigger = function(player, npc)
+    player:messageSpecial(ID.text.NOTHING_OUT_HERE)
+end
+
+entity.onTimeTrigger = function(npc, triggerID)
+    local currentPoint = npc:getLocalVar("currentPoint")
+    local nextPoint = currentPoint + 1
+
+    if nextPoint > 4 then
+        nextPoint = 1
+    end
+
+    local nextPointLoc = points[nextPoint]
+    npc:setLocalVar("currentPoint", nextPoint)
+    npcUtil.queueMove(npc, nextPointLoc, 1000)
+end
+
+entity.onSpawn = function(npc)
+    npc:setLocalVar("currentPoint", 1)
+end
+
+return entity

--- a/scripts/zones/Sacrarium/IDs.lua
+++ b/scripts/zones/Sacrarium/IDs.lua
@@ -57,11 +57,12 @@ zones[xi.zone.SACRARIUM] =
     },
     npc =
     {
-        STALE_DRAFT_OFFSET  = 16892097,
-        LABYRINTH_OFFSET    = 16892110,
-        SMALL_KEYHOLE       = 16892142,
-        QM_MARISELLE_OFFSET = 16892155, -- qm_professor_mariselle in npc_list.sql
-        TREASURE_CHEST      = 16892183,
+        STALE_DRAFT_OFFSET    = 16892097,
+        LABYRINTH_OFFSET      = 16892110,
+        SMALL_KEYHOLE         = 16892142,
+        QM_MARISELLE_OFFSET   = 16892155, -- qm_professor_mariselle in npc_list.sql
+        TREASURE_CHEST        = 16892183,
+        QM_TAVNAZIAN_COOKBOOK = 16892184,
     },
 }
 

--- a/scripts/zones/Sacrarium/Zone.lua
+++ b/scripts/zones/Sacrarium/Zone.lua
@@ -13,6 +13,9 @@ zoneObject.onInitialize = function(zone)
     -- randomize Old Prof. Mariselle's spawn location
     GetNPCByID(ID.npc.QM_MARISELLE_OFFSET + math.random(0, 5)):setLocalVar("hasProfessorMariselle", 1)
 
+    -- FFXI wiki claims 4hours and 10mins game time for movement in Sacrarium
+    GetNPCByID(ID.npc.QM_TAVNAZIAN_COOKBOOK):addPeriodicTrigger(0, 250, 0)
+
     xi.treasure.initZone(zone)
 end
 

--- a/scripts/zones/Sacrarium/npcs/qm_tavnazian_cookbook.lua
+++ b/scripts/zones/Sacrarium/npcs/qm_tavnazian_cookbook.lua
@@ -1,0 +1,40 @@
+-----------------------------------
+-- Area: Sacrarium
+--  NPC: ??? for Tavnazian Cookbook
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/npc_util")
+local ID = require("scripts/zones/Sacrarium/IDs")
+-----------------------------------
+local entity = {}
+
+local points =
+{
+    [1]  = { 11.720, -3.999, -99.957 },  -- H-11 on a shelf
+    [2]  = { 108.300, -3.999, -99.957 }, -- F-11 on a shelf
+    [3]  = { 108.300, -3.999, 99.957 },  -- H-5 on a shelf
+    [4]  = { 11.720, -3.999, 99.957 }    -- F-5 on a shelf
+}
+
+entity.onTrigger = function(player, npc)
+    player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
+end
+
+entity.onTimeTrigger = function(npc, triggerID)
+    local currentPoint = npc:getLocalVar("currentPoint")
+    local nextPoint = currentPoint + 1
+
+    if nextPoint > 4 then
+        nextPoint = 1
+    end
+
+    local nextPointLoc = points[nextPoint]
+    npc:setLocalVar("currentPoint", nextPoint)
+    npcUtil.queueMove(npc, nextPointLoc, 1000)
+end
+
+entity.onSpawn = function(npc)
+    npc:setLocalVar("currentPoint", 1)
+end
+
+return entity

--- a/scripts/zones/Tavnazian_Safehold/npcs/Jonette.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Jonette.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Area: Tavnazian Safehold
 --  NPC: Jonette
+-- Main Quest NPC for Secrets of Ovens Lost
 -----------------------------------
 local entity = {}
 


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds Quest Secrets of Ovens Lost

## Steps to test these changes

The wiki has the best steps I can provide
[Secrets Of Ovens Lost Wiki](https://ffxiclopedia.fandom.com/wiki/Secrets_of_Ovens_Lost)

Other than the wiki, you can speed up some testing by:
giving/deleting the KI `TAVNAZIAN_COOKBOOK`
using SetPlayerVar [playerName] `Quest[4][73]Option` 0 to reset the conquest tally for reset
using !gotoid `16888123 `(Phomiuna Aqueducts) and `16892184 `(Sacrarium) to get to the ???s

Can also go to the ??? NPCs and see that they move every 4 hours 10mins in game

