### PR TITLE
Do not load Voidwalker system if not enabled

### DIFF
--- a/scripts/globals/voidwalker.lua
+++ b/scripts/globals/voidwalker.lua
@@ -239,6 +239,10 @@ end
 -- Zone On Init
 -----------------------------------
 xi.voidwalker.zoneOnInit = function(zone)
+    if xi.settings.main.ENABLE_VOIDWALKER == 0 then
+        return
+    end
+
     local zoneId = zone:getID()
     local voidwalkerMobs = zones[zoneId].mob.VOIDWALKER
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

N/A server development only.

## What does this pull request do? (Please be technical)

Voidwalker was running an init on tons of zones even when the content was not enabled. This was leading to hundreds of warnings on every server startup due to **GetMobByID** returning nothing as the mobs themselves were content disabled.

## Steps to test these changes

Update your settings `settings/main.lua`
```lua
    -- VoidWalker
    ENABLE_VOIDWALKER = 0,
```

It should no longer disable tons of warnings when set to 0.

## Special Deployment Considerations

Update your settings `settings/main.lua`
```lua
    -- VoidWalker
    ENABLE_VOIDWALKER = 0,
```


