### PR TITLE
Remove the normal BLM two hour from COP 3-5 Diabolos

### DIFF
--- a/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
@@ -23,6 +23,8 @@ entity.onMobSpawn = function(mob)
         mob:addMod(xi.mod.ATTP, -15)
         mob:addMod(xi.mod.DEFP, -15)
         mob:addMod(xi.mod.MDEF, -40)
+        -- If this is CoP mission Diabolos then no 2hr
+        xi.mix.jobSpecial.config(mob, { specials = { }, })
     else
     -- If this is Diabolos Prime, give him Ruinous Omen
         xi.mix.jobSpecial.config(mob, {
@@ -37,14 +39,16 @@ entity.onMobSpawn = function(mob)
     local triggerVal = math.random(1, 28) + math.random(1, 28) + 18
 
     -- If this is prime, adjust the "base" to be the prime set
-    if mob:getID() >= dPrimeBase then dBase = dPrimeBase end  -- Prime "block" of mobs is offset 27 from CoP mobs
+    -- Prime "block" of mobs is offset 27 from CoP mobs
+    if mob:getID() >= dPrimeBase then
+        dBase = dPrimeBase
+    end
 
     local area = utils.clamp((mob:getID() - dBase) / 7 + 1, 1, 3)
 
     mob:setLocalVar("TileTriggerHPP", triggerVal) -- Starting point for tile drops
     mob:setLocalVar("Area", area)
     mob:setMobMod(xi.mobMod.DRAW_IN, 1)
-
 end
 
 entity.onMobFight = function(mob, target)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR removes the normal BLM two hour from COP 3-5 Diabolos as Diabolos does not use.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
