### PR TITLE
Fixes various onMobDeath accidental multicalls

### DIFF
--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_X.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_X.lua
@@ -33,6 +33,7 @@ entity.onMobWeaponSkill = function(target, mob, skill)
     if skill:getID() == 695 then
         mob:messageText(mob, ID.text.END_THE_HUNT)
     end
+
     mob:setMobMod(xi.mobMod.SKILL_LIST, 0)
     mob:setLocalVar("control", 0)
     mob:setLocalVar("TP", 0)
@@ -40,8 +41,8 @@ end
 
 entity.onMobFight = function(mob, target)
     if mob:getTP() == 3000 and mob:getLocalVar("control") == 0 then
-        local shikY = GetMobByID(mob:getID()-1)
-        local shikZ = GetMobByID(mob:getID()-2)
+        local shikY = GetMobByID(mob:getID() - 1)
+        local shikZ = GetMobByID(mob:getID() - 2)
         local shikYTP = shikY:getLocalVar("TP")
         local shikZTP = shikZ:getLocalVar("TP")
         mob:setLocalVar("TP", 1)
@@ -110,10 +111,12 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    mob:messageText(mob, ID.text.AT_MY_BEST)
-    -- Reset controls so thatremaining shiks don't get locked from weaponskilling
-    GetMobByID(mob:getID()-1):setLocalVar("control", 0)
-    GetMobByID(mob:getID()-2):setLocalVar("control", 0)
+    if optParams.isKiller then
+        mob:messageText(mob, ID.text.AT_MY_BEST)
+        -- Reset controls so that remaining shiks don't get locked from weaponskilling
+        GetMobByID(mob:getID() - 1):setLocalVar("control", 0)
+        GetMobByID(mob:getID() - 2):setLocalVar("control", 0)
+    end
 end
 
 return entity

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_Y.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_Y.lua
@@ -33,6 +33,7 @@ entity.onMobWeaponSkill = function(target, mob, skill)
     if skill:getID() == 695 then
         mob:messageText(mob, ID.text.SCENT_OF_BLOOD)
     end
+
     mob:setMobMod(xi.mobMod.SKILL_LIST, 0)
     mob:setLocalVar("control", 0)
     mob:setLocalVar("TP", 0)
@@ -44,8 +45,8 @@ end
 
 entity.onMobFight = function(mob, target)
     if mob:getTP() == 3000 and mob:getLocalVar("control") == 0 then
-        local shikX = GetMobByID(mob:getID()+1)
-        local shikZ = GetMobByID(mob:getID()-1)
+        local shikX = GetMobByID(mob:getID() + 1)
+        local shikZ = GetMobByID(mob:getID() - 1)
         local shikXTP = shikX:getLocalVar("TP")
         local shikZTP = shikZ:getLocalVar("TP")
         mob:setLocalVar("TP", 1)
@@ -107,17 +108,19 @@ entity.onMobFight = function(mob, target)
 
         -- Shik Y is last alive
         else
-                mob:messageText(mob, dialogue[math.random(1,3)])
+                mob:messageText(mob, dialogue[math.random(1, 3)])
                 mob:setMobMod(xi.mobMod.SKILL_LIST, 1166)
         end
     end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    mob:messageText(mob, ID.text.I_LOST)
-    -- Reset controls so that remaining shiks don't get locked from weaponskilling
-    GetMobByID(mob:getID()+1):setLocalVar("control", 0)
-    GetMobByID(mob:getID()-1):setLocalVar("control", 0)
+    if optParams.isKiller then
+        mob:messageText(mob, ID.text.I_LOST)
+        -- Reset controls so that remaining shiks don't get locked from weaponskilling
+        GetMobByID(mob:getID() + 1):setLocalVar("control", 0)
+        GetMobByID(mob:getID() - 1):setLocalVar("control", 0)
+    end
 end
 
 return entity

--- a/scripts/zones/Boneyard_Gully/mobs/Shikaree_Z.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Shikaree_Z.lua
@@ -36,8 +36,8 @@ end
 
 entity.onMobFight = function(mob, target)
     if mob:getTP() == 3000 and mob:getLocalVar("control") == 0 then
-        local shikY = GetMobByID(mob:getID()+1)
-        local shikX = GetMobByID(mob:getID()+2)
+        local shikY = GetMobByID(mob:getID() + 1)
+        local shikX = GetMobByID(mob:getID() + 2)
         local shikYTP = shikY:getLocalVar("TP")
         local shikXTP = shikX:getLocalVar("TP")
         mob:setLocalVar("TP", 1)
@@ -93,17 +93,19 @@ entity.onMobFight = function(mob, target)
 
         -- Shik Z is last alive
         else
-                mob:messageText(mob, dialogue[math.random(1,3)])
+                mob:messageText(mob, dialogue[math.random(1, 3)])
                 mob:setMobMod(xi.mobMod.SKILL_LIST, 1167)
         end
     end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    mob:messageText(mob, ID.text.HOW_IS_THIS_POSSIBLE)
-    -- Reset controls so that remaining shiks don't get locked from weaponskilling
-    GetMobByID(mob:getID()+1):setLocalVar("control", 0)
-    GetMobByID(mob:getID()+2):setLocalVar("control", 0)
+    if optParams.isKiller then
+        mob:messageText(mob, ID.text.HOW_IS_THIS_POSSIBLE)
+        -- Reset controls so that remaining shiks don't get locked from weaponskilling
+        GetMobByID(mob:getID() + 1):setLocalVar("control", 0)
+        GetMobByID(mob:getID() + 2):setLocalVar("control", 0)
+    end
 end
 
 return entity

--- a/scripts/zones/Waughroon_Shrine/mobs/Titanis_Dax.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Titanis_Dax.lua
@@ -12,10 +12,12 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    local id = mob:getID()
-    for i = 1, 3 do
-        if GetMobByID(id - i):isAlive() then
-            GetMobByID(id - i):addMod(xi.mod.DELAY, 1000)
+    if optParams.isKiller then
+        local id = mob:getID()
+        for i = 1, 3 do
+            if GetMobByID(id - i):isAlive() then
+                GetMobByID(id - i):addMod(xi.mod.DELAY, 1000)
+            end
         end
     end
 end

--- a/scripts/zones/Waughroon_Shrine/mobs/Titanis_Jax.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Titanis_Jax.lua
@@ -12,13 +12,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    local id = mob:getID()
-    if GetMobByID(id - 1):isAlive() then
-        GetMobByID(id - 1):addMod(xi.mod.DELAY, 1000)
-    end
-    for i = 1, 2 do
-        if GetMobByID(id + i):isAlive() then
-            GetMobByID(id + i):addMod(xi.mod.DELAY, 1000)
+    if optParams.isKiller then
+        local id = mob:getID()
+        if GetMobByID(id - 1):isAlive() then
+            GetMobByID(id - 1):addMod(xi.mod.DELAY, 1000)
+        end
+
+        for i = 1, 2 do
+            if GetMobByID(id + i):isAlive() then
+                GetMobByID(id + i):addMod(xi.mod.DELAY, 1000)
+            end
         end
     end
 end

--- a/scripts/zones/Waughroon_Shrine/mobs/Titanis_Max.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Titanis_Max.lua
@@ -12,9 +12,11 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    local id = mob:getID()
-    for i = 1, 3 do
-        GetMobByID(id + i):addMod(xi.mod.DELAY, 1000)
+    if optParams.isKiller then
+        local id = mob:getID()
+        for i = 1, 3 do
+            GetMobByID(id + i):addMod(xi.mod.DELAY, 1000)
+        end
     end
 end
 

--- a/scripts/zones/Waughroon_Shrine/mobs/Titanis_Xax.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Titanis_Xax.lua
@@ -12,13 +12,16 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    local id = mob:getID()
-    if GetMobByID(id + 1):isAlive() then
-        GetMobByID(id + 1):addMod(xi.mod.DELAY, 1000)
-    end
-    for i = 1, 2 do
-        if GetMobByID(id - i):isAlive() then
-            GetMobByID(id - i):addMod(xi.mod.DELAY, 1000)
+    if optParams.isKiller then
+        local id = mob:getID()
+        if GetMobByID(id + 1):isAlive() then
+            GetMobByID(id + 1):addMod(xi.mod.DELAY, 1000)
+        end
+
+        for i = 1, 2 do
+            if GetMobByID(id - i):isAlive() then
+                GetMobByID(id - i):addMod(xi.mod.DELAY, 1000)
+            end
         end
     end
 end


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixes various onMobDeath accidental multicalls

## What does this pull request do? (Please be technical)

mob entity onDeath is called once per player in alliance (or party if that is all you have).
Scanned through onMobDeath with some creative greps to pull out all onMobDeaths that contain actual code.
Went through those and found any that were not gated by ```if optParams.isKiller then```.
Applied ```if optParams.isKiller then``` to those that made sense - except Prishe in Dawn.  Im not touching Prishe atm.

Net effect - Mithran trackers will not spam their on death message 6x times.
Prehistoric Pigeons will build up to sub 100 fist attack speed instead of getting further than they should on one kill.
(Each pigeon death should lower the delay of the others by 1k.  Previous impl was lowering by 6k per death.  Was hilarious to watch the birbs animation glitch themselves

## Steps to test these changes

Run the CoP mission for mithran trackers with 2+ party members.
Run Prehistoric Pigeons with 2+ party members.

## Special Deployment Considerations

None
