### PR TITLE
Updates ENM Sheep In Antlion loot pool

### DIFF
--- a/scripts/zones/Boneyard_Gully/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Boneyard_Gully/npcs/Armoury_Crate.lua
@@ -58,12 +58,23 @@ local loot =
         },
 
         {
+            { itemid =    0,  droprate = 512 }, -- Nothing
             { itemid = 17829, droprate =  82 }, -- Hagun
-            { itemid = 17945, droprate =  92 }, -- Martial Axe
+            { itemid = 17945, droprate =  93 }, -- Martial Axe
             { itemid = 17467, droprate =  63 }, -- Martial Wand
-            { itemid = 13690, droprate = 105 }, -- Forager's Mantle
-            { itemid = 13109, droprate = 121 }, -- Harmonia's Torque
+            { itemid = 13690, droprate = 128 }, -- Forager's Mantle
+            { itemid = 13109, droprate = 122 }, -- Harmonia's Torque
         },
+
+        {
+            { itemid =    0,  droprate = 512 }, -- Nothing
+            { itemid = 17829, droprate =  82 }, -- Hagun
+            { itemid = 17945, droprate =  93 }, -- Martial Axe
+            { itemid = 17467, droprate =  63 }, -- Martial Wand
+            { itemid = 13690, droprate = 128 }, -- Forager's Mantle
+            { itemid = 13109, droprate = 122 }, -- Harmonia's Torque
+        },
+
     },
 
     -- ENM: Shell We Dance?


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Updates ENM Sheep In Antlions Clothing loot pool to match wiki drop rates and drop pattern observerd on all ENMs.
This introduces a new pool, matching the existing loot grouping but also adds the potential to recieve nothing from the pool.

Following the wiki history, it appears to be a one man crusade to claim that _Triple_ drops were possible.
There is no such evidence from this or any ENM.
Due to their constant updating of [this page specifically](https://ffxiclopedia.fandom.com/wiki/Sheep_in_Antlion%27s_Clothing?direction=next&oldid=1087696) - the page was constantly reverted to a single pool.

---

**Sources for double drops**
https://www.youtube.com/watch?v=OIIOy-kHH3k

マーシャルアクス
Martial ax 
マーシャルワンド
Martial wand
![image](https://user-images.githubusercontent.com/105882290/228325048-573dd4d9-63b7-4cd0-9e3b-2a1d40071745.png)

[This Horizon issue (which is based on ASB)](https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1229)

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1229

## What does this pull request do? (Please be technical)

Duplicates a drop pool and adds the ability for that pool to have nothing
Matches drop rates to wiki claims (as per all other ENMs)

## Steps to test these changes

Run the ENM a bunch and see a double drop

## Special Deployment Considerations

None
