### PR TITLE
Fix several Enchantment and status effect gear issues

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -3732,6 +3732,7 @@ xi.items =
     VALOR_CAPE                      = 15481,
     BARDS_CAPE                      = 15482,
     SUMMONERS_CAPE                  = 15484,
+    BREATH_MANTLE                   = 15486,
     HIGH_BREATH_MANTLE              = 15487,
     GUNNERS_MANTLE                  = 15488,
     STORM_CAPE                      = 15489,

--- a/scripts/globals/items/acrobats_belt.lua
+++ b/scripts/globals/items/acrobats_belt.lua
@@ -10,16 +10,17 @@ require("scripts/globals/items")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.ACROBATS_BELT then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ACROBATS_BELT) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ACROBATS_BELT)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.ACROBATS_BELT)
+    if target:hasEquipped(xi.items.ACROBATS_BELT) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.ACROBATS_BELT)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/aero_mufflers.lua
+++ b/scripts/globals/items/aero_mufflers.lua
@@ -7,11 +7,6 @@ require("scripts/globals/items")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENAERO)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.AERO_MUFFLERS then
-        target:delStatusEffect(xi.effect.ENAERO)
-    end
-
     return 0
 end
 

--- a/scripts/globals/items/aiming_gloves.lua
+++ b/scripts/globals/items/aiming_gloves.lua
@@ -10,16 +10,17 @@ require("scripts/globals/items")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.AIMING_GLOVES then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.AIMING_GLOVES) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.AIMING_GLOVES)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.AIMING_GLOVES)
+    if target:hasEquipped(xi.items.AIMING_GLOVES) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.AIMING_GLOVES)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/armored_ring.lua
+++ b/scripts/globals/items/armored_ring.lua
@@ -9,19 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.ARMORED_RING
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ARMORED_RING) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ARMORED_RING)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.ARMORED_RING)
+    if target:hasEquipped(xi.items.ARMORED_RING) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.ARMORED_RING)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/assailants_axe.lua
+++ b/scripts/globals/items/assailants_axe.lua
@@ -9,19 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.ASSAILANTS_AXE
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ASSAILANTS_AXE) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ASSAILANTS_AXE)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.ASSAILANTS_AXE)
+    if target:hasEquipped(xi.items.ASSAILANTS_AXE) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.ASSAILANTS_AXE)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/assassins_ring.lua
+++ b/scripts/globals/items/assassins_ring.lua
@@ -9,19 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.ASSASSINS_RING
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ASSASSINS_RING) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ASSASSINS_RING)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.ASSASSINS_RING)
+    if target:hasEquipped(xi.items.ASSASSINS_RING) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.ASSASSINS_RING)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/astral_pot.lua
+++ b/scripts/globals/items/astral_pot.lua
@@ -10,22 +10,21 @@ require("scripts/globals/msg")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
     local pet = target:getPet()
     if not pet then
         return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.ASTRAL_POT
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    elseif target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ASTRAL_POT) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ASTRAL_POT)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 300, 0, 0, 0, xi.items.ASTRAL_POT)
+    local pet = target:getPet()
+    if target:hasEquipped(xi.items.ASTRAL_POT) and pet ~= nil then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 300, 0, 0, 0, xi.items.ASTRAL_POT)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/augmenting_belt.lua
+++ b/scripts/globals/items/augmenting_belt.lua
@@ -9,19 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.AUGMENTING_BELT
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.AUGMENTING_BELT) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.AUGMENTING_BELT)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.AUGMENTING_BELT)
+    if target:hasEquipped(xi.items.AUGMENTING_BELT) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.AUGMENTING_BELT)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/bag_of_wyvern_feed.lua
+++ b/scripts/globals/items/bag_of_wyvern_feed.lua
@@ -10,22 +10,21 @@ require("scripts/globals/msg")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
     local pet = target:getPet()
     if not pet then
         return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.BAG_OF_WYVERN_FEED
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    elseif target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.BAG_OF_WYVERN_FEED) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.BAG_OF_WYVERN_FEED)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.BAG_OF_WYVERN_FEED)
+    local pet = target:getPet()
+    if target:hasEquipped(xi.items.BAG_OF_WYVERN_FEED) and pet ~= nil then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.BAG_OF_WYVERN_FEED)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/bannaret_mail.lua
+++ b/scripts/globals/items/bannaret_mail.lua
@@ -9,19 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.BANNARET_MAIL
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.BANNARET_MAIL) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.BANNARET_MAIL)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.BANNARET_MAIL)
+    if target:hasEquipped(xi.items.BANNARET_MAIL) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.BANNARET_MAIL)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/blaze_hose.lua
+++ b/scripts/globals/items/blaze_hose.lua
@@ -9,18 +9,11 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.BLAZE_SPIKES)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.BLAZE_HOSE
-    then
-        target:delStatusEffect(xi.effect.BLAZE_SPIKES)
-    end
-
     return 0
 end
 
 itemObject.onItemUse = function(target)
+    target:delStatusEffect(xi.effect.BLAZE_SPIKES)
     target:addStatusEffect(xi.effect.BLAZE_SPIKES, 15, 0, 180, 0, 0, 0, xi.items.BLAZE_HOSE)
 end
 

--- a/scripts/globals/items/blink_band.lua
+++ b/scripts/globals/items/blink_band.lua
@@ -9,14 +9,6 @@ require("scripts/globals/msg")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.BLINK)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.BLINK_BAND
-    then
-        target:delStatusEffect(xi.effect.BLINK)
-    end
-
     return 0
 end
 

--- a/scripts/globals/items/blizzard_gloves.lua
+++ b/scripts/globals/items/blizzard_gloves.lua
@@ -6,14 +6,6 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENBLIZZARD)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.BLIZZARD_GLOVES
-    then
-        target:delStatusEffect(xi.effect.ENBLIZZARD)
-    end
-
     return 0
 end
 

--- a/scripts/globals/items/breath_mantle.lua
+++ b/scripts/globals/items/breath_mantle.lua
@@ -9,21 +9,15 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil then
-        if effect:getItemSourceID() == xi.items.BREATH_MANTLE then
-            target:delStatusEffect(xi.effect.ENCHANTMENT)
-        end
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.BREATH_MANTLE) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.BREATH_MANTLE)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.ENCHANTMENT) then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
-        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.BREATH_MANTLE)
-    else
+    if target:hasEquipped(xi.items.BREATH_MANTLE) then
         target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.BREATH_MANTLE)
     end
 end

--- a/scripts/globals/items/coated_shield.lua
+++ b/scripts/globals/items/coated_shield.lua
@@ -9,14 +9,6 @@ require("scripts/globals/msg")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.SHELL)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.COATED_SHIELD
-    then
-        target:delStatusEffect(xi.effect.SHELL)
-    end
-
     return 0
 end
 

--- a/scripts/globals/items/counter_earring.lua
+++ b/scripts/globals/items/counter_earring.lua
@@ -9,19 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.COUNTER_EARRING
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.COUNTER_EARRING) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.COUNTER_EARRING)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.COUNTER_EARRING)
+    if target:hasEquipped(xi.items.COUNTER_EARRING) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.COUNTER_EARRING)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/czars_belt.lua
+++ b/scripts/globals/items/czars_belt.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.CZARS_BELT then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.CZARS_BELT) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.CZARS_BELT)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.CZARS_BELT)
+    if target:hasEquipped(xi.items.CZARS_BELT) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.CZARS_BELT)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/deadeye_earring.lua
+++ b/scripts/globals/items/deadeye_earring.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.DEADEYE_EARRING then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.DEADEYE_EARRING) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.DEADEYE_EARRING)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.DEADEYE_EARRING)
+    if target:hasEquipped(xi.items.DEADEYE_EARRING) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.DEADEYE_EARRING)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/death_chakram.lua
+++ b/scripts/globals/items/death_chakram.lua
@@ -8,16 +8,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.DEATH_CHAKRAM then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.DEATH_CHAKRAM) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.DEATH_CHAKRAM)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.DEATH_CHAKRAM)
+    if target:hasEquipped(xi.items.DEATH_CHAKRAM) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.DEATH_CHAKRAM)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/deductive_brocade_obi.lua
+++ b/scripts/globals/items/deductive_brocade_obi.lua
@@ -9,19 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.DEDUCTIVE_BROCADE_OBI
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.DEDUCTIVE_BROCADE_OBI) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.DEDUCTIVE_BROCADE_OBI)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.DEDUCTIVE_BROCADE_OBI)
+    if target:hasEquipped(xi.items.DEDUCTIVE_BROCADE_OBI) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.DEDUCTIVE_BROCADE_OBI)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/dhalmel_whistle.lua
+++ b/scripts/globals/items/dhalmel_whistle.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.DHALMEL_WHISTLE then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.DHALMEL_WHISTLE) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.DHALMEL_WHISTLE)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.DHALMEL_WHISTLE)
+    if target:hasEquipped(xi.items.DHALMEL_WHISTLE) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.DHALMEL_WHISTLE)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/eldritch_bone_hairpin.lua
+++ b/scripts/globals/items/eldritch_bone_hairpin.lua
@@ -9,19 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.ELDRITCH_BONE_HAIRPIN
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ELDRITCH_BONE_HAIRPIN) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ELDRITCH_BONE_HAIRPIN)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.ELDRITCH_BONE_HAIRPIN)
+    if target:hasEquipped(xi.items.ELDRITCH_BONE_HAIRPIN) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.ELDRITCH_BONE_HAIRPIN)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/eldritch_horn_hairpin.lua
+++ b/scripts/globals/items/eldritch_horn_hairpin.lua
@@ -9,19 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.ELDRITCH_HORN_HAIRPIN
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ELDRITCH_HORN_HAIRPIN) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ELDRITCH_HORN_HAIRPIN)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.ELDRITCH_HORN_HAIRPIN)
+    if target:hasEquipped(xi.items.ELDRITCH_HORN_HAIRPIN) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.ELDRITCH_HORN_HAIRPIN)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/enthralling_brocade_obi.lua
+++ b/scripts/globals/items/enthralling_brocade_obi.lua
@@ -9,19 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if
-        effect ~= nil and
-        effect:getItemSourceID() == xi.items.ENTHRALLING_BROCADE_OBI
-    then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ENTHRALLING_BROCADE_OBI) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.ENTHRALLING_BROCADE_OBI)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.ENTHRALLING_BROCADE_OBI)
+    if target:hasEquipped(xi.items.ENTHRALLING_BROCADE_OBI) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.ENTHRALLING_BROCADE_OBI)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/flexible_pole.lua
+++ b/scripts/globals/items/flexible_pole.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.FLEXIBLE_POLE then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.FLEXIBLE_POLE) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.FLEXIBLE_POLE)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.FLEXIBLE_POLE)
+    if target:hasEquipped(xi.items.FLEXIBLE_POLE) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.FLEXIBLE_POLE)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/gamushara_earring.lua
+++ b/scripts/globals/items/gamushara_earring.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.GAMUSHARA_EARRING then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.GAMUSHARA_EARRING) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.GAMUSHARA_EARRING)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.GAMUSHARA_EARRING)
+    if target:hasEquipped(xi.items.GAMUSHARA_EARRING) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.GAMUSHARA_EARRING)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/getsul_ring.lua
+++ b/scripts/globals/items/getsul_ring.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.GETSUL_RING then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.GETSUL_RING) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.GETSUL_RING)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.GETSUL_RING)
+    if target:hasEquipped(xi.items.GETSUL_RING) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.GETSUL_RING)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/gimlet_spear.lua
+++ b/scripts/globals/items/gimlet_spear.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.GIMLET_SPEAR then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.GIMLET_SPEAR) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.GIMLET_SPEAR)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.GIMLET_SPEAR)
+    if target:hasEquipped(xi.items.GIMLET_SPEAR) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.GIMLET_SPEAR)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/hallowed_sword.lua
+++ b/scripts/globals/items/hallowed_sword.lua
@@ -18,19 +18,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENLIGHT
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.HALLOWED_SWORD) then
+        local effect = xi.effect.ENLIGHT
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.HALLOWED_SWORD)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.HALLOWED_SWORD)
 end
 
 return itemObject

--- a/scripts/globals/items/haste_belt.lua
+++ b/scripts/globals/items/haste_belt.lua
@@ -18,10 +18,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if not target:hasStatusEffect(xi.effect.HASTE) then
-        target:addStatusEffect(xi.effect.HASTE, 1000, 0, 180, 0, 0, 0, xi.items.HASTE_BELT)
-    else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    if target:hasEquipped(xi.items.HASTE_BELT) then
+        if not target:hasStatusEffect(xi.effect.HASTE) then
+            target:addStatusEffect(xi.effect.HASTE, 1000, 0, 180, 0, 0, 0, xi.items.HASTE_BELT)
+        else
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        end
     end
 end
 

--- a/scripts/globals/items/healing_feather.lua
+++ b/scripts/globals/items/healing_feather.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.HEALING_FEATHER then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HEALING_FEATHER) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HEALING_FEATHER)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.HEALING_FEATHER)
+    if target:hasEquipped(xi.items.HEALING_FEATHER) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.HEALING_FEATHER)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/high_breath_mantle.lua
+++ b/scripts/globals/items/high_breath_mantle.lua
@@ -9,21 +9,15 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil then
-        if effect:getItemSourceID() == xi.items.HIGH_BREATH_MANTLE then
-            target:delStatusEffect(xi.effect.ENCHANTMENT)
-        end
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HIGH_BREATH_MANTLE) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HIGH_BREATH_MANTLE)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.ENCHANTMENT) then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
-        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.HIGH_BREATH_MANTLE)
-    else
+    if target:hasEquipped(xi.items.HIGH_BREATH_MANTLE) then
         target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.HIGH_BREATH_MANTLE)
     end
 end

--- a/scripts/globals/items/high_mana_wand.lua
+++ b/scripts/globals/items/high_mana_wand.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.HIGH_MANA_WAND then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HIGH_MANA_WAND) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HIGH_MANA_WAND)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.HIGH_MANA_WAND)
+    if target:hasEquipped(xi.items.HIGH_MANA_WAND) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.HIGH_MANA_WAND)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/hydra_doublet.lua
+++ b/scripts/globals/items/hydra_doublet.lua
@@ -18,10 +18,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.REFRESH) then
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
-    else
-        target:addStatusEffect(xi.effect.REFRESH, 4, 3, 180, 0, 0, 0, xi.items.HYDRA_DOUBLET)
+    if target:hasEquipped(xi.items.HYDRA_DOUBLET) then
+        if target:hasStatusEffect(xi.effect.REFRESH) then
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        else
+            target:addStatusEffect(xi.effect.REFRESH, 4, 3, 180, 0, 0, 0, xi.items.HYDRA_DOUBLET)
+        end
     end
 end
 

--- a/scripts/globals/items/hydra_harness.lua
+++ b/scripts/globals/items/hydra_harness.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.HYDRA_HARNESS then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HYDRA_HARNESS) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HYDRA_HARNESS)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.HYDRA_HARNESS)
+    if target:hasEquipped(xi.items.HYDRA_HARNESS) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.HYDRA_HARNESS)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/hydra_haubert.lua
+++ b/scripts/globals/items/hydra_haubert.lua
@@ -21,10 +21,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.REFRESH) then
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
-    else
-        target:addStatusEffect(xi.effect.REFRESH, 4, 3, 180, 0, 0, 0, xi.items.HYDRA_HAUBERT)
+    if target:hasEquipped(xi.items.HYDRA_HARNESS) then
+        if target:hasStatusEffect(xi.effect.REFRESH) then
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        else
+            target:addStatusEffect(xi.effect.REFRESH, 4, 3, 180, 0, 0, 0, xi.items.HYDRA_HAUBERT)
+        end
     end
 end
 

--- a/scripts/globals/items/hydra_mittens.lua
+++ b/scripts/globals/items/hydra_mittens.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.HYDRA_MITTENS then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HYDRA_MITTENS) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HYDRA_MITTENS)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.HYDRA_MITTENS)
+    if target:hasEquipped(xi.items.HYDRA_MITTENS) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.HYDRA_MITTENS)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/hydra_spats.lua
+++ b/scripts/globals/items/hydra_spats.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.EVASION_BOOST, 15, 0, 1200, 0, 0, 0, xi.items.HYDRA_SPATS)
+    if target:hasEquipped(xi.items.HYDRA_SPATS) then
+        target:addStatusEffect(xi.effect.EVASION_BOOST, 15, 0, 1200, 0, 0, 0, xi.items.HYDRA_SPATS)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/hydra_tiara.lua
+++ b/scripts/globals/items/hydra_tiara.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.POTENCY, 7, 0, 180, 0, 0, 0, xi.items.HYDRA_TIARA)
+    if target:hasEquipped(xi.items.HYDRA_TIARA) then
+        target:addStatusEffect(xi.effect.POTENCY, 7, 0, 180, 0, 0, 0, xi.items.HYDRA_TIARA)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/hydra_tights.lua
+++ b/scripts/globals/items/hydra_tights.lua
@@ -19,10 +19,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if not target:hasStatusEffect(xi.effect.HASTE) then
-        target:addStatusEffect(xi.effect.HASTE, 1000, 0, 180, 0, 0, 0, xi.items.HYDRA_TIGHTS)
-    else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    if target:hasEquipped(xi.items.HYDRA_TIGHTS) then
+        if not target:hasStatusEffect(xi.effect.HASTE) then
+            target:addStatusEffect(xi.effect.HASTE, 1000, 0, 180, 0, 0, 0, xi.items.HYDRA_TIGHTS)
+        else
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        end
     end
 end
 

--- a/scripts/globals/items/ice_trousers.lua
+++ b/scripts/globals/items/ice_trousers.lua
@@ -9,11 +9,6 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ICE_SPIKES)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.ICE_TROUSERS then
-        target:delStatusEffect(xi.effect.ICE_SPIKES)
-    end
-
     return 0
 end
 

--- a/scripts/globals/items/invisible_mantle.lua
+++ b/scripts/globals/items/invisible_mantle.lua
@@ -19,10 +19,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.INVISIBLE) then
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
-    else
-        target:addStatusEffect(xi.effect.INVISIBLE, 0, 10, math.floor(180 * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER), 0, 0, 0, xi.items.INVISIBLE_MANTLE)
+    if target:hasEquipped(xi.items.INVISIBLE_MANTLE) then
+        if target:hasStatusEffect(xi.effect.INVISIBLE) then
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        else
+            target:addStatusEffect(xi.effect.INVISIBLE, 0, 10, math.floor(180 * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER), 0, 0, 0, xi.items.INVISIBLE_MANTLE)
+        end
     end
 end
 

--- a/scripts/globals/items/janizary_earring.lua
+++ b/scripts/globals/items/janizary_earring.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.DEFENSE_BOOST, 32, 0, 180, 0, 0, 0, xi.items.JANIZARY_EARRING)
+    if target:hasEquipped(xi.items.JANIZARY_EARRING) then
+        target:addStatusEffect(xi.effect.DEFENSE_BOOST, 32, 0, 180, 0, 0, 0, xi.items.JANIZARY_EARRING)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/jolt_axe.lua
+++ b/scripts/globals/items/jolt_axe.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ATTACK_BOOST, 3, 0, 1800, 0, 0, 0, xi.items.JOLT_AXE)
+    if target:hasEquipped(xi.items.JOLT_AXE) then
+        target:addStatusEffect(xi.effect.ATTACK_BOOST, 3, 0, 1800, 0, 0, 0, xi.items.JOLT_AXE)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/keen_zaghnal.lua
+++ b/scripts/globals/items/keen_zaghnal.lua
@@ -19,7 +19,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ACCURACY_BOOST, 3, 0, 1800, 0, 0, 0, xi.items.KEEN_ZAGHNAL)
+    if target:hasEquipped(xi.items.KEEN_ZAGHNAL) then
+        target:addStatusEffect(xi.effect.ACCURACY_BOOST, 3, 0, 1800, 0, 0, 0, xi.items.KEEN_ZAGHNAL)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/koen.lua
+++ b/scripts/globals/items/koen.lua
@@ -16,19 +16,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENFIRE
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.KOEN) then
+        local effect = xi.effect.ENFIRE
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.KOEN)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.KOEN)
 end
 
 return itemObject

--- a/scripts/globals/items/maharajas_belt.lua
+++ b/scripts/globals/items/maharajas_belt.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.MAHARAJAS_BELT then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.MAHARAJAS_BELT) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.MAHARAJAS_BELT)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.MAHARAJAS_BELT)
+    if target:hasEquipped(xi.items.MAHARAJAS_BELT) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 60, 0, 0, 0, xi.items.MAHARAJAS_BELT)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/mana_wand.lua
+++ b/scripts/globals/items/mana_wand.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.MANA_WAND then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.MANA_WAND) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.MANA_WAND)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.MANA_WAND)
+    if target:hasEquipped(xi.items.MANA_WAND) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.MANA_WAND)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/manashell_ring.lua
+++ b/scripts/globals/items/manashell_ring.lua
@@ -19,7 +19,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.MAX_MP_BOOST, 9, 0, 180, 0, 0, 0, xi.items.MANASHELL_RING)
+    if target:hasEquipped(xi.items.MANASHELL_RING) then
+        target:addStatusEffect(xi.effect.MAX_MP_BOOST, 9, 0, 180, 0, 0, 0, xi.items.MANASHELL_RING)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/melt_baselard.lua
+++ b/scripts/globals/items/melt_baselard.lua
@@ -12,14 +12,14 @@ local itemObject = {}
 itemObject.onItemCheck = function(target)
     local effect = target:getStatusEffect(xi.effect.MAX_MP_BOOST)
     if effect ~= nil and effect:getItemSourceID() == xi.items.MELT_BASELARD then
-        target:delStatusEffect(xi.effect.MAX_MP_BOOST)
+        --target:delStatusEffect(xi.effect.EN)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.EN, 9, 0, 180, 0, 0, 0, xi.items.MELT_BASELARD)
+    --target:addStatusEffect(xi.effect.EN, 9, 0, 180, 0, 0, 0, xi.items.MELT_BASELARD)
 end
 
 return itemObject

--- a/scripts/globals/items/memento_muffler.lua
+++ b/scripts/globals/items/memento_muffler.lua
@@ -19,7 +19,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.VIT_BOOST, 7, 0, 300, 0, 0, 0, xi.items.MEMENTO_MUFFLER)
+    if target:hasEquipped(xi.items.MEMENTO_MUFFLER) then
+        target:addStatusEffect(xi.effect.VIT_BOOST, 7, 0, 300, 0, 0, 0, xi.items.MEMENTO_MUFFLER)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/messhikimaru.lua
+++ b/scripts/globals/items/messhikimaru.lua
@@ -19,7 +19,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ARCANE_CIRCLE, 20, 0, 600, 0, 0, 0, xi.items.MESSHIKIMARU)
+    if target:hasEquipped(xi.items.MESSHIKIMARU) then
+        target:addStatusEffect(xi.effect.ARCANE_CIRCLE, 20, 0, 600, 0, 0, 0, xi.items.MESSHIKIMARU)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/mighty_ring.lua
+++ b/scripts/globals/items/mighty_ring.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.MIGHTY_RING then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.MIGHTY_RING) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.MIGHTY_RING)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.MIGHTY_RING)
+    if target:hasEquipped(xi.items.MIGHTY_RING) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.MIGHTY_RING)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/mist_crown.lua
+++ b/scripts/globals/items/mist_crown.lua
@@ -18,10 +18,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if not target:hasStatusEffect(xi.effect.EVASION_BOOST) then
-        target:addStatusEffect(xi.effect.EVASION_BOOST, 15, 0, 180, 0, 0, 0, xi.items.MIST_CROWN)
-    else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    if target:hasEquipped(xi.items.MIST_CROWN) then
+        if not target:hasStatusEffect(xi.effect.EVASION_BOOST) then
+            target:addStatusEffect(xi.effect.EVASION_BOOST, 15, 0, 180, 0, 0, 0, xi.items.MIST_CROWN)
+        else
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        end
     end
 end
 

--- a/scripts/globals/items/mist_mitts.lua
+++ b/scripts/globals/items/mist_mitts.lua
@@ -18,10 +18,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if not target:hasStatusEffect(xi.effect.EVASION_BOOST) then
-        target:addStatusEffect(xi.effect.EVASION_BOOST, 15, 0, 180, 0, 0, 0, xi.items.MIST_MITTS)
-    else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    if target:hasEquipped(xi.items.MIST_MITTS) then
+        if not target:hasStatusEffect(xi.effect.EVASION_BOOST) then
+            target:addStatusEffect(xi.effect.EVASION_BOOST, 15, 0, 180, 0, 0, 0, xi.items.MIST_MITTS)
+        else
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        end
     end
 end
 

--- a/scripts/globals/items/mist_pumps.lua
+++ b/scripts/globals/items/mist_pumps.lua
@@ -18,10 +18,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if not target:hasStatusEffect(xi.effect.EVASION_BOOST) then
-        target:addStatusEffect(xi.effect.EVASION_BOOST, 15, 0, 180, 0, 0, 0, xi.items.MIST_PUMPS)
-    else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    if target:hasEquipped(xi.items.MIST_PUMPS) then
+        if not target:hasStatusEffect(xi.effect.EVASION_BOOST) then
+            target:addStatusEffect(xi.effect.EVASION_BOOST, 15, 0, 180, 0, 0, 0, xi.items.MIST_PUMPS)
+        else
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        end
     end
 end
 

--- a/scripts/globals/items/mist_slacks.lua
+++ b/scripts/globals/items/mist_slacks.lua
@@ -18,10 +18,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if not target:hasStatusEffect(xi.effect.EVASION_BOOST) then
-        target:addStatusEffect(xi.effect.EVASION_BOOST, 15, 0, 180, 0, 0, 0, xi.items.MIST_SLACKS)
-    else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    if target:hasEquipped(xi.items.MIST_SLACKS) then
+        if not target:hasStatusEffect(xi.effect.EVASION_BOOST) then
+            target:addStatusEffect(xi.effect.EVASION_BOOST, 15, 0, 180, 0, 0, 0, xi.items.MIST_SLACKS)
+        else
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        end
     end
 end
 

--- a/scripts/globals/items/mist_tunic.lua
+++ b/scripts/globals/items/mist_tunic.lua
@@ -18,10 +18,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if not target:hasStatusEffect(xi.effect.EVASION_BOOST) then
-        target:addStatusEffect(xi.effect.EVASION_BOOST, 20, 0, 180, 0, 0, 0, xi.items.MIST_TUNIC)
-    else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    if target:hasEquipped(xi.items.MIST_TUNIC) then
+        if not target:hasStatusEffect(xi.effect.EVASION_BOOST) then
+            target:addStatusEffect(xi.effect.EVASION_BOOST, 20, 0, 180, 0, 0, 0, xi.items.MIST_TUNIC)
+        else
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        end
     end
 end
 

--- a/scripts/globals/items/naruko_earring.lua
+++ b/scripts/globals/items/naruko_earring.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENMITY_BOOST, 10, 0, 180, 0, 0, 0, xi.items.NARUKO_EARRING)
+    if target:hasEquipped(xi.items.NARUKO_EARRING) then
+        target:addStatusEffect(xi.effect.ENMITY_BOOST, 10, 0, 180, 0, 0, 0, xi.items.NARUKO_EARRING)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/pacifist_ring.lua
+++ b/scripts/globals/items/pacifist_ring.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENMITY_DOWN, 12, 0, 180, 0, 0, 0, xi.items.PACIFIST_RING)
+    if target:hasEquipped(xi.items.PACIFIST_RING) then
+        target:addStatusEffect(xi.effect.ENMITY_DOWN, 12, 0, 180, 0, 0, 0, xi.items.PACIFIST_RING)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/palmers_bangles.lua
+++ b/scripts/globals/items/palmers_bangles.lua
@@ -10,16 +10,17 @@ require("scripts/globals/msg")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.PALMERS_BANGLES then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.PALMERS_BANGLES) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.PALMERS_BANGLES)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.PALMERS_BANGLES)
+    if target:hasEquipped(xi.items.PALMERS_BANGLES) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.PALMERS_BANGLES)
+    end
 end
 
 itemObject.onEffectGain = function(target)

--- a/scripts/globals/items/pendragons_belt.lua
+++ b/scripts/globals/items/pendragons_belt.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.DEX_BOOST, 10, 0, 60, 0, 0, 0, xi.items.PENDRAGONS_BELT)
+    if target:hasEquipped(xi.items.PENDRAGONS_BELT) then
+        target:addStatusEffect(xi.effect.DEX_BOOST, 10, 0, 60, 0, 0, 0, xi.items.PENDRAGONS_BELT)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/piercing_dagger.lua
+++ b/scripts/globals/items/piercing_dagger.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ATTACK_BOOST, 3, 0, 1800, 0, 0, 0, xi.items.PIERCING_DAGGER)
+    if target:hasEquipped(xi.items.PIERCING_DAGGER) then
+        target:addStatusEffect(xi.effect.ATTACK_BOOST, 3, 0, 1800, 0, 0, 0, xi.items.PIERCING_DAGGER)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/prominence_axe.lua
+++ b/scripts/globals/items/prominence_axe.lua
@@ -16,19 +16,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.FIRE
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.PROMINENCE_AXE) then
+        local effect = xi.effect.ENFIRE
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.PROMINENCE_AXE)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.PROMINENCE_AXE)
 end
 
 return itemObject

--- a/scripts/globals/items/prominence_sword.lua
+++ b/scripts/globals/items/prominence_sword.lua
@@ -16,19 +16,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.FIRE
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.PROMINENCE_SWORD) then
+        local effect = xi.effect.ENFIRE
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.PROMINENCE_SWORD)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.PROMINENCE_SWORD)
 end
 
 return itemObject

--- a/scripts/globals/items/purgatory_collar.lua
+++ b/scripts/globals/items/purgatory_collar.lua
@@ -10,16 +10,17 @@ require("scripts/globals/msg")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.PURGATORY_COLLAR then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.PURGATORY_COLLAR) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.PURGATORY_COLLAR)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 45, 0, 0, 0, xi.items.PURGATORY_COLLAR)
+    if target:hasEquipped(xi.items.PURGATORY_COLLAR) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 45, 0, 0, 0, xi.items.PURGATORY_COLLAR)
+    end
 end
 
 itemObject.onEffectGain = function(target)

--- a/scripts/globals/items/regen_collar.lua
+++ b/scripts/globals/items/regen_collar.lua
@@ -18,10 +18,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        target:addStatusEffect(xi.effect.REGEN, 1, 3, 120, 0, 0, 0, xi.items.REGEN_COLLAR)
-    else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    if target:hasEquipped(xi.items.REGEN_COLLAR) then
+        if not target:hasStatusEffect(xi.effect.REGEN) then
+            target:addStatusEffect(xi.effect.REGEN, 1, 3, 120, 0, 0, 0, xi.items.REGEN_COLLAR)
+        else
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        end
     end
 end
 

--- a/scripts/globals/items/regen_cuirass.lua
+++ b/scripts/globals/items/regen_cuirass.lua
@@ -18,10 +18,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.REGEN) then
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
-    else
-        target:addStatusEffect(xi.effect.REGEN, 5, 3, 75, 0, 0, 0, xi.items.REGEN_CUIRASS)
+    if target:hasEquipped(xi.items.REGEN_CUIRASS) then
+        if target:hasStatusEffect(xi.effect.REGEN) then
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        else
+            target:addStatusEffect(xi.effect.REGEN, 5, 3, 75, 0, 0, 0, xi.items.REGEN_CUIRASS)
+        end
     end
 end
 

--- a/scripts/globals/items/runners_belt.lua
+++ b/scripts/globals/items/runners_belt.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.DEX_BOOST, 3, 0, 60, 0, 0, 0, xi.items.RUNNERS_BELT)
+    if target:hasEquipped(xi.items.RUNNERS_BELT) then
+        target:addStatusEffect(xi.effect.DEX_BOOST, 3, 0, 60, 0, 0, 0, xi.items.RUNNERS_BELT)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/sacred_degen.lua
+++ b/scripts/globals/items/sacred_degen.lua
@@ -16,19 +16,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENLIGHT
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.SACRED_DEGEN) then
+        local effect = xi.effect.ENLIGHT
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_DEGEN)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_DEGEN)
 end
 
 return itemObject

--- a/scripts/globals/items/sacred_lance.lua
+++ b/scripts/globals/items/sacred_lance.lua
@@ -16,19 +16,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENLIGHT
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.SACRED_LANCE) then
+        local effect = xi.effect.ENLIGHT
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_LANCE)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_LANCE)
 end
 
 return itemObject

--- a/scripts/globals/items/sacred_mace.lua
+++ b/scripts/globals/items/sacred_mace.lua
@@ -16,19 +16,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENLIGHT
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.SACRED_MACE) then
+        local effect = xi.effect.ENLIGHT
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_MACE)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_MACE)
 end
 
 return itemObject

--- a/scripts/globals/items/sacred_maul.lua
+++ b/scripts/globals/items/sacred_maul.lua
@@ -16,19 +16,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENLIGHT
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.SACRED_MAUL) then
+        local effect = xi.effect.ENLIGHT
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_MAUL)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_MAUL)
 end
 
 return itemObject

--- a/scripts/globals/items/sacred_sword.lua
+++ b/scripts/globals/items/sacred_sword.lua
@@ -16,19 +16,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENLIGHT
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.SACRED_SWORD) then
+        local effect = xi.effect.ENLIGHT
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_SWORD)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_SWORD)
 end
 
 return itemObject

--- a/scripts/globals/items/sacred_wand.lua
+++ b/scripts/globals/items/sacred_wand.lua
@@ -16,19 +16,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENLIGHT
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.SACRED_WAND) then
+        local effect = xi.effect.ENLIGHT
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_WAND)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.SACRED_WAND)
 end
 
 return itemObject

--- a/scripts/globals/items/samsonian_belt.lua
+++ b/scripts/globals/items/samsonian_belt.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.STR_BOOST, 3, 0, 60, 0, 0, 0, xi.items.SAMSONIAN_BELT)
+    if target:hasEquipped(xi.items.SAMSONIAN_BELT) then
+        target:addStatusEffect(xi.effect.STR_BOOST, 3, 0, 60, 0, 0, 0, xi.items.SAMSONIAN_BELT)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/sanation_ring.lua
+++ b/scripts/globals/items/sanation_ring.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.SANATION_RING then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.SANATION_RING) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.SANATION_RING)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.SANATION_RING)
+    if target:hasEquipped(xi.items.SANATION_RING) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.SANATION_RING)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/shock_subligar.lua
+++ b/scripts/globals/items/shock_subligar.lua
@@ -9,11 +9,6 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.SHOCK_SPIKES)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.SHOCK_SUBLIGAR then
-        target:delStatusEffect(xi.effect.SHOCK_SPIKES)
-    end
-
     return 0
 end
 

--- a/scripts/globals/items/smash_cesti.lua
+++ b/scripts/globals/items/smash_cesti.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.SMASH_CESTI then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.SMASH_CESTI) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.SMASH_CESTI)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.SMASH_CESTI)
+    if target:hasEquipped(xi.items.SMASH_CESTI) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.SMASH_CESTI)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/spirit_lantern.lua
+++ b/scripts/globals/items/spirit_lantern.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.SPIRIT_LANTERN then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.SPIRIT_LANTERN) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.SPIRIT_LANTERN)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.SPIRIT_LANTERN)
+    if target:hasEquipped(xi.items.SPIRIT_LANTERN) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.SPIRIT_LANTERN)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/stoneskin_torque.lua
+++ b/scripts/globals/items/stoneskin_torque.lua
@@ -18,10 +18,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:addStatusEffect(xi.effect.STONESKIN, 104, 0, 300, 0, 0, 4, xi.items.STONESKIN_TORQUE) then
-        target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.STONESKIN)
-    else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    if target:hasEquipped(xi.items.STONESKIN_TORQUE) then
+        if target:addStatusEffect(xi.effect.STONESKIN, 104, 0, 300, 0, 0, 4, xi.items.STONESKIN_TORQUE) then
+            target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.STONESKIN)
+        else
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        end
     end
 end
 

--- a/scripts/globals/items/sturdy_slacks.lua
+++ b/scripts/globals/items/sturdy_slacks.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.STURDY_SLACKS then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.STURDY_SLACKS) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.STURDY_SLACKS)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.STURDY_SLACKS)
+    if target:hasEquipped(xi.items.STURDY_SLACKS) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.STURDY_SLACKS)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/sturdy_trousers.lua
+++ b/scripts/globals/items/sturdy_trousers.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.MAX_HP_BOOST, 10, 0, 1800, 0, 0, 0, xi.items.STURDY_TROUSERS)
+    if target:hasEquipped(xi.items.STURDY_TROUSERS) then
+        target:addStatusEffect(xi.effect.MAX_HP_BOOST, 10, 0, 1800, 0, 0, 0, xi.items.STURDY_TROUSERS)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/sultans_belt.lua
+++ b/scripts/globals/items/sultans_belt.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.STR_BOOST, 10, 0, 60, 0, 0, 0, xi.items.SULTANS_BELT)
+    if target:hasEquipped(xi.items.SULTANS_BELT) then
+        target:addStatusEffect(xi.effect.STR_BOOST, 10, 0, 60, 0, 0, 0, xi.items.SULTANS_BELT)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/tactical_ring.lua
+++ b/scripts/globals/items/tactical_ring.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.TACTICAL_RING then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.TACTICAL_RING) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.TACTICAL_RING)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 120, 0, 0, 0, xi.items.TACTICAL_RING)
+    if target:hasEquipped(xi.items.TACTICAL_RING) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 120, 0, 0, 0, xi.items.TACTICAL_RING)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/taikyoku_kenpogi.lua
+++ b/scripts/globals/items/taikyoku_kenpogi.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.EVASION_BOOST, 3, 0, 1800, 0, 0, 0, xi.items.TAIKYOKU_KENPOGI)
+    if target:hasEquipped(xi.items.TAIKYOKU_KENPOGI) then
+        target:addStatusEffect(xi.effect.EVASION_BOOST, 3, 0, 1800, 0, 0, 0, xi.items.TAIKYOKU_KENPOGI)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/talisman_obi.lua
+++ b/scripts/globals/items/talisman_obi.lua
@@ -9,16 +9,17 @@ require("scripts/globals/msg")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect and effect:getItemSourceID() == xi.items.TALISMAN_OBI then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.TALISMAN_OBI) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.TALISMAN_OBI)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.TALISMAN_OBI)
+    if target:hasEquipped(xi.items.TALISMAN_OBI) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.TALISMAN_OBI)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/thunder_mittens.lua
+++ b/scripts/globals/items/thunder_mittens.lua
@@ -6,11 +6,6 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENTHUNDER)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.THUNDER_MITTENS then
-        target:delStatusEffect(xi.effect.ENTHUNDER)
-    end
-
     return 0
 end
 

--- a/scripts/globals/items/tough_belt.lua
+++ b/scripts/globals/items/tough_belt.lua
@@ -18,7 +18,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.VIT_BOOST, 3, 0, 60, 0, 0, 0, xi.items.TOUGH_BELT)
+    if target:hasEquipped(xi.items.TOUGH_BELT) then
+        target:addStatusEffect(xi.effect.VIT_BOOST, 3, 0, 60, 0, 0, 0, xi.items.TOUGH_BELT)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/twicer.lua
+++ b/scripts/globals/items/twicer.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.TWICER then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.TWICER) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.TWICER)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 30, 0, 0, 0, xi.items.TWICER)
+    if target:hasEquipped(xi.items.TWICER) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 30, 0, 0, 0, xi.items.TWICER)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/vial_of_refresh_musk.lua
+++ b/scripts/globals/items/vial_of_refresh_musk.lua
@@ -21,7 +21,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.REFRESH, 3, 3, 60, 0, 0, 0, xi.items.VIAL_OF_REFRESH_MUSK)
+    if target:hasEquipped(xi.items.VIAL_OF_REFRESH_MUSK) then
+        target:addStatusEffect(xi.effect.REFRESH, 3, 3, 60, 0, 0, 0, xi.items.VIAL_OF_REFRESH_MUSK)
+    end
 end
 
 return itemObject

--- a/scripts/globals/items/vision_ring.lua
+++ b/scripts/globals/items/vision_ring.lua
@@ -9,16 +9,17 @@ require("scripts/globals/status")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.VISION_RING then
-        target:delStatusEffect(xi.effect.ENCHANTMENT)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.VISION_RING) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.VISION_RING)
     end
 
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.VISION_RING)
+    if target:hasEquipped(xi.items.VISION_RING) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 0, 0, 0, xi.items.VISION_RING)
+    end
 end
 
 itemObject.onEffectGain = function(target, effect)

--- a/scripts/globals/items/vulcan_blade.lua
+++ b/scripts/globals/items/vulcan_blade.lua
@@ -19,19 +19,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENFIRE
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.VULCAN_BLADE) then
+        local effect = xi.effect.ENFIRE
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.VULCAN_BLADE)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.VULCAN_BLADE)
 end
 
 return itemObject

--- a/scripts/globals/items/vulcan_claymore.lua
+++ b/scripts/globals/items/vulcan_claymore.lua
@@ -19,19 +19,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENFIRE
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.VULCAN_CLAYMORE) then
+        local effect = xi.effect.ENFIRE
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.VULCAN_CLAYMORE)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.VULCAN_CLAYMORE)
 end
 
 return itemObject

--- a/scripts/globals/items/vulcan_degen.lua
+++ b/scripts/globals/items/vulcan_degen.lua
@@ -19,19 +19,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENFIRE
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.VULCAN_DEGEN) then
+        local effect = xi.effect.ENFIRE
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.VULCAN_DEGEN)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.VULCAN_DEGEN)
 end
 
 return itemObject

--- a/scripts/globals/items/vulcan_sword.lua
+++ b/scripts/globals/items/vulcan_sword.lua
@@ -19,19 +19,21 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local effect = xi.effect.ENFIRE
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
-    local potency = 0
+    if target:hasEquipped(xi.items.VULCAN_SWORD) then
+        local effect = xi.effect.ENFIRE
+        local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+        local potency = 0
 
-    if magicskill <= 200 then
-        potency = 3 + math.floor(6 * magicskill / 100)
-    elseif magicskill > 200 then
-        potency = 5 + math.floor(5 * magicskill / 100)
+        if magicskill <= 200 then
+            potency = 3 + math.floor(6 * magicskill / 100)
+        elseif magicskill > 200 then
+            potency = 5 + math.floor(5 * magicskill / 100)
+        end
+
+        potency = utils.clamp(potency, 3, 25)
+
+        target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.VULCAN_SWORD)
     end
-
-    potency = utils.clamp(potency, 3, 25)
-
-    target:addStatusEffect(effect, potency, 0, 180, 0, 0, 0, xi.items.VULCAN_SWORD)
 end
 
 return itemObject

--- a/scripts/globals/items/water_mitts.lua
+++ b/scripts/globals/items/water_mitts.lua
@@ -6,11 +6,6 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.ENWATER)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.WATER_MITTS then
-        target:delStatusEffect(xi.effect.ENWATER)
-    end
-
     return 0
 end
 

--- a/scripts/globals/items/wing_gorget.lua
+++ b/scripts/globals/items/wing_gorget.lua
@@ -18,10 +18,12 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.REGAIN) then
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
-    else
-        target:addStatusEffect(xi.effect.REGAIN, 5, 3, 30, 0, 0, 0, xi.items.WING_GORGET)
+    if target:hasEquipped(xi.items.WING_GORGET) then
+        if target:hasStatusEffect(xi.effect.REGAIN) then
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        else
+            target:addStatusEffect(xi.effect.REGAIN, 5, 3, 30, 0, 0, 0, xi.items.WING_GORGET)
+        end
     end
 end
 

--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -196,7 +196,7 @@ INSERT INTO `status_effects` VALUES (158,'provoke',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (159,'penalty',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (160,'preparations',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (161,'sprint',32,0,0,0,0,0,0,0,0);
-INSERT INTO `status_effects` VALUES (162,'enchantment',32,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (162,'enchantment',288,0,0,4,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (163,'azure_lore',4194336,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (164,'chain_affinity',4194336,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (165,'burst_affinity',4194336,0,0,0,0,0,0,0,0);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3368,6 +3368,28 @@ std::optional<CLuaItem> CLuaBaseEntity::getEquippedItem(uint8 slot)
 }
 
 /************************************************************************
+ *  Function: hasEquipped(equipmentID)
+ *  Purpose : Returns true if the player has the item equipped in any slot
+ *  Example : player:hasEquipped(xi.items.BREATH_MANTLE)
+ *  Notes   :
+ ************************************************************************/
+
+bool CLuaBaseEntity::hasEquipped(uint16 equipmentID)
+{
+    if (m_PBaseEntity->objtype == TYPE_PC)
+    {
+        for (uint8 equipmentSlot = 0; equipmentSlot <= 15; equipmentSlot++)
+        {
+            if (getEquipID((SLOTTYPE)equipmentSlot) == equipmentID)
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/************************************************************************
  *  Function: hasItem()
  *  Purpose : Returns true if a player possesses an item
  *  Example : if player:hasItem(500) then -- Second var optional
@@ -11008,10 +11030,10 @@ bool CLuaBaseEntity::addStatusEffectEx(sol::variadic_args va)
  *  Function: getStatusEffect()
  *  Purpose : Returns the Object of a specified Status ID
  *  Example : local debilitation = target:getStatusEffect(xi.effect.DEBILITATION)
- *  Notes   :
+ *  Notes   : Can specify Power of the Effect as an option or the Item Source (will use power if both specified)
  ************************************************************************/
 
-std::optional<CLuaStatusEffect> CLuaBaseEntity::getStatusEffect(uint16 StatusID, sol::object const& SubID)
+std::optional<CLuaStatusEffect> CLuaBaseEntity::getStatusEffect(uint16 StatusID, sol::object const& SubID, sol::object const& ItemSourceID)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
@@ -11028,6 +11050,11 @@ std::optional<CLuaStatusEffect> CLuaBaseEntity::getStatusEffect(uint16 StatusID,
     {
         auto uint16_SubID = SubID.as<uint16>();
         PStatusEffect     = PBattleEntity->StatusEffectContainer->GetStatusEffect(effect_StatusID, uint16_SubID);
+    }
+    else if (ItemSourceID != sol::lua_nil)
+    {
+        auto uint16_ItemSourceID = ItemSourceID.as<uint16>();
+        PStatusEffect            = PBattleEntity->StatusEffectContainer->GetStatusEffectByItemSource(effect_StatusID, uint16_ItemSourceID);
     }
     else
     {
@@ -11188,12 +11215,13 @@ uint8 CLuaBaseEntity::countEffect(uint16 StatusID)
  *  Function: delStatusEffect()
  *  Purpose : Deletes a specified Effect from the Entity's Status Effect Container
  *  Example : target:delStatusEffect(xi.effect.RERAISE)
- *  Notes   : Can specify Power of the Effect as an option
+ *  Notes   : Can specify Power of the Effect as an option or the Item Source (will use power if both specified)
  ************************************************************************/
 
-bool CLuaBaseEntity::delStatusEffect(uint16 StatusID, sol::object const& SubID)
+bool CLuaBaseEntity::delStatusEffect(uint16 StatusID, sol::object const& SubID, sol::object const& ItemSourceID)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    XI_DEBUG_BREAK_IF(SubID != sol::lua_nil && ItemSourceID != sol::lua_nil);
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11209,6 +11237,11 @@ bool CLuaBaseEntity::delStatusEffect(uint16 StatusID, sol::object const& SubID)
     {
         auto uint16_SubID = SubID.as<uint16>();
         result            = PBattleEntity->StatusEffectContainer->DelStatusEffect(effect_StatusID, uint16_SubID);
+    }
+    else if (ItemSourceID != sol::lua_nil)
+    {
+        auto uint16_ItemSourceID = ItemSourceID.as<uint16>();
+        result                   = PBattleEntity->StatusEffectContainer->DelStatusEffectByItemSource(effect_StatusID, uint16_ItemSourceID);
     }
     else
     {
@@ -15822,6 +15855,7 @@ void CLuaBaseEntity::Register()
     // Items
     SOL_REGISTER("getEquipID", CLuaBaseEntity::getEquipID);
     SOL_REGISTER("getEquippedItem", CLuaBaseEntity::getEquippedItem);
+    SOL_REGISTER("hasEquipped", CLuaBaseEntity::hasEquipped);
     SOL_REGISTER("hasItem", CLuaBaseEntity::hasItem);
     SOL_REGISTER("addItem", CLuaBaseEntity::addItem);
     SOL_REGISTER("delItem", CLuaBaseEntity::delItem);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -211,6 +211,7 @@ public:
     // Items
     uint16 getEquipID(SLOTTYPE slot);                              // Gets the Item Id of the item in specified slot
     auto   getEquippedItem(uint8 slot) -> std::optional<CLuaItem>; // Returns the item object from specified slot
+    bool   hasEquipped(uint16 equipmentID);                        // Returns true if item is equipped in any slot
     bool   hasItem(uint16 itemID, sol::object const& location);    // Check to see if Entity has item in inventory (hasItem(itemNumber))
     bool   addItem(sol::variadic_args va);                         // Add item to Entity inventory (additem(itemNumber,quantity))
     bool   delItem(uint16 itemID, int32 quantity, sol::object const& containerID);
@@ -609,7 +610,7 @@ public:
     // Status Effects
     bool   addStatusEffect(sol::variadic_args va);
     bool   addStatusEffectEx(sol::variadic_args va);
-    auto   getStatusEffect(uint16 StatusID, sol::object const& SubID) -> std::optional<CLuaStatusEffect>;
+    auto   getStatusEffect(uint16 StatusID, sol::object const& SubID, sol::object const& ItemSourceID) -> std::optional<CLuaStatusEffect>;
     auto   getStatusEffects() -> sol::table;
     int16  getStatusEffectElement(uint16 statusId);
     bool   canGainStatusEffect(uint16 effect, sol::object const& powerObj); // Returns true if the effect can be added
@@ -617,14 +618,14 @@ public:
     uint16 hasStatusEffectByFlag(uint16 StatusID);                          // Checks to see if a character has an effect with the specified flag
     uint8  countEffect(uint16 StatusID);                                    // Gets the number of effects of a specific type on the player
 
-    bool   delStatusEffect(uint16 StatusID, sol::object const& SubID);                   // Removes Status Effect
-    void   delStatusEffectsByFlag(uint32 flag, sol::object const& silent);               // Removes Status Effects by Flag
-    bool   delStatusEffectSilent(uint16 StatusID);                                       // Removes Status Effect, suppresses message
-    uint16 eraseStatusEffect();                                                          // Used with "Erase" spell
-    uint8  eraseAllStatusEffect();                                                       // Erases all effects and returns number erased
-    int32  dispelStatusEffect(sol::object const& flagObj);                               // Used with "Dispel" spell
-    uint8  dispelAllStatusEffect(sol::object const& flagObj);                            // Dispels all effects and returns number erased
-    uint16 stealStatusEffect(CLuaBaseEntity* PTargetEntity, sol::object const& flagObj); // Used in mob skills to steal effects
+    bool   delStatusEffect(uint16 StatusID, sol::object const& SubID, sol::object const& ItemSourceID); // Removes Status Effect
+    void   delStatusEffectsByFlag(uint32 flag, sol::object const& silent);                              // Removes Status Effects by Flag
+    bool   delStatusEffectSilent(uint16 StatusID);                                                      // Removes Status Effect, suppresses message
+    uint16 eraseStatusEffect();                                                                         // Used with "Erase" spell
+    uint8  eraseAllStatusEffect();                                                                      // Erases all effects and returns number erased
+    int32  dispelStatusEffect(sol::object const& flagObj);                                              // Used with "Dispel" spell
+    uint8  dispelAllStatusEffect(sol::object const& flagObj);                                           // Dispels all effects and returns number erased
+    uint16 stealStatusEffect(CLuaBaseEntity* PTargetEntity, sol::object const& flagObj);                // Used in mob skills to steal effects
 
     void  addMod(uint16 type, int16 amount); // Adds Modifier Value
     int16 getMod(uint16 modID);              // Retrieves Modifier Value

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -695,6 +695,19 @@ bool CStatusEffectContainer::DelStatusEffect(EFFECT StatusID, uint16 SubID)
     return false;
 }
 
+bool CStatusEffectContainer::DelStatusEffectByItemSource(EFFECT StatusID, uint16 ItemSourceID)
+{
+    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    {
+        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetItemSourceID() == ItemSourceID && !PStatusEffect->deleted)
+        {
+            RemoveStatusEffect(PStatusEffect);
+            return true;
+        }
+    }
+    return false;
+}
+
 bool CStatusEffectContainer::DelStatusEffectByTier(EFFECT StatusID, uint16 tier)
 {
     for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
@@ -1294,6 +1307,18 @@ CStatusEffect* CStatusEffectContainer::GetStatusEffect(EFFECT StatusID, uint32 S
     for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSubID() == SubID && !PStatusEffect->deleted)
+        {
+            return PStatusEffect;
+        }
+    }
+    return nullptr;
+}
+
+CStatusEffect* CStatusEffectContainer::GetStatusEffectByItemSource(EFFECT StatusID, uint16 ItemSourceID)
+{
+    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    {
+        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetItemSourceID() == ItemSourceID && !PStatusEffect->deleted)
         {
             return PStatusEffect;
         }

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -49,6 +49,7 @@ public:
     bool DelStatusEffect(EFFECT StatusID);
     bool DelStatusEffectSilent(EFFECT StatusID);
     bool DelStatusEffect(EFFECT StatusID, uint16 SubID);
+    bool DelStatusEffectByItemSource(EFFECT StatusID, uint16 ItemSourceID);
     void DelStatusEffectsByFlag(uint32 flag, bool silent = false); // Remove all the status effects with the specified type
     void DelStatusEffectsByIcon(uint16 IconID);                    // Remove all effects with the specified icon
     void DelStatusEffectsByType(uint16 Type);
@@ -69,6 +70,7 @@ public:
 
     CStatusEffect* GetStatusEffect(EFFECT StatusID);
     CStatusEffect* GetStatusEffect(EFFECT StatusID, uint32 SubID);
+    CStatusEffect* GetStatusEffectByItemSource(EFFECT StatusID, uint16 ItemSourceID);
 
     std::vector<EFFECT> GetStatusEffectsInIDRange(EFFECT start, EFFECT end);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Players can now have several enchantment status effects active at the same time. Enchantment status effects also now wear off when zoning. Also Breath Mantle now works correctly. (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes several issues:
- Fixes an exploit where players could keep an enchantment even after unequipping the gear that gives the enchantment
- Also allows multiple enchantment effects to be active on a player at the same time (was validated on retail by siknoz)
- Fixes breath mantle to actually give enchantment
- Fixes several pieces of gear that give the status effects that should not be wear off upon unequipping gear (based on JP wiki)
- Enchantment status effects now wear off when zoning

## Steps to test these changes
- Use breath mantle and check enchantment
- Use two enchantment items such as high breath mantle (15487) and vision ring (15559) to see two status effects and then remove two gear one by one to see only correct enchantment removed
- Message on discord for exploit testing instructions
- Use aero mufflers then remove and see that enaero status effect remains
- Zone with an enchantment to see it wear off

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
