### PR TITLE
Fixes inconsistent parrying tracking during an attack

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -174,13 +174,23 @@ bool CAttack::IsBlocked() const
     return m_isBlocked;
 }
 
+/************************************************************************
+ *                                                                      *
+ *  Gets the Parried flag if set, else calculates a new one and returns.*
+ *                                                                      *
+ ************************************************************************/
 bool CAttack::IsParried()
 {
+    if (m_isParried.has_value())
+    {
+        return m_isParried.value();
+    }
+
     if (m_attackType != PHYSICAL_ATTACK_TYPE::DAKEN)
     {
-        return attackutils::IsParried(m_attacker, m_victim);
+        m_isParried.emplace(attackutils::IsParried(m_attacker, m_victim));
     }
-    return false;
+    return m_isParried.value_or(false);
 }
 
 bool CAttack::IsAnticipated() const

--- a/src/map/attack.h
+++ b/src/map/attack.h
@@ -119,12 +119,13 @@ private:
     bool                      m_isCountered{ false };
     bool                      m_isCovered{ false }; // Flag: Is someone covering the victim?
     bool                      m_anticipated{ false };
-    bool                      m_isFirstSwing{ false };  // Flag: Is this attack the first swing?
-    float                     m_damageRatio{ false };   // The damage ratio.
-    int32                     m_damage{ 0 };            // The damage for this attack.
-    int32                     m_trickAttackDamage{ 0 }; // The damage from trick attack.
-    int32                     m_naturalH2hDamage{ 0 };  // The damage from natural H2H.
-    int32                     m_baseDamage{ 0 };        // The base damage.
+    bool                      m_isFirstSwing{ false };     // Flag: Is this attack the first swing?
+    float                     m_damageRatio{ false };      // The damage ratio.
+    int32                     m_damage{ 0 };               // The damage for this attack.
+    int32                     m_trickAttackDamage{ 0 };    // The damage from trick attack.
+    int32                     m_naturalH2hDamage{ 0 };     // The damage from natural H2H.
+    int32                     m_baseDamage{ 0 };           // The base damage.
+    std::optional<bool>       m_isParried{ std::nullopt }; // Is this attack parried by the victim?
 };
 
 #endif


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixes an issue which was causing parrying to be inconsistent across a single attack.
This fix does not change parrying rate or parrying skill up rate in any way.


## What does this pull request do? (Please be technical)
If an attack was parried or not was being calculated 3 diffrent times through the course of a single attack.
Once to determine if the animation should play, and if dmg was taken.
Once to determine if a skill up could occurr.
Once to determine if evasion could skill up.

A player's animation and actual parrying (log message, no dmg taken) were correctly tied together and no rate change occured due to the mutiple calculations.
The only impact was that a player could recieve a skill up when they did not parry or could be denied a chance at an evasion skill up when they did not parry.
Note that since each indvidual check used the same forumlas and inputs, there is no case of higher or lower rate of parrying, skill ups, or evasion checks.  It is just that the state was inconsistent throughout the attack.

Also, it could be argued that calculating the random 3 times using additional computing power that was not needed - but I have not run a performance test of the random calc vs the implementation I have made via optional.  Generally, the overhead cost on optionals is very low so would think this is an improvement - but I have no proof.


## Steps to test these changes
Ensure PARRY_OLD_SKILLUP_STYLE is true on the server
Ensure the player is not capped on parry and can skill up on the mob to be fought
Give the player an insane INQUARTATA mod.  This will come into play after capped parry of 20%.
Immortal a mob, and give the mob ~1k accuracy
engage, fight, and note that parry skill ups ONLY occur on parries.
Note that no evasion skill ups happen when a parry procs


## Special Deployment Considerations

None
