### PR TITLE
Fix Mother Globe Shock Spikes effect

### DIFF
--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Mother_Globe.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Mother_Globe.lua
@@ -176,7 +176,8 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar("nextSlaveSpawnTime", os.time() + 30) -- spawn first 30s from now
     mob:setLocalVar("posNum", math.random(1, 9))
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
-    mob:addStatusEffectEx(xi.effect.SHOCK_SPIKES, 0, 60, 0, 0) -- ~60 damage
+    -- 60 damage spikes with duration of 1 hour (in case stolen by thf)
+    mob:addStatusEffectEx(xi.effect.SHOCK_SPIKES, 0, 60, 0, 3600)
     mob:setSpeed(20)
 end
 
@@ -195,12 +196,9 @@ entity.onMobFight = function(mob, target)
         trySpawnSlaveGlobe(mob, os.time(), spawnedSlaves, notSpawnedSlaves, validSlavePositions)
     end
 
-    if not mob:hasStatusEffect(xi.effect.SHOCK_SPIKES) and mob:getLocalVar("control") == 0 then
-        mob:setLocalVar("control", 1)
-        mob:castSpell(251, mob) -- shock spikes
-        mob:timer(15000, function(mobArg1)
-            mobArg1:setLocalVar("control", 0)
-        end)
+    if not mob:hasStatusEffect(xi.effect.SHOCK_SPIKES) then
+        -- 60 damage spikes with duration of 1 hour (in case stolen by thf)
+        mob:addStatusEffectEx(xi.effect.SHOCK_SPIKES, 0, 60, 0, 3600)
     end
 end
 
@@ -235,6 +233,7 @@ entity.onMobRoam = function(mob)
         while newPos == posNum do
             newPos = math.random(1, 9)
         end
+
         for k, pos in pairs(pathNodes) do
             if k == newPos then
                 moveX = pos.x
@@ -243,8 +242,14 @@ entity.onMobRoam = function(mob)
                 break
             end
         end
+
         mob:pathTo(moveX, moveY, moveZ)
         mob:setLocalVar("posNum", newPos)
+    end
+
+    if not mob:hasStatusEffect(xi.effect.SHOCK_SPIKES) then
+        -- 60 damage spikes with duration of 1 hour (in case stolen by thf)
+        mob:addStatusEffectEx(xi.effect.SHOCK_SPIKES, 0, 60, 0, 3600)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fix the shock spikes effect of Mother Globe to do the correct damage

## What does this pull request do? (Please be technical)
The PR fixes the shock spikes effect of Mother Globe such that MG does not actually ever cast shock spikes but just regains the effect immediately on being removed (as per wiki) or wearing.

## Steps to test these changes
Fight MG and attempt to dispel Shock Spikes

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1223
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
