### PR TITLE
Updated DRG AF 2 quest to appropriate level to accept

### DIFF
--- a/scripts/zones/Port_San_dOria/npcs/Ceraulian.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Ceraulian.lua
@@ -42,7 +42,7 @@ entity.onTrigger = function(player, npc)
     elseif
         quotasStatus == QUEST_AVAILABLE and
         player:getMainJob() == xi.job.DRG and
-        player:getMainLvl() >= xi.settings.main.AF1_QUEST_LEVEL and
+        player:getMainLvl() >= xi.settings.main.AF2_QUEST_LEVEL and
         quotasNo == 0
     then
         player:startEvent(18) -- Long version of quest start


### PR DESCRIPTION
https://ffxiclopedia.fandom.com/wiki/Chasing_Quotas Lvl 50+ no 40+

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Updates xi.settings.main.AF1_QUEST_LEVEL to xi.settings.main.AF2_QUEST_LEVEL (50+)
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1049 
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
