### PR TITLE
Refactor avoidance priority (parry > shadows)

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2064,21 +2064,22 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
         else if ((xirand::GetRandomNumber(100) < attack.GetHitRate() || attackRound.GetSATAOccured()) &&
                  !PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_ALL_MISS))
         {
-            // attack hit, try to be absorbed by shadow unless it is a SATA attack round
-            if (!(attackRound.GetSATAOccured()) && battleutils::IsAbsorbByShadow(PTarget, this))
-            {
-                actionTarget.messageID = MSGBASIC_SHADOW_ABSORB;
-                actionTarget.param     = 1;
-                actionTarget.reaction  = REACTION::EVADE;
-                attack.SetEvaded(true);
-            }
-            else if (attack.IsParried())
+            // attack hit, try to be deflected by parry unless it is a SATA attack round
+            if (!(attackRound.GetSATAOccured()) && attack.IsParried())
             {
                 actionTarget.messageID  = 70;
                 actionTarget.reaction   = REACTION::PARRY | REACTION::HIT;
                 actionTarget.speceffect = SPECEFFECT::NONE;
                 battleutils::HandleTacticalParry(PTarget);
                 battleutils::HandleIssekiganEnmityBonus(PTarget, this);
+            }
+            // attack hit, try to be absorbed by shadow unless it is a SATA attack round
+            else if (!(attackRound.GetSATAOccured()) && battleutils::IsAbsorbByShadow(PTarget, this))
+            {
+                actionTarget.messageID = MSGBASIC_SHADOW_ABSORB;
+                actionTarget.param     = 1;
+                actionTarget.reaction  = REACTION::EVADE;
+                attack.SetEvaded(true);
             }
             else if (attack.CheckAnticipated() || attack.CheckCounter())
             {


### PR DESCRIPTION
Re-ordered parry and shadow interactions on successful hits.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Adjusted the avoidance priority to place Parry checks ahead of Utsusemi shadows.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Refactors the avoidance checks such that Parry checks occur before shadows are absorbed on successful hits. Also attaches a SATA check to Parry to ensure that Hide > Sneak Attack combinations are not incorrectly parried.

**Data for this change:**
Timestamped video (2008) showing a parry occurring before a shadow with a shadow immediately consumed afterward:
https://www.youtube.com/watch?v=HywIWjRnZJ8&t=53s

Screencapped image of the relevant combat log:
https://user-images.githubusercontent.com/8106757/226143566-cdce1c90-6870-4f18-81f6-5fe7e5418c19.png

Wiki entry for parry skill:
https://ffxiclopedia.fandom.com/wiki/Parrying_Skill

Guide circa 2007 detailing parry behavior:
https://www.staronion.com/maiev/nfblog/?page_id=279

Original pull request (closed due to poor branching, should be resolved):
https://github.com/AirSkyBoat/AirSkyBoat/pull/2888


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

1k accuracy immortal mob as invincible player.
Shadows up, watch for parries. Current pre-merge behavior is that parries cannot occur while shadows are active. See: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1253

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
