### PR TITLE
Update to BCNM tango_with_a_tracker.lua 

### DIFF
--- a/scripts/zones/Boneyard_Gully/bcnms/tango_with_a_tracker.lua
+++ b/scripts/zones/Boneyard_Gully/bcnms/tango_with_a_tracker.lua
@@ -39,7 +39,7 @@ end
 
 battlefield_object.onEventFinish = function(player, csid, option)
     if csid == 32001 then
-        player:addGil(10000)
+        npcUtil.giveCurrency(player, "gil", xi.settings.main.GIL_RATE * 10000)
         player:addTitle(xi.title.SIN_HUNTER_HUNTER)
         player:completeQuest(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.TANGO_WITH_A_TRACKER)
     end

--- a/scripts/zones/Boneyard_Gully/bcnms/tango_with_a_tracker.lua
+++ b/scripts/zones/Boneyard_Gully/bcnms/tango_with_a_tracker.lua
@@ -7,7 +7,7 @@ require("scripts/globals/battlefield")
 require("scripts/globals/keyitems")
 require('scripts/globals/quests')
 -----------------------------------
-local battlefield_object = {}
+local battlefieldObject = {}
 
 battlefield_object.onBattlefieldInitialise = function(battlefield)
 end

--- a/scripts/zones/Boneyard_Gully/bcnms/tango_with_a_tracker.lua
+++ b/scripts/zones/Boneyard_Gully/bcnms/tango_with_a_tracker.lua
@@ -9,23 +9,23 @@ require('scripts/globals/quests')
 -----------------------------------
 local battlefieldObject = {}
 
-battlefield_object.onBattlefieldInitialise = function(battlefield)
+battlefieldObject.onBattlefieldInitialise = function(battlefield)
 end
 
-battlefield_object.onBattlefieldTick = function(battlefield, tick)
+battlefieldObject.onBattlefieldTick = function(battlefield, tick)
     xi.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
-battlefield_object.onBattlefieldRegister = function(player, battlefield)
+battlefieldObject.onBattlefieldRegister = function(player, battlefield)
 end
 
-battlefield_object.onBattlefieldEnter = function(player, battlefield)
+battlefieldObject.onBattlefieldEnter = function(player, battlefield)
     if player:hasKeyItem(xi.ki.LETTER_FROM_SHIKAREE_X) then
         player:delKeyItem(xi.ki.LETTER_FROM_SHIKAREE_X)
     end
 end
 
-battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
+battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
@@ -34,10 +34,10 @@ battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
     end
 end
 
-battlefield_object.onEventUpdate = function(player, csid, option)
+battlefieldObject.onEventUpdate = function(player, csid, option)
 end
 
-battlefield_object.onEventFinish = function(player, csid, option)
+battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 then
         npcUtil.giveCurrency(player, "gil", xi.settings.main.GIL_RATE * 10000)
         player:addTitle(xi.title.SIN_HUNTER_HUNTER)

--- a/scripts/zones/Boneyard_Gully/bcnms/tango_with_a_tracker.lua
+++ b/scripts/zones/Boneyard_Gully/bcnms/tango_with_a_tracker.lua
@@ -45,4 +45,4 @@ battlefield_object.onEventFinish = function(player, csid, option)
     end
 end
 
-return battlefield_object
+return battlefieldObject


### PR DESCRIPTION
changed player:addGil to proper npcUtil

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
changes player:addGil to npcUtil.GiveCurrency
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
uses updated npcUtil in order to correct the issues in which players do not receive the message informing them that they recieved the 10000 gil reward from the BCNM.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Closes issue on the HorizonXI Issue Tracker [#1212](https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1212).
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
