### PR TITLE
Adds ENM Timer NPCs. Fixes ENM Time issues.

### DIFF
--- a/scripts/globals/enm.lua
+++ b/scripts/globals/enm.lua
@@ -1,0 +1,109 @@
+------------------------------------------
+-- Shared functionality for ENM timer NPCs
+--  Ophelia (Southern San dOria)
+--  Gregory (Bastok Mines)
+--  Istvan (Windurst Woods)
+--  Moritz (Upper Jeuno)
+------------------------------------------
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
+require("scripts/globals/npc_util")
+require("scripts/globals/settings")
+require("scripts/globals/status")
+require("scripts/globals/zone")
+-----------------------------------
+xi = xi or {}
+xi.enm = xi.enm or {}
+
+local cutscenes =
+{
+    ["Moritz"]  = { introduction = 10028, recurring = 10029, default = 10027 },
+    ["Ophelia"] = { introduction = 752,   recurring = 753,   default = 751 },
+    ["Gregory"] = { introduction = 257,   recurring = 258,   default = 256 },
+    ["Istvan"]  = { introduction = 693,   recurring = 694,   default = 692 },
+}
+
+local enmOptionToEnablementCriteria =
+{
+    [1]   = { missionReq = xi.mission.id.cop.THE_RITES_OF_LIFE,    cooldownPlayerVar = "[ENM]abandonmentTimer" }, --Spire Of Holla
+    [2]   = { missionReq = xi.mission.id.cop.THE_RITES_OF_LIFE,    cooldownPlayerVar = "[ENM]antipathyTimer" },   --Spire Of Dem
+    [3]   = { missionReq = xi.mission.id.cop.THE_RITES_OF_LIFE,    cooldownPlayerVar = "[ENM]animusTimer" },      --Spire Of Mea
+    [4]   = { missionReq = xi.mission.id.cop.SLANDEROUS_UTTERINGS, cooldownPlayerVar = "[ENM]acrimonyTimer" },    --Spire Of Vahzl
+    [5]   = { missionReq = xi.mission.id.cop.AN_ETERNAL_MELODY,    cooldownPlayerVar = "[ENM]MonarchBeard" },     --Monarch Linn
+    [6]   = { missionReq = xi.ki.PSOXJA_PASS,                      cooldownPlayerVar = "[ENM]AstralCovenant" },   --The Shrouded Maw
+    [7]   = { missionReq = nil,                                    cooldownPlayerVar = "[ENM]OperatingLever" },   --Mine Shaft 2716 Lever
+    [8]   = { missionReq = nil,                                    cooldownPlayerVar = "[ENM]ZephyrFan" },        --Bearclaw Pinnacle
+    [9]   = { missionReq = nil,                                    cooldownPlayerVar = "[ENM]MiasmaFilter" },     --Boneyard Gully
+    [100] = { missionReq = nil,                                    cooldownPlayerVar = "[ENM]GateDial" },         --Mine Shaft 2716 Dial
+}
+
+local function hasPlayerTriggeredEnmCoolDown(player)
+    for _, v in pairs(enmOptionToEnablementCriteria) do
+        if player:getCharVar(v.cooldownPlayerVar) then
+            return true
+        end
+    end
+
+    return false
+end
+
+local function getBitmaskForAvailableENMs(player)
+    -- The cutscene allows filtering of which ENMs are shown to the player
+    -- 2^option aligns the bitmask to the ENM
+    local bitmask = 0
+    local copMissionProgress = player:getCurrentMission(xi.mission.log_id.COP)
+
+    for i = 1, 5 do
+        if copMissionProgress <= enmOptionToEnablementCriteria[i].missionReq then
+            bitmask = bitmask + bit.lshift(1, i)
+        end
+    end
+
+    -- Special case for AstralCovenant, which is holding a ki vs a mission
+    if not player:hasKeyItem(xi.ki.PSOXJA_PASS) then
+        bitmask = bitmask + bit.lshift(1, 6)
+    end
+
+    -- Note: Bearclaw Pinnacle, Boneyard Gully, and Mine Shaft 2716 are never filtered
+    return bitmask
+end
+
+xi.enm.timerNpcOnTrigger = function(player, npc)
+    local hasPlayerAckdIntro = player:getCharVar(string.format("[ENM]" ..npc:getName().. "IntroCS")) == 1
+    -- reusing hasPlayerAckdIntro to prevent querying multiple player vars (enm timers) each interaction
+    if hasPlayerAckdIntro or hasPlayerTriggeredEnmCoolDown(player) then
+        if not hasPlayerAckdIntro then
+            player:startEvent(cutscenes[npc:getName()].introduction, getBitmaskForAvailableENMs(player))
+        else
+            player:startEvent(cutscenes[npc:getName()].recurring, getBitmaskForAvailableENMs(player))
+        end
+    else
+        player:startEvent(cutscenes[npc:getName()].default)
+    end
+end
+
+xi.enm.timerNpcOnEventUpdate = function(player, csid, option)
+    -- update required for a decline
+    if option == 0 then
+        player:updateEvent(1)
+        return
+    end
+
+    local enmAvailableVanaTime = player:getCharVar(enmOptionToEnablementCriteria[option].cooldownPlayerVar)
+    if enmAvailableVanaTime > VanadielTime() then
+        player:updateEvent(0, enmAvailableVanaTime)
+    else
+        player:updateEvent(0)
+    end
+end
+
+xi.enm.timerNpcOnEventFinish = function(player, csid, option)
+    local npc = player:getEventTarget()
+    -- Handle intro CS
+    if
+        csid == cutscenes[npc:getName()].introduction and option >= 0 and
+        option <= 100
+    then
+        player:setCharVar(string.format("[ENM]" ..npc:getName().. "IntroCS"), 1)
+    end
+end

--- a/scripts/zones/Attohwa_Chasm/npcs/Jakaka.lua
+++ b/scripts/zones/Attohwa_Chasm/npcs/Jakaka.lua
@@ -24,9 +24,9 @@ entity.onTrigger = function(player, npc)
     if player:hasKeyItem(xi.ki.MIASMA_FILTER) then
         player:startEvent(11)
     else
-        if miasmaFilterCD >= os.time() then
+        if miasmaFilterCD >= VanadielTime() then
             -- Both Vanadiel time and unix timestamps are based on seconds. Add the difference to the event.
-            player:startEvent(14, VanadielTime() + (miasmaFilterCD - os.time()))
+            player:startEvent(14, miasmaFilterCD)
         else
             if player:hasItem(1778) or player:hasItem(1777) then -- Parradamo Stones, Flaxen Pouch
                 player:startEvent(15)
@@ -44,7 +44,7 @@ entity.onEventFinish = function(player, csid, option)
     if csid == 12 then
         player:addKeyItem(xi.ki.MIASMA_FILTER)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MIASMA_FILTER)
-        player:setCharVar("[ENM]MiasmaFilter", os.time() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
+        player:setCharVar("[ENM]MiasmaFilter", VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
     elseif csid == 13 then
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1777) -- Flaxen Pouch

--- a/scripts/zones/Bastok_Mines/npcs/Gregory.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Gregory.lua
@@ -1,8 +1,10 @@
 -----------------------------------
 -- Area: Bastok Mines
 --  NPC: Gregory
--- Type: ENM
+-- Type: ENM Quest Timer
 -- !pos 51.530 -1 -83.940 234
+-----------------------------------
+require("scripts/globals/enm")
 -----------------------------------
 local entity = {}
 
@@ -10,13 +12,15 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(256)
+    xi.enm.timerNpcOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    xi.enm.timerNpcOnEventUpdate(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
+    xi.enm.timerNpcOnEventFinish(player, csid, option)
 end
 
 return entity

--- a/scripts/zones/Lower_Jeuno/npcs/Ghebi_Damomohe.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Ghebi_Damomohe.lua
@@ -37,10 +37,16 @@ end
 entity.onTrigger = function(player, npc)
     local astralCovenantCD = player:getCharVar("[ENM]AstralCovenant")
 
-    if player:hasKeyItem(xi.ki.PSOXJA_PASS) and astralCovenantCD < os.time() then
+    if
+        player:hasKeyItem(xi.ki.PSOXJA_PASS) and
+        astralCovenantCD < VanadielTime()
+    then
         player:startEvent(106, 4, 1, 1782, 604)
-    elseif player:hasKeyItem(xi.ki.PSOXJA_PASS) and astralCovenantCD >= os.time() then
-        player:startEvent(106, 4, 2, 675, VanadielTime() + (astralCovenantCD - os.time()))
+    elseif
+        player:hasKeyItem(xi.ki.PSOXJA_PASS) and
+        astralCovenantCD >= VanadielTime()
+    then
+        player:startEvent(106, 4, 2, 675, astralCovenantCD)
     elseif player:hasKeyItem(xi.ki.ASTRAL_COVENANT) then
         player:startEvent(106, 4)
     end
@@ -66,7 +72,7 @@ entity.onEventFinish = function(player, csid, option)
         player:setTitle(xi.title.TENSHODO_MEMBER)
 
     elseif csid == 10047 then
-        player:setCharVar("[ENM]AstralCovenant", os.time() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
+        player:setCharVar("[ENM]AstralCovenant", VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.ASTRAL_COVENANT)
         player:addKeyItem(xi.ki.ASTRAL_COVENANT)
     end

--- a/scripts/zones/Oldton_Movalpolos/npcs/Twinkbrix.lua
+++ b/scripts/zones/Oldton_Movalpolos/npcs/Twinkbrix.lua
@@ -33,7 +33,7 @@ entity.onTrade = function(player, npc, trade)
         not player:hasKeyItem(xi.ki.SHAFT_GATE_OPERATING_DIAL) and
         tradeGil > 0 and tradeGil <= 10000 and
         npcUtil.tradeHasExactly(trade, { { "gil", tradeGil } }) and
-        gateDialCD < os.time()
+        gateDialCD < VanadielTime()
     then
         local maxRoll = tradeGil / 200
         local diceRoll = math.random(2, 100)
@@ -43,7 +43,7 @@ entity.onTrade = function(player, npc, trade)
     elseif
         trade:hasItemQty(1781, 1) and
         trade:getItemCount() == 1 and
-        operatingLeverCD < os.time()
+        operatingLeverCD < VanadielTime()
     then
         player:startEvent(51, 1781)
     end
@@ -53,14 +53,17 @@ entity.onTrigger = function(player, npc)
     local operatingLeverCD = player:getCharVar("[ENM]OperatingLever")
     local gateDialCD = player:getCharVar("[ENM]GateDial")
 
-    if player:hasKeyItem(xi.ki.SHAFT_GATE_OPERATING_DIAL) or player:hasKeyItem(xi.ki.SHAFT_2716_OPERATING_LEVER) then
+    if
+        player:hasKeyItem(xi.ki.SHAFT_GATE_OPERATING_DIAL) or
+        player:hasKeyItem(xi.ki.SHAFT_2716_OPERATING_LEVER)
+    then
         player:startEvent(50)
 
-    elseif operatingLeverCD > os.time() then
-        player:startEvent(53, 1781, VanadielTime() + (operatingLeverCD - os.time()))
+    elseif operatingLeverCD > VanadielTime() then
+        player:startEvent(53, 1781, operatingLeverCD)
 
-    elseif gateDialCD > os.time() then
-        player:startEvent(52, 1781, 432000, 10, VanadielTime() + (gateDialCD - os.time()), 2, 209, 209, 0)
+    elseif gateDialCD > VanadielTime() then
+        player:startEvent(52, 1781, 432000, 10, gateDialCD, 2, 209, 209, 0)
 
     else
         player:startEvent(52, 1781)
@@ -74,12 +77,12 @@ entity.onEventFinish = function(player, csid, option)
     print(option)
 
     if csid == 51 then
-        player:setCharVar("[ENM]OperatingLever", os.time() + (xi.settings.main.ENM_COOLDOWN * 3600))
+        player:setCharVar("[ENM]OperatingLever", VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600))
         npcUtil.giveKeyItem(player, xi.ki.SHAFT_2716_OPERATING_LEVER)
         player:tradeComplete()
 
     elseif csid == 55 and option == 1 then
-        player:setCharVar("[ENM]GateDial", os.time() + (xi.settings.main.ENM_COOLDOWN * 3600))
+        player:setCharVar("[ENM]GateDial", VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600))
         npcUtil.giveKeyItem(player, xi.ki.SHAFT_GATE_OPERATING_DIAL)
 
     elseif csid == 56 and option == 1 then

--- a/scripts/zones/Southern_San_dOria/npcs/Ophelia.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ophelia.lua
@@ -1,7 +1,9 @@
 -----------------------------------
 -- Area: Southern San d'Oria
 --  NPC: Ophelia
---  General Info NPC
+-- Type: ENM Quest Timer
+-----------------------------------
+require("scripts/globals/enm")
 -----------------------------------
 local entity = {}
 
@@ -9,13 +11,15 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(751)
+    xi.enm.timerNpcOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    xi.enm.timerNpcOnEventUpdate(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
+    xi.enm.timerNpcOnEventFinish(player, csid, option)
 end
 
 return entity

--- a/scripts/zones/Tavnazian_Safehold/npcs/Morangeart.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Morangeart.lua
@@ -15,14 +15,20 @@ end
 entity.onTrigger = function(player, npc)
     local cd = player:getCharVar("[ENM]MonarchBeard")
 
-    if player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.AN_ETERNAL_MELODY and cd < os.time() then
+    if
+        player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.AN_ETERNAL_MELODY and
+        cd < VanadielTime()
+    then
         if player:hasKeyItem(xi.ki.MONARCH_BEARD) then
             player:startEvent(520)
         else
             player:startEvent(521)
         end
-    elseif player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.AN_ETERNAL_MELODY and cd > os.time() then
-        player:startEvent(522)
+    elseif
+        player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.AN_ETERNAL_MELODY and
+        cd > VanadielTime()
+    then
+        player:startEvent(522, cd)
     else
         player:startEvent(523)
     end
@@ -35,7 +41,7 @@ entity.onEventFinish = function(player, csid, option)
     if csid == 521 then
         player:addKeyItem(xi.ki.MONARCH_BEARD)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MONARCH_BEARD)
-        player:setCharVar("[ENM]MonarchBeard", os.time() + (xi.settings.main.ENM_COOLDOWN*3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
+        player:setCharVar("[ENM]MonarchBeard", VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
     end
 end
 

--- a/scripts/zones/Uleguerand_Range/npcs/Zebada.lua
+++ b/scripts/zones/Uleguerand_Range/npcs/Zebada.lua
@@ -23,9 +23,9 @@ entity.onTrigger = function(player, npc)
     if player:hasKeyItem(xi.ki.ZEPHYR_FAN) then
         player:startEvent(12)
     else
-        if zephyrFanCD >= os.time() then
+        if zephyrFanCD >= VanadielTime() then
             -- Both Vanadiel time and unix timestamps are based on seconds. Add the difference to the event.
-            player:startEvent(15, VanadielTime() + (zephyrFanCD - os.time()))
+            player:startEvent(15, zephyrFanCD)
         else
             if player:hasItem(1780) or player:hasItem(1779) then -- Chamnaet Ice -- Cotton Pouch
                 player:startEvent(16)
@@ -43,7 +43,7 @@ entity.onEventFinish = function(player, csid, option)
     if csid == 13 then
         player:addKeyItem(xi.ki.ZEPHYR_FAN)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.ZEPHYR_FAN)
-        player:setCharVar("[ENM]ZephyrFan", os.time() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
+        player:setCharVar("[ENM]ZephyrFan", VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
     elseif csid == 14 then
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1779) -- Cotton Pouch

--- a/scripts/zones/Upper_Jeuno/npcs/Moritz.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Moritz.lua
@@ -1,6 +1,9 @@
 -----------------------------------
 -- Area: Upper Jeuno
 --  NPC: Moritz
+-- Type: ENM Quest Timer
+-----------------------------------
+require("scripts/globals/enm")
 -----------------------------------
 local entity = {}
 
@@ -8,13 +11,15 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(10027)
+    xi.enm.timerNpcOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    xi.enm.timerNpcOnEventUpdate(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
+    xi.enm.timerNpcOnEventFinish(player, csid, option)
 end
 
 return entity

--- a/scripts/zones/Windurst_Woods/npcs/Istvan.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Istvan.lua
@@ -4,19 +4,23 @@
 -- Type: ENM Quest Timer
 -- !pos 116.294 -6 -98.164 241
 -----------------------------------
+require("scripts/globals/enm")
+-----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(692)
+    xi.enm.timerNpcOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    xi.enm.timerNpcOnEventUpdate(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
+    xi.enm.timerNpcOnEventFinish(player, csid, option)
 end
 
 return entity


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Adds ENM Timer NPCs listed below and fixes a few ENM timer reporting issues.
Note: If you have never done or an ENM the timer NPCs wont have much to say.
Note2: These in era NPCs with their retail functionality.  Nothing custom.  I just learned they existed like 2 days ago.
Update notes that added them: http://www.playonline.com/updateus/050224hu5ol2.html
```
Ophelia (Southern San d’Oria)
Gregory (Bastok Mines)
Istvan (Windurst Woods)
Moritz (Upper Jeuno)
```

## What does this pull request do? (Please be technical)

Adds 4 new NPCs which report ENM timers in towns.
Does so via a global shared file that could be expanded to include the other ENM NPCs.

Updates all other ENM NPCs to use VanadielTime() instead of os.time() or some mixing of the two.

## Steps to test these changes

These ENM Timer NPCs have some fun behavior.

1) If you have never done an ENM ever - they will give their default dialog similar to ```This dark plague grows ever stronger... If it is not stopped soon...```

2) If you have done an ENM - you will get an intro CS where they ask if you have seen an ENM
2a) if the player responds no - they will continue to get the intro CS each time they talk to the NPC
2b) if the player responds yes, then instead of making a selection on the next CS - they hit esc, they will continue to get the intro CS each time they talk to the NPC (the yes option does not trigger an update server side)
2c) if the player responds yes and selects any option from the following dialog - the player will then forever get the reoccuring dialog, not the intro dialog

3) The npcs will only show options that the player has access to.  Boneyard, Bearclaw, and Mineshaft are always available.  The rest rely upon CoP progress and match when the ENM becomes available.

These 4 npcs will report enm time remaining or, in the event of no wait time - they will report that it should be ready.

All ENM NPCs (except venessa) have been updated to report the correct time.
Venessa was already updated

## Special Deployment Considerations

The following ENM tracking variables should be **_set to the value 1_** for all players, as their current values will be wildly off base now, preventing players from running ENMs for a decade or more.
Setting the vars to 1 instead of deleting them will maintain the historical record of if a player has ever done an ENM, but also fix the time discrepancy.

```
[ENM]MonarchBeard
[ENM]AstralCovenant
[ENM]OperatingLever
[ENM]ZephyrFan       
[ENM]MiasmaFilter
[ENM]GateDial
```
