### PR TITLE
Fixed some issues with Tredecim

### DIFF
--- a/scripts/globals/items/tredecim_scythe.lua
+++ b/scripts/globals/items/tredecim_scythe.lua
@@ -5,13 +5,13 @@
 local itemObject = {}
 
 itemObject.onItemDrop = function(player, item)
-    player:setLocalVar('TREDECIM_COUNTER', 0)
+    player:setCharVar('TREDECIM_COUNTER', 0)
 end
 
 itemObject.onItemEquip = function(player, item)
     player:addListener("ATTACK", "TREDECIM_ATTACK", function(playerArg, mob)
         -- Setting of critical attack is handled in battleentity.cpp
-        playerArg:setLocalVar("TREDECIM_COUNTER", playerArg:getLocalVar("TREDECIM_COUNTER") + 1)
+        playerArg:setCharVar("TREDECIM_COUNTER", playerArg:getCharVar("TREDECIM_COUNTER") + 1)
     end)
 end
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2163,11 +2163,16 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
 
                 actionTarget.reaction = REACTION::HIT;
 
-                if (this->GetLocalVar("TREDECIM_COUNTER") == 13 && weaponSlot == SLOT_MAIN)
+                if (this->objtype == TYPE_PC && weaponSlot == SLOT_MAIN && ((CCharEntity*)this)->getCharVar("TREDECIM_COUNTER") > 12)
                 {
-                    // Ensure critical is only set to main weapon slot
-                    attack.SetCritical(true, weaponSlot, attack.IsGuarded());
-                    this->SetLocalVar("TREDECIM_COUNTER", -1);
+                    // Check for Tredecim
+                    auto* equippedWeapon = dynamic_cast<CItemWeapon*>(this->m_Weapons[SLOT_MAIN]);
+                    if (equippedWeapon->getID() == 18052)
+                    {
+                        // Ensure critical is only set to main weapon slot
+                        attack.SetCritical(true, weaponSlot, attack.IsGuarded());
+                        ((CCharEntity*)this)->setCharVar("TREDECIM_COUNTER", -1);
+                    }
                 }
 
                 // Critical hit.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Fixes: #1778

Fixed some issues I noticed with the original implementation:

* Equipping Tredecim for 12 swings, then switching to another weapon will give guaranteed critical to the other weapon
* If for any reason the handler is missed (ie. counter reaches 14+) the variable would cause the effect to be permanently broken
* The counter [should continue on logout or zoning](https://ffxiclopedia.fandom.com/wiki/Tredecim_Scythe) (LocalVars won't do this)

## Steps to test these changes

```lua
!changejob drk 75
!capallskills
!additem 18052
```