### PR TITLE
[DRG] Correct Dragoon Wyvern weapon damage to match data capture from retail

### DIFF
--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1154,7 +1154,7 @@ namespace petutils
         LoadAvatarStats(PMaster, PPet);                                                                               // follows PC calcs (w/o SJ)
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (320.0f / 60.0f)))); // 320 delay
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (320.0f / 60.0f))));
-        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDamage((uint16)(1 + floor(mLvl * 0.9f)));
+        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDamage((uint16)(floor(mLvl / 2) + 3));
         // Set stat modifiers
         PPet->setModifier(Mod::DEF, mobutils::GetDefense(PPet, PPet->defRank));
         PPet->setModifier(Mod::EVA, mobutils::GetBase(PPet, PPet->evaRank));


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Correct Dragoon Wyvern weapon damage formula to match data capture from retail (WinterSolstice)

## What does this pull request do? (Please be technical)

Does what it says on the tin, fixes DRG wyvern weapon damage.

The following applies from era (around 2009)
Per Jimmayus:

Previously, Wyvern weapon damage was generated using a system with no apparent source. This value was arbitrarily higher than anecdotal observations, but until recently we did not have the required parse data to accurately derive a formula with acceptable precision. Casey recently sourced an acceptably high sample of parse data for wyverns on a static set of targets which allowed us to generate meaningful conclusions from the data.

The test set were Robber Crabs of levels 61-63, whose relevant VIT values and DEF values according to /check method reconfirmations indicate that Wyvern base damage and susceptibility to Boolean value observation (the so-called "1.0 PDIF spike" observable in player data and as documented in the formula found in https://ffxiclopedia.fandom.com/wiki/Level_Correction_Function_and_pDIF#Distribution_of_melee_hits ) would be unaffected by differences on monster level. As wyverns are npcs level correction is a factor, and the results indicate a PDIF spike when Crab defense buffs were present (which is predicted by the formula). The distribution of wyvern hits is observable here: https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?usp=sharing. As noted above the PDIF spike is present at the lower range, and our model would predict its existence only when a Defense Buff is present. The range is arbitrarily larger than secondary randomizer would predict, but this is consistent with STR down debuffs being applied to the wyvern (unfortunately this isn't filterable, but the range present is consistent with decayed debuff effects).

The conclusions are as follows:

1) Wyverns benefit positively from level correction, and have STR and Attack values consistent with estimates based on other monster and pet STR and Attack calculations. 2) Wyvern Base Damage is consistent with an offset of 3 and a slope of .5, or D: 3 + floor(level * .5)
2) Wyvern Base Damage is consistent with an offset of 3 and a slope of .5, or D: 3 + floor(level * .5)

## Steps to test these changes

Breakpoint on the changed item and analyze the math worked right

## Special Deployment Considerations

N/A
