### PR TITLE
Fix Ix'ghrah HP resetting on form change

### DIFF
--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixghrah.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixghrah.lua
@@ -112,31 +112,39 @@ entity.onMobFight = function(mob, target)
         while state == mob:getAnimationSub() do
             state = math.random(0, 3)
         end
+
+        local hpp = mob:getHPP()
         if state == 0 then -- Ball
             mob:changeJob(xi.job.BLM)
+            -- need to set hpp back to level before job change since the change heals to full
+            mob:setHP(math.floor(mob:getMaxHP() * (hpp / 100.0)))
             mob:setMagicCastingEnabled(true)
             mob:setMod(xi.mod.DMG, 0)
             mob:setMod(xi.mod.DMGPHYS, 0)
             mob:setDamage(79)
         elseif state == 1 then -- Human
             mob:changeJob(xi.job.PLD)
+            mob:setHP(math.floor(mob:getMaxHP() * (hpp / 100.0)))
             mob:setMagicCastingEnabled(true)
             mob:setMod(xi.mod.DMG, -5000)
             mob:setMod(xi.mod.DMGPHYS, 0)
             mob:setDamage(79)
         elseif state == 2 then -- Spider
             mob:changeJob(xi.job.WAR)
+            mob:setHP(math.floor(mob:getMaxHP() * (hpp / 100.0)))
             mob:setMagicCastingEnabled(false)
             mob:setMod(xi.mod.DMG, 0)
             mob:setMod(xi.mod.DMGPHYS, 3000)
             mob:setDamage(140)
         elseif state == 3 then -- Bird
             mob:changeJob(xi.job.THF)
+            mob:setHP(math.floor(mob:getMaxHP() * (hpp / 100.0)))
             mob:setMagicCastingEnabled(false)
             mob:setMod(xi.mod.DMG, 0)
             mob:setMod(xi.mod.DMGPHYS, 0)
             mob:setDamage(79)
         end
+
         mob:setLocalVar("state", state)
         mob:setAnimationSub(state)
         mob:setLocalVar("change", 0)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue where Ix'ghrah HP is resetting to 100% on form change due to the use of the jobchange function.

## Steps to test these changes
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1086
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2802