### PR TITLE
Make table for Inside the Belly accessible

### DIFF
--- a/scripts/quests/otherAreas/Inside_the_Belly.lua
+++ b/scripts/quests/otherAreas/Inside_the_Belly.lua
@@ -16,49 +16,6 @@ local quest = Quest:new(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.INSI
 
 quest.reward = { }
 
-local fishRewards =
-{
-    ----- Quest 1 -----
-    [     xi.items.DARK_BASS] = { gil =  10, items = { { chance =  4.9, itemId =     xi.items.GREEN_ROCK } } },
-    [ xi.items.VEYDAL_WRASSE] = { gil = 225, items = { { chance =    5, itemId =     xi.items.NEBIMONITE }, { chance = 5, itemId = xi.items.SEASHELL } } },
-    [      xi.items.OGRE_EEL] = { gil =  16, items = { { chance =  2.6, itemId = xi.items.TURQUOISE_RING } }, title = xi.title.CORDON_BLEU_FISHER },
-    [ xi.items.GIANT_CATFISH] = { gil =  50, items = { { chance =  7.2, itemId =     xi.items.EARTH_WAND } }, title = xi.title.CORDON_BLEU_FISHER },
-    ----- Quest 2 -----
-    [  xi.items.ZAFMLUG_BASS] = { gil =  15, items = { { chance =  1.4, itemId =                  xi.items.BLUE_ROCK } } },
-    [   xi.items.GIANT_DONKO] = { gil =  96, items = { { chance =  4.7, itemId = xi.items.BROKEN_HALCYON_FISHING_ROD } } },
-    [     xi.items.BLADEFISH] = { gil = 200, items = { { chance = 11.7, itemId =                 xi.items.ROBBER_RIG } } },
-    [xi.items.BHEFHEL_MARLIN] = { gil = 150, items = { { chance =  3.0, itemId =             xi.items.BRIGANDS_CHART }, { chance = 4.4, itemId = xi.items.PIRATES_CHART } } },
-    [  xi.items.SILVER_SHARK] = { gil = 250, items = { { chance =  1.3, itemId =                    xi.items.TRIDENT } }, title = xi.title.ACE_ANGLER },
-    ----- Quest 3 -----
-    [xi.items.JUNGLE_CATFISH] = { gil = 300, items = { { chance = 3, itemId =    xi.items.BROKEN_HUME_FISHING_ROD } } },
-    [   xi.items.GAVIAL_FISH] = { gil = 250, items = { { chance = 5, itemId =              xi.items.DRONE_EARRING } } },
-    [  xi.items.EMPEROR_FISH] = { gil = 300, items = { { chance = 1, itemId =             xi.items.CUIR_HIGHBOOTS } } },
-    [  xi.items.MORINABALIGI] = { gil = 300, items = { { chance = 5, itemId =                xi.items.CUIR_GLOVES } } },
-    [      xi.items.PIRARUCU] = { gil = 516, items = { { chance = 5, itemId =                xi.items.WYVERN_SKIN }, { chance = 2.5, itemId =         xi.items.PEISTE_SKIN } } },
-    [     xi.items.MEGALODON] = { gil = 532, items = { { chance = 3, itemId = xi.items.BROKEN_MITHRAN_FISHING_ROD }, { chance =   3, itemId = xi.items.MITHRAN_FISHING_ROD } } },
-    ----- Quest 4 -----
-    [    xi.items.PTERYGOTUS] = { gil = 390, items = { { chance =  6.6, itemId =           xi.items.LAPIS_LAZULI } } },
-    [  xi.items.KALKANBALIGI] = { gil = 390, items = { { chance =  3.3, itemId =            xi.items.FLAT_SHIELD } } },
-    [      xi.items.TAKITARO] = { gil = 350, items = { { chance =  2.1, itemId =     xi.items.PHILOSOPHERS_STONE } } },
-    [    xi.items.SEA_ZOMBIE] = { gil = 350, items = { { chance = 23.4, itemId =         xi.items.DRILL_CALAMARY } } },
-    [   xi.items.CAVE_CHERAX] = { gil = 800, items = { { chance = 23.2, itemId =            xi.items.DWARF_PUGIL } } },
-    [       xi.items.TRICORN] = { gil = 810, items = { { chance =    4, itemId = xi.items.CHUNK_OF_DARKSTEEL_ORE } } },
-    [   xi.items.TURNABALIGI] = { gil = 340, items = { { chance =  0.8, itemId =      xi.items.CHUNK_OF_DARK_ORE }, { chance = 1.6, itemId = xi.items.CHUNK_OF_ICE_ORE }, { chance = 1.3, itemId = xi.items.CHUNK_OF_WATER_ORE } } },
-    [    xi.items.TITANICTUS] = { gil = 350, items = { { chance =  1.4, itemId =          xi.items.ANCIENT_SWORD } }, title = xi.title.LU_SHANG_LIKE_FISHER_KING },
-    ----- Unlisted -----
-    [  xi.items.GIANT_CHIRAI] = { gil = 550, items = { { chance =  1.2, itemId =  xi.items.SPOOL_OF_TWINTHREAD } } },
-    [   xi.items.GUGRUSAURUS] = { gil = 880, items = { { chance =  0.4, itemId =          xi.items.SABER_SHOOT } } },
-    [           xi.items.LIK] = { gil = 880, items = { { chance =  0.5, itemId =   xi.items.SPOOL_OF_OPAL_SILK } } },
-    [   xi.items.RYUGU_TITAN] = { gil = 800, items = { { chance =    1, itemId =      xi.items.MERCURIAL_SWORD } } },
-    [   xi.items.GERROTHORAX] = { gil = 423, items = { { chance =  1.2, itemId =          xi.items.RISKY_PATCH } } },
-    [    xi.items.MONKE_ONKE] = { gil = 150, items = { { chance =    2, itemId = xi.items.PINCH_OF_POISON_DUST } } },
-    [   xi.items.KILICBALIGI] = { gil = 150, items = { { chance =    2, itemId =     xi.items.RUSTY_GREATSWORD } } },
-    [xi.items.ARMORED_PISCES] = { gil = 475, items = { { chance =  0.4, itemId =   xi.items.STOLID_BREASTPLATE } } },
-    [     xi.items.MOLA_MOLA] = { gil = 478, items = { { chance =  1.8, itemId =      xi.items.MERCURIAL_SPEAR } } },
-    [       xi.items.AHTAPOT] = { gil = 350, items = { { chance = 18.8, itemId =        xi.items.DECAYED_INGOT }, { chance = 10.6, itemId = xi.items.MILDEWY_INGOT } } },
-    [       xi.items.LAKERDA] = { gil =  51, items = { { chance =    2, itemId =                xi.items.PEARL }, { chance = 10.6, itemId =   xi.items.BLACK_PEARL } } },
-}
-
 local skillCheck = function(player)
     local fishingSkill = player:getSkillLevel(xi.skill.FISHING)
     local fishingRank = player:getSkillRank(xi.skill.FISHING)
@@ -71,7 +28,7 @@ local tradeFish = function(player, fishId)
     player:setCharVar("insideBellyFishId", fishId)
     player:setCharVar("insideBellyItemIdx", 0)
 
-    local rewards = fishRewards[fishId].items
+    local rewards = xi.zones.Selbina.npcs.Zaldon.fishRewards[fishId].items
     local roll = math.random(1000) / 10
     local sum = 0
     local item = nil
@@ -102,7 +59,7 @@ local giveReward = function(player, csid)
     if csid == 166 or csid == 167 then
         local fishId  = player:getCharVar("insideBellyFishId")
         local itemIdx = player:getCharVar("insideBellyItemIdx")
-        local reward = fishRewards[fishId]
+        local reward  = xi.zones.Selbina.npcs.Zaldon.fishRewards[fishId]
 
         local itemId = nil
         local itemQt = nil
@@ -168,7 +125,7 @@ quest.sections =
             ['Zaldon'] =
             {
                 onTrade = function(player, npc, trade)
-                    for fish, _ in pairs(fishRewards) do
+                    for fish, _ in pairs(xi.zones.Selbina.npcs.Zaldon.fishRewards) do
                         if npcUtil.tradeHasExactly(trade, fish) then
                             return tradeFish(player, fish)
                         end
@@ -213,7 +170,7 @@ quest.sections =
             ['Zaldon'] =
             {
                 onTrade = function(player, npc, trade)
-                    for fish, _ in pairs(fishRewards) do
+                    for fish, _ in pairs(xi.zones.Selbina.npcs.Zaldon.fishRewards) do
                         if npcUtil.tradeHasExactly(trade, fish) then
                             return tradeFish(player, fish)
                         end

--- a/scripts/zones/Selbina/npcs/Zaldon.lua
+++ b/scripts/zones/Selbina/npcs/Zaldon.lua
@@ -14,6 +14,49 @@ require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
+entity.fishRewards =
+{
+    ----- Quest 1 -----
+    [     xi.items.DARK_BASS] = { gil =  10, items = { { chance =  4.9, itemId =                 xi.items.GREEN_ROCK } } },
+    [ xi.items.VEYDAL_WRASSE] = { gil = 225, items = { { chance =    5, itemId =                 xi.items.NEBIMONITE }, { chance = 5, itemId = xi.items.SEASHELL } } },
+    [      xi.items.OGRE_EEL] = { gil =  16, items = { { chance =  2.6, itemId =             xi.items.TURQUOISE_RING } }, title = xi.title.CORDON_BLEU_FISHER },
+    [ xi.items.GIANT_CATFISH] = { gil =  50, items = { { chance =  7.2, itemId =                 xi.items.EARTH_WAND } }, title = xi.title.CORDON_BLEU_FISHER },
+    ----- Quest 2 -----
+    [  xi.items.ZAFMLUG_BASS] = { gil =  15, items = { { chance =  1.4, itemId =                  xi.items.BLUE_ROCK } } },
+    [   xi.items.GIANT_DONKO] = { gil =  96, items = { { chance =  4.7, itemId = xi.items.BROKEN_HALCYON_FISHING_ROD } } },
+    [     xi.items.BLADEFISH] = { gil = 200, items = { { chance = 11.7, itemId =                 xi.items.ROBBER_RIG } } },
+    [xi.items.BHEFHEL_MARLIN] = { gil = 150, items = { { chance =  3.0, itemId =             xi.items.BRIGANDS_CHART }, { chance = 4.4, itemId = xi.items.PIRATES_CHART } } },
+    [  xi.items.SILVER_SHARK] = { gil = 250, items = { { chance =  1.3, itemId =                    xi.items.TRIDENT } }, title = xi.title.ACE_ANGLER },
+    ----- Quest 3 -----
+    [xi.items.JUNGLE_CATFISH] = { gil = 300, items = { { chance =    3, itemId =    xi.items.BROKEN_HUME_FISHING_ROD } } },
+    [   xi.items.GAVIAL_FISH] = { gil = 250, items = { { chance =    5, itemId =              xi.items.DRONE_EARRING } } },
+    [  xi.items.EMPEROR_FISH] = { gil = 300, items = { { chance =    1, itemId =             xi.items.CUIR_HIGHBOOTS } } },
+    [  xi.items.MORINABALIGI] = { gil = 300, items = { { chance =    5, itemId =                xi.items.CUIR_GLOVES } } },
+    [      xi.items.PIRARUCU] = { gil = 516, items = { { chance =    5, itemId =                xi.items.WYVERN_SKIN }, { chance = 2.5, itemId =         xi.items.PEISTE_SKIN } } },
+    [     xi.items.MEGALODON] = { gil = 532, items = { { chance =    3, itemId = xi.items.BROKEN_MITHRAN_FISHING_ROD }, { chance =   3, itemId = xi.items.MITHRAN_FISHING_ROD } } },
+    ----- Quest 4 -----
+    [    xi.items.PTERYGOTUS] = { gil = 390, items = { { chance =  6.6, itemId =               xi.items.LAPIS_LAZULI } } },
+    [  xi.items.KALKANBALIGI] = { gil = 390, items = { { chance =  3.3, itemId =                xi.items.FLAT_SHIELD } } },
+    [      xi.items.TAKITARO] = { gil = 350, items = { { chance =  2.1, itemId =         xi.items.PHILOSOPHERS_STONE } } },
+    [    xi.items.SEA_ZOMBIE] = { gil = 350, items = { { chance = 23.4, itemId =             xi.items.DRILL_CALAMARY } } },
+    [   xi.items.CAVE_CHERAX] = { gil = 800, items = { { chance = 23.2, itemId =                xi.items.DWARF_PUGIL } } },
+    [       xi.items.TRICORN] = { gil = 810, items = { { chance =    4, itemId =     xi.items.CHUNK_OF_DARKSTEEL_ORE } } },
+    [   xi.items.TURNABALIGI] = { gil = 340, items = { { chance =  0.8, itemId =          xi.items.CHUNK_OF_DARK_ORE }, { chance = 1.6, itemId = xi.items.CHUNK_OF_ICE_ORE }, { chance = 1.3, itemId = xi.items.CHUNK_OF_WATER_ORE } } },
+    [    xi.items.TITANICTUS] = { gil = 350, items = { { chance =  1.4, itemId =              xi.items.ANCIENT_SWORD } }, title = xi.title.LU_SHANG_LIKE_FISHER_KING },
+    ----- Unlisted -----
+    [  xi.items.GIANT_CHIRAI] = { gil = 550, items = { { chance =  1.2, itemId =        xi.items.SPOOL_OF_TWINTHREAD } } },
+    [   xi.items.GUGRUSAURUS] = { gil = 880, items = { { chance =  0.4, itemId =                xi.items.SABER_SHOOT } } },
+    [           xi.items.LIK] = { gil = 880, items = { { chance =  0.5, itemId =         xi.items.SPOOL_OF_OPAL_SILK } } },
+    [   xi.items.RYUGU_TITAN] = { gil = 800, items = { { chance =    1, itemId =            xi.items.MERCURIAL_SWORD } } },
+    [   xi.items.GERROTHORAX] = { gil = 423, items = { { chance =  1.2, itemId =                xi.items.RISKY_PATCH } } },
+    [    xi.items.MONKE_ONKE] = { gil = 150, items = { { chance =    2, itemId =       xi.items.PINCH_OF_POISON_DUST } } },
+    [   xi.items.KILICBALIGI] = { gil = 150, items = { { chance =    2, itemId =           xi.items.RUSTY_GREATSWORD } } },
+    [xi.items.ARMORED_PISCES] = { gil = 475, items = { { chance =  0.4, itemId =         xi.items.STOLID_BREASTPLATE } } },
+    [     xi.items.MOLA_MOLA] = { gil = 478, items = { { chance =  1.8, itemId =            xi.items.MERCURIAL_SPEAR } } },
+    [       xi.items.AHTAPOT] = { gil = 350, items = { { chance = 18.8, itemId =              xi.items.DECAYED_INGOT }, { chance = 10.6, itemId = xi.items.MILDEWY_INGOT } } },
+    [       xi.items.LAKERDA] = { gil =  51, items = { { chance =    2, itemId =                      xi.items.PEARL }, { chance = 10.6, itemId =   xi.items.BLACK_PEARL } } },
+}
+
 entity.onTrade = function(player, npc, trade)
     -- A BOY'S DREAM
     if player:getCharVar("aBoysDreamCS") >= 4 and npcUtil.tradeHas(trade, 4562) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

N/A development only

## What does this pull request do? (Please be technical)

When Inside the Belly was moved to interaction framework, the table was transferred from the Zaldon which prevented it being accessible. I moved it back to Zaldon's lua (In line with LSB) and attached it to the entity object, so it can be accessed and modified by modules, eg. for custom content, per server economy changes, or era accurate adjustments.

I've attached an example of how Inside the Belly / Zaldon's table can be updated using the changes in this PR. This example adds a new item but the same approach can be used to adjust gil, rates or items for any existing fish.

```lua
-----------------------------------
require("modules/module_utils")
require("scripts/globals/items")
require("scripts/zones/Selbina/npcs/Zaldon")
-----------------------------------
local m = Module:new("custom_zaldon")

m:addOverride("xi.zones.Selbina.Zone.onInitialize", function(zone)
    super(zone)

    -- Add item example
    xi.zones.Selbina.npcs.Zaldon.fishRewards[xi.items.NORG_SHELL] =
    {
        gil = 500,
        items =
        {
            {
                chance = 5.0,
                itemId = xi.items.PEARL,
            },
            {
                chance = 3.0,
                itemId = xi.items.BLACK_PEARL,
            },
            {
                chance = 1.0,
                itemId = xi.items.SOUTHERN_PEARL,
            },
        }
    }
end)

return m
```

## Steps to test these changes

```lua
!pos -11.810 -7.287 -6.742
!addquest 4 26 (player)
```

* Add custom module example to modules/init.txt
* Should be able to trade existing fish (eg. `!additem GAVIAL_FISH`)
* Should be able to trade new fish

## Special Deployment Considerations

N/A
