### PR TITLE
Deathwarps by players below level 5 no longer hurt conquest

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2308,7 +2308,8 @@ void CCharEntity::Die()
     setBlockingAid(false);
 
     // influence for conquest system
-    conquest::LoseInfluencePoints(this);
+    if (this->GetMLevel() >= 5)
+        conquest::LoseInfluencePoints(this);
 
     if (GetLocalVar("MijinGakure") == 0 &&
         (PBattlefield == nullptr || (PBattlefield->GetRuleMask() & RULES_LOSE_EXP) == RULES_LOSE_EXP) &&


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Deaths by players below level 5 no longer hurt conquest
![image](https://user-images.githubusercontent.com/105882290/226250396-d0d89f07-6fbe-49ec-a834-fdded1cb4475.png)
Source: https://www.bg-wiki.com/ffxi/The_History_of_Final_Fantasy_XI/2003

## What does this pull request do? (Please be technical)

Does not apply conquest::LoseInfluence unless the player triggering the loss is above level 5

## Steps to test these changes

Hop on a level, set your hompoint somewhere dangerous and die a lot.
Note that beastmen influence should not rise.
Tav is the best region to see a jump, followed by a 4 way tie - Vollbow, Valdeaunia, Fauregandi, Elshimo Uplands

## Special Deployment Considerations

None
