### PR TITLE
[lua] Fix some issues with Apocalypse Nigh

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -1098,7 +1098,7 @@ local function checkReqs(player, npc, bfid, registrant)
         end,
 
         [1057] = function() -- Apocalypse Nigh
-            return player:getCharVar("Quest[3][89]Prog") == 3
+            return player:getCharVar("Quest[3][89]Status") == 3
         end,
 
         [1090] = function() -- Quest: Puppetmaster Blues

--- a/scripts/zones/Norg/npcs/_700.lua
+++ b/scripts/zones/Norg/npcs/_700.lua
@@ -9,12 +9,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if
-        player:getCharVar('ApocalypseNigh') == 6 and
-        os.time() < player:getCharVar("Apoc_Nigh_Reward")
-    then
-        player:startEvent(235)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fix various issues with Apocalypse Nigh that could prevent progression, rewards and/or resetting the quest (WinterSolstice)

## What does this pull request do? (Please be technical)

* Fix JP midnight wait which was not working at all
* Fix battlefield entry requirement to match IF progress status
* Fix completing the quest early if you did not get a reward
* Fix being unable to repeat the quest
* Fix being unable to repeat the quest if you didn't choose the option to do so the first time
* Remove obsolete apocalypse nigh variable checks in Oaken Door script (_700.lua)

## Steps to test these changes

Do everything possible with Apoc Nigh:

Start the quest after shadows of the departed, do all the cutscenes.

But in particular:
Win the BCNM, talk to Aldo, click the Oaken Door in Norg and have the doorman tell you Gilgamesh is gone, and upon waiting for JP midnight you should be able to enter and get a reward.

When getting the reward, perform the following:
Refuse acceptance of the reward to choose later.
Fill your inventory, try to choose a reward and get a full inventory message and be able to try again.

After getting the reward, go to the reset npc in Empyreal Paradox:
It should not respond with anything other than a cryptic message until you drop your earring.
Drop your earring, click it, refuse to lose memories.
Click it again, accept losing memories then refuse them on the "are you sure?" prompt
Click it again, and accept losing memories twice. You should be reset and able to zone back into Ru'Lude gardens and re-attempt Shadows of the Departed via the palace CS.

add/get the KI again for shadows of the departed, repeat above until you die of heart failure

## Special Deployment Considerations

Understand this check box actually has meaning and we want to trust you when you check it
![image](https://user-images.githubusercontent.com/60417494/230268769-ec7450cd-69f2-4516-b903-a8d0d9e20cd2.png)