### PR TITLE
Fix several CoP Diabolos issues

### DIFF
--- a/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
@@ -49,6 +49,8 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar("TileTriggerHPP", triggerVal) -- Starting point for tile drops
     mob:setLocalVar("Area", area)
     mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN_INCLUDE_PARTY, 1)
+    mob:setMod(xi.mod.DMGPHYS, -5000)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/The_Shrouded_Maw/mobs/Diremite.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diremite.lua
@@ -2,6 +2,8 @@
 -- Area: The Shrouded Maw
 -- Mob: Diremite
 -- Mission: Darkness Named
+-- There is navmesh issue with the multi-level such that these diremites currently do not aggro
+-- because they think cannot see the player (specifically CMobController::CanSeePoint fails)
 -----------------------------------
 local entity = {}
 
@@ -10,6 +12,10 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    mob:setRespawnTime(10) -- respawn in 10 seconds
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed Diabolos (in CoP 3-5 BCNM Darkness Named and Quest BCNM Waking Dreams) to correctly draw-in entire party and have physical damage reduction. 

## What does this pull request do? (Please be technical)
This PR fixes several issues with CoP Diabolos (see [here](https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1132)). Note that the manafont issue was fixed in prior PR. 

## Steps to test these changes
Fight Diabolos as party to check draw-in and damage with physical attacks to check damage reduction

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1132
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
