### PR TITLE
Adds configurable EXP Scroll rate.

### DIFF
--- a/modules/custom/lua/custom_scroll_exp_rate.lua
+++ b/modules/custom/lua/custom_scroll_exp_rate.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- Allow custom rate of exp scrolls.
+-----------------------------------
+require("scripts/globals/status")
+-----------------------------------
+local m = Module:new("custom_scroll_exp_rate")
+
+-- Only apply overrides if the config is present and meaningful
+if
+    xi.settings.main.SCROLL_EXP_RATE and
+    xi.settings.main.SCROLL_EXP_RATE ~= 1
+then
+    m:addOverride("xi.globals.items.copy_of_ginuvas_battle_theory.onItemUse", function(target)
+        target:addExp(xi.settings.main.EXP_RATE * math.random(50, 200) * xi.settings.main.SCROLL_EXP_RATE)
+    end)
+
+    m:addOverride("xi.globals.items.copy_of_schultz_stratagems.onItemUse", function(target)
+      target:addExp(xi.settings.main.EXP_RATE * math.random(150, 500) * xi.settings.main.SCROLL_EXP_RATE)
+    end)
+
+    m:addOverride("xi.globals.items.page_from_balrahns_reflections.onItemUse", function(target)
+      target:addExp(xi.settings.main.EXP_RATE * math.random(200, 500) * xi.settings.main.SCROLL_EXP_RATE)
+    end)
+
+    m:addOverride("xi.globals.items.page_from_miratetes_memoirs.onItemUse", function(target)
+      target:addExp(xi.settings.main.EXP_RATE * math.random(750, 1500) * xi.settings.main.SCROLL_EXP_RATE)
+    end)
+
+    m:addOverride("xi.globals.items.page_from_the_dragon_chronicles.onItemUse", function(target)
+      target:addExp(xi.settings.main.EXP_RATE * math.random(500, 1000) * xi.settings.main.SCROLL_EXP_RATE)
+    end)
+end
+
+return m

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -112,6 +112,7 @@ xi.settings.main =
     BAYLD_RATE      = 1.000, -- Multiples bayld earned from quests.
     -- Note: EXP rates are also influenced by conf setting
     EXP_RATE        = 1.000, -- Multiplies exp from script (except FoV/GoV).
+    SCROLL_EXP_RATE = 1.000, -- Multiplies exp from single use XP Scrolls (e.g. Miratete's Memoirs).
     BOOK_EXP_RATE   = 1.000, -- Multiplies exp from FoV/GoV book pages.
     TABS_RATE       = 1.000, -- Multiplies tabs earned from fov.
     ROE_EXP_RATE    = 1.000, -- Multiplies exp earned from records of eminence.


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Adds a server configuration to modify the rate of EXP gained from EXP Scrolls.

## What does this pull request do? (Please be technical)

Adds configurable EXP Scroll rate.
Note that this rate is multiplicative with the base EXP_RATE
```target:addExp(xi.settings.main.EXP_RATE * math.random(750, 1500) * xi.settings.main.SCROLL_EXP_RATE)```

## Steps to test these changes

Set the config, use a page.
0 makes pages worthless
1.0 makes em normal
greater than 1.0 makes em worth more

Here is an example with 20.0
![image](https://user-images.githubusercontent.com/105882290/227659802-274382ea-8ded-4ca9-8e0a-258eb6413ea9.png)


## Special Deployment Considerations
This is an update to Settings/main.lua - new setting ```SCROLL_EXP_RATE```
modules/init.txt should have the following added to the custom section:
```
custom/lua/custom_scroll_exp_rate.lua
```
