### PR TITLE
Fixes Euvhi behavior

### DIFF
--- a/scripts/mixins/families/euvhi.lua
+++ b/scripts/mixins/families/euvhi.lua
@@ -27,12 +27,7 @@ local function openFlower(mob)
     mob:setMod(xi.mod.SLASH_SDT, 2000)
     mob:setMod(xi.mod.PIERCE_SDT, 2000)
     mob:setMod(xi.mod.IMPACT_SDT, 2000)
-    for n =1, #xi.magic.resistMod, 1 do
-        mob:setMod(xi.magic.resistMod[n], 25)
-    end
-    for n =1, #xi.magic.defenseMod, 1 do
-        mob:setMod(xi.magic.defenseMod[n], -128) -- 50% more damage from magic
-    end
+    mob:setMod(xi.mod.UDMG, 5000) -- Takes double damage from all sources when open
     mob:setAnimationSub(2)
 end
 
@@ -46,13 +41,9 @@ local function closeFlower(mob)
     mob:setMod(xi.mod.SLASH_SDT, 1000)
     mob:setMod(xi.mod.PIERCE_SDT, 1000)
     mob:setMod(xi.mod.IMPACT_SDT, 1000)
-    for n =1, #xi.magic.resistMod, 1 do
-        mob:setMod(xi.magic.resistMod[n], 0)
-    end
-    for n =1, #xi.magic.defenseMod, 1 do
-        mob:setMod(xi.magic.defenseMod[n], 0)
-    end
-    mob:setLocalVar("[euvhi]changeTime", mob:getBattleTime() + math.random(45, 60))
+    mob:setMod(xi.mod.UDMG, 0) -- Takes predicted damage when open
+
+    mob:setLocalVar("[euvhi]changeTime", mob:getBattleTime() + 80) -- Flower will open after 80 seconds
     mob:setAnimationSub(1)
 end
 
@@ -68,6 +59,7 @@ g_mixins.families.euvhi = function(euvhiArg)
         if mob:getAnimationSub() == 0 then
             mob:setAnimationSub(1) -- stem will appear after engaging target
         end
+
         mob:setLocalVar("PhysicalDamage", 0)
         mob:setLocalVar("MagicalDamage", 0)
         mob:setLocalVar("RangedDamage", 0)
@@ -98,9 +90,15 @@ g_mixins.families.euvhi = function(euvhiArg)
 
     euvhiArg:addListener("COMBAT_TICK", "EUVHI_CTICK", function(mob)
         local sum = mob:getLocalVar("PhysicalDamage") + mob:getLocalVar("MagicalDamage") + mob:getLocalVar("RangedDamage") + mob:getLocalVar("BreathDamage")
-        if mob:getAnimationSub() == 2 and sum > 500 then
+        if
+            mob:getAnimationSub() == 2 and
+            sum > 350
+        then
             closeFlower(mob)
-        elseif mob:getAnimationSub() == 1 and mob:getBattleTime() > mob:getLocalVar("[euvhi]changeTime") then
+        elseif
+            mob:getAnimationSub() == 1 and
+            mob:getBattleTime() > mob:getLocalVar("[euvhi]changeTime")
+        then
             openFlower(mob)
         end
     end)


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Fixes damage thresholds and damage taken on the Euvhi family.  (Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
+ Damage threshold changed from 500 to 350 due to retail testing
+ When the flower is open this should be taking damage * 1.5 from all sources
+ After entering closed this should have a set duration of 80 seconds to when it opens
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Find any mob part of the Euvhi family
Attack it and wait for it to open.
Once its open do over 350 damage to it and watch it close
Once its closed wait 80 seconds and watch it open again

The damage taken when its open should be doubled from when its closed
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
