### PR TITLE
Fix several Dawn fight issues

### DIFF
--- a/scripts/globals/spells/black/meteor.lua
+++ b/scripts/globals/spells/black/meteor.lua
@@ -14,6 +14,12 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
     -- TODO: Correct message is "Incorrect job, job level too low, or required ability not activated."  Unable to locate this in our basic or system message functions.
     -- The client blocks the spell via menus, but it can still be cast via text commands, so we have to block it here, albiet with the wrong message.
     if caster:isMob() then
+        -- Promathia has significant fast cast thus need to increase cast time
+        -- to match the retail cast time of 10 seconds
+        if caster:getName() == "Promathia_2" then
+            spell:setCastTime(18000)
+        end
+
         return 0
     elseif caster:hasStatusEffect(xi.effect.ELEMENTAL_SEAL) then
         return 0

--- a/scripts/globals/spells/healing_spell.lua
+++ b/scripts/globals/spells/healing_spell.lua
@@ -139,6 +139,12 @@ xi.spells.healing.doHealingSpell = function(caster, target, spell, isWhiteMagic)
     -- Clamp on base instead of maxCap. Power can create over-cure
     base = utils.clamp(base, 0, base)
 
+    -- special case where healing spells should have no effect
+    if target:getMod(xi.mod.CURE_POTENCY_RCVD) == -100 then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return 0
+    end
+
     if xi.magic.isValidHealTarget(caster, target) then
         final = xi.spells.healing.applyCasterBonuses(caster, base, spell:getElement(), isWhiteMagic)
         final = (final + (final * target:getMod(xi.mod.CURE_POTENCY_RCVD))) * xi.settings.main.CURE_POWER

--- a/scripts/globals/spells/white/cure_vi.lua
+++ b/scripts/globals/spells/white/cure_vi.lua
@@ -50,6 +50,12 @@ spellObject.onSpellCast = function(caster, target, spell)
         basepower = 0
     end
 
+    -- special case where healing spells should have no effect
+    if target:getMod(xi.mod.CURE_POTENCY_RCVD) == -100 then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return 0
+    end
+
     if xi.magic.isValidHealTarget(caster, target) then
         basecure = xi.magic.getBaseCure(power, divisor, constant, basepower)
         final = xi.magic.getCureFinal(caster, spell, basecure, minCure, false)
@@ -111,7 +117,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         else
             -- e.g. monsters healing themselves.
-            if (xi.settings.main.USE_OLD_CURE_FORMULA == true) then
+            if xi.settings.main.USE_OLD_CURE_FORMULA then
                 basecure = xi.magic.getBaseCureOld(power, divisor, constant)
             else
                 basecure = xi.magic.getBaseCure(power, divisor, constant, basepower)

--- a/scripts/globals/spells/white/raise.lua
+++ b/scripts/globals/spells/white/raise.lua
@@ -13,14 +13,8 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     if target:isPC() then
         target:sendRaise(1)
-    else
-        if target:getName() == "Prishe" then
-            -- CoP 8-4 Prishe
-            target:setLocalVar("Raise", 1)
-            target:entityAnimationPacket("sp00")
-            target:addHP(target:getMaxHP())
-            target:addMP(target:getMaxMP())
-        end
+    elseif bit.band(target:getBehaviour(), xi.behavior.RAISABLE) == xi.behavior.RAISABLE then
+        target:triggerListener("RAISE_RECEIVED", target, 1)
     end
 
     spell:setMsg(xi.msg.basic.MAGIC_CASTS_ON)

--- a/scripts/globals/spells/white/raise_ii.lua
+++ b/scripts/globals/spells/white/raise_ii.lua
@@ -13,14 +13,8 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     if target:isPC() then
         target:sendRaise(2)
-    else
-        if target:getName() == "Prishe" then
-            -- CoP 8-4 Prishe
-            target:setLocalVar("Raise", 1)
-            target:entityAnimationPacket("sp00")
-            target:addHP(target:getMaxHP())
-            target:addMP(target:getMaxMP())
-        end
+    elseif bit.band(target:getBehaviour(), xi.behavior.RAISABLE) == xi.behavior.RAISABLE then
+        target:triggerListener("RAISE_RECEIVED", target, 2)
     end
 
     spell:setMsg(xi.msg.basic.MAGIC_CASTS_ON)

--- a/scripts/globals/spells/white/raise_iii.lua
+++ b/scripts/globals/spells/white/raise_iii.lua
@@ -13,14 +13,8 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     if target:isPC() then
         target:sendRaise(3)
-    else
-        if target:getName() == "Prishe" then
-            -- CoP 8-4 Prishe
-            target:setLocalVar("Raise", 1)
-            target:entityAnimationPacket("sp00")
-            target:addHP(target:getMaxHP())
-            target:addMP(target:getMaxMP())
-        end
+    elseif bit.band(target:getBehaviour(), xi.behavior.RAISABLE) == xi.behavior.RAISABLE then
+        target:triggerListener("RAISE_RECEIVED", target, 3)
     end
 
     spell:setMsg(xi.msg.basic.MAGIC_CASTS_ON)

--- a/scripts/missions/cop/8_4_Dawn.lua
+++ b/scripts/missions/cop/8_4_Dawn.lua
@@ -38,11 +38,13 @@ local checkAdditionalCS = function(player)
             csCount = csCount + 1
         end
     end
+
     if csCount == 5 then
         for _, cs in pairs(additionalCS) do
             mission:setVar(player, cs, 0)
         end
     end
+
     return csCount
 end
 
@@ -59,6 +61,7 @@ local ringCheck = function(player)
             return true
         end
     end
+
     return false
 end
 
@@ -142,7 +145,9 @@ mission.sections =
                 end,
 
                 [3] = function(player, csid, option)
-                    mission:setVar(player, 'Status', 4)
+                    if mission:getVar(player, 'Status') < 4 then
+                        mission:setVar(player, 'Status', 4)
+                    end
                 end,
 
                 [6] = function(player, csid, option)
@@ -151,10 +156,12 @@ mission.sections =
                     if not player:hasKeyItem(xi.ki.TEAR_OF_ALTANA) then
                         npcUtil.giveKeyItem(player, xi.ki.TEAR_OF_ALTANA)
                     end
+
                     if mission:getVar(player, 'Status') < 3 then
                         mission:setVar(player, 'Wait', getMidnight())
                         mission:setVar(player, 'Status', 3)
                     end
+
                     return mission:progressEvent(3)
                 end,
             },
@@ -333,11 +340,13 @@ mission.sections =
                             if mission:getVar(player, 'ColoredDrop') < 4258 then
                                 mission:setVar(player, 'ColoredDrop', coloredDrop)
                             end
+
                             return mission:messageSpecial(zones[npc:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED, coloredDrop)
                         else
                             if mission:getVar(player, 'ColoredDrop') < 4258 then
                                 mission:setVar(player, 'ColoredDrop', coloredDrop)
                             end
+
                             return mission:progressEvent(43)
                         end
                     end

--- a/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
+++ b/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
@@ -37,8 +37,6 @@ battlefieldObject.onBattlefieldTick = function(battlefield, tick)
 end
 
 battlefieldObject.onBattlefieldRegister = function(player, battlefield)
-    local promathia = GetMobByID(ID.mob.PROMATHIA_OFFSET + battlefield:getArea())
-    promathia:setLocalVar("spawner", player:getID())
 end
 
 battlefieldObject.onBattlefieldEnter = function(player, battlefield)

--- a/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
@@ -11,6 +11,14 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:addMod(xi.mod.REGAIN, 30)
     mob:setMobMod(xi.mobMod.NO_REST, 1)
+    mob:addListener('RAISE_RECEIVED', 'PRISHE_RAISE_RECEIVED', function(target, raiseLevel)
+        target:setLocalVar("Raise", 1)
+        target:entityAnimationPacket("sp00")
+        target:addHP(target:getMaxHP())
+        target:addMP(target:getMaxMP())
+        target:disengage()
+        target:resetAI()
+    end)
 end
 
 entity.onMobRoam = function(mob)
@@ -18,6 +26,7 @@ entity.onMobRoam = function(mob)
     if not GetMobByID(promathia):isAlive() then
         promathia = promathia + 1
     end
+
     local wait = mob:getLocalVar("wait")
     local ready = mob:getLocalVar("ready")
 

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
@@ -73,10 +73,10 @@ entity.onMobFight = function(mob, target)
 
     if chainsUsed < chainsTrigger and mob:canUseAbilities() then
         local chains = {}
-        local spawner = mob:getLocalVar("spawner")
+        local players = mob:getBattlefield():getPlayers()
 
         -- Create table of usable Chains TP moves
-        for _, member in pairs(GetPlayerByID(spawner):getParty()) do
+        for _, member in pairs(players) do
             local trigger = 0
             local race = member:getRace()
             for _, v in pairs(chains) do
@@ -129,6 +129,7 @@ entity.onMobWeaponSkill = function(target, mob, skill)
                 mob:showText(mob, ID.text.PROMATHIA_TEXT + tp[2])
                 mob:setLocalVar("tpMessage", 1)
             end
+
             mob:setTP(mobTP)
         end
     end
@@ -162,9 +163,17 @@ entity.onEventFinish = function(player, csid, option, target)
         local mob = SpawnMob(target:getID() + 1)
         local bcnmAllies = mob:getBattlefield():getAllies()
         for i, v in pairs(bcnmAllies) do
+            -- reset local vars so prise stars by waiting and can use 2hr again and such
             v:resetLocalVars()
-            local spawn = v:getSpawnPos()
-            v:setPos(spawn.x, spawn.y, spawn.z, spawn.rot)
+            -- only reset Prishe position if she is alive at end of first phase
+            if v:isAlive() then
+                v:disengage()
+                local spawn = v:getSpawnPos()
+                v:setPos(spawn.x, spawn.y, spawn.z, spawn.rot)
+            end
+
+            -- TODO: figure out how to make Prishe start fighting right away when she dies in first phase
+            -- and is raised in second phase before engaging 2nd phase Promathia
         end
     end
 end

--- a/scripts/zones/Empyreal_Paradox/mobs/Selhteus.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Selhteus.lua
@@ -17,7 +17,7 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobFight = function(mob, target)
-    if target:getTarget():getID() ~= mob:getID() then
+    if target:getTarget() and target:getTarget():getID() ~= mob:getID() then
         local targetPos = target:getPos()
         local radians = (256 - targetPos.rot) * (math.pi / 128)
         mob:pathTo(targetPos.x + math.cos(radians) * 16, targetPos.y, targetPos.z + math.sin(radians) * 16)

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -633,7 +633,9 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
                 {
                     if (std::find(m_AllyList.begin(), m_AllyList.end(), PMobEntity) != m_AllyList.end())
                     {
-                        if (PMobEntity->isAlive() && PMobEntity->PAI->IsSpawned())
+                        // We should not put an isAlive check here because some ally can be dead at cleanup
+                        // but not despawned (for example Prise in Dawn fight)
+                        if (PMobEntity->PAI->IsSpawned())
                         {
                             PEntity->status = STATUS_TYPE::DISAPPEAR;
                             PEntity->loc.zone->UpdateEntityPacket(PEntity, ENTITY_DESPAWN, UPDATE_NONE);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes several issues with the Dawn fight:
- Prevents players from curing Selhteus (which was killing him and ending fight)
- Increases meteor casting time of Promathia to retail accurate ten seconds 
- Allows correctly cleaning up dead Prishe during battlefield cleanup
- Prevent error on Promathia due to local var spawner being reset on spawn
- Add ResetAI on Prishe raise to fix some logic issues
- Add disengage from Prishe between phases and raises to fix claim issues
- Fix Dawn from regressing when re-clearing it for other players

## Steps to test these changes
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/973
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2859
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2851
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2854
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2852