### PR TITLE
[core] Fix paralyze counting twice for JAs and bad packets, correctly cancel /ra animation upon paralyze

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1346,12 +1346,6 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
             }
         }
 
-        if (battleutils::IsParalyzed(this))
-        {
-            setActionInterrupted(action, PTarget, MSGBASIC_IS_PARALYZED, 0);
-            return;
-        }
-
         // get any available merit recast reduction
         uint8 meritRecastReduction = 0;
         uint8 chargeTime           = 0;
@@ -1447,12 +1441,17 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
             }
         }
 
-        if (battleutils::IsParalyzed(this) && !(PAbility->getRecastTime() == 7200)) // If Paralyzed and Not JSA (7200s = 2Hr)
+        if (battleutils::IsParalyzed(this))
         {
-            // display paralyzed
-            PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), action.recast);
-            pushPacket(new CCharRecastPacket(this));
-            loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_IS_PARALYZED));
+            setActionInterrupted(action, PTarget, MSGBASIC_IS_PARALYZED, 0);
+
+            // You got paralyzed, reset the timer for this JA which is era behavior, unless it is the 2hr.
+            // RecastID 0 & 254 are starting 2hr and level 96 2hr respectively. 2hrs do not get their recast eaten.
+            if (PAbility->getRecastId() != 0 && PAbility->getRecastId() != 254)
+            {
+                PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), action.recast);
+                pushPacket(new CCharRecastPacket(this));
+            }
             return;
         }
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1698,13 +1698,6 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
     TracyZoneScoped;
     auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
 
-    if (battleutils::IsParalyzed(this))
-    {
-        // display paralyzed
-        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_IS_PARALYZED));
-        return;
-    }
-
     int32 damage      = 0;
     int32 totalDamage = 0;
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1698,6 +1698,28 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
     TracyZoneScoped;
     auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
 
+    if (battleutils::IsParalyzed(this))
+    {
+        // setup new action packet to send paralyze message
+        action_t paralyze_action = {};
+        setActionInterrupted(paralyze_action, PTarget, MSGBASIC_IS_PARALYZED, 0);
+        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CActionPacket(paralyze_action));
+
+        // Set up /ra action to be interrupted
+        action.actiontype = ACTION_RANGED_INTERRUPT; // This handles some magic numbers in CActionPacket to cancel actions
+        action.id         = id;
+
+        actionList_t& actionList  = action.getNewActionList();
+        actionList.ActionTargetID = id;
+
+        actionTarget_t& actionTarget = actionList.getNewActionTarget();
+        actionTarget.animation       = 0x1FC; // Seems hardcoded, two bits away from 0x1FF (0x1FC = 1 1111 1100)
+        actionTarget.speceffect      = SPECEFFECT::RECOIL;
+        actionTarget.reaction        = REACTION::NONE;
+
+        return;
+    }
+
     int32 damage      = 0;
     int32 totalDamage = 0;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Job abilities are now correctly only checked once for paralyze instead of twice (WinterSolstice)
Fix bad paralyze packets from players causing addons to crash (WinterSolstice)
Paralyzed ranged attacks now correctly cancel the animation (WinterSolstice)

## What does this pull request do? (Please be technical)

The packets were verified on retail.

Fixes job ability paralyze check so it is only checked once
Fixes job ability paralyze packet so it correctly sends the paralyze message which will no longer crash addons
Makes the 2hr check for paralyze not consuming the timer more robust by using the recastID instead of ability recast timer
Adds in the mechanic where 2hrs still have the paralyze check even if the timer isn't consumed

One cherry-picked commit for /ra paralzye packet/animation from LSB which corrects:
- Bad packet for paralyze message which crashes addons
- /ra animation is canceled instead of keeping your weapon out


## Steps to test these changes
!setmod paralyze 100 on yousrelf
/ra and pull your weapon out, but eventually get paralyzed and put it away
use JAs and see the paralyze message and get your timer reset
use 2hrs and see the paralyze message but don't get your timer reset

## Special Deployment Considerations
N/A