### PR TITLE
Added KICK_DMG mod to Kick Attacks damage

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -463,11 +463,7 @@ void CAttack::ProcessDamage(bool isCritical, bool isGuarded, bool isKick)
     {
         m_baseDamage       = 0;
         m_naturalH2hDamage = (int32)(m_attacker->GetSkill(SKILL_HAND_TO_HAND) * 0.11f) + 3;
-
-        if (!isKick)
-        {
-            m_baseDamage = m_attacker->GetMainWeaponDmg();
-        }
+        m_baseDamage = isKick ? m_attacker->getMod(Mod::KICK_DMG) : m_attacker->GetMainWeaponDmg();
 
         if (m_attacker->objtype == TYPE_MOB)
         {

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -463,7 +463,7 @@ void CAttack::ProcessDamage(bool isCritical, bool isGuarded, bool isKick)
     {
         m_baseDamage       = 0;
         m_naturalH2hDamage = (int32)(m_attacker->GetSkill(SKILL_HAND_TO_HAND) * 0.11f) + 3;
-        m_baseDamage = isKick ? m_attacker->getMod(Mod::KICK_DMG) : m_attacker->GetMainWeaponDmg();
+        m_baseDamage       = isKick ? m_attacker->getMod(Mod::KICK_DMG) : m_attacker->GetMainWeaponDmg();
 
         if (m_attacker->objtype == TYPE_MOB)
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes: #2795 

`KICK_DMG` mod currently does nothing, so I implemented it.
Kick Attacks ignore weapon damage and the mod should set a base damage instead (eg. Dune Boots DMG: 30)

This affects:

- Dune Boots
- Kung Fu Shoes
- Wulong Shoes
- Wulong Shoes +1


## Steps to test these changes

Test attack damage with and without boots
