### PR TITLE
Fix NPC Status Issue

### DIFF
--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -40,6 +40,12 @@ npcUtil = {}
 function npcUtil.popFromQM(player, qm, mobId, params)
     local qmId = qm:getID()
 
+    -- add additional check to make sure players can only
+    -- spawn mobs from visible NPCs
+    if qm:getStatus() ~= xi.status.NORMAL then
+        return false
+    end
+
     -- default params
     if not params then
         params = {}
@@ -53,7 +59,10 @@ function npcUtil.popFromQM(player, qm, mobId, params)
         params.hide = xi.settings.main.FORCE_SPAWN_QM_RESET_TIME
     end
 
-    if params.enmityPlayerList == nil or type(params.enmityPlayerList) ~= "table" then
+    if
+        params.enmityPlayerList == nil or
+        type(params.enmityPlayerList) ~= "table"
+    then
         params.enmityPlayerList = false
     end
 
@@ -105,11 +114,12 @@ function npcUtil.popFromQM(player, qm, mobId, params)
 
         --add base enmity to an entire list of players (like a party)
         if params.enmityPlayerList then
-            for _,member in pairs(params.enmityPlayerList) do
+            for _, member in pairs(params.enmityPlayerList) do
                 mob:updateEnmity(member)
             end
+
             --add a bit more (1 CE) to player that pops mob so mob goes for them first
-            mob:addEnmity(player,1,0)
+            mob:addEnmity(player, 1, 0)
         end
 
         -- look

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/qm_ixaern_mnk.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/qm_ixaern_mnk.lua
@@ -13,7 +13,7 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     local nm = GetMobByID(ID.mob.IXAERN_MNK)
 
-    if not nm:isSpawned() then
+    if npc:getStatus() == xi.status.NORMAL and not nm:isSpawned() then
         local chance = 0 -- percent chance that an item will drop.
 
         if npcUtil.tradeHas(trade, { { xi.items.HIGH_QUALITY_AERN_ORGAN, 3 } }) then

--- a/scripts/zones/Korroloka_Tunnel/npcs/qm1.lua
+++ b/scripts/zones/Korroloka_Tunnel/npcs/qm1.lua
@@ -17,6 +17,7 @@ end
 
 entity.onTrade = function(player, npc, trade)
     if
+        npc:getStatus() == xi.status.NORMAL and
         npcUtil.tradeHasExactly(trade, 643) and
         npcUtil.popFromQM(player, npc, ID.mob.MORION_WORM, { radius = 1, hide = 0 })
     then

--- a/scripts/zones/Kuftal_Tunnel/npcs/qm1.lua
+++ b/scripts/zones/Kuftal_Tunnel/npcs/qm1.lua
@@ -18,6 +18,7 @@ end
 
 entity.onTrade = function(player, npc, trade)
     if
+        npc:getStatus() == xi.status.NORMAL and
         npcUtil.tradeHasExactly(trade, 645) and
         npcUtil.popFromQM(player, npc, ID.mob.PHANTOM_WORM, { radius = 1, hide = 0 })
     then

--- a/scripts/zones/Misareaux_Coast/globals.lua
+++ b/scripts/zones/Misareaux_Coast/globals.lua
@@ -41,7 +41,11 @@ local misareauxGlobal =
     -----------------------------------
     ziphiusOnTrade = function(player, npc, trade)
         local baited = npc:getLocalVar("[Ziphius]Baited") == 1
-        if not baited and npcUtil.tradeHas(trade, xi.items.SLICE_OF_CARP) then
+        if
+            npc:getStatus() == xi.status.NORMAL and
+            not baited and
+            npcUtil.tradeHas(trade, xi.items.SLICE_OF_CARP)
+        then
             npc:setLocalVar("[Ziphius]Bait"..player:getName(), 1)
             npc:setLocalVar("[Ziphius]Baited", 1)
             player:confirmTrade()

--- a/scripts/zones/Temple_of_Uggalepih/npcs/qm1.lua
+++ b/scripts/zones/Temple_of_Uggalepih/npcs/qm1.lua
@@ -13,16 +13,19 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if not player:hasItem(xi.items.TONBERRY_RATTLE) then
+    if
+        npc:getStatus() == xi.status.NORMAL and
+        not player:hasItem(xi.items.TONBERRY_RATTLE)
+    then
         if npcUtil.giveItem(player, xi.items.TONBERRY_RATTLE) then -- Tonberry Rattle
             local positions =
             {
                 { 126.84, 0.00,  -5.644 },
                 { 126.84, 0.00, -25.704 },
                 { 126.84, 0.00, -86.419 },
-                { 126.84, 0.00,-105.698 },
-                { 113.68, 0.00,-127.061 },
-                { 93.67, 0.00,-127.061  },
+                { 126.84, 0.00, -105.698 },
+                { 113.68, 0.00, -127.061 },
+                { 93.67, 0.00, -127.061 },
             }
             local newPosition = npcUtil.pickNewPosition(npc:getID(), positions)
             npc:setStatus(xi.status.DISAPPEAR)

--- a/scripts/zones/Temple_of_Uggalepih/npcs/qm2.lua
+++ b/scripts/zones/Temple_of_Uggalepih/npcs/qm2.lua
@@ -13,16 +13,19 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if not player:hasItem(xi.items.OFFERING_TO_UGGALEPIH) then
+    if
+        npc:getStatus() == xi.status.NORMAL and
+        not player:hasItem(xi.items.OFFERING_TO_UGGALEPIH)
+    then
         if npcUtil.giveItem(player, xi.items.OFFERING_TO_UGGALEPIH) then -- Uggalepih Offering
             local positions =
             {
-                { 393.78,-0.30,272.287 },
-                { 393.78,-0.30,247.382 },
-                { 373.88,-0.30,247.382 },
-                { 373.88,-0.30,272.287 },
-                { 313.59, 0.00,230.870 },
-                { 293.92, 0.00,230.870 },
+                { 393.78, -0.30, 272.287 },
+                { 393.78, -0.30, 247.382 },
+                { 373.88, -0.30, 247.382 },
+                { 373.88, -0.30, 272.287 },
+                { 313.59, 0.00, 230.870 },
+                { 293.92, 0.00, 230.870 },
             }
             local newPosition = npcUtil.pickNewPosition(npc:getID(), positions)
             npc:setStatus(xi.status.DISAPPEAR)

--- a/scripts/zones/Temple_of_Uggalepih/npcs/qm3.lua
+++ b/scripts/zones/Temple_of_Uggalepih/npcs/qm3.lua
@@ -13,7 +13,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if not player:hasItem(xi.items.UGGALEPIH_WHISTLE) then
+    if
+        npc:getStatus() == xi.status.NORMAL and
+        not player:hasItem(xi.items.UGGALEPIH_WHISTLE)
+    then
         if npcUtil.giveItem(player, xi.items.UGGALEPIH_WHISTLE) then -- Uggalepih Whistle
             local positions =
             {

--- a/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm1.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm1.lua
@@ -9,7 +9,11 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:hasItemQty(1195, 1) and trade:getItemCount() == 1 then -- Trade Ro'Maeve Water
+    if
+        npc:getStatus() == xi.status.NORMAL and
+        trade:hasItemQty(1195, 1) and
+        trade:getItemCount() == 1
+    then -- Trade Ro'Maeve Water
         for i = ID.mob.OLLAS_OFFSET, ID.mob.OLLAS_OFFSET + 2 do
             if GetMobByID(i):isSpawned() then
                 return

--- a/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm2.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm2.lua
@@ -9,7 +9,10 @@ require("scripts/globals/npc_util")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, { 1404, 1405, 1406, 1407 }) then
+    if
+        npc:getStatus() == xi.status.NORMAL and
+        npcUtil.tradeHas(trade, { 1404, 1405, 1406, 1407 })
+    then
         player:startEvent(101)
         player:confirmTrade()
     end

--- a/scripts/zones/Valkurm_Dunes/npcs/qm4.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/qm4.lua
@@ -46,7 +46,10 @@ entity.onTrade = function(player, npc, trade)
     elseif player:checkSoloPartyAlliance() == 2 then
         player:messageSpecial(ID.text.ALLIANCE_NOT_ALLOWED, 0)
     else
-        if npcUtil.tradeHasExactly(trade, xi.items.PIRATES_CHART) then
+        if
+            npc:getStatus() == xi.status.NORMAL and
+            npcUtil.tradeHasExactly(trade, xi.items.PIRATES_CHART)
+        then
             player:messageSpecial(ID.text.RETURN_TO_SEA, xi.items.PIRATES_CHART)
             player:startEvent(14, 0, 0, 0, 3)
         end
@@ -87,7 +90,6 @@ entity.onEventFinish = function(player, csid, option, npc)
     }
 
     local function rangeChecking(spawnNpc, spawnerID, timeToMobSpawn, timeOfLastCheck, wasInRangeLastCheck, timeOutOfRangeLastMsg)
-
         local spawner = GetPlayerByID(spawnerID)
         -- spawner does not meet some condition so can stop checking
         -- so will not spawn mobs in any case
@@ -139,13 +141,34 @@ entity.onEventFinish = function(player, csid, option, npc)
         rangeChecking(npc, playerID, 50000, ServerEpochTimeMS(), true, 0)
 
         -- need to use the qm4 npc for showing text because the taru has a blank name and need a ???
-        panictaru:timer(3000 , function(taru) taru:sendNpcEmote(shimmering, xi.emote.POINT, xi.emoteMode.MOTION) npc:showText(npc, ID.text.SHIMMERY_POINT) end)
-        panictaru:timer(23000, function(taru) taru:sendNpcEmote(shimmering, xi.emote.PANIC, xi.emoteMode.MOTION) npc:showText(npc, ID.text.HURRY_UP) end)
-        panictaru:timer(33000, function(taru) taru:sendNpcEmote(shimmering, xi.emote.PANIC, xi.emoteMode.MOTION) npc:showText(npc, ID.text.ITS_COMING) end)
-        panictaru:timer(43000, function(taru) taru:sendNpcEmote(shimmering, xi.emote.PANIC, xi.emoteMode.MOTION) npc:showText(npc, ID.text.THREE_OF_THEM)  end)
-        panictaru:timer(45000, function(taru) npc:showText(npc, ID.text.NOOOOO) end)
-        panictaru:timer(45000, function(taru) taru:entityAnimationPacket("dead") taru:messageText(taru, ID.text.CRY_OF_ANGUISH, false) end)
-        panictaru:timer(50000, function(taru) taru:setStatus(xi.status.DISAPPEAR) taru:entityAnimationPacket("stnd") end)
+        panictaru:timer(3000 , function(taru)
+            taru:sendNpcEmote(shimmering, xi.emote.POINT, xi.emoteMode.MOTION) npc:showText(npc, ID.text.SHIMMERY_POINT)
+        end)
+
+        panictaru:timer(23000, function(taru)
+            taru:sendNpcEmote(shimmering, xi.emote.PANIC, xi.emoteMode.MOTION) npc:showText(npc, ID.text.HURRY_UP)
+        end)
+
+        panictaru:timer(33000, function(taru)
+            taru:sendNpcEmote(shimmering, xi.emote.PANIC, xi.emoteMode.MOTION) npc:showText(npc, ID.text.ITS_COMING)
+        end)
+
+        panictaru:timer(43000, function(taru)
+            taru:sendNpcEmote(shimmering, xi.emote.PANIC, xi.emoteMode.MOTION) npc:showText(npc, ID.text.THREE_OF_THEM)
+        end)
+
+        panictaru:timer(45000, function(taru)
+            npc:showText(npc, ID.text.NOOOOO)
+        end)
+
+        panictaru:timer(45000, function(taru)
+            taru:entityAnimationPacket("dead") taru:messageText(taru, ID.text.CRY_OF_ANGUISH, false)
+        end)
+
+        panictaru:timer(50000, function(taru)
+            taru:setStatus(xi.status.DISAPPEAR) taru:entityAnimationPacket("stnd")
+        end)
+
         npc:timer(50000,
         function(npcArg)
             local spawner = GetPlayerByID(playerID)
@@ -169,12 +192,14 @@ entity.onEventFinish = function(player, csid, option, npc)
                     if member:hasStatusEffect(xi.effect.LEVEL_RESTRICTION) then
                         member:delStatusEffect(xi.effect.LEVEL_RESTRICTION)
                     end
+
                     member:changeMusic(0, 0)
                     member:changeMusic(1, 0)
                     member:changeMusic(2, 101)
                     member:changeMusic(3, 102)
                     member:setLocalVar("Chart", 0)
                 end
+
                 -- time limit of 10 mins (600 seconds)
                 , { timeLimit = 600,
                 validPlayerFunc = function(member)
@@ -185,7 +210,8 @@ entity.onEventFinish = function(player, csid, option, npc)
                     else
                         return false
                     end
-                 end,
+                end,
+
                 -- give all registered players in confrontation emnity
                 allRegPlayerEnmity = true }
                 )

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -621,6 +621,12 @@ void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
                     PChar->updateEntityPacket(PCurrentNpc, ENTITY_DESPAWN, UPDATE_NONE);
                 }
             }
+            // NPC not visible, remove it from spawn list if it's in there
+            else if (NPC != PChar->SpawnNPCList.end())
+            {
+                PChar->SpawnNPCList.erase(NPC);
+                PChar->updateEntityPacket(PCurrentNpc, ENTITY_DESPAWN, UPDATE_NONE);
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Certain NPCs will now always correctly disappear when they should (such as ??? for spawning certain monsters). (Tracent, WinterSolstice)

## What does this pull request do? (Please be technical)
This PR fixes an issue introduced in this [commit](https://github.com/AirSkyBoat/AirSkyBoat/pull/2837/commits/62be9ddabe1d5289c4baed2696c548088d8f89ea) whereby setStatus(xi.status.DISAPPEAR) would not always send an update packet to the player to actually remove the NPC from the players view. Additionally, the PR adds checks to make sure that NPCs have NORMAL status when players are interacting with them (thus preventing interaction in case of similar issue in the future).

## Steps to test these changes

Test many different NPCs that spawn things such as Morion Worm, Kirin, etc.
(This is improvement of https://github.com/AirSkyBoat/AirSkyBoat/pull/2987)

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1382
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1381
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1386

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
