### PR TITLE
Fixes bug causing PD and All Miss to negate all smn BPs

### DIFF
--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -59,6 +59,7 @@ xi.summon.getAvatardINT = function(avatarInt, targetInt, avatar)
     if dINT >= 0 then
         dINT = math.floor(dINT * 1.5)
     end
+
     -- There is no upper limit of dstat, but there is a lower limit of -65
     return utils.clamp(dINT, -65, 100)
 end
@@ -189,7 +190,7 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, wsParams, tp)
 
         local pDifTable = {}
         -- Calculate pDIF
-        if wsParams.melee == true then
+        if wsParams.melee then
             pDifTable = xi.weaponskills.cMeleeRatio(avatar, target, wsParams, 0, calcParams.tp, xi.slot.MAIN)
         else
             pDifTable = xi.weaponskills.cRangedRatio(avatar, target, wsParams, 0, calcParams.tp)
@@ -330,15 +331,18 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
 
     -- handle pd
     if
-        target:hasStatusEffect(xi.effect.PERFECT_DODGE) or
-        target:hasStatusEffect(xi.effect.ALL_MISS) and
+        (target:hasStatusEffect(xi.effect.PERFECT_DODGE) or
+        target:hasStatusEffect(xi.effect.ALL_MISS)) and
         skilltype == xi.attackType.PHYSICAL
     then
         return 0
     end
 
     -- handle super jump
-    if target:hasStatusEffect(xi.effect.ALL_MISS) and target:getStatusEffect(xi.effect.ALL_MISS):getPower() > 1 then
+    if
+        target:hasStatusEffect(xi.effect.ALL_MISS) and
+        target:getStatusEffect(xi.effect.ALL_MISS):getPower() > 1
+    then
         skill:setMsg(xi.msg.basic.JA_MISS_2)
         return 0
     end


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes bug causing PD and All Miss to negate all smn BPs - not just physical BPs

## What does this pull request do? (Please be technical)

Formatting made this one hard to spot but easy to fix

## Steps to test these changes

Nether blast a PD mob (byakko maybe?)

## Special Deployment Considerations

None - can even hotfix this.
