### PR TITLE
Various LSB cherrypicks for QoLs

### DIFF
--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -107,32 +107,63 @@ bool CWeaponSkillState::Update(time_point tick)
 {
     if (!IsCompleted())
     {
-        SpendCost();
-        action_t action;
-        m_PEntity->OnWeaponSkillFinished(*this, action);
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+        CBattleEntity* PTarget = dynamic_cast<CBattleEntity*>(GetTarget());
+        action_t       action;
 
-        auto* PTarget{ GetTarget() };
-
-        // Reset Restraint bonus and trackers on weaponskill use
-        if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_RESTRAINT))
+        if (PTarget && PTarget->isAlive())
         {
-            uint16 WSBonus = m_PEntity->StatusEffectContainer->GetStatusEffect(EFFECT_RESTRAINT)->GetPower();
-            m_PEntity->StatusEffectContainer->GetStatusEffect(EFFECT_RESTRAINT)->SetPower(0);
-            m_PEntity->StatusEffectContainer->GetStatusEffect(EFFECT_RESTRAINT)->SetSubPower(0);
-            m_PEntity->delModifier(Mod::ALL_WSDMG_FIRST_HIT, WSBonus);
-        }
+            SpendCost();
 
-        if (action.actiontype == ACTION_WEAPONSKILL_FINISH) // category changes upon being out of range. This does not count for RoE and delay is not increased beyond the normal delay.
-        {
-            // only send lua the WS events if we are in range
-            m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), m_PSkill->getID(), m_spent, CLuaAction(&action));
-            PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", CLuaBaseEntity(PTarget), CLuaBaseEntity(m_PEntity), m_PSkill->getID(), m_spent, CLuaAction(&action));
+            m_PEntity->OnWeaponSkillFinished(*this, action);
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
 
-            if (m_PEntity->objtype == TYPE_PC)
+            // Reset Restraint bonus and trackers on weaponskill use
+            if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_RESTRAINT))
             {
-                roeutils::event(ROE_EVENT::ROE_WSKILL_USE, static_cast<CCharEntity*>(m_PEntity), RoeDatagram("skillType", m_PSkill->getType()));
+                uint16 WSBonus = m_PEntity->StatusEffectContainer->GetStatusEffect(EFFECT_RESTRAINT)->GetPower();
+                m_PEntity->StatusEffectContainer->GetStatusEffect(EFFECT_RESTRAINT)->SetPower(0);
+                m_PEntity->StatusEffectContainer->GetStatusEffect(EFFECT_RESTRAINT)->SetSubPower(0);
+                m_PEntity->delModifier(Mod::ALL_WSDMG_FIRST_HIT, WSBonus);
             }
+
+            if (action.actiontype == ACTION_WEAPONSKILL_FINISH) // category changes upon being out of range. This does not count for RoE and delay is not increased beyond the normal delay.
+            {
+                // only send lua the WS events if we are in range
+                m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), m_PSkill->getID(), m_spent, CLuaAction(&action));
+                PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", CLuaBaseEntity(PTarget), CLuaBaseEntity(m_PEntity), m_PSkill->getID(), m_spent, CLuaAction(&action));
+
+                if (m_PEntity->objtype == TYPE_PC)
+                {
+                    roeutils::event(ROE_EVENT::ROE_WSKILL_USE, static_cast<CCharEntity*>(m_PEntity), RoeDatagram("skillType", m_PSkill->getType()));
+                }
+            }
+        }
+        else // Mob is dead before we could finish WS, generate interrupt for WS
+        {
+            // Could not reproduce on retail due to server tick rate, this entire block is assumed.
+            // Ideally, you would ready a WS then have the mob die to either a DoT or a JA like Quick Draw/Jump and dump the packet.
+            // To the best of our knowledge this would produce a similar-enough effect to cancel the WS animation
+            // Essentially, very similar to "too far away" and casting out of range spell cancellation, with no message.
+            action.actiontype        = ACTION_MAGIC_FINISH;
+            action.actionid          = 28787; // Some hardcoded magic for interrupts
+            actionList_t& actionList = action.getNewActionList();
+
+            if (PTarget)
+            {
+                actionList.ActionTargetID = PTarget->id;
+            }
+            else // Dead code? PTarget should probably never be nullptr.
+            {
+                actionList.ActionTargetID = 0;
+            }
+
+            actionTarget_t& actionTarget = actionList.getNewActionTarget();
+
+            actionTarget.animation = 0x1FC;
+            actionTarget.messageID = 0;
+            actionTarget.reaction  = REACTION::ABILITY | REACTION::HIT;
+
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
         }
 
         auto delay   = m_PSkill->getAnimationTime(); // TODO: Is delay time a fixed number if the weaponskill is used out of range?

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -899,7 +899,12 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
                 first = false;
             }
         }
-        PTargetFound->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+
+        if (PSkill->getValidTargets() & TARGET_ENEMY)
+        {
+            PTargetFound->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+        }
+
         if (PTargetFound->isDead())
         {
             battleutils::ClaimMob(PTargetFound, this);

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -565,7 +565,12 @@ void CPetEntity::OnPetSkillFinished(CPetSkillState& state, action_t& action)
                 first = false;
             }
         }
-        PTargetFound->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+
+        if (PSkill->getValidTargets() & TARGET_ENEMY)
+        {
+            PTargetFound->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+        }
+
         if (PTargetFound->isDead())
         {
             battleutils::ClaimMob(PTargetFound, this);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5596,13 +5596,17 @@ void SmallPacket0x0BE(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 if (PChar->PMeritPoints->IsMeritExist(merit))
                 {
+                    const Merit_t* PMerit = PChar->PMeritPoints->GetMerit(merit);
+
                     switch (operation)
                     {
                         case 0:
                             PChar->PMeritPoints->LowerMerit(merit);
+                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, data.ref<uint16>(0x06), PMerit->count, MSGBASIC_MERIT_DECREASE));
                             break;
                         case 1:
                             PChar->PMeritPoints->RaiseMerit(merit);
+                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, data.ref<uint16>(0x06), PMerit->count, MSGBASIC_MERIT_INCREASE));
                             break;
                     }
                     PChar->pushPacket(new CMenuMeritPacket(PChar));

--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -167,6 +167,9 @@ enum MSGBASIC_ID : uint16
     MSGBASIC_ROE_TIMED    = 705, // You have undertaken the timed record X.
     MSGBASIC_ROE_RECORD   = 697, // Records of Eminence: <record>.
     MSGBASIC_ROE_PROGRESS = 698, // Progress: <amount>/<amount>.
+    /* Merits */
+    MSGBASIC_MERIT_INCREASE = 380, // Your <merit> modification has risen to level <level>
+    MSGBASIC_MERIT_DECREASE = 381, // Your <merit> modification has dropped to level <level>
     /* DEBUG MESSAGES */
     MSGBASIC_DEBUG_RESISTED_SPELL   = 66, /* Debug: Resisted spell! */
     MSGBASIC_DEBUG_RECEIVED_STATUS  = 73, /* Debug: <target>'s status is now .. */

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -109,6 +109,7 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 AHCategoryID, int8*
 
             PAHItem->SingleAmount = sql->GetIntData(2);
             PAHItem->StackAmount  = sql->GetIntData(3);
+            PAHItem->Category     = AHCategoryID;
 
             if (sql->GetIntData(1) == 1)
             {
@@ -164,6 +165,41 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 AHCategoryID, int8*
     }
 
     return ItemList;
+}
+
+// Return single item including category and how many are listed
+ahItem CDataLoader::GetAHItemFromItemID(uint16 ItemID)
+{
+    const char* fmtQuery = "SELECT aH, COUNT(*)-SUM(stack), SUM(stack) "
+                           "FROM item_basic "
+                           "LEFT JOIN auction_house ON item_basic.itemId = auction_house.itemid AND auction_house.buyer_name IS NULL "
+                           "LEFT JOIN item_equipment ON item_basic.itemid = item_equipment.itemid "
+                           "LEFT JOIN item_weapon ON item_basic.itemid = item_weapon.itemid "
+                           "WHERE item_basic.itemid = %u";
+
+    int32 ret = sql->Query(fmtQuery, ItemID);
+
+    ahItem CAHItem       = {};
+    CAHItem.ItemID       = ItemID;
+    CAHItem.Category     = 0;
+    CAHItem.SingleAmount = 0;
+    CAHItem.StackAmount  = 0;
+
+    if (ret != SQL_ERROR && sql->NumRows() != 0)
+    {
+        while (sql->NextRow() == SQL_SUCCESS)
+        {
+            CAHItem.Category     = sql->GetIntData(0);
+            CAHItem.SingleAmount = sql->GetIntData(1);
+            CAHItem.StackAmount  = sql->GetIntData(2);
+
+            if (sql->GetIntData(1) == 1)
+            {
+                CAHItem.StackAmount = 0;
+            }
+        }
+    }
+    return CAHItem;
 }
 
 /************************************************************************

--- a/src/search/data_loader.h
+++ b/src/search/data_loader.h
@@ -37,6 +37,7 @@ struct ahItem
     uint16 ItemID;
     uint32 SingleAmount;
     uint32 StackAmount;
+    uint16 Category;
 };
 
 struct ahHistory
@@ -93,6 +94,7 @@ public:
     std::list<SearchEntity*> GetPlayersList(search_req sr, int* count);
     std::string              GetSearchComment(uint32 playerId);
     std::vector<ahItem*>     GetAHItemsToCategory(uint8 AHCategoryID, int8* OrderByString);
+    ahItem                   GetAHItemFromItemID(uint16 ItemID);
     void                     ExpireAHItems(uint16 expireAgeInDays);
 
 private:

--- a/src/search/packets/auction_history.cpp
+++ b/src/search/packets/auction_history.cpp
@@ -27,14 +27,22 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #include "auction_history.h"
 
-CAHHistoryPacket::CAHHistoryPacket(uint16 ItemID)
+CAHHistoryPacket::CAHHistoryPacket(ahItem item, uint8 stack)
 : m_count(0)
 {
     memset(m_PData, 0, sizeof(m_PData));
 
-    ref<uint8>(m_PData, (0x0A)) = 0x80;
-    ref<uint8>(m_PData, (0x0B)) = 0x85; // packet type
-    ref<uint16>(m_PData, 0x10)  = ItemID;
+    // Comments and RE by atom0s
+    ref<uint8>(m_PData, 0x0A)  = 0x80;        // flags, may be int8 as it's checked against negative.
+    ref<uint8>(m_PData, 0x0B)  = 0x85;        // packet type, masked as val & 0x1F
+    ref<uint16>(m_PData, 0x0E) = 0;           // Unknown use
+    ref<uint16>(m_PData, 0x10) = item.ItemID; // may be obsolete
+    ref<uint16>(m_PData, 0x12) = 0;           // Unknown use
+    ref<uint16>(m_PData, 0x14) = 0;           // Unknown use
+    ref<uint16>(m_PData, 0x16) = 0;           // Unknown use
+    ref<uint16>(m_PData, 0x18) = item.ItemID;
+    ref<uint32>(m_PData, 0x1A) = stack != 0 ? item.StackAmount : item.SingleAmount;
+    ref<uint16>(m_PData, 0x1E) = item.Category;
 }
 
 void CAHHistoryPacket::AddItem(ahHistory* item)

--- a/src/search/packets/auction_history.h
+++ b/src/search/packets/auction_history.h
@@ -27,7 +27,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 class CAHHistoryPacket
 {
 public:
-    CAHHistoryPacket(uint16 ItemID);
+    CAHHistoryPacket(ahItem item, uint8 stack);
 
     void AddItem(ahHistory* item);
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -667,10 +667,11 @@ void HandleAuctionHouseHistory(CTCPRequestPacket& PTCPRequest)
     uint16 ItemID = ref<uint16>(data, 0x12);
     uint8  stack  = ref<uint8>(data, 0x15);
 
-    CAHHistoryPacket PAHPacket(ItemID);
-
     CDataLoader             PDataLoader;
     std::vector<ahHistory*> HistoryList = PDataLoader.GetAHItemHystory(ItemID, stack != 0);
+    ahItem                  item        = PDataLoader.GetAHItemFromItemID(ItemID);
+
+    CAHHistoryPacket PAHPacket = CAHHistoryPacket(item, stack);
 
     for (auto& i : HistoryList)
     {


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Check if mob is dead during completion of a WS and not remove TP (WinterSolstice)
Only remove Sneak/Invis when mob/pet ability is an attack (WinterSolstice)
Add upgrade/downgrade merit messages (WinterSolstice)
Display of category and total amount of listings in AH sell menu (WinterSolstice)

## What does this pull request do? (Please be technical)

- Check if mob is dead during completion of a WS and not remove TP
- Don't remove Sneak/Invis if pet BP is a buff
- Adds messaging to upgrading/downgrading merits
![image](https://user-images.githubusercontent.com/60417494/229324515-392a061b-2d14-4b3e-bcd9-603db5012bef.png)
- Displays category (top left, Clothcraft) and number of items on sale (top right, one of that item on sale)
![image](https://user-images.githubusercontent.com/60417494/229324503-f8e27771-0cb5-49d5-996d-c8bd17596fa5.png)


## Steps to test these changes

Check if mob is dead during completion of a WS and not remove TP:
Easiest way to test TP not being removed on a dead mob is to breakpoint in the modified function and manually setting the mob HP to 0 during the WS ending so you can see if there's no adverse effects to doing so.

Don't remove Sneak/Invis if pet BP is a buff:
Sneak yourself, then use something like earthen ward and keep sneak

Adds messaging to upgrading/downgrading merits:
upgrade/downgrade merits and see the messages

Displays category (top left, Clothraft) and number of items on sale (top right, one of that item on sale):
!additem yourself with an item you can sell, list it, list a second one and see the stack count increased by one -- also verify stacks are pulling different numbers

## Special Deployment Considerations

N/A