### PR TITLE
Fixes Spell Accuracy nil check

### DIFF
--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -397,8 +397,13 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     local spellId       = spell:getID()
     local eleBonusMagicAccuracy = pTable[spellId][bonusMAcc]
 
-    local magicAcc      = caster:getMod(xi.mod.MACC) + caster:getILvlMacc() + eleBonusMagicAccuracy
-    local resMod        = 0 -- Some spells may possibly be non elemental.
+    local magicAcc = caster:getMod(xi.mod.MACC) + caster:getILvlMacc()
+    local resMod   = 0 -- Some spells may possibly be non elemental.
+
+    -- The only damage spells that have bonus accuracy are single target ele nukes
+    if eleBonusMagicAccuracy ~= nil then
+        magicAcc = magicAcc + eleBonusMagicAccuracy
+    end
 
     -- Magic Bursts of the correct element do not get resisted. SDT isn't involved here.
     local _, skillchainCount = xi.magic.FormMagicBurst(spellElement, target)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
+ This needs a nil check for the other Ele damage tables that do not have bonuses

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Cast any -ga spell and not see a message that does 1312312312 damage.
<!-- Clear and detailed steps to test your changes here -->
