### PR TITLE
Dragon Kick should only use KICK_DMG with Footwork

### DIFF
--- a/scripts/globals/weaponskills/dragon_kick.lua
+++ b/scripts/globals/weaponskills/dragon_kick.lua
@@ -26,7 +26,11 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.canCrit = false
     params.acc100 = 1.0 params.acc200 = 1.0 params.acc300 = 1.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
-    params.kick = true -- https://www.bluegartr.com/threads/112776-Dev-Tracker-Findings-Posts-%28NO-DISCUSSION%29?p=6712150&viewfull=1#post6712150
+
+    if player:hasStatusEffect(xi.effect.FOOTWORK) then
+        -- https://www.bluegartr.com/threads/112776-Dev-Tracker-Findings-Posts-%28NO-DISCUSSION%29?p=6712150&viewfull=1#post6712150
+        params.kick = true
+    end
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true -- https://www.bg-wiki.com/ffxi/Dragon_Kick


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Dragon Kick will no longer use the Kick Attack damage formula without Footwork (Loxley)

## What does this pull request do? (Please be technical)

Dragon Kick is currently set to use the KICK_DMG modifier which was implemented in #2796 but this is incorrect. Dragon Kick should only use KICK_DMG under the effect of Footwork. Dragon Kick is currently doing H2H base damage and ignoring weapon damage.

> Dragon Kick is only affected by equipment that increases [Kick Attacks](https://ffxiclopedia.fandom.com/wiki/Kick_Attacks) damage such as [Kung Fu Shoes](https://ffxiclopedia.fandom.com/wiki/Kung_Fu_Shoes) under the effect of [Footwork](https://ffxiclopedia.fandom.com/wiki/Footwork).

https://ffxiclopedia.fandom.com/wiki/Dragon_Kick

## Steps to test these changes

Test with and without KICK_DMG modifier items eg. Dune Boots.

## Special Deployment Considerations

Can and should be hotfixed live, as this is an important issue which affects one of the main weaponskills used by MNK.