### PR TITLE
Converted distance correction function to lua

### DIFF
--- a/scripts/globals/damage/distance_correction.lua
+++ b/scripts/globals/damage/distance_correction.lua
@@ -1,0 +1,116 @@
+-----------------------------------
+xi = xi or {}
+xi.damage = xi.damage or {}
+xi.damage.distanceCorrection = xi.damage.distanceCorrection or {}
+-----------------------------------
+
+xi.damage.distanceCorrection.table =
+{
+    LONGBOW =
+    {
+        { range =  3.00, base = 0.65, modifier =  1.67 }, -- <=3'
+        { range =  5.00, base = 0.65, modifier =  2.60 }, -- <=5.0'
+        { range =  7.49, base = 0.65, modifier =  4.66 }, -- <7.5'
+        { range = 10.50, base = 1.00, modifier =   nil }, -- Sweet Spot from 7.5' to 10.5'
+        { range = 15.00, base = 1.00, modifier = -1.78 }, -- <=15.0'
+        { range = 20.00, base = 1.00, modifier = -1.15 }, -- <=20.0'
+        { range =   nil, base = 1.00, modifier = -0.90 }, -- Default to >20' Curve w/o Cap
+    },
+
+    CROSSBOW =
+    {
+        { range =  3.00, base = 0.65, modifier =  3.30 }, -- <=3'
+        { range =  5.00, base = 0.65, modifier =  4.40 }, -- <=5'
+        { range =  5.99, base = 0.65, modifier =  5.83 }, -- <6'
+        { range = 10.00, base = 1.00, modifier =   nil }, -- Sweet Spot from 6' to 10'
+        { range = 15.00, base = 1.00, modifier = -2.00 }, -- <=15'
+        { range = 20.00, base = 1.00, modifier = -1.10 }, -- <=20'
+        { range =   nil, base = 0.86, modifier =   nil }, -- Default to >20' Curve w/o Cap
+    },
+
+    GUN =
+    {
+        { range =  3.00, base = 0.75, modifier =  3.33 }, -- <=3'
+        { range =  4.49, base = 0.75, modifier =  5.56 }, -- <4.5'
+        { range =  5.50, base = 1.00, modifier =   nil }, -- Sweet spot from 4.5' to 5.5'
+        { range =  7.50, base = 1.00, modifier = -2.50 }, -- <=7.5'
+        { range = 10.00, base = 1.00, modifier = -2.22 }, -- <=10'
+        { range = 15.00, base = 1.00, modifier = -1.26 }, -- <=15'
+        { range = 20.00, base = 1.00, modifier = -0.96 }, -- <=20'
+        { range =   nil, base = 1.00, modifier = -0.67 }, -- Default to >20' Curve w/o Cap
+    },
+}
+
+xi.damage.distanceCorrection.applyCurve = function(distance, curve)
+    for i = 1, #curve do
+        if curve[i].modifier == nil then
+            return curve[i].base
+        end
+
+        if
+            distance <= curve[i].range or
+            curve[i].range == nil
+        then
+            return curve[i].base + ((curve[i].modifier * distance) / 100)
+        end
+    end
+
+    -- Fallback
+    return 1.00
+end
+
+xi.damage.distanceCorrection.throwing = function(distance)
+    if distance <= 1.00 then
+        return 1.00 -- Sweet Spot Under or at 1'
+    end
+
+    return 1.00 - ((1.00 * distance) / 100) -- Lose 1%/yalm
+end
+
+xi.damage.distanceCorrection.automaton = function(distance)
+    if distance <= 3.0 then -- Automaton will generally stay around 3' from the target.
+        return 1.0
+    elseif distance <= 25.0 then -- Beyond 3' linearly drop 1%/yalm
+        return 1.0 - (distance / 100.0)
+    end
+
+    return 0.75 -- Cap at 0.75 modifier past 25 yalms
+end
+
+xi.damage.distanceCorrection.getValue = function(attacker, distance)
+    if attacker == nil then
+        return 1.00 -- Just in case BattleEntity is null, then we will just return full damage.
+    end
+
+    -- Automaton
+    if not attacker:isPC() then
+        return xi.damage.distanceCorrection.automaton(distance)
+    end
+
+    local rMainType = 0
+    local rMainSub = 0
+
+    if attacker:getEquipID(xi.slot.RANGED) > 0 then
+        rMainType = attacker:getWeaponSkillType(xi.slot.RANGED)
+        rMainSub  = attacker:getWeaponSubSkillType(xi.slot.RANGED)
+    end
+
+    local longBowCurve  = (rMainType == xi.skill.ARCHERY) and rMainSub == 9                                       -- Longbows Only
+    local crossbowCurve = (rMainType == xi.skill.ARCHERY or rMainType == xi.skill.MARKSMANSHIP) and rMainSub == 0 -- Crossbows and Shortbows
+    local gunCurve      = (rMainType == xi.skill.MARKSMANSHIP) and rMainSub == 1                                  -- Guns Only
+
+    if longBowCurve then
+        return xi.damage.distanceCorrection.applyCurve(distance, xi.damage.distanceCorrection.table.LONGBOW)
+
+    elseif crossbowCurve then
+        return xi.damage.distanceCorrection.applyCurve(distance, xi.damage.distanceCorrection.table.CROSSBOW)
+
+    elseif gunCurve then
+        return xi.damage.distanceCorrection.applyCurve(distance, xi.damage.distanceCorrection.table.GUN)
+
+    else -- Default to Throwing Curve
+        return xi.damage.distanceCorrection.throwing(distance)
+    end
+end
+
+return xi.damage.distanceCorrection

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -264,6 +264,7 @@ int32 do_init(int32 argc, char** argv)
     battleutils::LoadMobSkillsList();
     battleutils::LoadPetSkillsList();
     battleutils::LoadSkillChainDamageModifiers();
+    battleutils::LoadDistanceCorrection();
     petutils::LoadPetList();
     trustutils::LoadTrustList();
     mobutils::LoadCustomMods();

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -312,6 +312,14 @@ namespace battleutils
     }
 
     /************************************************************************
+     *  Load Distance Correction                                            *
+     ************************************************************************/
+    void LoadDistanceCorrection()
+    {
+        luautils::CacheLuaObjectFromFile("./scripts/globals/damage/distance_correction.lua");
+    }
+
+    /************************************************************************
      *  Clear Weapon Skills List                                             *
      ************************************************************************/
 
@@ -7202,102 +7210,25 @@ namespace battleutils
 
     float GetRangedDistanceCorrection(CBattleEntity* PBattleEntity, float distance)
     {
-        CCharEntity* PChar = nullptr;
+        TracyZoneScoped;
 
-        if (PBattleEntity->objtype == TYPE_PC)
+        auto distanceCorrectionGetValue = lua["xi"]["damage"]["distanceCorrection"]["getValue"];
+        if (!distanceCorrectionGetValue.valid())
         {
-            PChar = (CCharEntity*)PBattleEntity;
-        }
-        else // Automaton
-        {
-            if (distance <= 3.0f) // Automaton will generally stay around 3' from the target.
-                return 1.0f;
-            if (distance <= 25.0f) // Beyond 3' linearly drop 1%/yalm
-                return 1.0f - (distance / 100.0f);
-
-            return 0.75f; // Cap at 0.75 modifier past 25 yalms
+            sol::error err = distanceCorrectionGetValue;
+            ShowError("battleutils::GetRangedDistanceCorrection: %s", err.what());
+            return 1.00f;
         }
 
-        if (PChar == nullptr)
+        auto result = distanceCorrectionGetValue(CLuaBaseEntity(PBattleEntity), distance);
+        if (!result.valid())
         {
-            return 1.0f; // Just in case PChar is null, then we will just return full damage.
+            sol::error err = result;
+            ShowError("battleutils::GetRangedDistanceCorrection: %s", err.what());
+            return 1.00f;
         }
 
-        uint8 RMainType = 0;
-        uint8 RMainSub  = 0;
-
-        CItemEquipment* PRangedSlot = PChar->getEquip(SLOT_RANGED);
-
-        if (PRangedSlot)
-        {
-            RMainType = ((CItemWeapon*)PRangedSlot)->getSkillType();
-            RMainSub  = ((CItemWeapon*)PRangedSlot)->getSubSkillType();
-        }
-
-        bool LongBowCurve  = (RMainType == 25 && RMainSub == 9);                                         // Longbows Only
-        bool CrossBowCurve = ((RMainType == 25 && RMainSub == 0) || (RMainType == 26 && RMainSub == 0)); // Crossbows and Shortbows
-        bool GunCurve      = (RMainType == 26 && RMainSub == 1);                                         // Guns Only
-
-        if (LongBowCurve)
-        {
-            if (distance <= 3.00f) // <=3'
-                return 0.65f + ((1.67f * distance) / 100);
-            if (distance <= 5.00f) // <=5.0'
-                return 0.65f + ((2.60f * distance) / 100);
-            if (distance < 7.50f) // <7.5'
-                return 0.65f + ((4.66f * distance) / 100);
-            if (distance <= 10.50f) // Sweet Spot from 7.5' to 10.5'
-                return 1.00f;
-            if (distance <= 15.00f) // <=15.0'
-                return 1.00f + ((-1.78f * distance) / 100);
-            if (distance <= 20.00f) // <=20.0'
-                return 1.00f + ((-1.15f * distance) / 100);
-
-            return 1.00f + ((-0.90f * distance) / 100); // Default to >20' Curve w/o Cap
-        }
-        else if (CrossBowCurve)
-        {
-            if (distance <= 3.00f) // <=3'
-                return 0.65f + ((3.30f * distance) / 100);
-            if (distance <= 5.00f) // <=5'
-                return 0.65f + ((4.40f * distance) / 100);
-            if (distance < 6.00f) // <6'
-                return 0.65f + ((5.83f * distance) / 100);
-            if (distance <= 10.00f) // Sweet Spot from 6' to 10'
-                return 1.00f;
-            if (distance <= 15.00f) // <=15'
-                return 1.00f + ((-2.00f * distance) / 100);
-            if (distance <= 20.00f) // <=20'
-                return 1.00f + ((-1.10f * distance) / 100);
-
-            return 0.86f; // Default to >20' Curve w/ 86% Cap
-        }
-        else if (GunCurve)
-        {
-            if (distance <= 3.00f) // <=3'
-                return 0.75 + ((3.33f * distance) / 100);
-            if (distance < 4.50f) // <4.5'
-                return 0.75 + ((5.56f * distance) / 100);
-            if (distance <= 5.50f) // Sweet spot from 4.5' to 5.5'
-                return 1.00f;
-            if (distance <= 7.50f) // <=7.5'
-                return 1.00f + ((-2.50f * distance) / 100);
-            if (distance <= 10) // <=10'
-                return 1.00f + ((-2.22f * distance) / 100);
-            if (distance <= 15) // <=15'
-                return 1.00f + ((-1.26f * distance) / 100);
-            if (distance <= 20) // <=20'
-                return 1.00f + ((-0.96f * distance) / 100);
-
-            return 1.00f + ((-0.67f * distance) / 100);
-        }
-        else // Default to Throwing Curve
-        {
-            if (distance <= 1.0f)
-                return 1.00f; // Sweet Spot Under or at 1'
-
-            return 1.00f - ((1.00f * distance) / 100); // Lose 1%/yalm
-        }
+        return result.get_type() == sol::type::number ? result.get<float>() : 1.0f;
     }
 
     float CheckLiementAbsorb(CBattleEntity* PBattleEntity, DAMAGE_TYPE DamageType)

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -103,6 +103,7 @@ namespace battleutils
     void LoadMobSkillsList();
     void LoadPetSkillsList();
     void LoadSkillChainDamageModifiers();
+    void LoadDistanceCorrection();
 
     uint8 CheckMultiHits(CBattleEntity* PEntity, CItemWeapon* PWeapon);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

N/A development only

## What does this pull request do? (Please be technical)

Converted distance correction function from C++ into Lua. This allows it to be overwritten by modules or turned off (Bypassed) which is era accurate before July 19, 2005.

Some examples below:
```lua
-- Velocity Shot bypasses distance correction
m:addOverride("xi.damage.distanceCorrection.getValue", function(attacker, distance)
    if attacker:isPC() and attacker:hasStatusEffect(xi.effect.VELOCITY_SHOT) then
        return 1.00
    else
        return super(attacker, distance)
    end
end)

-- Distance correction only applies in parties
m:addOverride("xi.damage.distanceCorrection.getValue", function(attacker, distance)
    if attacker:isPC() and attacker:getPartySize() > 1 then
        return super(attacker, distance)
    else
        return 1.00
    end
end)

-- Turn off distance correction (era before July 19, 2005)
m:addOverride("xi.damage.distanceCorrection.getValue", function(attacker, distance)
    return 1.00
end)
```

The values have been converted into a table so they can be easily overwritten to make adjustments on a per server basis.

Example:
```lua
xi.damage.distanceCorrection.table.LONGBOW =
{
    { range =  3.00, base = 0.65, modifier =  2.60 }, -- <=3'
    { range =  5.49, base = 0.65, modifier =  4.66 }, -- <5.5'
    { range = 10.50, base = 1.00, modifier =   nil }, -- Sweet Spot from 5.5' to 10.5'
    { range = 15.00, base = 1.00, modifier = -1.78 }, -- <=15.0'
    { range = 20.00, base = 1.00, modifier = -1.15 }, -- <=20.0'
    { range =   nil, base = 1.00, modifier = -0.90 }, -- Default to >20' Curve w/o Cap
}
```

## Steps to test these changes

Test longbow, crossbow and gun at a variety of distances and compare results.
https://ffxiclopedia.fandom.com/wiki/Distance#Distance_and_Ranged_Attack

## Special Deployment Considerations

N/A
