### PR TITLE
[conquest] Add minimum level setting to lose conquest influence

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -71,6 +71,10 @@ xi.settings.map =
     -- Minimum level at which experience points can be lost
     EXP_LOSS_LEVEL = 4,
 
+    -- Minimum level at which regional influence is lost in conquest when a player dies
+    -- Level 5 and below don't lose influence: http://wiki.ffo.jp/html/498.html
+    MINIMUM_LEVEL_CONQUEST_INFUENCE_LOSS = 6,
+
     -- Enable/disable Level Sync
     LEVEL_SYNC_ENABLE = true,
 

--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -129,6 +129,12 @@ namespace conquest
 
     void LoseInfluencePoints(CCharEntity* PChar)
     {
+        // http://wiki.ffo.jp/html/498.html
+        if (PChar->GetMLevel() < settings::get<uint8>("map.MINIMUM_LEVEL_CONQUEST_INFUENCE_LOSS"))
+        {
+            return;
+        }
+
         REGION_TYPE region = PChar->loc.zone->GetRegionID();
         int         points = 0;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Players below level 6 will no longer cause the region they died in to lose conquest influence to the beastmen. (WinterSolstice)

## What does this pull request do? (Please be technical)

Add minimum level setting to lose conquest influence. This commit is cherry-picked from LSB.

## Steps to test these changes

By default, die at <= level 5 and don't lose influence in your region

## Special Deployment Considerations

Copy the new setting from the default map setting lua
