### PR TITLE
Revert "Sets sj bst charm duration based on bst job level"

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5040,17 +5040,6 @@ namespace battleutils
 
             int8 dLvl = PCharmer->GetMLevel() - PVictim->GetMLevel();
 
-            // This function (TryCharm) is only used by the bst charm ability via charmPet.  Brd uses charm, not charmPet for Maiden's Virelai
-            // Therefore, unless something very wrong has happened, the player is either main or sub BST
-            if (PCharmer->GetSJob() == JOBTYPE::JOB_BST)
-            {
-                int bstLevel = ((CCharEntity*)PCharmer)->jobs.job[JOBTYPE::JOB_BST];
-                if (bstLevel < PCharmer->GetMLevel())
-                {
-                    dLvl = bstLevel - PVictim->GetMLevel();
-                }
-            }
-
             // dLvl -6 or lower
             float dLvlCharmMod = 1 / 24.f;
 


### PR DESCRIPTION
This reverts commit 198956d1f09179c05eaa4d296ba37fe814c9cd0d.

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Sets charm duration based on main job level only - my previous commit was based on [less valid sources](https://www.ffxiah.com/forum/topic/5230/bst-as-a-sub/#244141)

See this link for confirmation: https://web.archive.org/web/20130925230727/https://ffxi.allakhazam.com/forum.html?forum=262&mid=1298635397162868956&h=50&p=6#276

## What does this pull request do? (Please be technical)

Reverts a previous commit

## Steps to test these changes
Find a level 15 mob and spam charm as a level 75/bst1 - charm will have a 5% chance to land but when it lands, the duration will be very long.

## Special Deployment Considerations
None