### PR TITLE
changed goblin swordsman sylvan stone drop to @ALWAYS

### DIFF
--- a/modules/era/sql/era_mob_droplist.sql
+++ b/modules/era/sql/era_mob_droplist.sql
@@ -9597,7 +9597,7 @@ INSERT INTO `mob_droplist` VALUES (1165,0,0,1000,12936,@VRARE); -- Greaves (Very
 INSERT INTO `mob_droplist` VALUES (1165,2,0,1000,750,0);        -- Silver Beastcoin (Steal)
 
 -- ZoneID:  12 - Goblin Swordsman
-INSERT INTO `mob_droplist` VALUES (1166,0,0,1000,1781,@COMMON); -- Sylvan Stone (Common, 15%)
+INSERT INTO `mob_droplist` VALUES (1166,0,0,1000,1781,@ALWAYS); -- Sylvan Stone (Always, 100%)
 INSERT INTO `mob_droplist` VALUES (1166,0,0,1000,508,@RARE);    -- Goblin Helm (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (1166,0,0,1000,507,@VRARE);   -- Goblin Mail (Very Rare, 1%)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Corrected the drop rate of Sylvan Stones from Goblin Swordsmen.

## What does this pull request do? (Please be technical)

Changes the era_mob_droplist table entry for Sylvan Stone from Goblin Swordsman from `@Common` to `@Always`.

Source from 06: https://ffxiclopedia.fandom.com/wiki/Goblin_Swordsman?oldid=137748

[FFXIDB](http://www.ffxidb.com/items/1781) shows the drop rate being slightly less than 100%, while ffxiclopedia states the drop is 100% and multiple can drop. However, [this page](https://ffxiclopedia.fandom.com/wiki/Sylvan_Stone) states that it is affected by day of the week, which would require retail testing to confirm. For now, `@Always` is much closer to accurate than `@Common`, and as far as I know there is no system in our drop tables to factor in days of the week (this is the first case I've ever even heard of the day mattering so I'm not sure how credible it even is.)

## Steps to test these changes

Pull, update DB, kill Goblin Swordsman.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
