### PR TITLE
Fixes pets not losing hate on teleports.  Heals pets in CoP 6-4

### DIFF
--- a/scripts/zones/Sealions_Den/bcnms/one_to_be_feared_helper.lua
+++ b/scripts/zones/Sealions_Den/bcnms/one_to_be_feared_helper.lua
@@ -15,6 +15,12 @@ local function healCharacter(player)
     player:setHP(player:getMaxHP())
     player:setMP(player:getMaxMP())
     player:setTP(0)
+    if player:getPet() ~= nil then
+        local pet = player:getPet()
+        pet:setHP(pet:getMaxHP())
+        pet:setMP(pet:getMaxMP())
+        pet:setTP(0)
+    end
 end
 
 local function returnToAirship(player)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10824,6 +10824,10 @@ void CLuaBaseEntity::clearEnmity(CLuaBaseEntity* PEntity)
     {
         auto* PBattleEntity = static_cast<CBattleEntity*>(PEntity->m_PBaseEntity);
         PMob->PEnmityContainer->Clear(PBattleEntity->id);
+        if (PEntity->getPet().has_value())
+        {
+            PMob->PEnmityContainer->Clear(PEntity->getPet().value().getID());
+        }
         auto* PTarget = PMob->PEnmityContainer->GetHighestEnmity();
         PMob->SetBattleTargetID(PTarget ? PTarget->targid : 0);
     }


### PR DESCRIPTION
Fixes pets not losing hate on teleports.  
Heals pets in CoP 6-4

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes pets not losing hate on teleports.  
Pets will now be healed during One To Be Feared (CoP 6-4) intermissions.

## What does this pull request do? (Please be technical)

When a player has its hate cleared on teleport (or otherwise, although teleport is the only use case today), its pet will also have its hate cleared.
I condisered adding a param to specify that pet hate should or should not be cleared.
Given that all current use cases have intent to clear pet hate if possible, I've opted to not to add the param and just clear pet if/when it exists.
Note - getPet returns an optional so using the standard if has value, use value pattern.

## What does this pull request doesnt do
Does not change current behavior that when the CS completes, hate is wiped _regardless if the player said yes or no to the warp_.
Would need verification of how/when hate is dropped for a change.

## Steps to test these changes
**Portals Round 1**
Use two characters
Pick a portal
Player A (Observer) gets ```!speed 255``` ```!wallhack``` and should ```/follow`` a mob near the portal.
Player B is a bst or smn or pup or drg w/ their pet
Player B gets hate on the pet and runs for the portal.
Player B portals.
Player A follows the mob to see if it gives up or if it chases the player's pet.
Note: Since we remove emnity as the CS completes - the mob may take a second to deaggro.  Will need a capture to better determine exactly when the hate loss occurs. (when player says yes vs CS complete).

**Portals Round 2**
Do the same as above, but add in shinnanigans.
Desummon the pet right before catching the portal CS.
Take hate from the pet, Speed 255 to the portal
Take hate from pet, Speed 255 to the portal, kill pet, take portal.
Have the observer kill the pet (!hp 0) as the player ports

**One to be Feared**
Go through the fight, drop your pets health to half on the first phase
Verify that hp is refilled during intermission
Verify that mp is refilled during intermission (Carrie has MP)
Verify TP is set to 0 during intermission.

## Special Deployment Considerations

None
