### PR TITLE
Make ex charmed pets hate players

### DIFF
--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1522,7 +1522,8 @@ namespace petutils
                 // charm time is up, mob attacks player now
                 if (PMob->PEnmityContainer->IsWithinEnmityRange(PMob->PMaster))
                 {
-                    PMob->PEnmityContainer->UpdateEnmity(PChar, 0, 0);
+                    PMob->PEnmityContainer->UpdateEnmity(PChar, 1, 1);
+                    PMob->SetBattleTargetID(PChar->targid);
                 }
                 else
                 {


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixes a bug which prevents pets which decharm from attacking players.
Note: On servers like Horizon where mobs despawn when far from home, this will fix the issue where a pet will un charm mid fight and immediately despawn. 

## What does this pull request do? (Please be technical)
One of the major issues wrt charmed mob's despawning/misbehaving today on ASB is that the sequence of a mob decharming while in the attack state 

The pet, while in attack state decharms.
Specific de-charm logic clears the enmity list of the pet, then applies enmity for the player to the now ex-pet. (good)
After applying enmity, the attack state completes and gets cleaned up.  This cleanup includes ensuring the mob disengages.
The mob disengage logic triggers an enmity wipe on the ex-pet - undoing the hate that was added by the decharm logic. (bad)

Then the mob controller takes over in a roam tick.
With nothing in the enmity container - the mob does not engage the player - usually instant despawning.

What this code change does is instead of completely disengaging the pet and allowing the attack state to cleanup - the target of the now de-charmed pet is immediately shifted to the ex-master.

## Steps to test these changes

Mess around with charmed pets - ideally forcing through code or another way, short charm durations.

## Special Deployment Considerations

None.
