### PR TITLE
Parry rate reformulation

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2064,21 +2064,22 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
         else if ((xirand::GetRandomNumber(100) < attack.GetHitRate() || attackRound.GetSATAOccured()) &&
                  !PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_ALL_MISS))
         {
-            // attack hit, try to be absorbed by shadow unless it is a SATA attack round
-            if (!(attackRound.GetSATAOccured()) && battleutils::IsAbsorbByShadow(PTarget, this))
-            {
-                actionTarget.messageID = MSGBASIC_SHADOW_ABSORB;
-                actionTarget.param     = 1;
-                actionTarget.reaction  = REACTION::EVADE;
-                attack.SetEvaded(true);
-            }
-            else if (attack.IsParried())
+            // attack hit, try to be deflected by parry unless it is a SATA attack round
+            if (!(attackRound.GetSATAOccured()) && attack.IsParried())
             {
                 actionTarget.messageID  = 70;
                 actionTarget.reaction   = REACTION::PARRY | REACTION::HIT;
                 actionTarget.speceffect = SPECEFFECT::NONE;
                 battleutils::HandleTacticalParry(PTarget);
                 battleutils::HandleIssekiganEnmityBonus(PTarget, this);
+            }
+            // attack hit, try to be absorbed by shadow unless it is a SATA attack round
+            else if (!(attackRound.GetSATAOccured()) && battleutils::IsAbsorbByShadow(PTarget, this))
+            {
+                actionTarget.messageID = MSGBASIC_SHADOW_ABSORB;
+                actionTarget.param     = 1;
+                actionTarget.reaction  = REACTION::EVADE;
+                attack.SetEvaded(true);
             }
             else if (attack.CheckAnticipated() || attack.CheckCounter())
             {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1921,35 +1921,20 @@ namespace battleutils
         CItemWeapon* PWeapon = GetEntityWeapon(PDefender, SLOT_MAIN);
         if (((PDefender->objtype == TYPE_PC && PWeapon != nullptr && PWeapon->getID() != 0 && PWeapon->getID() != 65535 && PWeapon->getSkillType() != SKILL_HAND_TO_HAND) ||
              (PDefender->objtype == TYPE_MOB && PDefender->m_EcoSystem == ECOSYSTEM::BEASTMAN && PDefender->GetMJob() != JOB_MNK && PDefender->isInDynamis())) &&
-            PDefender->PAI->IsEngaged())
-        {
-            // http://wiki.ffxiclopedia.org/wiki/Talk:Parrying_Skill
-            // {(Parry Skill x .125) + ([Player Agi - Enemy Dex] x .125)} x Diff
+              PDefender->PAI->IsEngaged())
+        
+            float  defender_parry_skill = (float)(PDefender->GetSkill(SKILL_PARRY) + PDefender->getMod(Mod::PARRY) + PWeapon->getILvlParry());
+            uint16 attackSkill          = PAttacker->GetSkill((SKILLTYPE)(weapon ? weapon->getSkillType(): 0 ));
 
-            float skill = (float)(PDefender->GetSkill(SKILL_PARRY) + PDefender->getMod(Mod::PARRY) + PWeapon->getILvlParry());
+            auto parryRate = std::clamp<uint8>(uint8)(20.0f + (defender_parry_skill - attackSkill) / 8.0f, 5.0f, 30.0f)
 
-            float diff = 1.0f + ((PDefender->GetMLevel() - PAttacker->GetMLevel()) * 0.05f);
-
-            if (PWeapon != nullptr && PWeapon->isTwoHanded())
-            {
-                // two handed weapons get a bonus
-                diff += 0.1f;
-            }
-
-            float diffCorrect = std::clamp<float>(diff, 0.4f, 1.4f);
-
-            float dex = PAttacker->DEX();
-            float agi = PDefender->AGI();
-
-            auto parryRate = std::clamp<uint8>((uint8)(((skill * 0.125f) + ((agi - dex) * 0.125f)) * diffCorrect), 5, 20);
-
-            // Issekigan grants parry rate bonus. From best available data, if you already capped out at 25% parry it grants another 25% bonus for ~50%
-            // parry rate
-            if ((PDefender->objtype == TYPE_PC || PDefender->objtype == TYPE_TRUST) && PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_ISSEKIGAN))
-            {
+                // Issekigan grants parry rate bonus. From best available data, if you already capped out at 25% parry it grants another 25% bonus for ~50%
+                // parry rate
+                if ((PDefender->objtype == TYPE_PC || PDefender->objtype == TYPE_TRUST) && PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_ISSEKIGAN))
+                {
                 int16 issekiganBonus = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_ISSEKIGAN)->GetPower();
                 parryRate += issekiganBonus;
-            }
+                }
 
             // Inquartata grants a flat parry rate bonus.
             int16 inquartataBonus = PDefender->getMod(Mod::INQUARTATA);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Adjusted the parry formula to more appropriate era values.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

parry_rate = clamp(20 + (player_parry_skill - mob_combat_skill) / 8, 5, 30) + mod(inquartata)

**Data Sources**
1. Principle parry data from level 75 is: https://www.staronion.com/maiev/nfblog/?page_id=279 and https://www.staronion.com/maiev/nfblog/?p=286 (but really https://www.staronion.com/maiev/nfblog/?cat=972 generally)
2. Principle parry data from level 99 is: https://www.bluegartr.com/threads/120223-Agility-s-effect-on-Parrying-and-Shield-rate?p=6042523&viewfull=1#post6042523
3. Further: https://ffxilogdialy.hatenablog.com/archive/category/%E9%AD%94%E5%89%A3 (generally) and especially: https://ffxilogdialy.hatenablog.com/entry/2018/08/10/113719 and https://ffxilogdialy.hatenablog.com/entry/2018/08/04/214031 which discusses inquartata and the interaction with parry skillcaps (also 99) and investigates the actual parry cap. 

**Synthesis**
Ok, so, what all does this teach us? 
1. Maiev vs: steelsheels (75-76) https://www.staronion.com/maiev/img/p269_graph.jpg ranges from ~16-23% parry over 230 to 269 skill on samurai at 75.
2. Martel on pld vs. EP to DC mobs in abyssea https://www.bluegartr.com/threads/120223-Agility-s-effect-on-Parrying-and-Shield-rate?p=6042523&viewfull=1#post6042523 gets ~9.3-9.6% parry with capped parry skill (level 99) 
3. We can fit a slope to this data. The slope on the maiev data is +1% parry proc rate per 8 skill, roughly.
4.  The cap is most likely 30% based on the jp inquartata data: here: https://ffxilogdialy.hatenablog.com/entry/2018/08/05/141636
Grand Grenade (CL128)
No    装備条件    攻撃数    回避数    母数    受け流し数    **発生率**    回避率
D1    タタ+0      174      7        167    83          **49.70%**   4.02%
(inquartata itself is adding 19% at level 99, tata+0 = no extra gear)

5. If we assume it is similar to block: then we're looking at a formula roughly like: 

parry_rate = clamp(C + (player_parry_skill - mob_combat_skill) / 8, 5, 30)
where C is what we're solving for.

6. With Maeiv: a level 75 Steelshell has 276 combat skill, a level 76 has 281. both of these suggest that C is basically "20", the best fit for the graph is roughly C=22, which is probably wrong, data fuzziness right?
8. Back to Martel: pld parry is E, he's fighting EP-DC (see the rest of the thread) which are roughly -6 at 99 on average: a roughly level 93 mob has roughly 382 combat skill. a 99 pld has 300 parry skill. he got roughly 9-10% parry. (382-300)/8 is 10.25, so he also suggests that C=21 roughly, if there's no two segment curve.
8. What about inquartata? the jp data suggests inquartarta is a flat % bonus that stacks on top of your calculated parry rate, and exceeds the cap.
[A. As an Aside, it is most likely the case that the formula here (and everywhere) rounds to the nearest whole 1%, based on the fact that this is how melee hit, magic hit, fstr, wsc, etc. etc. all work. (no 0.5%s) This probably isn't critical but is likely the source of the uncertainty.]

**Proposal:**
parry_rate = clamp(20 + (player_parry_skill - mob_combat_skill) / 8, 5, 30) + mod(inquartata)

where parry_rate and mod(inquartata) are both expressed in terms of %age. tata effect+ is roughly +1% per +1 and the "tata+5%" effect is just a weird way to say tata+5. borne out by e.g. https://ffxilogdialy.hatenablog.com/entry/2018/10/13/145632 

_**Pros and cons:**
pro:_ This makes parry function along similar lines as block, which cares about mob combat skill and does not have "magic number" coefficients based on how the mob checks.
_pro:_ This scales into the ilvl 119 regime, where you can get multiple pieces of +250 parry gear.
assumed. (it's also not really reachable in content that mattered at 75 which is why we missed it.)
_con:_ We should probably do additional testing to confirm it's not two-segment at parry_skill=combat_skill
_con:_ Still need to address Issekigan (nin 95 ability) 
_con:_ We should probably do additional testing to confirm the parry rate cap is actually 30%, that's higher than historically 

What is the current formula?
// http://wiki.ffxiclopedia.org/wiki/Talk:Parrying_Skill
// {(Parry Skill x .125) + ([Player Agi - Enemy Dex] x .125)} x Diff

is the note in LSB/ASB on the parry rate function. 
auto parryRate = std::clamp<uint8>((uint8)((skill * 0.1f + (agi - dex) * 0.125f + 10.0f) * diff), 5, 25);

Where skill and AGI are player stats, DEX is mob DEX, and "diff" is a value which ranges from 0.4 to 1.5 depending on the relative level of the mob (at -9 levels, low EP, it's 1.4 || at +9 levels, high IT it's 0.4  || this is further modified by a 0.1f bonus for 2handers); with a base parry rate of 10%, a min of 5% and a max of 25%.

This formula comes from https://ffxiclopedia.fandom.com/wiki/Talk:Parrying_Skill#Theoretical_Formula which is a bad, data free source. where the poster themself says things like "These are, of course, purely out of no where" "these are by no means accurate" "I feel I am onto something" "there are issues with a formula like this" "if I am right, in terms of structure, it means that all currently unknown formulas are based on this structure". 

Notably, this formula maxes out at 25% parry rate against high-IT mobs when the player has roughly 520 parry skill, and the amount you need as a level 10 vs. level 19 (520) is the same as the amount you need as a level 90 vs. 99 (520). 

Ok, so, what do we know today?
1) Block does not work anything like this, the principle check in block is shield skill vs. combat skill and neither agi nor dex  nor net hit rate matters
2) Martel demonstrated that AGI does not impact parry at all https://www.bluegartr.com/threads/120223-Agility-s-effect-on-Parrying-and-Shield-rate?p=6042523&viewfull=1#post6042523
3) We know from other sources that the cap is higher than 25%: https://ffxilogdialy.hatenablog.com/entry/2018/08/05/141636 (with 19% inquartata job trait, 49% parry rate - suggests cap is at least 30%)
4) Nearly all ilvl weapons grant >250 parry skill ( https://www.bg-wiki.com/ffxi/Gandring ) and having parry values >700 is achievable (rune has 474 parry naked, at ML50, and will be over 730 with just their weapon.)
5) Level adjustments no longer exist in most parts of FFXI (deprecated in favor of giving mobs more raw skill and stats) but we do not see evidence in the hatenablog source of this impacting parry rates - suggesting that skill, not diff_level is the key component in the formula.
6) No evidence has been found confirming the talk speculation about the 'bonus' 10% parry rate for 2hers. (it is worth noting that 2her jobs in general have better parry than 1her jobs and worse evasion, and we now know that evasion checks first, suppressing the relative rate of parry).

Combined with the original source denigrating its own remarks, I think we can safely conclude that the original formula is likely wrong and should be changed, at least because we have no evidence that the formula should saturate in just the 500s and because we have disconfirming evidence regarding Agility.

As an afterword: it's worth remarking that Guard is currently based on a similar ffxiclopedia talk comment that is similarly "pulled from nowhere" and should probably be researched further as well.

## Steps to test these changes

1k accuracy, immortal mob, test as invincible player and compare observed parry rate to baseline.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
