### PR TITLE
Fix teleport location after promy reclear for Mea and Holla

### DIFF
--- a/scripts/zones/Spire_of_Dem/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Dem/bcnms/ancient_flames_beckon.lua
@@ -48,10 +48,14 @@ battlefieldObject.onEventUpdate = function(player, csid, option)
 end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
-    if player:getLocalVar('newPromy') ~= 1 and player:getLocalVar('promyLeaveCode') == xi.battlefield.leaveCode.WON then
+    if
+        player:getLocalVar('newPromy') ~= 1 and
+        player:getLocalVar('promyLeaveCode') == xi.battlefield.leaveCode.WON
+    then
         player:addExp(1500)
         xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)
     end
+
     player:setLocalVar('promyLeaveCode', 0)
     player:setLocalVar('newPromy', 0)
 end

--- a/scripts/zones/Spire_of_Holla/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Holla/bcnms/ancient_flames_beckon.lua
@@ -48,10 +48,14 @@ battlefieldObject.onEventUpdate = function(player, csid, option)
 end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
-    if player:getLocalVar('newPromy') ~= 1 and player:getLocalVar('promyLeaveCode') == xi.battlefield.leaveCode.WON then
+    if
+        player:getLocalVar('newPromy') ~= 1 and
+        player:getLocalVar('promyLeaveCode') == xi.battlefield.leaveCode.WON
+    then
         player:addExp(1500)
-        xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)
+        xi.teleport.to(player, xi.teleport.id.EXITPROMHOLLA)
     end
+
     player:setLocalVar('promyLeaveCode', 0)
     player:setLocalVar('newPromy', 0)
 end

--- a/scripts/zones/Spire_of_Mea/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Mea/bcnms/ancient_flames_beckon.lua
@@ -48,10 +48,14 @@ battlefieldObject.onEventUpdate = function(player, csid, option)
 end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
-    if player:getLocalVar('newPromy') ~= 1 and player:getLocalVar('promyLeaveCode') == xi.battlefield.leaveCode.WON then
+    if
+        player:getLocalVar('newPromy') ~= 1 and
+        player:getLocalVar('promyLeaveCode') == xi.battlefield.leaveCode.WON
+    then
         player:addExp(1500)
-        xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)
+        xi.teleport.to(player, xi.teleport.id.EXITPROMMEA)
     end
+
     player:setLocalVar('promyLeaveCode', 0)
     player:setLocalVar('newPromy', 0)
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes the teleport location after defeating a promy boss fight (mea and holla) for the second time.

## Steps to test these changes
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2811