### PR TITLE
Fixed module to only override ToAU NPCs if enabled

### DIFF
--- a/modules/era/lua/era_rent_a_room.lua
+++ b/modules/era/lua/era_rent_a_room.lua
@@ -21,9 +21,12 @@ local renterNPCs =
     "xi.zones.Lower_Jeuno.npcs.Miladi-Nildi",
     "xi.zones.Upper_Jeuno.npcs.Zekobi-Morokobi",
     "xi.zones.RuLude_Gardens.npcs.Perisa-Neburusa",
-    "xi.zones.Al_Zahbi.npcs.Krujaal",
-    "xi.zones.Aht_Urhgan_Whitegate.npcs.Zhamwaa",
 }
+
+if xi.settings.main.ENABLE_TOAU == 1 then
+    table.insert(renterNPCs, "xi.zones.Al_Zahbi.npcs.Krujaal")
+    table.insert(renterNPCs, "xi.zones.Aht_Urhgan_Whitegate.npcs.Zhamwaa")
+end
 
 for _, npcString in pairs(renterNPCs) do
     m:addOverride(string.format("%s.onTrigger", npcString), function(player, npc)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

N/A server development only.

## What does this pull request do? (Please be technical)

This module was attempting to override NPCs when they didn't exist (ie. `ENABLE_TOAU = 0`) leading to a bunch of error messages on start up. So I changed it to only add overrides for those NPCs when TOAU is enabled.

## Steps to test these changes

Module should load correctly with either setting in `settings/main.lua`
```
ENABLE_TOAU = 0
```

```
ENABLE_TOAU = 1
```

## Special Deployment Considerations

N/A
