### PR TITLE
Converts Her Majestys Garden to IF.

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -103,6 +103,7 @@ xi.items =
     CASTLE_FLOOR_PLANS              = 530,
     LANOLIN_CUBE                    = 531,
     MAGICMART_FLYER                 = 532,
+    CHUNK_OF_DERFLAND_HUMUS         = 533,
     CLUMP_OF_GAUSEBIT_WILDGRASS     = 534,
     ADVENTURERS_COUPON              = 536,
     DAMSELFLY_WORM                  = 537,

--- a/scripts/quests/sandoria/Her_Majesty_S_Garden.lua
+++ b/scripts/quests/sandoria/Her_Majesty_S_Garden.lua
@@ -1,0 +1,103 @@
+-----------------------------------
+-- Her Majestys Garden
+-----------------------------------
+-- Log ID: 0, Quest ID: 62
+-- Chalvatot : !gotoid 17731598
+-- Map of the Northlands
+-----------------------------------
+require('scripts/globals/npc_util')
+require('scripts/globals/items')
+require('scripts/globals/keyitems')
+require('scripts/globals/quests')
+require('scripts/globals/status')
+require('scripts/globals/zone')
+require('scripts/globals/interaction/quest')
+-----------------------------------
+local ID = require("scripts/zones/Chateau_dOraguille/IDs")
+
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
+
+quest.reward =
+{
+    fame     = 30,
+    fameArea = xi.quest.fame_area.SANDORIA,
+    keyItem  = xi.ki.MAP_OF_THE_NORTHLANDS_AREA,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE and
+            player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 4
+        end,
+
+        [xi.zone.CHATEAU_DORAGUILLE] =
+        {
+            ['Chalvatot'] =
+            {
+                onTrigger = function(player, npc)
+                    local questProgress = quest:getVar(player, 'Prog')
+
+                    if questProgress == 0 and player:getNation() ~= xi.nation.SANDORIA then -- Non sandy folk gets a CS prior to getting acceptance
+                        return quest:progressEvent(583)
+                    elseif questProgress == 0 and player:getNation() == xi.nation.SANDORIA then -- Sandy folks go directly to CS acceptance
+                        return quest:progressEvent(84)
+                    elseif questProgress == 1 then
+                        return quest:progressEvent(84)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [583] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+
+                [84] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:begin(player)
+                        quest:setVar(player, 'Prog', 0)
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.CHATEAU_DORAGUILLE] =
+        {
+            ['Chalvatot'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(82)
+                end,
+
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, { xi.items.CHUNK_OF_DERFLAND_HUMUS }) then
+                        return quest:progressEvent(83)
+                    end
+                end,
+
+            },
+
+            onEventFinish =
+            {
+                [83] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:confirmTrade()
+                    end
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Chateau_dOraguille/DefaultActions.lua
+++ b/scripts/zones/Chateau_dOraguille/DefaultActions.lua
@@ -5,6 +5,7 @@ return {
     ['_6h4']        = { text = ID.text.ITS_LOCKED_TIGHT },
     ['Arsha']       = { event = 513 },
     ['Chaphoire']   = { event = 512 },
+    ['Chalvatot']   = { event = 531 },
     ['Chupaile']    = { event = 514 },
     ['Ferdechiond'] = { event = 511 },
     ['Halver']      = { text = ID.text.HALVER_OFFSET + 1092 },

--- a/scripts/zones/Chateau_dOraguille/npcs/Chalvatot.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Chalvatot.lua
@@ -16,16 +16,6 @@ require("scripts/globals/utils")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local herMajestysGarden = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
-
-    -- HER MAJESTY'S GARDEN (derfland humus)
-    if
-        herMajestysGarden == QUEST_ACCEPTED and
-        trade:hasItemQty(533, 1) and
-        trade:getItemCount() == 1
-    then
-        player:startEvent(83)
-    end
 end
 
 entity.onTrigger = function(player, npc)
@@ -33,7 +23,6 @@ entity.onTrigger = function(player, npc)
     local circleProgress = player:getCharVar("circleTime")
     local lureOfTheWildcat = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT)
     local wildcatSandy = player:getCharVar("WildcatSandy")
-    local herMajestysGarden = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
 
     -- CIRCLE OF TIME (Bard AF3)
     if circleOfTime == QUEST_ACCEPTED then
@@ -53,19 +42,6 @@ entity.onTrigger = function(player, npc)
         not utils.mask.getBit(wildcatSandy, 19)
     then
         player:startEvent(561)
-
-    -- HER MAJESTY'S GARDEN
-    elseif
-        herMajestysGarden == QUEST_AVAILABLE and
-        player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 4
-    then
-        player:startEvent(84)
-    elseif herMajestysGarden == QUEST_ACCEPTED then
-        player:startEvent(82)
-
-    -- DEFAULT DIALOG
-    else
-        player:startEvent(531)
     end
 end
 
@@ -94,16 +70,6 @@ entity.onEventFinish = function(player, csid, option)
     -- LURE OF THE WILDCAT
     elseif csid == 561 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 19, true))
-
-    -- HER MAJESTY'S GARDEN
-    elseif csid == 84 and option == 1 then
-        player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
-    elseif csid == 83 then
-        player:tradeComplete()
-        player:addKeyItem(xi.ki.MAP_OF_THE_NORTHLANDS_AREA)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MAP_OF_THE_NORTHLANDS_AREA)
-        player:addFame(xi.quest.fame_area.SANDORIA, 30)
-        player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
     end
 end
 


### PR DESCRIPTION
Converts Her Majesty's Garden quest to IF.

Adds correct options for non sandy folk.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Addresses issues where players from nations besides Sandy, would not be able to get correct dialog prior to accepting quest. Also addresses issues where players were unable to accept/complete quest.
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Converted to IF - added in checks for player nation as there is a different CS for those. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!gotoid 17731598 - if not sandy then will get CS 583 else will get cs 84
Accept quest 
!additem CHUNK_OF_DERFLAND_HUMUS 
Trade and complete quest - get map of Northlands - era has no gil or exp reward IAW https://ffxiclopedia.fandom.com/wiki/Her_Majesty%27s_Garden?oldid=11878
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
