### PR TITLE
Converts Blackmail to IF

### DIFF
--- a/scripts/quests/sandoria/Blackmail.lua
+++ b/scripts/quests/sandoria/Blackmail.lua
@@ -1,0 +1,128 @@
+-----------------------------------
+-- Blackmail
+-----------------------------------
+-- Log ID: 0, Quest ID: 71
+-- Dauperiat !gotoid 17723525
+-- Halver !gotoid 17731591
+-----------------------------------
+require('scripts/globals/items')
+require('scripts/globals/npc_util')
+require('scripts/globals/quests')
+require('scripts/globals/zone')
+require('scripts/globals/interaction/quest')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL)
+
+quest.reward =
+{
+    fame = 30,
+    fameArea = xi.quest.fame_area.SANDORIA,
+    gil = 900,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE and
+            player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 3 -- Rank 3 for home nation is assumed to get into Chateau... no need to check for it
+        end,
+
+        [xi.zone.NORTHERN_SAN_DORIA] =
+        {
+            ['Dauperiat']  = quest:progressEvent(643),
+
+            onEventFinish =
+            {
+                [643] = function(player, csid, option, npc)
+                    quest:begin(player)
+                    npcUtil.giveKeyItem(player, xi.ki.SUSPICIOUS_ENVELOPE)
+                end,
+            },
+        },
+    },
+
+    -- These functions check the status of ~= QUEST_AVAILABLE to support repeating
+    -- the quest.  Does not have to be flagged again to complete an additional time.
+    {
+        check = function(player, status, vars)
+            return status ~= QUEST_AVAILABLE
+        end,
+
+        [xi.zone.NORTHERN_SAN_DORIA] =
+        {
+            ['Dauperiat'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if
+                        npcUtil.tradeHasExactly(trade, { { xi.items.CASTLE_FLOOR_PLANS, 1 } }) and
+                        quest:getVar(player, 'Prog') == 2
+                        then
+                            return quest:progressEvent(648, 0, 530)
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.SUSPICIOUS_ENVELOPE) then
+                        return quest:event(645)
+                    elseif quest:getVar(player, 'Prog') == 1 then
+                        return quest:progressEvent(646, 0, 530)
+                    elseif quest:getVar(player, 'Prog') == 2 then
+                        return quest:event(647, 0, 530)
+                    elseif player:hasCompletedQuest(quest.areaId, quest.questId) then
+                        return quest:event(650, 0, 530)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [646] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:setVar(player, 'Prog', 2)
+                    end
+                end,
+
+                [648] = function(player, csid, option, npc)
+                    player:confirmTrade()
+                        if not player:hasCompletedQuest(quest.areaId, quest.questId) then
+                            quest:complete(player)
+                        else
+                            player:addFame(xi.quest.fame_area.SANDORIA, 5)
+                            npcUtil.giveCurrency(player, "gil", xi.settings.main.GIL_RATE * 900)
+                            quest:setVar(player, 'Prog', 0)
+                        end
+                end,
+
+                [650] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:setVar(player, 'Prog', 2)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.CHATEAU_DORAGUILLE] =
+        {
+            ['Halver'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.SUSPICIOUS_ENVELOPE) then
+                        return quest:event(549)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [549] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                    player:delKeyItem(xi.ki.SUSPICIOUS_ENVELOPE)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
@@ -29,14 +29,6 @@ entity.onTrigger = function(player, npc)
         not utils.mask.getBit(wildcatSandy, 16)
     then
         player:startEvent(558)
-    -- Blackmail quest
-    elseif
-        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL) == QUEST_ACCEPTED and
-        player:hasKeyItem(xi.ki.SUSPICIOUS_ENVELOPE)
-    then
-        player:startEvent(549)
-        player:setCharVar("BlackMailQuest", 1)
-        player:delKeyItem(xi.ki.SUSPICIOUS_ENVELOPE)
     elseif pNation == xi.nation.SANDORIA then
         -- Rank 10 default dialogue
         if player:getRank(player:getNation()) == 10 then

--- a/scripts/zones/Northern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Northern_San_dOria/DefaultActions.lua
@@ -6,6 +6,7 @@ return {
     ['Ailbeche']   = { event = 868 },
     ['Bacherume']  = { text = ID.text.BACHERUME_DIALOG },
     ['Chasalvige'] = { event = 6 },
+    ['Dauperiat']  = { event = 641 },
     ['Eperdur']    = { event = 678 },
     ['Gilipese']   =
     {

--- a/scripts/zones/Northern_San_dOria/npcs/Dauperiat.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Dauperiat.lua
@@ -14,70 +14,15 @@ local ID = require("scripts/zones/Northern_San_dOria/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local black = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL)
-    local questState = player:getCharVar("BlackMailQuest")
-
-    if black == QUEST_ACCEPTED and questState == 2 or black == QUEST_COMPLETED then
-        if trade:hasItemQty(530, 1) and trade:getItemCount() == 1 then
-            player:startEvent(648, 0, 530) --648
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    -- "Blackmail" quest status
-    local blackMail = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL)
-    local sanFame = player:getFameLevel(xi.quest.fame_area.SANDORIA)
-    local homeRank = player:getRank(player:getNation())
-    local questState = player:getCharVar("BlackMailQuest")
-
-    if blackMail == QUEST_AVAILABLE and sanFame >= 3 and homeRank >= 3 then
-        player:startEvent(643) -- 643 gives me letter
-    elseif
-        blackMail == QUEST_ACCEPTED and
-        player:hasKeyItem(xi.ki.SUSPICIOUS_ENVELOPE)
-    then
-        player:startEvent(645)  -- 645 recap, take envelope!
-
-    elseif blackMail == QUEST_ACCEPTED and questState == 1 then
-        player:startEvent(646, 0, 530) --646  after giving letter to H, needs param
-
-    elseif blackMail == QUEST_ACCEPTED and questState == 2 then
-        player:startEvent(647, 0, 530) --647 recap of 646
-
-    else
-        if player:needToZone() then
-            player:startEvent(642) --642 Quiet!
-        else
-            player:startEvent(641) --641 -- Quiet! leave me alone
-            player:needToZone(true)
-        end
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 643 then
-        player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL)
-        player:addKeyItem(xi.ki.SUSPICIOUS_ENVELOPE)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.SUSPICIOUS_ENVELOPE)
-    elseif csid == 646 and option == 1 then
-        player:setCharVar("BlackMailQuest", 2)
-    elseif csid == 648 then
-        player:tradeComplete()
-        player:addGil(xi.settings.main.GIL_RATE * 900)
-        player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 900)
-        if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL) == QUEST_ACCEPTED then
-            player:addFame(xi.quest.fame_area.SANDORIA, 30)
-            player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL)
-        else
-            player:addFame(xi.quest.fame_area.SANDORIA, 5)
-        end
-    elseif csid == 40 and option == 1 then
-        player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL)
-    end
 end
 
 return entity


### PR DESCRIPTION
Corrects some dialog issues when repeating the quest.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Addresses issues where players may not be able to complete/repeat the quest "Blackmail". 
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Converts to IF - updated the correct dialog tables to accept the repeatable portion of the quest. Verified that the original turn in will give the correct (30) fame and subsequent will give 5. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!gotoid 17723525 - accept quest
!gotoid 17731591 - havler
back to 17723525 for next portion (retrieve castle floor plans (!additem 530)
trade floor plans - get reward
speak to Dauperiat again and will be presented with correct dialog to repeat 
Added check in to ensure player has accepted the repeat portion.
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
SQL statement one time run. 

UPDATE `char_vars` SET `varname` = 'Quest[0][71]Prog' WHERE `varname` = "BlackMailQuest";

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
