### PR TITLE
Custom Chest System (Module)

### DIFF
--- a/modules/custom/content/custom_chest.lua
+++ b/modules/custom/content/custom_chest.lua
@@ -1,0 +1,117 @@
+-----------------------------------
+-- Custom Treasure Chest System
+-----------------------------------
+require("modules/module_utils")
+require("scripts/globals/items")
+require("scripts/globals/npc_util")
+local customUtil = require("modules/custom/content/custom_util")
+-----------------------------------
+local m = Module:new("custom_chest")
+
+m.zone = {}
+
+m.rate    = customUtil.rate
+m.rateTH  = customUtil.rateTH
+m.respawn =
+{
+    SHORT      = {  720000,  900000 }, -- 12-15 minutes
+    MODERATE   = { 1500000, 1800000 }, -- 25-30 minutes
+    LONG       = { 2100000, 2700000 }, -- 35-45 minutes
+    VERY_LONG  = { 3000000, 3600000 }, -- 50-60 minutes
+}
+m.look   =
+{
+    TREASURE_CHEST = 960,
+}
+
+local moveChest = function(npc)
+    local zoneId  = npc:getZoneID()
+    local respawn = m.zone[zoneId].respawn
+    local nextPos = m.zone[zoneId].points[math.random(1, #m.zone[zoneId].points)]
+
+    -- Fixed respawn or random range
+    if type(respawn) == "table" then
+        respawn = math.random(respawn[1], respawn[2])
+    end
+
+    npc:timer(respawn, function(npcArg)
+        npcArg:setPos(nextPos[1], nextPos[2], nextPos[3], nextPos[4])
+        npcUtil.showCrate(npcArg)
+    end)
+end
+
+local onTrigger = function(player, npc)
+    local zoneId = player:getZoneID()
+    local keyName = m.zone[zoneId].key
+
+    if m.zone[zoneId].dialog then
+        customUtil.dialogTable(player, m.zone[zoneId].dialog, "", { keyName })
+    else
+        customUtil.dialogTable(player, {
+            "The chest appears to be locked.",
+            " If only you had %s, perhaps you could open it...",
+        }, "", { keyName })
+    end
+end
+
+local onTrade = function(player, npc, trade)
+    local zoneId = npc:getZoneID()
+    local keyId  = m.zone[zoneId].id
+    local items  = m.zone[zoneId].items
+
+    player:delStatusEffect(xi.effect.INVISIBLE)
+    player:delStatusEffect(xi.effect.SNEAK)
+
+    if npcUtil.tradeHasExactly(trade, keyId) then
+        npcUtil.openCrate(npc, function()
+            local result = customUtil.pickItem(player, items)
+            player:addTreasure(result[2])
+            player:tradeComplete()
+
+            npc:timer(7000, function(npcArg)
+                -- For whatever reason xi.status.DISAPPEAR doesn't work with dynamicEntities
+                npcArg:setStatus(xi.status.INVISIBLE)
+                moveChest(npcArg)
+            end)
+        end)
+    else
+        player:PrintToPlayer("Nothing happens.", xi.msg.channel.NS_SAY)
+    end
+end
+
+m.initZone = function(zone)
+    local zoneId   = zone:getID()
+    local zoneName = zone:getName()
+
+    for _, v in ipairs(m.zone[zoneId].mobs) do
+        local mobName = v[1]
+        local rate    = v[2]
+
+        customUtil.duplicateOverride(xi.zones[zoneName].mobs[mobName], "onMobDeath", function(mob, player, optParams)
+            super(mob, player, optParams)
+
+            if math.random(0, 10000) < customUtil.getRateTH(mob, rate) then
+                player:addTreasure(m.zone[zoneId].id, mob)
+            end
+        end)
+    end
+
+    local pos = m.zone[zoneId].points[math.random(1, #m.zone[zoneId].points)]
+
+    local dynamicChest = zone:insertDynamicEntity({
+        objtype   = xi.objType.NPC,
+        name      = m.zone[zoneId].name,
+        look      = m.zone[zoneId].look,
+        x         = pos[1],
+        y         = pos[2],
+        z         = pos[3],
+        rotation  = pos[4],
+        widescan  = 0,
+        onTrigger = onTrigger,
+        onTrade   = onTrade,
+    })
+
+    utils.unused(dynamicChest)
+end
+
+return m

--- a/modules/custom/content/custom_chest.lua
+++ b/modules/custom/content/custom_chest.lua
@@ -11,7 +11,6 @@ local m = Module:new("custom_chest")
 m.zone = {}
 
 m.rate    = customUtil.rate
-m.rateTH  = customUtil.rateTH
 m.respawn =
 {
     SHORT      = {  720000,  900000 }, -- 12-15 minutes
@@ -89,10 +88,7 @@ m.initZone = function(zone)
 
         customUtil.duplicateOverride(xi.zones[zoneName].mobs[mobName], "onMobDeath", function(mob, player, optParams)
             super(mob, player, optParams)
-
-            if math.random(0, 10000) < customUtil.getRateTH(mob, rate) then
-                player:addTreasure(m.zone[zoneId].id, mob)
-            end
+            player:addTreasure(m.zone[zoneId].id, mob, rate)
         end)
     end
 

--- a/modules/custom/content/custom_util.lua
+++ b/modules/custom/content/custom_util.lua
@@ -9,37 +9,14 @@ local m = Module:new("custom_util")
 
 m.rate =
 {
-    VERY_COMMON = 2400,
-    COMMON      = 1500,
-    UNCOMMON    = 1000,
-    RARE        =  500,
-    VERY_RARE   =  100,
-    SUPER_RARE  =   50,
-    ULTRA_RARE  =   10,
+    VERY_COMMON = 240, --  24%
+    COMMON      = 150, --  15%
+    UNCOMMON    = 100, --  10%
+    RARE        =  50, --   5%
+    VERY_RARE   =  10, --   1%
+    SUPER_RARE  =   5, -- 0.5%
+    ULTRA_RARE  =   1, -- 0.1%
 }
-
-m.rateTH =
-{
-    VERY_COMMON = { 2400, 4800, 5600, 6000, 6400, },
-    COMMON      = { 1500, 3000, 4000, 4250, 4500, },
-    UNCOMMON    = { 1000, 1200, 1500, 1650, 1800, },
-    RARE        = {  500,  600,  700,  750,  800, },
-    VERY_RARE   = {  100,  150,  200,  225,  250, },
-    SUPER_RARE  = {   50,   75,  100,  120,  140, },
-    ULTRA_RARE  = {   10,   20,   30,   35,   40, },
-}
-
-m.getRateTH = function(mob, rate)
-    local level = mob:getTHlevel() + 1
-
-    for k, v in pairs(m.rate) do
-        if v == rate then
-            return m.rateTH[k][level]
-        end
-    end
-
-    return rate
-end
 
 -- player, { { rate, item } }, modifier
 m.pickItem = function(player, items, mod)
@@ -93,20 +70,24 @@ m.dialogTable = function(player, tbl, npcName, param)
 
     for i = 1, #tbl do
         local result = tbl[i]
+        local delay  = (i - 1) * 1000
+
         if param then
             result = string.format(tbl[i], param[1], param[2], param[3], param[4])
         end
 
         if tbl[i]:sub(1, 1) == " " then
             -- Paragraph continue
-            player:PrintToPlayer(result, xi.msg.channel.NS_SAY)
+            player:timer(delay, function(playerArg)
+                playerArg:PrintToPlayer(result, xi.msg.channel.NS_SAY)
+            end)
         else
             -- New paragraph
-            player:PrintToPlayer(prefix .. result, xi.msg.channel.NS_SAY)
+            player:timer(delay, function(playerArg)
+                playerArg:PrintToPlayer(prefix .. result, xi.msg.channel.NS_SAY)
+            end)
         end
     end
-
-    -- TODO: timer delay
 end
 
 m.duplicateOverride = function(entity, event, func)

--- a/modules/custom/content/custom_util.lua
+++ b/modules/custom/content/custom_util.lua
@@ -1,0 +1,132 @@
+-----------------------------------
+-- custom_util
+-----------------------------------
+require("modules/module_utils")
+require("scripts/globals/items")
+require("scripts/globals/npc_util")
+-----------------------------------
+local m = Module:new("custom_util")
+
+m.rate =
+{
+    VERY_COMMON = 2400,
+    COMMON      = 1500,
+    UNCOMMON    = 1000,
+    RARE        =  500,
+    VERY_RARE   =  100,
+    SUPER_RARE  =   50,
+    ULTRA_RARE  =   10,
+}
+
+m.rateTH =
+{
+    VERY_COMMON = { 2400, 4800, 5600, 6000, 6400, },
+    COMMON      = { 1500, 3000, 4000, 4250, 4500, },
+    UNCOMMON    = { 1000, 1200, 1500, 1650, 1800, },
+    RARE        = {  500,  600,  700,  750,  800, },
+    VERY_RARE   = {  100,  150,  200,  225,  250, },
+    SUPER_RARE  = {   50,   75,  100,  120,  140, },
+    ULTRA_RARE  = {   10,   20,   30,   35,   40, },
+}
+
+m.getRateTH = function(mob, rate)
+    local level = mob:getTHlevel() + 1
+
+    for k, v in pairs(m.rate) do
+        if v == rate then
+            return m.rateTH[k][level]
+        end
+    end
+
+    return rate
+end
+
+-- player, { { rate, item } }, modifier
+m.pickItem = function(player, items, mod)
+    -- sum weights
+    local sum = 0
+    for i = 1, #items do
+        if mod ~= nil then
+            sum = sum + items[i][1][mod]
+        else
+            sum = sum + items[i][1]
+        end
+    end
+
+    -- pick weighted result
+    local item = items[1]
+
+    local pick = math.random(1, sum)
+    sum = 0
+
+    for i = 1, #items do
+        if mod ~= nil then
+            sum = sum + items[i][1][mod]
+        else
+            sum = sum + items[i][1]
+        end
+
+        if sum >= pick then
+            item = items[i]
+            break
+        end
+    end
+
+    return item
+end
+
+m.dialogTable = function(player, tbl, npcName, param)
+    local prefix = ""
+
+    if npcName and string.len(npcName) > 0 then
+        prefix = string.format("%s : ", npcName)
+    end
+
+    if #tbl == 1 then
+        local result = tbl[1]
+        if param then
+            result = string.format(tbl[1], param[1], param[2], param[3], param[4])
+        end
+            player:PrintToPlayer(prefix .. result, xi.msg.channel.NS_SAY)
+        return
+    end
+
+    for i = 1, #tbl do
+        local result = tbl[i]
+        if param then
+            result = string.format(tbl[i], param[1], param[2], param[3], param[4])
+        end
+
+        if tbl[i]:sub(1, 1) == " " then
+            -- Paragraph continue
+            player:PrintToPlayer(result, xi.msg.channel.NS_SAY)
+        else
+            -- New paragraph
+            player:PrintToPlayer(prefix .. result, xi.msg.channel.NS_SAY)
+        end
+    end
+
+    -- TODO: timer delay
+end
+
+m.duplicateOverride = function(entity, event, func)
+    if not entity then
+        return
+    end
+
+    local origEvent = event .. "Orig"
+
+    if entity[origEvent] == nil and entity[event] then
+        entity[origEvent] = entity[event]
+    end
+
+    local thisenv = getfenv(entity[event])
+    local env = { super = entity[origEvent] }
+
+    setmetatable(env, { __index = thisenv })
+    setfenv(func, env)
+
+    entity[event] = func
+end
+
+return m

--- a/modules/custom/content/custom_util.lua
+++ b/modules/custom/content/custom_util.lua
@@ -9,13 +9,14 @@ local m = Module:new("custom_util")
 
 m.rate =
 {
-    VERY_COMMON = 240, --  24%
-    COMMON      = 150, --  15%
-    UNCOMMON    = 100, --  10%
-    RARE        =  50, --   5%
-    VERY_RARE   =  10, --   1%
-    SUPER_RARE  =   5, -- 0.5%
-    ULTRA_RARE  =   1, -- 0.1%
+    GUARANTEED  = 1000, -- 100%
+    VERY_COMMON =  240, --  24%
+    COMMON      =  150, --  15%
+    UNCOMMON    =  100, --  10%
+    RARE        =   50, --   5%
+    VERY_RARE   =   10, --   1%
+    SUPER_RARE  =    5, -- 0.5%
+    ULTRA_RARE  =    1, -- 0.1%
 }
 
 -- player, { { rate, item } }, modifier
@@ -32,7 +33,6 @@ m.pickItem = function(player, items, mod)
 
     -- pick weighted result
     local item = items[1]
-
     local pick = math.random(1, sum)
     sum = 0
 

--- a/modules/custom/content/examples/custom_chest_example.lua
+++ b/modules/custom/content/examples/custom_chest_example.lua
@@ -22,6 +22,14 @@ chest.zone[xi.zone.QUFIM_ISLAND] =
         { chest.rate.RARE,        xi.items.PEARL,       }, --  5%
     },
 
+    -- Optional
+    gil =
+    {
+        rate = chest.rate.VERY_COMMON, -- 24%
+        min  = 1000,
+        max  = 2000,
+    },
+
     points =
     {
         { -249.422,  -20.000, 300.000, 120, }, -- !pos -249.422 -20.000 300.000

--- a/modules/custom/content/examples/custom_chest_example.lua
+++ b/modules/custom/content/examples/custom_chest_example.lua
@@ -1,0 +1,45 @@
+-----------------------------------
+-- Custom Treasure Chest (Example)
+-----------------------------------
+require("modules/module_utils")
+require("scripts/globals/items")
+local chest = require("modules/custom/content/custom_chest")
+-----------------------------------
+local m = Module:new("custom_chest_example")
+
+chest.zone[xi.zone.QUFIM_ISLAND] =
+{
+    name    = "Treasure Chest",          -- Target name
+    look    = chest.look.TREASURE_CHEST, -- Chest model
+    key     = "a Qufim Chest Key",       -- Description when clicked
+    id      = 12345,                     -- eg. Qufim Chest Key (DAT mod)
+    respawn = chest.respawn.MODERATE,    -- 25-30 minutes
+
+    items =
+    {
+        { chest.rate.VERY_COMMON, xi.items.SEASHELL,    }, -- 24%
+        { chest.rate.UNCOMMON,    xi.items.SHALL_SHELL, }, -- 10%
+        { chest.rate.RARE,        xi.items.PEARL,       }, --  5%
+    },
+
+    points =
+    {
+        { -249.422,  -20.000, 300.000, 120, }, -- !pos -249.422 -20.000 300.000
+        { -249.422,  -20.000, 310.000, 120, }, -- !pos -249.422 -20.000 310.000
+        { -249.422,  -20.000, 320.000, 120, }, -- !pos -249.422 -20.000 320.000
+        { -249.422,  -20.000, 330.000, 120, }, -- !pos -249.422 -20.000 330.000
+    },
+
+    mobs =
+    {
+        { "Dancing_Weapon", chest.rate.RARE }, -- 5%
+        { "Acrophies",      chest.rate.RARE }, -- 5%
+    },
+}
+
+m:addOverride("xi.zones.Qufim_Island.Zone.onInitialize", function(zone)
+    super(zone)
+    chest.initZone(zone)
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Created a module for adding custom Treasure Chests (Loxley)


## What does this pull request do? (Please be technical)

_Note to players: This is not part of 1.1 (To my knowledge)_

This is the first in a series modules I'm developing to simplify the creation of custom content. Once you've included the module, it's just a case of filling out a simple template. The idea is to make it approachable enough for a non-developer to design and balance new content. I've also included the basis of a `custom_util` library I will be using in these projects.

This module is Custom Treasure Chests. You can place them in any zone, including zones which already contain chests (For example, to add Coffers to a zone which doesn't have them). When the correct item is traded, the chest provides a result from a weighted list of items. Once open, it will animate, disappear, then respawn after the specified interval. Gil rewards are entirely optional. The chests do not currently interact with Thief's Tools or spawn mimics, but this will be added as an *option* in a future update.

Simply providing a mob name and rarity is enough to add the specified key to the mob's loot pool. No database work is required. Treasure Hunter applies just like it does to regular keys. The key or item, chest name, model, and the respawn time can all be adjusted in the template. These "chests" don't have to be called chests, or even look like chests, so feel free to get creative!

```lua
-----------------------------------
-- Custom Treasure Chest (Example)
-----------------------------------
require("modules/module_utils")
require("scripts/globals/items")
local chest = require("modules/custom/lua/custom_chest")
-----------------------------------
local m = Module:new("custom_chest_example")

chest.zone[xi.zone.QUFIM_ISLAND] =
{
    name    = "Treasure Chest",          -- Target name
    look    = chest.look.TREASURE_CHEST, -- Chest model
    key     = "a Qufim Chest Key",       -- Description when clicked
    id      = 12345,                     -- eg. Qufim Chest Key (DAT mod)
    respawn = chest.respawn.MODERATE,    -- 25-30 minutes

    items =
    {
        { chest.rate.VERY_COMMON, xi.items.SEASHELL,    }, -- 24%
        { chest.rate.UNCOMMON,    xi.items.SHALL_SHELL, }, -- 10%
        { chest.rate.RARE,        xi.items.PEARL,       }, --  5%
    },

    -- Optional
    gil =
    {
        rate = chest.rate.VERY_COMMON, -- 24%
        min  = 1000,
        max  = 2000,
    },

    points =
    {
        { -249.422,  -20.000, 300.000, 120, }, -- !pos -249.422 -20.000 300.000
        { -249.422,  -20.000, 310.000, 120, }, -- !pos -249.422 -20.000 310.000
        { -249.422,  -20.000, 320.000, 120, }, -- !pos -249.422 -20.000 320.000
        { -249.422,  -20.000, 330.000, 120, }, -- !pos -249.422 -20.000 330.000
    },

    mobs =
    {
        { "Dancing_Weapon", chest.rate.RARE }, -- 5%
        { "Acrophies",      chest.rate.RARE }, -- 5%
    },
}

m:addOverride("xi.zones.Qufim_Island.Zone.onInitialize", function(zone)
    super(zone)
    chest.initZone(zone)
end)

return m

```

Dialog can be customised with this optional property
```lua
    dialog =
    {
        "The chest appears to be locked.",
        " If only you had %s, perhaps you could open it...",
    },
```

Respawn can be set with provided presets, a random range or a fixed number in milliseconds. The following are all valid values:
```lua
respawn = chest.respawn.MODERATE, -- 25-30 minutes
respawn =    { 1500000, 1800000 }, -- 25-30 minutes
respawn =                 1800000, -- 30 minutes
```

Position values are x, y, z, rotation. Use `!pos` to find these in game.
```lua
{ -249.422,  -20.000, 300.000, 120, }, -- !pos -249.422 -20.000 300.000
```

The default model is a standard Treasure Chest but this can be replaced with any npc model id. Use `!getmodelid` and `!costume` to find these in game.
```lua
look    = chest.look.TREASURE_CHEST,
```


## Steps to test these changes

* Save the above example as `custom_chest_example.lua`

* Add the modules to `modules/init.txt`

```lua
custom/content/custom_util.lua
custom/content/custom_chest.lua
custom/content/examples/custom_chest_example.lua
```


## Special Deployment Considerations

N/A
