### PR TITLE
Fixes spelling mistake in Spice Gals

### DIFF
--- a/scripts/quests/sandoria/Spice_Gals.lua
+++ b/scripts/quests/sandoria/Spice_Gals.lua
@@ -135,7 +135,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if not player:hasKeyItem(xi.ki.RIVERNEWORT) then
                         player:addKeyItem(xi.ki.RIVERNEWORT)
-                        return quest:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RIVERNWORT)
+                        return quest:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RIVERNEWORT)
                     end
                 end,
             },
@@ -148,7 +148,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if not player:hasKeyItem(xi.ki.RIVERNEWORT) then
                         player:addKeyItem(xi.ki.RIVERNEWORT)
-                        return quest:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RIVERNWORT)
+                        return quest:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RIVERNEWORT)
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes a spelling mistake preventing the message "obtained rivernewort" from displaying

## What does this pull request do? (Please be technical)
Fixes a spelling mistake preventing the message "obtained rivernewort" from displaying

## Steps to test these changes
Run the quest on repeat - and get the KI

## Special Deployment Considerations
None
