### PR TITLE
Address issue on Wish Upon a Star quest

### DIFF
--- a/scripts/quests/bastok/Wish_Upon_A_Star.lua
+++ b/scripts/quests/bastok/Wish_Upon_A_Star.lua
@@ -84,9 +84,9 @@ quest.sections =
                             (player:getWeather() == xi.weather.NONE or player:getWeather() == xi.weather.SUNSHINE) and
                             (VanadielTOTD() == xi.time.NIGHT or VanadielTOTD() == xi.time.MIDNIGHT)
                         then
-                            player:progressEvent(334)
+                            return quest:progressEvent(334)
                         else
-                            player:startEvent(337)
+                            return quest:event(337)
                         end
                     end
                 end,


### PR DESCRIPTION
After the first trade, dialog would not work.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Addresses issue where player turning in quest completion item for completion, if not at correct weather/time, would not get correct dialog. 
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
changes player:progressEvent to return quest:progressEvent
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!addmission 1 64
!additem fallen_star
!setplayervar <NAME> Quest[1][64]Prog 3
trade fallen star item to Enu. Dialog will be based on time/weather.
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
None