### PR TITLE
When clearing "Dawn", only set the missions status if it would move y…

### DIFF
--- a/scripts/missions/cop/8_4_Dawn.lua
+++ b/scripts/missions/cop/8_4_Dawn.lua
@@ -142,7 +142,9 @@ mission.sections =
                 end,
 
                 [3] = function(player, csid, option)
-                    mission:setVar(player, 'Status', 4)
+                    if mission:getVar(player, 'Status') < 4 then
+                       mission:setVar(player, 'Status', 4)
+                    end
                 end,
 
                 [6] = function(player, csid, option)


### PR DESCRIPTION
…ou forward in the mission

Otherwise, reclears of this mission will cause folks to actually regress in terms of progress blocking "Storms of Fate" and other things without re-triggering a ton of CS etc.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fix "Dawn" from regressing when reclearing it for other players

## What does this pull request do? (Please be technical)

Fix "Dawn" from regressing when reclearing it for other players

## Steps to test these changes
Clear Dawn once. Zone into Mhaura. Get CS. Clear Dawn again. Get CS again???
