### PR TITLE
Fix several Jailer of Temperance issues

### DIFF
--- a/scripts/globals/mobskills/reactor_cool.lua
+++ b/scripts/globals/mobskills/reactor_cool.lua
@@ -20,7 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffect  = xi.effect.ICE_SPIKES
     local typeEffect2 = xi.effect.DEFENSE_BOOST
 
-    skill:setMsg(xi.mobskills.MobBuffMove(mob, typeEffect, math.random(15, 30), 0, 60))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, math.random(15, 30), 0, 60))
     local effect1 = mob:getStatusEffect(xi.effect.ICE_SPIKES)
     effect1:unsetFlag(xi.effectFlag.DISPELABLE)
     xi.mobskills.mobBuffMove(mob, typeEffect2, 26, 0, 60)

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
@@ -14,8 +14,44 @@ local chargeOptic = function(mob)
     mob:setMobAbilityEnabled(false)
 
     mob:timer(3000, function(mobArg)
-        mobArg:useMobAbility(1465) -- JoT will use another Optic Induration shortly after using the first one.
+        if mobArg:isAlive() then
+            mobArg:useMobAbility(1465) -- JoT will use another Optic Induration shortly after using the first one.
+        end
     end)
+
+    -- set opticCounter back to 0 and set back to normal
+    -- after the second Optic Induration (even if it fails and thus onMobWeaponSkill not called)
+    mob:timer(6500, function(mobArg)
+        if mobArg:isAlive() then
+            mobArg:setLocalVar("opticCounter", 0)
+            mobArg:setAutoAttackEnabled(true)
+            mobArg:setMobAbilityEnabled(true)
+        end
+    end)
+end
+
+local changeToPot = function(mob)
+            mob:setMod(xi.mod.HTH_SDT, 1000)
+            mob:setMod(xi.mod.SLASH_SDT, 0)
+            mob:setMod(xi.mod.PIERCE_SDT, 0)
+            mob:setMod(xi.mod.IMPACT_SDT, 1000)
+            mob:setLocalVar("changeTime", mob:getBattleTime())
+end
+
+local changeToPole = function(mob)
+            mob:setMod(xi.mod.HTH_SDT, 0)
+            mob:setMod(xi.mod.SLASH_SDT, 0)
+            mob:setMod(xi.mod.PIERCE_SDT, 1000)
+            mob:setMod(xi.mod.IMPACT_SDT, 0)
+            mob:setLocalVar("changeTime", mob:getBattleTime())
+end
+
+local changeToRings = function(mob)
+            mob:setMod(xi.mod.HTH_SDT, 0)
+            mob:setMod(xi.mod.SLASH_SDT, 1000)
+            mob:setMod(xi.mod.PIERCE_SDT, 0)
+            mob:setMod(xi.mod.IMPACT_SDT, 0)
+            mob:setLocalVar("changeTime", mob:getBattleTime())
 end
 
 entity.onMobSpawn = function(mob)
@@ -42,12 +78,13 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.PIERCE_SDT, 0)
     mob:setMod(xi.mod.IMPACT_SDT, 1000)
     -- Set the magic resists. It always takes no damage from direct magic
-    mob:setMod(xi.mod.DMGMAGIC, -10000)
+    mob:setMod(xi.mod.UDMGMAGIC, -10000)
     mob:setAutoAttackEnabled(true)
     mob:setMobAbilityEnabled(true)
     mob:setMod(xi.mod.ATT, 553)
     mob:setMod(xi.mod.DEF, 514)
     mob:setMod(xi.mod.EVA, 335)
+    mob:setMod(xi.mod.MOVE, 50)
 end
 
 entity.onMobEngaged = function(mob, target)
@@ -80,17 +117,9 @@ entity.onMobFight = function(mob)
 
         -- We changed to Poles. Make it only take piercing.
         if aniChange == 2 then
-            mob:setMod(xi.mod.HTH_SDT, 0)
-            mob:setMod(xi.mod.SLASH_SDT, 0)
-            mob:setMod(xi.mod.PIERCE_SDT, 1000)
-            mob:setMod(xi.mod.IMPACT_SDT, 0)
-            mob:setLocalVar("changeTime", mob:getBattleTime())
+            changeToPole(mob)
         else -- We changed to Rings. Make it only take slashing.
-            mob:setMod(xi.mod.HTH_SDT, 0)
-            mob:setMod(xi.mod.SLASH_SDT, 1000)
-            mob:setMod(xi.mod.PIERCE_SDT, 0)
-            mob:setMod(xi.mod.IMPACT_SDT, 0)
-            mob:setLocalVar("changeTime", mob:getBattleTime())
+            changeToRings(mob)
         end
     -- We're in poles, but changing
     elseif
@@ -103,18 +132,10 @@ entity.onMobFight = function(mob)
         -- Changing to Pot, only take Blunt damage
         if aniChange == 0 then
             mob:setAnimationSub(0)
-            mob:setMod(xi.mod.HTH_SDT, 1000)
-            mob:setMod(xi.mod.SLASH_SDT, 0)
-            mob:setMod(xi.mod.PIERCE_SDT, 0)
-            mob:setMod(xi.mod.IMPACT_SDT, 1000)
-            mob:setLocalVar("changeTime", mob:getBattleTime())
+            changeToPot(mob)
         else -- Going to Rings, only take slashing
             mob:setAnimationSub(3)
-            mob:setMod(xi.mod.HTH_SDT, 0)
-            mob:setMod(xi.mod.SLASH_SDT, 1000)
-            mob:setMod(xi.mod.PIERCE_SDT, 0)
-            mob:setMod(xi.mod.IMPACT_SDT, 0)
-            mob:setLocalVar("changeTime", mob:getBattleTime())
+            changeToRings(mob)
         end
     -- We're in rings, but going to change to pot or poles
     elseif
@@ -130,17 +151,9 @@ entity.onMobFight = function(mob)
             aniChange == 0 or
             aniChange == 1
         then
-            mob:setMod(xi.mod.HTH_SDT, 1000)
-            mob:setMod(xi.mod.SLASH_SDT, 0)
-            mob:setMod(xi.mod.PIERCE_SDT, 0)
-            mob:setMod(xi.mod.IMPACT_SDT, 1000)
-            mob:setLocalVar("changeTime", mob:getBattleTime())
+            changeToPot(mob)
         else -- Changing to poles, only take piercing
-            mob:setMod(xi.mod.HTH_SDT, 0)
-            mob:setMod(xi.mod.SLASH_SDT, 0)
-            mob:setMod(xi.mod.PIERCE_SDT, 1000)
-            mob:setMod(xi.mod.IMPACT_SDT, 0)
-            mob:setLocalVar("changeTime", mob:getBattleTime())
+            changeToPole(mob)
         end
     end
 
@@ -153,15 +166,9 @@ end
 entity.onMobWeaponSkill = function(target, mob, skill)
     local skillID = skill:getID()
     if skillID == 1465 then -- On Optic Induration Do this
-        local opticCounter = mob:getLocalVar("opticCounter")
-
-        if opticCounter == 0 then
+        if mob:getLocalVar("opticCounter") == 0 then
             mob:setLocalVar("opticCounter", 1)
             chargeOptic(mob)
-        else
-            mob:setLocalVar("opticCounter", 0)
-            mob:setAutoAttackEnabled(true)
-            mob:setMobAbilityEnabled(true)
         end
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Jailer of Temperance will no longer take any direct magic damage, will no longer become stuck due to an issue with Optic Induration, and will now gain the full effects of Reactor Cool. (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes issues:
- JoT was taking 50% magic damage due to use of wrong mod (should be 0% magic damage)
- If the second Optic Induration was ranged then JoT would no longer auto-attack or use abilities due to invalid assumption that OnWeaponSkill would always be called
- Reactor Cool was calling a non-existent function that caused JoT to not gain Ice Spikes.

## Steps to test these changes
Fight JoT

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1356
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1355
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1191

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
