### PR TITLE
[lua] [sql] Pod Ejection target fix, Aern Wing Thrust fTP change to match Jimmayus's data

### DIFF
--- a/scripts/globals/mobskills/wing_thrust.lua
+++ b/scripts/globals/mobskills/wing_thrust.lua
@@ -20,8 +20,9 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 4
     local accmod = 1
-    -- reduced from ftp 8, 8, 8 per discord discussion - still needs balancing.
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, 1, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 1, 1)
+
+    -- https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit#gid=57955395&range=A967
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, 1, xi.mobskills.physicalTpBonus.DMG_BONUS, 0.5, 0.5, 0.5)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, info.hitslanded)
 
     xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SLOW, 1250, 0, 60)

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1430,7 +1430,7 @@ INSERT INTO `mob_skills` VALUES (1528,1087,'floodlight',2,15.0,2000,1500,4,0,0,0
 INSERT INTO `mob_skills` VALUES (1529,1089,'hyper_pulse',1,10.0,2000,1500,4,0,0,0,0,0,0); -- Proto-Omega
 INSERT INTO `mob_skills` VALUES (1530,1088,'stun_cannon',4,20.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1531,772,'wz_recover_all',1,20.0,0,0,1028,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1532,1124,'pod_ejection',0,7.0,4500,1,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1532,1124,'pod_ejection',0,7.0,4500,1,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1533,1117,'pile_pitch',0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1534,1118,'guided_missile',2,5.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1535,1119,'hyper_pulse',1,10.0,2000,1500,4,0,0,0,0,0,0); -- Omega


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Pod Ejection from Proto Omega now targets Proto Omega and cannot be outranged. (WinterSolstice)
Wing Thrust fTP set to proper value from Jimmayus's testing data (WinterSolstice, Jimmayus)

## What does this pull request do? (Please be technical)

Sets Proto-Omega's Pod Ejection to self-target as per caps from Aether
timestamp:
https://youtu.be/qk-f6a1kBBg?t=1774
cap: https://www.dropbox.com/s/mpn4xgw1tsnayx5/proto%20omega.rar?dl=0

![image](https://user-images.githubusercontent.com/60417494/231221067-dd1df34d-8566-4ecb-912d-314292d1abb8.png)

Sets Wing Thrust fTPs to 0.5 as per https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit#gid=57955395&range=A967
## Steps to test these changes

`!setmod move -100` on omega
!hp 1 omega, stand way way out of range. a gunpod should come to you every 5 minutes but you have to kill it repeatedly to get more.

take damage from Wing Thrust with no errors

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
