### PR TITLE
Sets sj bst charm duration based on bst job level

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5040,6 +5040,17 @@ namespace battleutils
 
             int8 dLvl = PCharmer->GetMLevel() - PVictim->GetMLevel();
 
+            // This function (TryCharm) is only used by the bst charm ability via charmPet.  Brd uses charm, not charmPet for Maiden's Virelai
+            // Therefore, unless something very wrong has happened, the player is either main or sub BST
+            if (PCharmer->GetSJob() == JOBTYPE::JOB_BST)
+            {
+                int bstLevel = ((CCharEntity*)PCharmer)->jobs.job[JOBTYPE::JOB_BST];
+                if (bstLevel < PCharmer->GetMLevel())
+                {
+                    dLvl = bstLevel - PVictim->GetMLevel();
+                }
+            }
+
             // dLvl -6 or lower
             float dLvlCharmMod = 1 / 24.f;
 


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Sets sj bst charm duration based on bst job level

## What does this pull request do? (Please be technical)

When charm is used, considers bst SJ bst level

## Steps to test these changes

Be a 75 whatever / BST 1
Got to valk and find a bunny, level 16 or less.
Make a macro.  line1: /ja charm <t>.  line2: /wait 1.  line3: !reset
Spam the macro until the bunny charms (5%) chance.  Note the charm time.
If the main job 75 is used - charm will last a looooong time
If the SJ bst level 1 is used  - it will be a short time (chr+50)*1.25
## Special Deployment Considerations

None
