### PR TITLE
Correct some Hakutaku stats to be retail accurate

### DIFF
--- a/scripts/zones/Den_of_Rancor/mobs/Hakutaku.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Hakutaku.lua
@@ -7,9 +7,9 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.GIL_MIN, 1600)
-    mob:setMobMod(xi.mobMod.GIL_MAX, 3500)
     mob:setMod(xi.mod.TRIPLE_ATTACK, 25)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 30)
+    mob:setMod(xi.mod.SILENCERES, 99)
     mob:setMod(xi.mod.FIRE_MEVA, 800)
 end
 

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -10991,7 +10991,7 @@ INSERT INTO `mob_groups` VALUES (32,2948,160,'Ogama',0,32,1840,0,0,80,84,0);
 INSERT INTO `mob_groups` VALUES (33,3953,160,'Tonberry_Decapitator',1260,0,2433,0,0,72,74,0);
 INSERT INTO `mob_groups` VALUES (34,3972,160,'Tonberry_Tracker',1560,0,2449,0,0,72,74,0);
 INSERT INTO `mob_groups` VALUES (35,3964,160,'Tonberry_Pontifex',86400,0,2443,0,0,75,75,0);
-INSERT INTO `mob_groups` VALUES (36,1877,160,'Hakutaku',0,128,1270,50000,0,85,85,0);
+INSERT INTO `mob_groups` VALUES (36,1877,160,'Hakutaku',0,128,1270,50000,50000,85,85,0);
 INSERT INTO `mob_groups` VALUES (37,2718,160,'Mokumokuren',0,128,0,9000,0,80,82,0);
 INSERT INTO `mob_groups` VALUES (38,6409,160,'Mousse',960,0,1749,0,0,64,70,0);
 INSERT INTO `mob_groups` VALUES (39,6882,160,'Azrael',0,128,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fix some issues with Hakutaku including adding silence resistance, increasing MP, adding double attack, and increasing amount of gil dropped.

## What does this pull request do? (Please be technical)
This PR fixes some issues with Hakutaku including adding silence resistance, increasing MP, adding double attack, and increasing amount of gil dropped. These changes were taken from retail capture (see [here](https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1214)).

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1214

## Steps to test these changes
!spawnmob 17433005
!gotoid 17433005
Fight Hakutaku and observer changes

## Special Deployment Considersings
None