### PR TITLE
[lua] Add missing BCNM.lua calls to Riverne A01

### DIFF
--- a/scripts/zones/Riverne-Site_A01/npcs/Unstable_Displacement.lua
+++ b/scripts/zones/Riverne-Site_A01/npcs/Unstable_Displacement.lua
@@ -14,7 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.A_GLOWING_MIST)
+    if not xi.bcnm.onTrigger(player, npc) then
+        player:messageSpecial(ID.text.A_GLOWING_MIST)
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option, extras)
@@ -22,6 +24,7 @@ entity.onEventUpdate = function(player, csid, option, extras)
 end
 
 entity.onEventFinish = function(player, csid, option)
+    xi.bcnm.onEventFinish(player, csid, option)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fix Unstable Displacement in Riverne - Site #A011 to allow other players entry into BCNMs that were activated by a trade. (WinterSolstice)

## What does this pull request do? (Please be technical)

Cherry picked LSB commit, this will allow Ouryu Cometh to bring in the alliance of the person who traded a Cloud Evoker.

## Steps to test these changes

Trade a Cloud Evoker to the Unstable Displacement in A01, have your party be able to enter.

## Special Deployment Considerations

N/A
