### PR TITLE
Fix Throat Stab damage on pets

### DIFF
--- a/scripts/globals/mobskills/throat_stab.lua
+++ b/scripts/globals/mobskills/throat_stab.lua
@@ -24,6 +24,10 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     local dmg = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
+    -- only allow a maximum of 95% damage even if modifiers would increase the damage
+    -- like weakness to piercing
+    dmg = math.min(damage, dmg)
+
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     mob:resetEnmity(target)
     return dmg


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue where Throat Stab was doing more than 95% damage to pets (often killing in one shot) in certain cases (for example weakness to something). This should not be the case (see for example video [here](https://youtube.com/clip/Ugkxsjp21AfHZrBRF67le1FwBhdAIxFJeFtJ)).

## Steps to test these changes
Change to BST and call crab pet
Find Tonberry and fight it with pet
Target Tonberry and use !exec target:useMobAbility(788)