### PR TITLE
Removed the overall clamp on base healing spell values.

### DIFF
--- a/scripts/globals/spells/healing_spell.lua
+++ b/scripts/globals/spells/healing_spell.lua
@@ -37,6 +37,7 @@ xi.spells.healing.calculatePower = function(player)
     if player then
         return 3 * player:getStat(xi.mod.MND) + player:getStat(xi.mod.VIT) + 3 * (math.floor(player:getSkillLevel(xi.skill.HEALING_MAGIC) / 5))
     end
+
     return 0
 end
 
@@ -107,7 +108,11 @@ xi.spells.healing.getAbilityBonus = function(caster, isWhiteMagic)
 end
 
 xi.spells.healing.handleAfflatusSolace = function(caster, target, final)
-    if caster:isPC() and caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and not target:hasStatusEffect(xi.effect.STONESKIN) then
+    if
+        caster:isPC() and
+        caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and
+        not target:hasStatusEffect(xi.effect.STONESKIN)
+    then
         local bonuses = { [11186] = 0.30, [11086] = 0.35 }
         local body = caster:getEquipID(xi.slot.BODY)
         local stoneskin = math.floor((final * utils.ternary(bonuses[body], bonuses[body], 0.25)) * 1 + caster:getMerit(xi.merit.ANIMUS_SOLACE) / 100)
@@ -128,8 +133,11 @@ xi.spells.healing.doHealingSpell = function(caster, target, spell, isWhiteMagic)
     local spellId      = spell:getID()
     local power        = xi.spells.healing.calculatePower(caster)
     local healingTable = xi.spells.healing.getHealTable(power, spellId)
-    local base         = utils.clamp((math.floor(power / 2) / healingTable.rate) + healingTable.constant, healingTable.minCap, healingTable.maxCap)
+    local base         = (math.floor(power / 2) / healingTable.rate) + healingTable.constant
     local healingspell = true
+
+    -- Clamp on base instead of maxCap. Power can create over-cure
+    base = utils.clamp(base, 0, base)
 
     if xi.magic.isValidHealTarget(caster, target) then
         final = xi.spells.healing.applyCasterBonuses(caster, base, spell:getElement(), isWhiteMagic)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR removes the improper clamp of healing spell's base healing. 
It specifically addresses when you have enough healing skill to hit a new tier to increase the healing values.

## Steps to test these changes

You can verify these caps via [Furen's healing calculator](https://web.archive.org/web/20080528091305/http://members.shaw.ca/pizza_steve/cure/Cure_Calculator.html)

At level 20, cure 1 should be capped at 30
At level 75, cure 1 should be capped at 32