### PR TITLE
Fixes droprate on Ul'xzomit mother

### DIFF
--- a/modules/era/sql/era_mob_droplist.sql
+++ b/modules/era/sql/era_mob_droplist.sql
@@ -19822,6 +19822,8 @@ INSERT INTO `mob_droplist` VALUES (2516,0,0,1000,1852,@RARE);     -- High-Qualit
 INSERT INTO `mob_droplist` VALUES (2516,2,0,1000,1783,0);         -- Sample Of Luminian Tissue (Steal)
 
 -- ZoneID:  33 - Ulxzomit
+INSERT INTO `mob_droplist` VALUES (2517,0,0,1000,1785,@ALWAYS);   -- Xzomit Organ (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (2517,0,0,1000,1783,@UNCOMMON); -- Luminian Tissue (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (2517,0,0,1000,1855,@UNCOMMON); -- High-Quality Xzomit Organ (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (2517,0,0,1000,1855,@UNCOMMON); -- High-Quality Xzomit Organ (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (2517,1,1,@UNCOMMON,4104,125);  -- Fire Cluster (Group 1 - Uncommon, 10% * 12.5%)


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Adds Xzomit Organ as a guaranteed drop on all Ul'xzomit mothers

## What does this pull request do? (Please be technical)

Closes #2807 

## Steps to test these changes

Update drop tables with latest era mob droplist
Go to Al'Taieu
Kill a Ul'xzomit mother
Receive their organs

## Special Deployment Considerations
Need to re-run era_mob_droplist.sql
