### PR TITLE
Cherry Pick Conquest Update rewrite from LSB

### DIFF
--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -51,10 +51,13 @@ namespace conquest
         zoneutils::ForEachZone([](CZone* PZone)
         {
             // only find chars for zones that have had conquest updated
-            if (PZone->GetRegionID() <= REGION_TYPE::TAVNAZIA)
+            if (PZone->GetRegionID() <= REGION_TYPE::DYNAMIS)
             {
                 luautils::OnConquestUpdate(PZone, Conquest_Update);
-                PZone->ForEachChar([](CCharEntity* PChar) { PChar->PLatentEffectContainer->CheckLatentsZone(); });
+                PZone->ForEachChar([](CCharEntity* PChar)
+                {
+                    PChar->PLatentEffectContainer->CheckLatentsZone();
+                });
             }
         });
         // clang-format on
@@ -371,7 +374,7 @@ namespace conquest
         zoneutils::ForEachZone([](CZone* PZone)
         {
             // only find chars for zones that have had conquest updated
-            if (PZone->GetRegionID() <= REGION_TYPE::TAVNAZIA)
+            if (PZone->GetRegionID() <= REGION_TYPE::DYNAMIS)
             {
                 luautils::OnConquestUpdate(PZone, Conquest_Tally_Start);
             }
@@ -398,7 +401,7 @@ namespace conquest
         zoneutils::ForEachZone([](CZone* PZone)
         {
             // only find chars for zones that have had conquest updated
-            if (PZone->GetRegionID() <= REGION_TYPE::TAVNAZIA)
+            if (PZone->GetRegionID() <= REGION_TYPE::DYNAMIS)
             {
                 luautils::OnConquestUpdate(PZone, Conquest_Tally_End);
                 PZone->ForEachChar([](CCharEntity* PChar)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

* The speed of conquest updates has been improved
* Troupe Valeriano will now always spawn under the correct conditions

## What does this pull request do? (Please be technical)

Cherrypicked from LSB
https://github.com/LandSandBoat/server/pull/3503
https://github.com/LandSandBoat/server/pull/3505

* This should dramatically improve the speed of conquest updates
* It also fixes some issues that prevented spawning Troupe Valeriano (Traveling merchant NPCs)

## Steps to test these changes

Troupe Valeriano should now appear according to the conquest results immediately upon server restart. The `!conquestupdate` command should also run without issue.

## Special Deployment Considerations

N/A
