### PR TITLE
Update  Nimble Snap

### DIFF
--- a/scripts/globals/mobskills/nimble_snap.lua
+++ b/scripts/globals/mobskills/nimble_snap.lua
@@ -13,11 +13,15 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local numhits = 3
-    local accmod = 1
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, 1, xi.mobskills.physicalTpBonus.DMG_VARIES, 3, 3.25, 3.5)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
-    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
+    if mob:isMobType(xi.mobskills.mobType.NOTORIOUS) then
+        numhits = 3
+    else
+        numhits = 1
+    end
+        accmod = 1
+        info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, 1, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 1.25, 1.5) --todo verify NM's FTP on retail/jimmy
+        dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
+        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg
 end
 


### PR DESCRIPTION
https://ffxiclopedia.fandom.com/wiki/Nimble_Snap

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes NQ mobs ability to  use nimble snap at 3x hits. 
https://ffxiclopedia.fandom.com/wiki/Nimble_Snap

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1192
## Steps to test these changes
Spawnmob 16793776 (Splacknuck) - NM will nimble snap 3x hit - then go to the boat and NQ efts will only nimble snap for 1x hit.

Will need to verify with retail about FTP settings. 
<!-- Clear and detailed steps to test your changes here -->
