### PR TITLE
Adjusted gravity & move speed mechanics

### DIFF
--- a/scripts/globals/spells/black/gravity.lua
+++ b/scripts/globals/spells/black/gravity.lua
@@ -15,7 +15,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Pull base stats.
     local dINT = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
 
-    local power = 26
+    -- -46% pulled from Retail
+    -- -26% not nearly even despite that value being listed on Wiki
+    local power = 46
 
     -- Duration, including resistance.  Unconfirmed.
     local duration = xi.magic.calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -256,9 +256,11 @@ uint8 CBattleEntity::GetSpeed()
     // Mod::MOUNT_MOVE (972)
     Mod mod = isMounted() ? Mod::MOUNT_MOVE : Mod::MOVE;
 
-    float modAmount = (100.0f + static_cast<float>(getMod(mod))) / 100.0f;
+    // Get the percentage of increase/decreate by mod
+    auto modAmount = static_cast<float>(getMod(mod)) / 100.0f;
+
     // Cap unmounted movement speed increase to 25%
-    if (mod == Mod::MOVE)
+    if (mod == Mod::MOVE && modAmount > 0) // Only clamp position/negatvie if we're increasing speed
     {
         if (StatusEffectContainer->GetStatusEffect(EFFECT_FLEE))
         {
@@ -270,9 +272,13 @@ uint8 CBattleEntity::GetSpeed()
         }
     }
 
-    float modifiedSpeed = static_cast<float>(startingSpeed) * modAmount;
-    uint8 outputSpeed   = static_cast<uint8>(modifiedSpeed < 0 ? 0 : modifiedSpeed);
+    // Add speed mod to base speed
+    auto modifiedSpeed = startingSpeed + static_cast<float>(startingSpeed) * modAmount;
 
+    // Make sure speed cannot go negative
+    auto outputSpeed = static_cast<uint8>(modifiedSpeed < 0 ? 0 : modifiedSpeed);
+
+    // Actually need this clamp?
     return std::clamp<uint8>(outputSpeed, std::numeric_limits<uint8>::min(), std::numeric_limits<uint8>::max());
 }
 


### PR DESCRIPTION
Intended to make gravity more "retail"-like
Intended to properly apply percentage reductions/increases

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Intended to fix Gravity to behave more like Retail.
Previous set to 26%, gravity adjustments with no gear applied a 46% movement speed down.

## Steps to test these changes

Apply gravity to a mob with zero move speed bonus
Apply gravity to a mob with positive move speed bonus
Apply gravity to a player to simulate a mob skill
