### PR TITLE
modifier.h file fix | Add spirit spellcast modifier for Summoners Spats

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1175,6 +1175,7 @@ xi.mod =
     HUMANOID_KILLER                 = 236,
     LUMORIAN_KILLER                 = 237,
     LUMINION_KILLER                 = 238,
+    WYRMAL_ABJ_KILLER_EFFECT        = 1178, -- Wyrmal Abjuration (Crimson/Blood) which makes players susceptible to Dragon Killer effects
     SLEEPRES                        = 240,
     POISONRES                       = 241,
     PARALYZERES                     = 242,
@@ -1273,7 +1274,6 @@ xi.mod =
     ENSPELL_CHANCE                  = 856,
     SPIKES_DMG                      = 344,
     TP_BONUS                        = 345,
-    PERPETUATION_REDUCTION          = 346,
 
     -- Warrior
     BERSERK_POTENCY                 = 948,  -- Augments "Berserk"/Enhances "Berserk" effect (Conqueror)
@@ -1307,6 +1307,8 @@ xi.mod =
     AVATAR_LVL_BONUS                = 1040, -- Avatar: Lv. ###/+ (Increases all avatar's base level above 99)
     CARBUNCLE_LVL_BONUS             = 1041, -- Carbuncle: Lv.+ (Increases Carbuncle's base level above 99)
     CAIT_SITH_LVL_BONUS             = 1042, -- Cait Sith: Lv.+ (Increases Cait Sith's base level above 99)
+    PERPETUATION_REDUCTION          = 346,
+    SPIRIT_SPELLCAST_DELAY          = 1179, -- Reduces the time between spellcasts of a summoned spirit by seconds provided
 
     -- Puppetmaster
     AUTOMATON_LVL_BONUS             = 1044, -- Automaton: Lv. (Increases automaton's base level above 99)
@@ -1548,7 +1550,7 @@ xi.mod =
     ITEM_ADDEFFECT_STATUS   = 951,  -- Status Effect ID to try to apply via Additional Effect or Spikes
     ITEM_ADDEFFECT_POWER    = 952,  -- Base Power for effect in MOD_ITEM_ADDEFFECT_STATUS
     ITEM_ADDEFFECT_DURATION = 953,  -- Base Duration for effect in MOD_ITEM_ADDEFFECT_STATUS
-    ITEM_ADDEFFECT_OPTION   = 1178, -- Additional parameters for more specific latents required to proc
+    ITEM_ADDEFFECT_OPTION   = 1180, -- Additional parameters for more specific latents required to proc
 
     FERAL_HOWL_DURATION             = 503, -- +20% duration per merit when wearing augmented Monster Jackcoat +2
     MANEUVER_BONUS                  = 504, -- Maneuver Stat Bonus
@@ -1839,8 +1841,6 @@ xi.mod =
     SILENCE_MEVA                  = 1175, -- Silence MEVA from Barspells
     VIRUS_MEVA                    = 1176, -- Virus MEVA from Barspells
     PETRIFY_MEVA                  = 1177, -- Petrify MEVA from Barspells
-
-    WYRMAL_ABJ_KILLER_EFFECT      = 1178, -- Wyrmal Abjuration (Crimson/Blood) which makes players susceptible to Dragon Killer effects
 
     -- IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN src/map/modifier.h ASWELL!
 

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -25525,10 +25525,11 @@ INSERT INTO `item_mods` VALUES (15130,9,5);    -- DEX: 5
 INSERT INTO `item_mods` VALUES (15130,363,10); -- HIGH_JUMP_ENMITY_REDUCTION: 10
 
 -- Summoners Spats
-INSERT INTO `item_mods` VALUES (15131,1,29);  -- DEF: 29
-INSERT INTO `item_mods` VALUES (15131,5,20);  -- MP: 20
-INSERT INTO `item_mods` VALUES (15131,13,3);  -- MND: 3
-INSERT INTO `item_mods` VALUES (15131,357,2); -- BP_DELAY: 2
+INSERT INTO `item_mods` VALUES (15131,1,29);   -- DEF: 29
+INSERT INTO `item_mods` VALUES (15131,5,20);   -- MP: 20
+INSERT INTO `item_mods` VALUES (15131,13,3);   -- MND: 3
+INSERT INTO `item_mods` VALUES (15131,357,2);  -- BP_DELAY: 2
+INSERT INTO `item_mods` VALUES (15131,1179,5); -- Spirit Spellcast Delay Reduction
 
 -- Warriors Calligae
 INSERT INTO `item_mods` VALUES (15132,1,19); -- DEF: 19
@@ -27826,9 +27827,10 @@ INSERT INTO `item_mods` VALUES (15593,9,6);    -- DEX: 6
 INSERT INTO `item_mods` VALUES (15593,363,10); -- HIGH_JUMP_ENMITY_REDUCTION: 10
 
 -- Summoners Spats +1
-INSERT INTO `item_mods` VALUES (15594,1,30);  -- DEF: 30
-INSERT INTO `item_mods` VALUES (15594,5,25);  -- MP: 25
-INSERT INTO `item_mods` VALUES (15594,357,2); -- BP_DELAY: 2
+INSERT INTO `item_mods` VALUES (15594,1,30);   -- DEF: 30
+INSERT INTO `item_mods` VALUES (15594,5,25);   -- MP: 25
+INSERT INTO `item_mods` VALUES (15594,357,2);  -- BP_DELAY: 2
+INSERT INTO `item_mods` VALUES (15594,1179,5); -- Spirit Spellcast Delay Reduction
 
 -- Hydra Brais
 INSERT INTO `item_mods` VALUES (15595,1,32);  -- DEF: 32

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -264,21 +264,22 @@ enum class Mod
     FOOD_DURATION = 937, // Percentage to increase food duration
 
     // Killer-Effects - (Most by Traits/JobAbility)
-    VERMIN_KILLER   = 224, // Enhances "Vermin Killer" effect
-    BIRD_KILLER     = 225, // Enhances "Bird Killer" effect
-    AMORPH_KILLER   = 226, // Enhances "Amorph Killer" effect
-    LIZARD_KILLER   = 227, // Enhances "Lizard Killer" effect
-    AQUAN_KILLER    = 228, // Enhances "Aquan Killer" effect
-    PLANTOID_KILLER = 229, // Enhances "Plantiod Killer" effect
-    BEAST_KILLER    = 230, // Enhances "Beast Killer" effect
-    UNDEAD_KILLER   = 231, // Enhances "Undead Killer" effect
-    ARCANA_KILLER   = 232, // Enhances "Arcana Killer" effect
-    DRAGON_KILLER   = 233, // Enhances "Dragon Killer" effect
-    DEMON_KILLER    = 234, // Enhances "Demon Killer" effect
-    EMPTY_KILLER    = 235, // Enhances "Empty Killer" effect
-    HUMANOID_KILLER = 236, // Enhances "Humanoid Killer" effect
-    LUMORIAN_KILLER = 237, // Enhances "Lumorian Killer" effect
-    LUMINION_KILLER = 238, // Enhances "Luminion Killer" effect
+    VERMIN_KILLER            = 224,  // Enhances "Vermin Killer" effect
+    BIRD_KILLER              = 225,  // Enhances "Bird Killer" effect
+    AMORPH_KILLER            = 226,  // Enhances "Amorph Killer" effect
+    LIZARD_KILLER            = 227,  // Enhances "Lizard Killer" effect
+    AQUAN_KILLER             = 228,  // Enhances "Aquan Killer" effect
+    PLANTOID_KILLER          = 229,  // Enhances "Plantiod Killer" effect
+    BEAST_KILLER             = 230,  // Enhances "Beast Killer" effect
+    UNDEAD_KILLER            = 231,  // Enhances "Undead Killer" effect
+    ARCANA_KILLER            = 232,  // Enhances "Arcana Killer" effect
+    DRAGON_KILLER            = 233,  // Enhances "Dragon Killer" effect
+    DEMON_KILLER             = 234,  // Enhances "Demon Killer" effect
+    EMPTY_KILLER             = 235,  // Enhances "Empty Killer" effect
+    HUMANOID_KILLER          = 236,  // Enhances "Humanoid Killer" effect
+    LUMORIAN_KILLER          = 237,  // Enhances "Lumorian Killer" effect
+    LUMINION_KILLER          = 238,  // Enhances "Luminion Killer" effect
+    WYRMAL_ABJ_KILLER_EFFECT = 1178, // Wyrmal Abjuration(Crimson / Blood) which makes players susceptible to Dragon Killer effects
 
     // Resistances to enfeebles - Traits/Job Ability
     SLEEPRES    = 240, // Enhances "Resist Sleep" effect
@@ -502,6 +503,7 @@ enum class Mod
     AVATAR_LVL_BONUS          = 1040, // Avatar: Lv.+ (Increases all avatar's base level above 99)
     CARBUNCLE_LVL_BONUS       = 1041, // Carbuncle: Lv.+ (Increases Carbuncle's base level above 99)
     CAIT_SITH_LVL_BONUS       = 1042, // Cait Sith: Lv.+ (Increases Cait Sith's base level above 99)
+    SPIRIT_SPELLCAST_DELAY    = 1179, // Reduces the time between spellcasts of a summoned spirit by seconds provided
 
     // Blue Mage
     BLUE_POINTS          = 309,  // Tracks extra blue points
@@ -776,7 +778,7 @@ enum class Mod
     ITEM_ADDEFFECT_STATUS   = 951,  // Status Effect ID to try to apply via Additional Effect or Spikes
     ITEM_ADDEFFECT_POWER    = 952,  // Base Power for effect in MOD_ITEM_ADDEFFECT_STATUS
     ITEM_ADDEFFECT_DURATION = 953,  // Base Duration for effect in MOD_ITEM_ADDEFFECT_STATUS
-    ITEM_ADDEFFECT_OPTION   = 1178, // Additional parameters for more specific latents required to proc
+    ITEM_ADDEFFECT_OPTION   = 1180, // Additional parameters for more specific latents required to proc
 
     GOV_CLEARS = 496, // 4% bonus per Grounds of Valor Page clear
 
@@ -969,8 +971,6 @@ enum class Mod
     VIRUS_MEVA             = 1176, // Virus MEVA from Barspells
     PETRIFY_MEVA           = 1177, // Petrify MEVA from Barspells
 
-    WYRMAL_ABJ_KILLER_EFFECT = 1178, // Wyrmal Abjuration(Crimson / Blood) which makes players susceptible to Dragon Killer effects
-
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/globals/status.lua ASWELL!
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
@@ -983,7 +983,7 @@ enum class Mod
     // 192 to 223
     // 261 to 280
     //
-    // SPARE = 1179, and onward
+    // SPARE = 1181, and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
n/a
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Cherry-pick from Horizon for Summoner Spats and fix modifier.h conflicts
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
n/a
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
