### PR TITLE
Fixes bug preventing sub 1.0 attack mods on ftp calcs

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -99,12 +99,12 @@ void CAttack::SetCritical(bool value, uint16 slot, bool isGuarded)
     }
     else
     {
-        float attBonus = 0.f;
+        float attBonus = 1.f;
         if (m_attackType == PHYSICAL_ATTACK_TYPE::KICK)
         {
             if (CStatusEffect* footworkEffect = m_attacker->StatusEffectContainer->GetStatusEffect(EFFECT_FOOTWORK))
             {
-                attBonus = footworkEffect->GetSubPower() / 256.f; // Mod is out of 256
+                attBonus = 1.0 + footworkEffect->GetSubPower() / 256.f; // Mod is out of 256
             }
         }
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2115,7 +2115,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                         // Calculate attack bonus for Counterstance Effect Job Points
                         // Needs verification, as there appears to be conflicting information regarding an attack bonus based on DEX
                         // vs a base damage increase.
-                        float csJpAtkBonus = 0;
+                        float csJpAtkBonus = 1;
                         if (PTarget->objtype == TYPE_PC && PTarget->GetMJob() == JOB_MNK && PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_COUNTERSTANCE))
                         {
                             auto*  PChar        = static_cast<CCharEntity*>(PTarget);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12067,7 +12067,7 @@ int CLuaBaseEntity::getMeleeHitDamage(CLuaBaseEntity* PLuaBaseEntity, sol::objec
 
     if (xirand::GetRandomNumber(100) < hitrate)
     {
-        float DamageRatio = battleutils::GetDamageRatio(PAttacker, PDefender, false, 0.f, SLOT_MAIN, 0, false);
+        float DamageRatio = battleutils::GetDamageRatio(PAttacker, PDefender, false, 1.f, SLOT_MAIN, 0, false);
         int   damage      = (uint16)((PAttacker->GetMainWeaponDmg() + battleutils::GetFSTR(PAttacker, PDefender, SLOT_MAIN)) * DamageRatio);
 
         return damage;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -804,7 +804,7 @@ namespace battleutils
                 bool crit = battleutils::GetCritHitRate(PDefender, PAttacker, true) > xirand::GetRandomNumber(100);
 
                 // Dmg math.
-                float  DamageRatio = GetDamageRatio(PDefender, PAttacker, crit, 0.f, SLOT_MAIN, 0, false);
+                float  DamageRatio = GetDamageRatio(PDefender, PAttacker, crit, 1.f, SLOT_MAIN, 0, false);
                 uint16 dmg         = (uint32)((PDefender->GetMainWeaponDmg() + battleutils::GetFSTR(PDefender, PAttacker, SLOT_MAIN)) * DamageRatio);
                 dmg                = attackutils::CheckForDamageMultiplier(((CCharEntity*)PDefender), dynamic_cast<CItemWeapon*>(PDefender->m_Weapons[SLOT_MAIN]), dmg,
                                                                            PHYSICAL_ATTACK_TYPE::NORMAL, SLOT_MAIN);
@@ -2877,11 +2877,7 @@ namespace battleutils
             }
         }
 
-        // Bonus attack currently only from footwork
-        if (bonusAttPercent >= 1)
-        {
-            attack = static_cast<uint16>(attack * bonusAttPercent);
-        }
+        attack = static_cast<uint16>(attack * bonusAttPercent);
 
         // Wholly possible for DEF to be near 0 with the amount of debuffs/effects now.
         uint16 defense = PDefender->DEF() - ignoredDef;
@@ -4926,12 +4922,12 @@ namespace battleutils
                 if (!battleutils::IsAbsorbByShadow(PVictim, PAttacker))
                 {
                     // successful hit, add damage
-                    float AttMultiplerPercent = 0.f;
+                    float AttMultiplerPercent = 1.f;
 
                     // get jump attack bonus from gear
                     if (PAttacker->objtype == TYPE_PC)
                     {
-                        AttMultiplerPercent = PAttacker->getMod(Mod::JUMP_ATT_BONUS) / 100.f;
+                        AttMultiplerPercent = 1.f + PAttacker->getMod(Mod::JUMP_ATT_BONUS) / 100.f;
                     }
 
                     bool isGuarded = attackutils::IsGuarded(PAttacker, PVictim);


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed a bug where attack modifiers of less than 1.0 did not have that attack modifier applied during ftp calculation
This impacts Drakesbane, Penta Thrust, Requiescat, Resolution
This also technically will help kick attacks under the effect of footwork - as the attack bonus for kicks was not being considered.

## What does this pull request do? (Please be technical)

Fixes bug preventing sub 1.0 attack mods on ftp calcs
Removes an if which shouldnt have been there

## Steps to test these changes

Penta pre patch, and penta post patch 
Make sure to read the branch name T.T

## Special Deployment Considerations

None
