### PR TITLE
Fix several dyna issues

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -1333,15 +1333,6 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
             [327] = -- Goblin Family
             {
                 [false] = { "V. Slime" , 130, 134, 0, 54, 229 }, -- Normal Goblin BST (VSlime)
-                [true] = -- Goblin NM
-                {
-                    ["Trailblix Goatmug"] = { "V. Slime" , 130, 134, 0, 54, 229 }, -- NM Goblin BST (VSlime)
-                    ["Rutrix Hamgams"] = { "V. Slime" , 130, 134, 0, 54, 229 }, -- NM Goblin BST (VSlime)
-                    ["Blazox Boneybod"] = { "V. Slime", 130, 134, 0, 54, 229 }, -- NM Goblin BST (VSlime)
-                    ["Routsix Rubbertendon"] = { "V. Slime" , 130, 134, 0, 54, 229 }, -- NM Goblin BST (VSlime)
-                    ["Blazax Boneybad"] = { "V. Slime" , 130, 134, 0, 54, 229 }, -- NM Goblin BST (VSlime)
-                    ["Woodnix Shrillwistle"] = { "W. Slime" , 7, 40, 0, 54, 229 }, -- NM Goblin BST (WSSlime)
-                },
             },
             [334] = -- Orc Family
             {
@@ -1384,17 +1375,24 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
                     ["Soo Jopo the Fiendking"] = { "V. Crow", 100, 134, 0, 52, 55 }, -- NM Yagudo BST (VCro)
                 },
             },
+            [373] = -- Goblin Armored Family
+            {
+                [true] = -- Goblin NM
+                {
+                    ["Trailblix Goatmug"] = { "V. Slime" , 130, 134, 0, 54, 229 }, -- NM Goblin BST (VSlime)
+                    ["Rutrix Hamgams"] = { "V. Slime" , 130, 134, 0, 54, 229 }, -- NM Goblin BST (VSlime)
+                    ["Blazox Boneybod"] = { "V. Slime", 130, 134, 0, 54, 229 }, -- NM Goblin BST (VSlime)
+                    ["Routsix Rubbertendon"] = { "V. Slime" , 130, 134, 0, 54, 229 }, -- NM Goblin BST (VSlime)
+                    ["Blazax Boneybad"] = { "V. Slime" , 130, 134, 0, 54, 229 }, -- NM Goblin BST (VSlime)
+                    ["Woodnix Shrillwistle"] = { "W. Slime" , 7, 40, 0, 54, 229 }, -- NM Goblin BST (WSSlime)
+                },
+            },
         },
         [xi.job.DRG] =
         {
             [327] = -- Goblin Family
             {
                 [false] = { "V. Wyvern", 27, 134, 0, 0, 714 },
-                [true] =
-                {
-                    ["Draklix Scalecrust"] = { "V. Wyvern", 27, 134, 0, 0, 714 }, -- Normal Vanguard's Wyvern (Vwyv)
-                    ["Wyrmwix Snakespecs"] = { "V. Wyvern", 27, 134, 0, 0, 714 }, -- Normal Vanguard's Wyvern (Vwyv)
-                },
             },
             [334] = -- Orc Family
             {
@@ -1446,18 +1444,20 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
                     ["Apocalyptic Beast"] = { "Dragon's Wyvern", 27, 134, 0, 0, 714 }, -- Dragon's Wyvern (Dwyv)
                 },
             },
+            [373] = -- Goblin Armored Family
+            {
+                [true] =
+                {
+                    ["Draklix Scalecrust"] = { "V. Wyvern", 27, 134, 0, 0, 714 }, -- Normal Vanguard's Wyvern (Vwyv)
+                    ["Wyrmwix Snakespecs"] = { "V. Wyvern", 27, 134, 0, 0, 714 }, -- Normal Vanguard's Wyvern (Vwyv)
+                },
+            },
         },
         [xi.job.SMN] =
         {
             [327] = -- Goblin Family
             {
                 [false] = { "V. Avatar" , 36, 134, 0, 0, 34 }, -- Vanguard's Avatar (VAva)
-                [true] = -- Goblin NM
-                {
-                    ["Morblox Chubbychin"] = { "V. Avatar" , 36, 134, 0, 0, 34 }, -- Vanguard's Avatar (VAva)
-                    ["Morgmox Moldnoggin"] = { "V. Avatar" , 36, 134, 0, 0, 34 }, -- Vanguard's Avatar (VAva)
-                    ["Mortilox Wartpaws"] = { "V. Avatar" , 36, 134, 0, 0, 34 }, -- Vanguard's Avatar (VAva)
-                },
             },
             [334] = -- Orc Family
             {
@@ -1508,6 +1508,15 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
                 [true] = -- Dwagon NM
                 {
                     ["Apocalyptic Beast"] = { "Dragon's Avatar", 36, 134, 0, 0, 34 }, -- Dragon's Avatar (Dava)
+                },
+            },
+            [373] = -- Goblin Armored Family
+            {
+                [true] = -- Goblin NM
+                {
+                    ["Morblox Chubbychin"] = { "V. Avatar" , 36, 134, 0, 0, 34 }, -- Vanguard's Avatar (VAva)
+                    ["Morgmox Moldnoggin"] = { "V. Avatar" , 36, 134, 0, 0, 34 }, -- Vanguard's Avatar (VAva)
+                    ["Mortilox Wartpaws"] = { "V. Avatar" , 36, 134, 0, 0, 34 }, -- Vanguard's Avatar (VAva)
                 },
             },
         },

--- a/modules/era/lua_dynamis/mob_spawning_files/dynamis_xarcabard_mobs.lua
+++ b/modules/era/lua_dynamis/mob_spawning_files/dynamis_xarcabard_mobs.lua
@@ -147,7 +147,7 @@ xi.dynamis.mobList[zoneID][54 ].info = {"Statue", "Vanguard Eye", nil, nil, nil}
 xi.dynamis.mobList[zoneID][55 ].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (055-D)
 xi.dynamis.mobList[zoneID][56 ].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (056-D)
 xi.dynamis.mobList[zoneID][57 ].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (057-D)
-xi.dynamis.mobList[zoneID][58 ].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (058-D)
+xi.dynamis.mobList[zoneID][58 ].info = {"Statue", "Vanguard Eye", nil, nil, "58_killed"} -- (058-D)
 xi.dynamis.mobList[zoneID][59 ].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (059-D)
 xi.dynamis.mobList[zoneID][60 ].info = {"Statue", "Tombstone Prototype", nil, nil, nil} -- (060-O)(30) Tombstone Prototype
 xi.dynamis.mobList[zoneID][61 ].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (061-D)
@@ -231,14 +231,14 @@ xi.dynamis.mobList[zoneID][138].info = {"Statue", "Vanguard Eye", nil, nil, nil}
 xi.dynamis.mobList[zoneID][139].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (139-D)  Pops King Zagan DRG
 xi.dynamis.mobList[zoneID][140].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (140-D)  Pops Count Vine SAM
 xi.dynamis.mobList[zoneID][141].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (141-D)  Pops Marquis Cimeries RNG
-xi.dynamis.mobList[zoneID][142].info = {"Statue", "Effigy Prototype", nil, nil, nil} -- (142-Q)(HP)     Effigy Prototype
-xi.dynamis.mobList[zoneID][143].info = {"Statue", "Statue Prototype", nil, nil, nil} -- (143-G)(30)     Statue Prototype
-xi.dynamis.mobList[zoneID][144].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (144-D)
-xi.dynamis.mobList[zoneID][145].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (145-D)
-xi.dynamis.mobList[zoneID][146].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (146-D)
-xi.dynamis.mobList[zoneID][147].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (147-D)
-xi.dynamis.mobList[zoneID][148].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (148-D)
-xi.dynamis.mobList[zoneID][149].info = {"Statue", "Vanguard Eye", nil, nil, nil} -- (149-D)
+xi.dynamis.mobList[zoneID][142].info = {"Statue", "Effigy Prototype", nil, nil, "142_killed"} -- (142-Q)(HP)     Effigy Prototype
+xi.dynamis.mobList[zoneID][143].info = {"Statue", "Statue Prototype", nil, nil, "143_killed"} -- (143-G)(30)     Statue Prototype
+xi.dynamis.mobList[zoneID][144].info = {"Statue", "Vanguard Eye", nil, nil, "144_killed"} -- (144-D)
+xi.dynamis.mobList[zoneID][145].info = {"Statue", "Vanguard Eye", nil, nil, "145_killed"} -- (145-D)
+xi.dynamis.mobList[zoneID][146].info = {"Statue", "Vanguard Eye", nil, nil, "146_killed"} -- (146-D)
+xi.dynamis.mobList[zoneID][147].info = {"Statue", "Vanguard Eye", nil, nil, "147_killed"} -- (147-D)
+xi.dynamis.mobList[zoneID][148].info = {"Statue", "Vanguard Eye", nil, nil, "148_killed"} -- (148-D)
+xi.dynamis.mobList[zoneID][149].info = {"Statue", "Vanguard Eye", nil, nil, "149_killed"} -- (149-D)
 xi.dynamis.mobList[zoneID][150].info = {"Statue", "Statue Prototype", nil, nil, nil} -- (150-G)(30)     Statue Prototype
 xi.dynamis.mobList[zoneID][151].info = {"NM", "Animated Hammer",    nil, nil, "hammer_killed"} -- ( 151 ) Animated Hammer
 xi.dynamis.mobList[zoneID][152].info = {"NM", "Animated Dagger",    nil, nil, "dagger_killed"} -- ( 152 ) Animated Dagger
@@ -428,7 +428,9 @@ xi.dynamis.mobList[zoneID][1].wave =
     32 , -- (032-D)  Avatar Icon
     33 , -- (033-D)  Manifest Icon
     34 , -- (034-D)  Avatar Icon
+    35 , -- (035-D)  Avatar Icon
     38 , -- (038-D)  Avatar Icon
+    39 , -- (039-D)  Avatar Icon
     42 , -- (042-D)  Manifest Icon
     44 , -- (044-D)  Avatar Icon
     45 , -- (045-D)  Manifest Icon

--- a/modules/era/sql_dynamis/era_dyna_sql.sql
+++ b/modules/era/sql_dynamis/era_dyna_sql.sql
@@ -87,6 +87,7 @@ REPLACE INTO `mob_droplist` VALUES (2558,0,0,1000,1455,240); -- Byne Bill 1
 REPLACE INTO `mob_droplist` VALUES (2558,0,0,1000,1455,150); -- Byne Bill 2
 REPLACE INTO `mob_droplist` VALUES (2558,0,0,1000,1455,100); -- Byne Bill 3
 REPLACE INTO `mob_droplist` VALUES (2558,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (2558,1,2,50,18314,250); -- Ito
 REPLACE INTO `mob_droplist` VALUES (2558,1,2,50,18302,250); -- Relic Scythe
 REPLACE INTO `mob_droplist` VALUES (2558,1,2,50,18284,250); -- Relic Axe
 REPLACE INTO `mob_droplist` VALUES (2558,1,2,50,18278,250); -- Relic Blade
@@ -304,16 +305,18 @@ REPLACE INTO `mob_droplist` VALUES (143,1,1,100,15115,91); -- DRG Hands
 -- REPLACE INTO `mob_droplist` VALUES (143,1,4,10,16352,1000); -- DNC Feet (Comment in for WoTG)
 REPLACE INTO `mob_droplist` VALUES (143,0,0,1000,1520,10); -- Goblin Grease
 REPLACE INTO `mob_droplist` VALUES (143,0,0,1000,1470,50); -- Sparkling Stone
-REPLACE INTO `mob_droplist` VALUES (143,0,0,1000,1455,150); -- Byne Bill
-REPLACE INTO `mob_droplist` VALUES (143,0,0,1000,1449,150); -- Whiteshell
-REPLACE INTO `mob_droplist` VALUES (143,0,0,1000,1452,150); -- Bronzepiece
-REPLACE INTO `mob_droplist` VALUES (143,0,0,1000,1455,100); -- Byne Bill
-REPLACE INTO `mob_droplist` VALUES (143,0,0,1000,1449,100); -- Whiteshell
-REPLACE INTO `mob_droplist` VALUES (143,0,0,1000,1452,100); -- Bronzepiece
+REPLACE INTO `mob_droplist` VALUES (143,1,2,@COMMON,1455,334);   -- Byne Bill
+REPLACE INTO `mob_droplist` VALUES (143,1,2,@COMMON,1449,333);   -- Whiteshell
+REPLACE INTO `mob_droplist` VALUES (143,1,2,@COMMON,1452,333);   -- Bronzepiece
+REPLACE INTO `mob_droplist` VALUES (143,1,3,@UNCOMMON,1455,334); -- Byne Bill
+REPLACE INTO `mob_droplist` VALUES (143,1,3,@UNCOMMON,1449,333); -- Whiteshell
+REPLACE INTO `mob_droplist` VALUES (143,1,3,@UNCOMMON,1452,333); -- Bronzepiece
+REPLACE INTO `mob_droplist` VALUES (143,2,0,1000,1455,0); -- Byne Bill (Steal)
 REPLACE INTO `mob_droplist` VALUES (143,2,0,1000,1449,0); -- Whiteshell (Steal)
-REPLACE INTO `mob_droplist` VALUES (143,1,2,10,1456,333); -- Hundred Byne
-REPLACE INTO `mob_droplist` VALUES (143,1,2,10,1450,333); -- Jadeshell
-REPLACE INTO `mob_droplist` VALUES (143,1,2,10,1453,334); -- Montiont Silverpiece
+REPLACE INTO `mob_droplist` VALUES (143,2,0,1000,1452,0); -- Bronzepiece (Steal)
+REPLACE INTO `mob_droplist` VALUES (143,1,4,10,1456,333); -- Hundred Byne
+REPLACE INTO `mob_droplist` VALUES (143,1,4,10,1450,333); -- Jadeshell
+REPLACE INTO `mob_droplist` VALUES (143,1,4,10,1453,334); -- Montiont Silverpiece
 --            Regular            --
 DELETE FROM `mob_droplist` WHERE dropid = "2543"; -- Delete
 REPLACE INTO `mob_droplist` VALUES (2543,1,1,50,15102,90); -- WAR Hands
@@ -333,14 +336,22 @@ REPLACE INTO `mob_droplist` VALUES (2543,1,1,50,15115,91); -- DRG Hands
 -- REPLACE INTO `mob_droplist` VALUES (2543,1,4,5,16352,1000); -- DNC Feet  (Comment in for WoTG)
 REPLACE INTO `mob_droplist` VALUES (2543,0,0,1000,1520,10); -- Goblin Grease
 REPLACE INTO `mob_droplist` VALUES (2543,0,0,1000,1470,50); -- Sparkling Stone
-REPLACE INTO `mob_droplist` VALUES (2543,0,0,1000,1455,240); -- Byne Bill
-REPLACE INTO `mob_droplist` VALUES (2543,0,0,1000,1449,150); -- Whiteshell
-REPLACE INTO `mob_droplist` VALUES (2543,0,0,1000,1452,100); -- Bronzepiece
+REPLACE INTO `mob_droplist` VALUES (2543,1,2,@VCOMMON,1455,334);  -- Byne Bill
+REPLACE INTO `mob_droplist` VALUES (2543,1,2,@VCOMMON,1449,333);  -- Whiteshell
+REPLACE INTO `mob_droplist` VALUES (2543,1,2,@VCOMMON,1452,333);  -- Bronzepiece
+REPLACE INTO `mob_droplist` VALUES (2543,1,3,@COMMON,1455,334);   -- Byne Bill
+REPLACE INTO `mob_droplist` VALUES (2543,1,3,@COMMON,1449,333);   -- Whiteshell
+REPLACE INTO `mob_droplist` VALUES (2543,1,3,@COMMON,1452,333);   -- Bronzepiece
+REPLACE INTO `mob_droplist` VALUES (2543,1,4,@UNCOMMON,1455,334); -- Byne Bill
+REPLACE INTO `mob_droplist` VALUES (2543,1,4,@UNCOMMON,1449,333); -- Whiteshell
+REPLACE INTO `mob_droplist` VALUES (2543,1,4,@UNCOMMON,1452,333); -- Bronzepiece
+REPLACE INTO `mob_droplist` VALUES (2543,2,0,1000,1455,0); -- Byne Bill (Steal)
 REPLACE INTO `mob_droplist` VALUES (2543,2,0,1000,1449,0); -- Whiteshell (Steal)
-REPLACE INTO `mob_droplist` VALUES (2543,1,2,50,18344,250); -- Relic Bow
-REPLACE INTO `mob_droplist` VALUES (2543,1,2,50,18338,250); -- Relic Horn
-REPLACE INTO `mob_droplist` VALUES (2543,1,2,50,18326,250); -- Relic Staff
-REPLACE INTO `mob_droplist` VALUES (2543,1,2,50,15066,250); -- Relic Shield
+REPLACE INTO `mob_droplist` VALUES (2543,2,0,1000,1452,0); -- Bronzepiece (Steal)
+REPLACE INTO `mob_droplist` VALUES (2543,1,5,50,18344,250); -- Relic Bow
+REPLACE INTO `mob_droplist` VALUES (2543,1,5,50,18338,250); -- Relic Horn
+REPLACE INTO `mob_droplist` VALUES (2543,1,5,50,18326,250); -- Relic Staff
+REPLACE INTO `mob_droplist` VALUES (2543,1,5,50,15066,250); -- Relic Shield
 -- ---------------------------------
 --   Special Mob Skills/Spells   --
 -- ---------------------------------
@@ -406,7 +417,9 @@ REPLACE INTO `mob_droplist` VALUES (176,0,0,1000,1452,150); -- Bronzepiece
 REPLACE INTO `mob_droplist` VALUES (176,0,0,1000,1455,100); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (176,0,0,1000,1449,100); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (176,0,0,1000,1452,100); -- Bronzepiece
+REPLACE INTO `mob_droplist` VALUES (176,2,0,1000,1455,0); -- Byne Bill (Steal)
 REPLACE INTO `mob_droplist` VALUES (176,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (176,2,0,1000,1452,0); -- Bronzepiece (Steal)
 REPLACE INTO `mob_droplist` VALUES (176,1,2,10,1456,333); -- Hundred Byne
 REPLACE INTO `mob_droplist` VALUES (176,1,2,10,1450,333); -- Jadeshell
 REPLACE INTO `mob_droplist` VALUES (176,1,2,10,1453,334); -- Montiont Silverpiece
@@ -554,7 +567,9 @@ REPLACE INTO `mob_droplist` VALUES (2542,1,3,@COMMON,1452,333);   -- Bronzepiece
 REPLACE INTO `mob_droplist` VALUES (2542,1,4,@UNCOMMON,1455,334); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (2542,1,4,@UNCOMMON,1449,333); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (2542,1,4,@UNCOMMON,1452,333); -- Bronzepiece
+REPLACE INTO `mob_droplist` VALUES (2542,2,0,1000,1455,0); -- Byne Bill (Steal)
 REPLACE INTO `mob_droplist` VALUES (2542,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (2542,2,0,1000,1452,0); -- Bronzepiece (Steal)
 DELETE FROM `mob_droplist` WHERE dropid = "2547"; -- Orc
 REPLACE INTO `mob_droplist` VALUES (2547,1,1,50,15117,66); -- WAR Legs
 REPLACE INTO `mob_droplist` VALUES (2547,1,1,50,15088,66); -- MNK Body
@@ -674,6 +689,8 @@ REPLACE INTO `mob_droplist` VALUES (3220,1,4,@UNCOMMON,1455,334); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (3220,1,4,@UNCOMMON,1449,333); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (3220,1,4,@UNCOMMON,1452,333); -- Bronzepiece
 REPLACE INTO `mob_droplist` VALUES (3220,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (3220,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (3220,2,0,1000,1452,0); -- Bronzepiece (Steal)
 -- ---------------------------------
 --   Special Mob Skills/Spells   --
 -- ---------------------------------
@@ -848,6 +865,8 @@ REPLACE INTO `mob_droplist` VALUES (1442,1,3,@COMMON,1452,333); -- Bronzepiece
 REPLACE INTO `mob_droplist` VALUES (1442,1,4,@UNCOMMON,1455,334); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (1442,1,4,@UNCOMMON,1449,333); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (1442,1,4,@UNCOMMON,1452,333); -- Bronzepiece
+REPLACE INTO `mob_droplist` VALUES (1442,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (1442,2,0,1000,1449,0); -- Whiteshell (Steal)
 REPLACE INTO `mob_droplist` VALUES (1442,2,0,1000,1452,0); -- Bronzepiece (Steal)
 DELETE FROM `mob_droplist` WHERE dropid = "2559"; -- Vanguard Dragon
 REPLACE INTO `mob_droplist` VALUES (2559,1,1,@VCOMMON,1455,334); -- Byne Bill
@@ -933,7 +952,9 @@ REPLACE INTO `mob_droplist` VALUES (2539,1,2,@COMMON,1452,333); -- Bronzepiece
 REPLACE INTO `mob_droplist` VALUES (2539,1,3,@UNCOMMON,1455,334); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (2539,1,3,@UNCOMMON,1449,333); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (2539,1,3,@UNCOMMON,1452,333); -- Bronzepiece
-REPLACE INTO `mob_droplist` VALUES (2539,2,0,1000,1449,0); -- Whiteshell
+REPLACE INTO `mob_droplist` VALUES (2539,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (2539,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (2539,2,0,1000,1452,0); -- Bronzepiece (Steal)
 DELETE FROM `mob_droplist` WHERE dropid = "2544"; -- Orc
 REPLACE INTO `mob_droplist` VALUES (2544,1,1,50,15132,66);  -- WAR Feet
 REPLACE INTO `mob_droplist` VALUES (2544,1,1,50,15133,66);  -- MNK Feet
@@ -1184,7 +1205,9 @@ REPLACE INTO `mob_droplist` VALUES (2667,0,0,1000,1452,150); -- Bronzepiece
 REPLACE INTO `mob_droplist` VALUES (2667,1,2,10,1456,333); -- Hundred Byne
 REPLACE INTO `mob_droplist` VALUES (2667,1,2,10,1450,334); -- Jadeshell
 REPLACE INTO `mob_droplist` VALUES (2667,1,2,10,1453,333); -- Montiont Silverpiece
-REPLACE INTO `mob_droplist` VALUES (2667,2,0,1000,1449,0); -- Whiteshell
+REPLACE INTO `mob_droplist` VALUES (2667,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (2667,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (2667,2,0,1000,1452,0); -- Bronzepiece (Steal)
 DELETE FROM `mob_droplist` WHERE dropid = "760"; -- Orc NM
 REPLACE INTO `mob_droplist` VALUES (760,1,1,100,15102,66);  -- WAR Hands
 REPLACE INTO `mob_droplist` VALUES (760,1,1,100,15118,66);  -- MNK Legs
@@ -1282,7 +1305,9 @@ REPLACE INTO `mob_droplist` VALUES (2540,1,1,100,15116,67);  -- SMN Hands
 REPLACE INTO `mob_droplist` VALUES (2540,0,0,1000,1455,150); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (2540,0,0,1000,1449,150); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (2540,0,0,1000,1452,150); -- Bronzepiece
-REPLACE INTO `mob_droplist` VALUES (2540,2,0,1000,1449,0); -- Whiteshell
+REPLACE INTO `mob_droplist` VALUES (2540,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (2540,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (2540,2,0,1000,1452,0); -- Bronzepiece (Steal)
 DELETE FROM `mob_droplist` WHERE dropid = "2545"; -- Orc
 REPLACE INTO `mob_droplist` VALUES (2545,1,1,100,15102,66);  -- WAR Hands
 REPLACE INTO `mob_droplist` VALUES (2545,1,1,100,15118,66);  -- MNK Legs
@@ -1410,7 +1435,9 @@ REPLACE INTO `mob_droplist` VALUES (1805,1,2,50,15878,500); -- DRG Waist
 REPLACE INTO `mob_droplist` VALUES (1805,0,0,1000,1455,150); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (1805,0,0,1000,1449,150); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (1805,0,0,1000,1452,150); -- Bronzepiece
-REPLACE INTO `mob_droplist` VALUES (1805,2,0,1000,1452,0); -- Bronzepiece
+REPLACE INTO `mob_droplist` VALUES (1805,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (1805,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (1805,2,0,1000,1452,0); -- Bronzepiece (Steal)
 DELETE FROM `mob_droplist` WHERE dropid = "1791"; -- Crab
 REPLACE INTO `mob_droplist` VALUES (1791,1,1,100,2035,66);  -- WAR -1 Hands
 REPLACE INTO `mob_droplist` VALUES (1791,1,1,100,2040,66);  -- MNK -1 Hands
@@ -1463,7 +1490,9 @@ REPLACE INTO `mob_droplist` VALUES (1798,1,2,50,15871,500); -- WAR Waist
 REPLACE INTO `mob_droplist` VALUES (1798,0,0,1000,1455,150); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (1798,0,0,1000,1449,150); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (1798,0,0,1000,1452,150); -- Bronzepiece
-REPLACE INTO `mob_droplist` VALUES (1798,2,0,1000,1449,0); -- Whiteshell
+REPLACE INTO `mob_droplist` VALUES (1798,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (1798,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (1798,2,0,1000,1452,0); -- Bronzepiece (Steal)
 DELETE FROM `mob_droplist` WHERE dropid = "2796"; -- Dhalmel
 REPLACE INTO `mob_droplist` VALUES (2796,1,1,100,2035,66);  -- WAR -1 Hands
 REPLACE INTO `mob_droplist` VALUES (2796,1,1,100,2040,66);  -- MNK -1 Hands
@@ -1597,7 +1626,9 @@ REPLACE INTO `mob_droplist` VALUES (1785,1,2,50,15481,500); -- PLD Back
 REPLACE INTO `mob_droplist` VALUES (1785,0,0,1000,1455,150); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (1785,0,0,1000,1449,150); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (1785,0,0,1000,1452,150); -- Bronzepiece
-REPLACE INTO `mob_droplist` VALUES (1785,2,0,1000,1455,0); -- Byne Bill
+REPLACE INTO `mob_droplist` VALUES (1785,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (1785,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (1785,2,0,1000,1452,0); -- Bronzepiece (Steal)
 -- ---------------------------------
 --   Special Mob Skills/Spells   --
 -- ---------------------------------
@@ -1676,7 +1707,9 @@ REPLACE INTO `mob_droplist` VALUES (2541,1,1,100,15146,67);  -- SMN Feet
 REPLACE INTO `mob_droplist` VALUES (2541,0,0,1000,1455,150); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (2541,0,0,1000,1449,150); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (2541,0,0,1000,1452,150); -- Bronzepiece
-REPLACE INTO `mob_droplist` VALUES (2541,2,0,1000,1449,0); -- Whiteshell
+REPLACE INTO `mob_droplist` VALUES (2541,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (2541,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (2541,2,0,1000,1452,0); -- Bronzepiece (Steal)
 DELETE FROM `mob_droplist` WHERE dropid = "2546"; -- Orc
 REPLACE INTO `mob_droplist` VALUES (2546,1,1,100,15072,66);  -- WAR Head
 REPLACE INTO `mob_droplist` VALUES (2546,1,1,100,15103,66);  -- MNK Hands
@@ -1781,7 +1814,9 @@ REPLACE INTO `mob_droplist` VALUES (1793,1,2,50,15875,200); -- BST Waist
 REPLACE INTO `mob_droplist` VALUES (1793,0,0,1000,1455,150); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (1793,0,0,1000,1449,150); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (1793,0,0,1000,1452,150); -- Bronzepiece
-REPLACE INTO `mob_droplist` VALUES (1793,2,0,1000,1455,0); -- Byne Bill
+REPLACE INTO `mob_droplist` VALUES (1793,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (1793,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (1793,2,0,1000,1452,0); -- Bronzepiece (Steal)
 DELETE FROM `mob_droplist` WHERE dropid = "1803"; -- Snoll
 REPLACE INTO `mob_droplist` VALUES (1803,1,1,100,2037,66);  -- WAR -1 Feet
 REPLACE INTO `mob_droplist` VALUES (1803,1,1,100,2042,66);  -- MNK -1 Feet
@@ -1813,7 +1848,9 @@ REPLACE INTO `mob_droplist` VALUES (1803,1,2,50,15875,143); -- BST Waist
 REPLACE INTO `mob_droplist` VALUES (1803,0,0,1000,1455,150); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (1803,0,0,1000,1449,150); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (1803,0,0,1000,1452,150); -- Bronzepiece
-REPLACE INTO `mob_droplist` VALUES (1803,2,0,1000,1455,0); -- Byne Bill
+REPLACE INTO `mob_droplist` VALUES (1803,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (1803,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (1803,2,0,1000,1452,0); -- Bronzepiece (Steal)
 DELETE FROM `mob_droplist` WHERE dropid = "1790"; -- Diremite
 REPLACE INTO `mob_droplist` VALUES (1790,1,1,100,2037,66);  -- WAR -1 Feet
 REPLACE INTO `mob_droplist` VALUES (1790,1,1,100,2042,66);  -- MNK -1 Feet
@@ -1844,7 +1881,9 @@ REPLACE INTO `mob_droplist` VALUES (1790,1,2,50,15876,200); -- RNG Waist
 REPLACE INTO `mob_droplist` VALUES (1790,0,0,1000,1455,150); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (1790,0,0,1000,1449,150); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (1790,0,0,1000,1452,150); -- Bronzepiece
-REPLACE INTO `mob_droplist` VALUES (1790,2,0,1000,1455,0); -- Byne Bill
+REPLACE INTO `mob_droplist` VALUES (1790,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (1790,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (1790,2,0,1000,1452,0); -- Bronzepiece (Steal)
 DELETE FROM `mob_droplist` WHERE dropid = "1804"; -- Stirge/Tiger/Weapon
 REPLACE INTO `mob_droplist` VALUES (1804,1,1,100,2037,66);  -- WAR -1 Feet
 REPLACE INTO `mob_droplist` VALUES (1804,1,1,100,2042,66);  -- MNK -1 Feet
@@ -1875,7 +1914,9 @@ REPLACE INTO `mob_droplist` VALUES (1804,1,2,50,15876,200); -- RNG Waist
 REPLACE INTO `mob_droplist` VALUES (1804,0,0,1000,1455,150); -- Byne Bill
 REPLACE INTO `mob_droplist` VALUES (1804,0,0,1000,1449,150); -- Whiteshell
 REPLACE INTO `mob_droplist` VALUES (1804,0,0,1000,1452,150); -- Bronzepiece
-REPLACE INTO `mob_droplist` VALUES (1804,2,0,1000,1455,0); -- Byne Bill
+REPLACE INTO `mob_droplist` VALUES (1804,2,0,1000,1455,0); -- Byne Bill (Steal)
+REPLACE INTO `mob_droplist` VALUES (1804,2,0,1000,1449,0); -- Whiteshell (Steal)
+REPLACE INTO `mob_droplist` VALUES (1804,2,0,1000,1452,0); -- Bronzepiece (Steal)
 -- ---------------------------------
 --   Special Mob Skills/Spells   --
 -- ---------------------------------


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Dynamis monsters that drop multiple types of currency (e.g., Dynamis-Jeuno goblins) will now drop each type at equal rates. Similarly, players can now steal a currency of any type from these monsters. (Tracent)
- Monsters in Dynamis-Bastok now drop Ito. (Tracent)
- Time extension monsters in Dynamis-Xarcabard will now spawn correctly. (Tracent)
- Goblin NMs with pets in Dynamis will now correctly spawn their pets. (Tracent)

## What does this pull request do? (Please be technical)
See the above description, note that this does not change the average currency per mob for normal mobs. For Dyna-Jeuno NMs the currency per mob is slightly lower because there was previously an incorrect chance of more than 3 currency from single NMs.

## Steps to test these changes
Fight and steal in dyna including Jeuno to check Goblin.

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/418
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
