### PR TITLE
Tango with a Tracker Adjustment

### DIFF
--- a/scripts/quests/otherAreas/Tango_with_a_Tracker.lua
+++ b/scripts/quests/otherAreas/Tango_with_a_Tracker.lua
@@ -54,7 +54,7 @@ quest.sections =
             {
                 [576] = function(player, csid, option, npc)
                         npcUtil.giveKeyItem(player, xi.ki.LETTER_FROM_SHIKAREE_X)
-                        player:addGil(10000)
+                        npcUtil.giveCurrency(player, "gil", xi.settings.main.GIL_RATE * 10000)
                 end,
             },
         }

--- a/scripts/quests/otherAreas/Tango_with_a_Tracker.lua
+++ b/scripts/quests/otherAreas/Tango_with_a_Tracker.lua
@@ -55,6 +55,7 @@ quest.sections =
                 [576] = function(player, csid, option, npc)
                         npcUtil.giveKeyItem(player, xi.ki.LETTER_FROM_SHIKAREE_X)
                         npcUtil.giveCurrency(player, "gil", xi.settings.main.GIL_RATE * 10000)
+                        player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 10000)
                 end,
             },
         }

--- a/scripts/quests/otherAreas/Tango_with_a_Tracker.lua
+++ b/scripts/quests/otherAreas/Tango_with_a_Tracker.lua
@@ -54,6 +54,7 @@ quest.sections =
             {
                 [576] = function(player, csid, option, npc)
                         npcUtil.giveKeyItem(player, xi.ki.LETTER_FROM_SHIKAREE_X)
+                        player:addGil(10000)
                 end,
             },
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

Adjusted rewards for quest Tango with a Tracker to properly reflect the wiki rewards as of February 2006, as seen [here](https://ffxiclopedia.fandom.com/wiki/Tango_with_a_Tracker?oldid=51284).

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Adds the 10,000 gil reward. Reference issue originates from the HorizonXI Issue Tracker and can be found [here](https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1212).

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

Attempted fight on several different characters, tests yielded optimal results and properly adjusted gil amounts. Tested fight a total of 10 times.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
