### PR TITLE
Corrects status afflicting additional effect checks to only display an animation on an unresisted check

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -106,7 +106,11 @@ xi.additionalEffect.calcDamage = function(attacker, element, defender, damage, a
     params.bonusmab   = 0
     params.includemab = false
 
-    if addType == xi.additionalEffect.procType.DAMAGE and element == xi.magic.ele.LIGHT and item:getSkillType() == xi.skill.MARKSMANSHIP then
+    if
+        addType == xi.additionalEffect.procType.DAMAGE and
+        element == xi.magic.ele.LIGHT and
+        item:getSkillType() == xi.skill.MARKSMANSHIP
+    then
         params.element = xi.magic.ele.LIGHT
         params.attribute = xi.mod.MND
         params.skillType = item:getSkillType()
@@ -157,7 +161,10 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
                 { status = xi.effect.TERROR,    immunity = xi.immunity.TERROR   },
             }
 
-    if addStatus == xi.effect.DEFENSE_DOWN  and item:getSkillType() == xi.skill.MARKSMANSHIP then
+    if
+        addStatus == xi.effect.DEFENSE_DOWN and
+        item:getSkillType() == xi.skill.MARKSMANSHIP
+    then
         local dLvl = defender:getMainLvl() - attacker:getMainLvl()
         if dLvl <= 0 then
             chance = 99
@@ -192,7 +199,10 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
     -- Additional Effect Damage
     --------------------------------------
     if addType == xi.additionalEffect.procType.DAMAGE then
-        if element == xi.magic.ele.LIGHT and item:getSkillType() == xi.skill.MARKSMANSHIP then
+        if
+            element == xi.magic.ele.LIGHT and
+            item:getSkillType() == xi.skill.MARKSMANSHIP
+        then
             damage = math.floor(attacker:getStat(xi.mod.MND) / 2) -- MAB/MDB bonuses caled in xi.additionalEffect.calcDamage.
         end
 
@@ -228,6 +238,8 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
                 defender:addStatusEffect(addStatus, power, tick, duration * resist)
                 msgID    = xi.msg.basic.ADD_EFFECT_STATUS
                 msgParam = addStatus
+            else
+                return 0, 0, 0
             end
         end
     --------------------------------------
@@ -401,9 +413,11 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
             defender:setUnkillable(false)
             damage = xi.additionalEffect.calcDamage(attacker, element, defender, damage, addType, item)
             msgID = xi.msg.basic.ADD_EFFECT_DMG
+
             if damage < 0 then
                 msgID = xi.msg.basic.ADD_EFFECT_HEAL
             end
+
             msgParam = damage
         else
             return 0, 0, 0 -- Conditions not hit


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

- Additional effects from weapons and items that apply a status effect will now properly only show the animation when the effect applies. (Critical)

## What does this pull request do? (Please be technical)

A failure return was missing on the resist check for all status effects from additional effects on weapons and items. So even if it resisted, it would still display the animation like it landed. Adding in an else to return nothing if resisted which stops the false animation from playing.

## Steps to test these changes

Equip Acid Bolts, see that if you spam attacks you will get the defense down animation with no text saying it applied. Apply this PR, see that the animation only plays when it successfully lands.

## Special Deployment Considerations

N/A
