### PR TITLE
Updates Full Break Duration to 180/240/300

### DIFF
--- a/scripts/globals/weaponskills/full_break.lua
+++ b/scripts/globals/weaponskills/full_break.lua
@@ -14,6 +14,7 @@
 -- Modifiers: STR:50%  VIT:50%
 -- 100%TP    200%TP    300%TP
 -- 1.00      1.00      1.00
+-- Duration is 180/240/300 - resulting in (tp / 1000 * 60) + 120
 -----------------------------------
 require("scripts/globals/status")
 require("scripts/globals/settings")
@@ -35,7 +36,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     effectParams.element = xi.magic.ele.WIND
     effectParams.effect = xi.effect.DEFENSE_DOWN
     effectParams.skillType = xi.skill.GREAT_AXE
-    effectParams.duration = (tp / 1000 * 30) + 60
+    effectParams.duration = (tp / 1000 * 60) + 120
     effectParams.power = 12.5
     effectParams.tick = 0
     effectParams.maccBonus = 0
@@ -44,7 +45,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     effectParams2.element = xi.magic.ele.WATER
     effectParams2.effect = xi.effect.ATTACK_DOWN
     effectParams2.skillType = xi.skill.GREAT_AXE
-    effectParams2.duration = (tp / 1000 * 30) + 60
+    effectParams2.duration = (tp / 1000 * 60) + 120
     effectParams2.power = 12.5
     effectParams2.tick = 0
     effectParams2.maccBonus = 0
@@ -53,7 +54,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     effectParams3.element = xi.magic.ele.ICE
     effectParams3.effect = xi.effect.EVASION_DOWN
     effectParams3.skillType = xi.skill.GREAT_AXE
-    effectParams3.duration = (tp / 1000 * 30) + 60
+    effectParams3.duration = (tp / 1000 * 60) + 120
     effectParams3.power = 20
     effectParams3.tick = 0
     effectParams3.maccBonus = 0
@@ -62,7 +63,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     effectParams4.element = xi.magic.ele.EARTH
     effectParams4.effect = xi.effect.ACCURACY_DOWN
     effectParams4.skillType = xi.skill.GREAT_AXE
-    effectParams4.duration = (tp / 1000 * 30) + 60
+    effectParams4.duration = (tp / 1000 * 60) + 120
     effectParams4.power = 20
     effectParams4.tick = 0
     effectParams4.maccBonus = 0


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Updates Full Break Duration to accurate sources.
Extended duration from 90/120/150 to 180/240/300

## What does this pull request do? (Please be technical)
Updates the formula for finding base (unresisted) duration from ```(tp / 1000 * 60) + 120``` to ```(tp / 1000 * 60) + 120```
## Steps to test these changes
Make a weak mob immortal
Try to get one who does not resist Wind, Water, Ice, or Earth.
Stack GAX skill

Full break a mob and start a timer
Watch log for wears off message.
Note: Full break applies 4 debuffs and each one resists individually, there fore duration can vary for each.
## Special Deployment Considerations

None
