### PR TITLE
Fix Everyones Grudge and Rancor for pets

### DIFF
--- a/scripts/globals/mobskills/everyones_grudge.lua
+++ b/scripts/globals/mobskills/everyones_grudge.lua
@@ -11,7 +11,14 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local realDmg = 5 * target:getCharVar("EVERYONES_GRUDGE_KILLS") -- Damage is 5 times the amount you have killed
+    local grudgeKills = 0
+    if target:isPC() then
+        grudgeKills = target:getCharVar("EVERYONES_GRUDGE_KILLS")
+    elseif target:isPet() then
+        grudgeKills = target:getMaster():getCharVar("EVERYONES_GRUDGE_KILLS")
+    end
+
+    local realDmg = 5 * grudgeKills -- Damage is 5 times the amount you have killed
     target:takeDamage(realDmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)
     return realDmg
 end

--- a/scripts/globals/mobskills/everyones_rancor.lua
+++ b/scripts/globals/mobskills/everyones_rancor.lua
@@ -27,7 +27,14 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local realDmg = 50 * target:getCharVar("EVERYONES_GRUDGE_KILLS")
+    local grudgeKills = 0
+    if target:isPC() then
+        grudgeKills = target:getCharVar("EVERYONES_GRUDGE_KILLS")
+    elseif target:isPet() then
+        grudgeKills = target:getMaster():getCharVar("EVERYONES_GRUDGE_KILLS")
+    end
+
+    local realDmg = 50 * grudgeKills
     target:takeDamage(realDmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)
     return realDmg
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes Everyones Grudge and Rancor to deal with situations where the moves are used on pets and thus needs to reference the masters hate to calculate damage.

## Steps to test these changes
Fight pet against tonberry and feed tp