### PR TITLE
Fix many small miscellaneous issues

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis.lua
@@ -1344,8 +1344,9 @@ end
 
 m:addOverride("xi.dynamis.qmOnTrigger", function(player, npc) -- Override standard qmOnTrigger()
     local zoneId = npc:getZoneID()
-    player:addKeyItem(xi.dynamis.dynaInfoEra[zoneId].winKI)
-    player:messageSpecial(zones[zoneId].text.KEYITEM_OBTAINED, xi.dynamis.dynaInfoEra[zoneId].winKI)
+    if not player:hasKeyItem(xi.dynamis.dynaInfoEra[zoneId].winKI) then
+        npcUtil.giveKeyItem(player, xi.dynamis.dynaInfoEra[zoneId].winKI)
+    end
 end)
 
 --------------------------------------------

--- a/modules/era/sql/era_mob_droplist.sql
+++ b/modules/era/sql/era_mob_droplist.sql
@@ -6913,7 +6913,7 @@ INSERT INTO `mob_droplist` VALUES (829,0,0,1000,2518,120); -- Smilodon Hide (12.
 INSERT INTO `mob_droplist` VALUES (829,0,0,1000,5668,40);  -- Smilodon Liver (4.0%)
 
 -- ZoneID:  30 - Firedrake
-INSERT INTO `mob_droplist` VALUES (830,0,0,1000,1691,@COMMON);   -- Giant Scale (Common, 15%)
+INSERT INTO `mob_droplist` VALUES (830,0,0,1000,1691,@VCOMMON);   -- Giant Scale (Very Common, 24%)
 INSERT INTO `mob_droplist` VALUES (830,0,0,1000,1122,@UNCOMMON); -- Wyvern Skin (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (830,0,0,1000,1124,@UNCOMMON); -- Wyvern Wing (Uncommon, 10%)
 
@@ -6998,7 +6998,7 @@ INSERT INTO `mob_droplist` VALUES (840,2,0,1000,1452,0);        -- Ordelle Bronz
 -- ZoneID:  30 - Flamedrake
 INSERT INTO `mob_droplist` VALUES (841,0,0,1000,1122,@COMMON); -- Wyvern Skin (Common, 15%)
 INSERT INTO `mob_droplist` VALUES (841,0,0,1000,1124,@COMMON); -- Wyvern Wing (Common, 15%)
-INSERT INTO `mob_droplist` VALUES (841,0,0,1000,1691,@COMMON); -- Giant Scale (Common, 15%)
+INSERT INTO `mob_droplist` VALUES (841,0,0,1000,1691,@VCOMMON); -- Giant Scale (Very Common, 24%)
 
 -- ZoneID: 216 - Flame Skimmer
 INSERT INTO `mob_droplist` VALUES (842,0,0,1000,3178,@UNCOMMON);  -- Ferine Seal Legs (Uncommon, 10%)
@@ -10994,7 +10994,7 @@ INSERT INTO `mob_droplist` VALUES (1351,4,0,1000,1606,0);         -- Remnant Of 
 
 -- ZoneID:  29 - Ignidrake
 -- ZoneID:  29 - Blazedrake
-INSERT INTO `mob_droplist` VALUES (1352,0,0,1000,1691,@COMMON); -- Giant Scale (Common, 15%)
+INSERT INTO `mob_droplist` VALUES (1352,0,0,1000,1691,@VCOMMON); -- Giant Scale (Very Common, 24%)
 INSERT INTO `mob_droplist` VALUES (1352,0,0,1000,1122,@RARE);   -- Wyvern Skin (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (1352,0,0,1000,1124,@VRARE);  -- Wyvern Wing (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (1352,2,0,1000,1691,0);       -- Giant Scale (Steal)
@@ -16404,7 +16404,7 @@ INSERT INTO `mob_droplist` VALUES (2047,0,0,1000,13180,@UNCOMMON); -- Republic S
 INSERT INTO `mob_droplist` VALUES (2047,0,0,1000,13181,@UNCOMMON); -- Federation Stables Scarf (Uncommon, 10%)
 
 -- ZoneID:  29 - Pyrodrake
-INSERT INTO `mob_droplist` VALUES (2048,0,0,1000,1691,@COMMON); -- Giant Scale (Common, 15%)
+INSERT INTO `mob_droplist` VALUES (2048,0,0,1000,1691,@VCOMMON); -- Giant Scale (Very Common, 24%)
 INSERT INTO `mob_droplist` VALUES (2048,0,0,1000,1122,@RARE);   -- Wyvern Skin (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (2048,0,0,1000,1124,@VRARE);  -- Wyvern Wing (Very Rare, 1%)
 

--- a/modules/era/sql/era_mob_droplist.sql
+++ b/modules/era/sql/era_mob_droplist.sql
@@ -9612,7 +9612,7 @@ INSERT INTO `mob_droplist` VALUES (1168,0,0,1000,17017,@UNCOMMON); -- Pet Food B
 INSERT INTO `mob_droplist` VALUES (1168,1,1,@VCOMMON,17860,350);   -- Jug of Carrot Broth (Group 1 - 35%)
 INSERT INTO `mob_droplist` VALUES (1168,1,1,@VCOMMON,17864,250);   -- Jug of Herbal Broth (Group 1 - 25%)
 INSERT INTO `mob_droplist` VALUES (1168,1,1,@VCOMMON,17876,100);   -- Jug of Fish Broth (Group 1 - 10%)
-INSERT INTO `mob_droplist` VALUES (1168,1,1,@VCOMMON,17920,100);   -- Jug of Meat Broth (Group 1 - 10%)
+INSERT INTO `mob_droplist` VALUES (1168,1,1,@VCOMMON,17870,100);   -- Jug of Meat Broth (Group 1 - 10%)
 INSERT INTO `mob_droplist` VALUES (1168,1,1,@VCOMMON,17872,100);   -- Jug of Tree Sap (Group 1 - 10%)
 INSERT INTO `mob_droplist` VALUES (1168,1,1,@VCOMMON,17867,50);    -- Jug of Cold Carrion Broth (Group 1 - 5%)
 INSERT INTO `mob_droplist` VALUES (1168,1,1,@VCOMMON,17877,50);    -- Jug of Fish Oil Broth (Group 1 - 5%)

--- a/modules/era/sql/synth_recipes_era.sql
+++ b/modules/era/sql/synth_recipes_era.sql
@@ -1385,6 +1385,9 @@ UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Platinum Mace'
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Anelace' AND ID = 14542;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Golden Spear' AND ID = 24017;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ID = 52502;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Dark Bronze Ingot' AND ID = 13511;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Lt. Steel Sheet' AND ID = 11529;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Lt. Steel Sheet' AND ID = 11534;
 
 -- ------------------------------------------------------------
 -- ToAU Synths
@@ -1416,8 +1419,6 @@ UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Wardrobe' AND
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Mezraq' AND ID = 5001;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ID = 11020;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Athenienne' AND ID = 11024;
-UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Lt. Steel Sheet' AND ID = 11529;
-UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Lt. Steel Sheet' AND ID = 11534;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Bannaret Mail' AND ID = 11553;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Throwing Tomahawk' AND ID = 12011;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Halo Claymore' AND ID = 12023;
@@ -1431,7 +1432,6 @@ UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Armor Plate I
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Jaridah Bazubands' AND ID = 13044;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Falsiam Vase' AND ID = 13501;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Kilij' AND ID = 13506;
-UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Dark Bronze Ingot' AND ID = 13511;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Hexagun' AND ID = 13525;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Regiment Kheten' AND ID = 13532;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Dark Amood' AND ID = 13539;

--- a/modules/era/sql/synth_recipes_era.sql
+++ b/modules/era/sql/synth_recipes_era.sql
@@ -1388,6 +1388,9 @@ UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ID = 52502;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Dark Bronze Ingot' AND ID = 13511;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Lt. Steel Sheet' AND ID = 11529;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Lt. Steel Sheet' AND ID = 11534;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Griffon Leather' AND ID = 44539;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Griffon Leather' AND ID = 44541;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Griffon Leather' AND ID = 44545;
 
 -- ------------------------------------------------------------
 -- ToAU Synths
@@ -1873,9 +1876,6 @@ UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Lynx Mantle' 
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Khromated Leather' AND ID = 44036;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Khromated Leather' AND ID = 44039;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Peiste Mantle' AND ID = 44530;
-UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Griffon Leather' AND ID = 44539;
-UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Griffon Leather' AND ID = 44541;
-UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Griffon Leather' AND ID = 44545;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ID = 45007;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ID = 52022;
 UPDATE `synth_recipes` SET ContentTag = 'WOTG' WHERE ResultName = 'Darksteel Jambiya' AND ID = 53005;

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -19755,6 +19755,7 @@ INSERT INTO `item_mods` VALUES (14074,23,12); -- ATT: 12
 -- Andvaranauts
 INSERT INTO `item_mods` VALUES (14075,1,12);  -- DEF: 12
 INSERT INTO `item_mods` VALUES (14075,12,-7); -- INT: -7
+INSERT INTO `item_mods` VALUES (14075,897,1); -- GILFINDER: 1
 
 -- Hecatomb Mittens
 INSERT INTO `item_mods` VALUES (14076,1,25);     -- DEF: 25

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -999,7 +999,7 @@ INSERT INTO `mob_groups` VALUES (42,4105,25,'Upyri',86400,0,2526,5000,0,43,47,0)
 INSERT INTO `mob_groups` VALUES (43,1389,25,'Fomor_Red_Mage',330,1,855,0,0,49,51,0);
 INSERT INTO `mob_groups` VALUES (44,1391,25,'Fomor_Summoner',330,1,880,0,0,48,50,0);
 INSERT INTO `mob_groups` VALUES (45,1395,25,'Fomors_Elemental',0,128,0,0,0,43,49,0);
-INSERT INTO `mob_groups` VALUES (46,1035,25,'Diatryma',330,0,651,0,0,47,51,0);
+INSERT INTO `mob_groups` VALUES (46,20016,25,'Diatryma',330,0,651,0,0,47,51,0);
 INSERT INTO `mob_groups` VALUES (47,5773,25,'Okyupete',0,32,3057,5550,0,57,60,0);
 INSERT INTO `mob_groups` VALUES (48,4814,25,'Bigclaw',330,0,271,0,0,45,48,0);
 INSERT INTO `mob_groups` VALUES (49,2491,25,'Makara',330,0,1579,0,0,46,49,0);

--- a/sql/mob_pools.sql
+++ b/sql/mob_pools.sql
@@ -7176,6 +7176,9 @@ INSERT INTO `mob_pools` VALUES (20013,'Land_Pugil_BE','Land_Pugil_BE',197,0x0000
 INSERT INTO `mob_pools` VALUES (20014,'Lemures','Lemures',121,0x0000700100000000000000000000000000000000,4,4,12,240,100,0,1,0,0,0,0,0,396,133,0,0,28,0,0,121,121);
 INSERT INTO `mob_pools` VALUES (20015,'Thousand_Eyes_KRT','Thousand_Eyes_KRT',139,0x0000800100000000000000000000000000000000,4,4,12,280,100,0,1,0,0,0,0,0,112,133,0,0,10,0,0,139,139);
 
+-- More mobs with different aggro and linking behaviors in diff zones
+INSERT INTO `mob_pools` VALUES (20016,'Diatryma','Diatryma',125,0x0000500100000000000000000000000000000000,1,1,11,240,100,0,0,0,1,0,0,0,680,131,0,0,0,0,0,125,125);
+
 -- End of AirSkyBoat section
 -- ------------------------------------------------------------
 

--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -395,7 +395,7 @@ INSERT INTO `synth_recipes` VALUES (3045,0,0,69,0,0,0,0,0,0,0,4098,4240,711,719,
 INSERT INTO `synth_recipes` VALUES (3046,0,0,70,37,0,0,0,19,0,0,4098,4240,654,717,719,893,932,0,0,0,17220,17227,17227,17227,1,1,1,1,'Heavy Crossbow'); -- one source 32 WW, one ?? Bone, others agree 10/29/21
 INSERT INTO `synth_recipes` VALUES (3047,0,0,70,18,0,0,0,0,0,0,4099,4241,662,725,725,0,0,0,0,0,12359,12370,12370,12370,1,1,1,1,'Hickory Shield'); -- ??SM, 8 & 18 posted (typo?), used 18 (iron sheet caps 22)
 INSERT INTO `synth_recipes` VALUES (3048,0,0,70,0,0,0,0,45,0,0,4098,4240,720,830,2513,2747,2762,0,0,0,18736,18736,18736,18736,1,1,1,1,'Fay Gendawa'); -- ??BO, 45/53 srcs, old era talk crafted at 39 - used 45
-INSERT INTO `synth_recipes` VALUES (3049,2,0,70,0,0,0,0,0,0,0,4102,4244,489,0,0,0,0,0,0,0,17386,17386,17386,17386,1,1,1,1,'Lu Shang\'s Fishing Rod'); -- multiple source agree 10/29/21
+INSERT INTO `synth_recipes` VALUES (3049,2,0,80,0,0,0,0,0,0,0,4102,4244,489,0,0,0,0,0,0,0,17386,17386,17386,17386,1,1,1,1,'Lu Shang\'s Fishing Rod'); -- multiple source agree 10/29/21
 -- INSERT INTO `synth_recipes` VALUES (3050,0,0,70,0,255,0,0,0,0,0,4099,4241,711,711,711,711,717,717,745,0,444,444,444,444,1,1,1,1,'Luxurious Chest');
 INSERT INTO `synth_recipes` VALUES (3501,0,0,71,0,0,0,0,0,0,0,4099,4241,719,719,927,0,0,0,0,0,17357,17833,17848,17848,1,1,1,1,'Ebony Harp');
 INSERT INTO `synth_recipes` VALUES (3502,0,0,71,0,0,0,0,0,0,0,4099,4241,662,716,716,716,0,0,0,0,95,95,95,95,1,1,1,1,'Water Barrel');


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

1. Increase Giant Scale drop rate to be closer to era drop rate. (Tracent)
2. Add missing Gilfinder bonus to Andvaranauts (Tracent)
3. Replaced out of era Meaty Broth with in-era Meat Broth as drop from Goblin Tamer (Tracent)
4. Add in-era Dark Bronze Ingot and Light Steel Sheet synths (Tracent)
5. Players can no longer attempt to get the same Dynamis key item multiple times (Tracent)
6. Fix Diatryma in Misareaux Coast to link and not aggro (Tracent)
7. Add in-era Griffon Leather synth (Tracent)
8. Correct Lu Shang's Fishing Rod synth to era accurate level (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes the above mentioned issues with proof for each issue as follows:

1. Increased base rate from 15% to 24% (see [ffxidb](http://www.ffxidb.com/zones/30/firedrake))
2. Gilfinder bonus was simply missing from item mods
3. Meaty Broth is OoE lvl 99 jug whereas Meat Broth is in-era lvl 28 jug
4. These synths are for AF+1 items and thus in CoP Era
5. Self-explanatory
6. Diatryma have different spawning and linking conditions in different zones (see [wiki](https://ffxiclopedia.fandom.com/wiki/Diatryma)), thus split into two different mob pools
7. Griffon Leather is in-era (see [here](https://ffxi.allakhazam.com/db/item.html?fitem=4915))
8. Lu Shang's Fishing Rod synth level was changed from 80 to 70 in 2015, thus should use older in-era level (see [here](http://forum.square-enix.com/ffxi/threads/47481-Jun-25-2015-%28JST%29-Version-Update))

## Steps to test these changes

1. Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1322
2. No github issue
4. Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1315
5. Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1314
6. Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1312
7. Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1242
8. Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1178
9. Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1237

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
