### PR TITLE
Fix AEs applying if they remove players last shadow

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -636,12 +636,12 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
         shadowbehav ~= xi.mobskills.shadowBehavior.IGNORE_SHADOWS
     then --remove 'shadowbehav' shadows.
 
+        local didTargetHaveShadows = target:hasStatusEffect(xi.effect.COPY_IMAGE) or target:hasStatusEffect(xi.effect.BLINK)
         dmg = utils.takeShadows(target, mob, dmg, shadowbehav)
 
-        -- dealt zero damage, so shadows took hit
+        -- dealt zero damage, so shadows took all hits
         if
-            (target:hasStatusEffect(xi.effect.COPY_IMAGE) or
-            target:hasStatusEffect(xi.effect.BLINK)) and
+            didTargetHaveShadows and
             dmg == 0
         then
             skill:setMsg(xi.msg.basic.SHADOW_ABSORB)
@@ -766,6 +766,7 @@ xi.mobskills.mobDrainMove = function(mob, target, drainType, drain, attackType, 
             return xi.msg.basic.DAMAGE
         end
     end
+
     return xi.msg.basic.SKILL_NO_EFFECT
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Checks for shadows before executing shadow removal, not after - therefore avoiding granting the mob an chance to apply additional effects on mob skills which take the last shadow, but dont actually "hit" the player.

Closes [1100](https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1100)

## Steps to test these changes

Pick a mob with a physical move with additional effect - ideally one with with a single hit skill as this will make testing easier.

### Basic Test Case - Last Shadow blocking a tp move should not count as the player being hit.
A good choice is a weapon, with whirl of rage.
If dev testing, grab the mob's lua and force the mob to only use while of rage - otherwise it can still use smite.
Make you and the mob !immortal
Give yourself chainspell and regen ~1k tick, be a nin main, set your level to EMish of the weapon.
Give the weapon an acc boost - we dont need misses. (1k acc is capped acc easy)
Give the weapon a major int boost - we want to avoid AE resists. 
Give yourself some shihei

Give the mob regain 3k/tick and cast shadows - observe behavior.

### Edge Case - MultiHit WS should still apply a hit if the last shadow is taken AND the resulting dmg is 0.  
This is code specific, since parts of the code treat dmg taken equal to 0 as "mustve been absorbed by shadows"

For fun, to test other cases:
If dev testing, change whirl to numHits 2, give a 10x acc mod
Change to whm 38 (saragoo champagin weapons are about that level)
add mod STONESKIN_BONUS_HP 2k to the player, add refresh 1k a tick, chainspell
toss up stonekin, toss up blink - wait for a whirl to go off when you have 1 shadow left
Enjoy getting stunned from the 2nd hit landing on stoneskin for 0 dmg, after the first hit wiped the last blink shadow
