### PR TITLE
Added command to print model info

### DIFF
--- a/scripts/commands/getmodelid.lua
+++ b/scripts/commands/getmodelid.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+-- func: !getmodel
+-- desc: Prints the target modelID, animationID and animationSubID
+-----------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = "s"
+}
+
+function error(player, msg)
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!getmodel <target>")
+end
+
+function onTrigger(player)
+    local target = player:getCursorTarget()
+
+    if target ~= nil and target:isMob() or target:isNPC() then
+        player:PrintToPlayer(string.format(
+            "%s (%d): model %d, animation %d, animationSub %d",
+            target:getName(),
+            target:getID(),
+            target:getModelId(),
+            target:getAnimation(),
+            target:getAnimationSub()
+        ))
+    else
+        error(player, string.format("Target is not a mob or NPC"))
+    end
+end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

N/A development only

## What does this pull request do? (Please be technical)

Constantly find myself needing this command to quickly check things in game while developing. Have rewritten it several times now. The use case is justified enough (for me at least) to submit it for a PR.

## Steps to test these changes

* Target an NPC or mob and use the command `!getmodel`
* Should display an error if targeting nothing or a player

## Special Deployment Considerations

N/A
