### PR TITLE
Jailer of Love fixes

### DIFF
--- a/scripts/zones/AlTaieu/mobs/Absolute_Virtue.lua
+++ b/scripts/zones/AlTaieu/mobs/Absolute_Virtue.lua
@@ -13,6 +13,7 @@ entity.onMobSpawn = function(mob)
     -- setMod
     mob:setMod(xi.mod.REGEN, 500)
 
+    -- TODO: these variables seem to be reset on kill of JoL and thus will never be set.
     local jailerOfLove = GetMobByID(ID.mob.JAILER_OF_LOVE)
     -- Special check for regen modification by JoL pets killed
     if jailerOfLove:getLocalVar("JoL_Qn_xzomit_Killed") == 9 then
@@ -54,7 +55,9 @@ entity.onMagicHit = function(caster, target, spell)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:addTitle(xi.title.VIRTUOUS_SAINT)
+    if player then
+        player:addTitle(xi.title.VIRTUOUS_SAINT)
+    end
 end
 
 return entity

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -975,7 +975,7 @@ namespace luautils
         return std::optional<CLuaBaseEntity>(PMob);
     }
 
-    std::optional<CLuaBaseEntity> GetEntityByID(uint32 entityid, sol::object const& instanceObj)
+    std::optional<CLuaBaseEntity> GetEntityByID(uint32 entityid, sol::object const& instanceObj, sol::object const& arg3)
     {
         TracyZoneScoped;
 
@@ -984,6 +984,8 @@ namespace luautils
         {
             PInstance = instanceObj.as<CLuaInstance>().GetInstance();
         }
+
+        bool silenceWarning = arg3.get_type() == sol::type::boolean ? arg3.as<bool>() : false;
 
         CBaseEntity* PEntity{ nullptr };
 
@@ -998,7 +1000,10 @@ namespace luautils
 
         if (!PEntity)
         {
-            ShowWarning("luautils::GetEntityByID Mob doesn't exist (%d)", entityid);
+            if (!silenceWarning)
+            {
+                ShowWarning("luautils::GetEntityByID Mob doesn't exist (%d)", entityid);
+            }
             return std::nullopt;
         }
 

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -132,13 +132,14 @@ namespace luautils
 
     void PopulateIDLookups(std::optional<uint16> maybeZoneId = std::nullopt);
 
-    void  SendEntityVisualPacket(uint32 npcid, const char* command);
-    void  InitInteractionGlobal();
-    auto  GetZone(uint16 zoneId) -> std::optional<CLuaZone>;
-    bool  IsZoneActive(uint16 zoneId);
-    auto  GetNPCByID(uint32 npcid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
-    auto  GetMobByID(uint32 mobid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
-    auto  GetEntityByID(uint32 mobid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
+    void SendEntityVisualPacket(uint32 npcid, const char* command);
+    void InitInteractionGlobal();
+    auto GetZone(uint16 zoneId) -> std::optional<CLuaZone>;
+    bool IsZoneActive(uint16 zoneId);
+    auto GetNPCByID(uint32 npcid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
+    auto GetMobByID(uint32 mobid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
+    auto GetEntityByID(uint32 mobid, sol::object const& instanceObj, sol::object const& arg3) -> std::optional<CLuaBaseEntity>;
+
     void  WeekUpdateConquest(sol::variadic_args va);
     uint8 GetRegionOwner(uint8 type);
     uint8 GetRegionInfluence(uint8 type); // Return influence graphics


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Jailer of Love will no longer absorb certain types of melee damage. (WinterSolstice)
Jailer of Love's Phuabos will continue to spawn after other adds are exhausted. (WinterSolstice)

## What does this pull request do? (Please be technical)

Add LSB commit for `[core] add silenceWarning to GetEntityByID`

JoL/AV fixes:

  * Store last Enmity list of JoL onMobFight so AV can aggro the highest existing entity with enmity
  * Change the 2HR animation to inject an action packet instead of using real abilities --
    this fixes a bug where JoL used an ability that made it absorb 250% damage for several melee damage types.
    These action packets were sourced from two captures:
    https://www.youtube.com/watch?v=zxZNmitQp2s
    https://www.youtube.com/watch?v=_oc9yIu65lo
    Each 2HR animation corresponds to one of 8 elements and is NOT random.
  * Fix Phuabo pet spawning past all other pets being spawned.
  * Add immunities into lua to make it more obvious that JoL has immunities to developers.
  * Add a TODO comment in AV
  * Add an if check for `player` in AV's death to grant title to remove an error if AV dies to a DoT without claim

## Steps to test these changes
Fight JoL for a really long time, kill all the adds, eventually only see Phuabos
!getmod impact_sdt should always be 1000
AV should target the pet or player with the highest enmity upon spawn.

## Special Deployment Considerations

N/A
