### PR TITLE
Fix repeated respawning of ZM5 mobs

### DIFF
--- a/scripts/missions/rotz/05_Headstone_Pilgrimage.lua
+++ b/scripts/missions/rotz/05_Headstone_Pilgrimage.lua
@@ -94,9 +94,7 @@ mission.sections =
             ['Ancient_Weapon'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    if optParams.isKiller then
-                        GetNPCByID(behemothsDominionID.npc.CERMET_HEADSTONE):setLocalVar("cooldown", os.time() + 900)
-                    end
+                    GetNPCByID(behemothsDominionID.npc.CERMET_HEADSTONE):setLocalVar("cooldown", os.time() + 900)
                 end,
             },
 
@@ -355,7 +353,7 @@ mission.sections =
             ['Tipha'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    if optParams.isKiller and GetMobByID(yuhtungaJungleID.mob.CARTHI):isDead() then
+                    if GetMobByID(yuhtungaJungleID.mob.CARTHI):isDead() then
                         GetNPCByID(yuhtungaJungleID.npc.CERMET_HEADSTONE):setLocalVar("cooldown", os.time() + 900)
                     end
                 end,
@@ -364,7 +362,7 @@ mission.sections =
             ['Carthi'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    if optParams.isKiller and GetMobByID(yuhtungaJungleID.mob.TIPHA):isDead() then
+                    if GetMobByID(yuhtungaJungleID.mob.TIPHA):isDead() then
                         GetNPCByID(yuhtungaJungleID.npc.CERMET_HEADSTONE):setLocalVar("cooldown", os.time() + 900)
                     end
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed issue where certain ZM5 monsters would repeatedly respawn when trying to get a fragment from headstone. (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes an issue where the cooldown variable would not set on a headstone when the mob was killed by a player not on ZM5.

## Steps to test these changes
- For one party member !addmission 3 10
- For another party member make sure they are not on ZM5
- !gotoid 17297493 and pop mob and kill with member not on ZM5
- Have player on ZM5 try to get the fragment

## Special Deployment Considersings
None