### PR TITLE
[lua] change Aern mixin to use IDs to resolve target after reraise

### DIFF
--- a/scripts/mixins/families/aern.lua
+++ b/scripts/mixins/families/aern.lua
@@ -31,18 +31,34 @@ g_mixins.families.aern = function(aernMob)
             mob:setMobMod(xi.mobMod.NO_DROPS, 1)
         end
 
-        local dropid = mob:getDropID()
-        local target = mob:getTarget()
+        local dropid   = mob:getDropID()
+        local target   = mob:getTarget()
+        local targetID = 0
+        local masterID = 0
 
-        if
-            target and
-            target:isPet() and
-            not target:isAlive()
-        then
-            target = target:getMaster()
+        if target then
+            targetID = target:getID()
+        end
+
+        if target:isPet() and target:getMaster() then
+            masterID = target:getMaster():getID()
         end
 
         mob:timer(12000, function(mobArg)
+            target = GetPlayerByID(targetID)
+            if target == nil then
+                -- try mob
+                target = GetEntityByID(targetID, mobArg:getInstance(), true)
+            end
+
+            if target == nil and masterID ~= 0 then
+                target = GetPlayerByID(masterID)
+                if target == nil then
+                    -- try mob
+                    target = GetEntityByID(masterID, mobArg:getInstance(), true)
+                end
+            end
+
             mobArg:setHP(mob:getMaxHP())
             mobArg:setDropID(dropid)
             mobArg:setAnimationSub(3)


### PR DESCRIPTION
* This fixes a crash where a pet may have killed the aern and reraised after the pet was deleted.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Change Aern mixin to not crash if resolving a player/mob ID that no longer exists upon reraise. (WinterSolstice)

## What does this pull request do? (Please be technical)

Change Aern mix to use IDs instead of storing CLuaBaseEntity references to target player/pet after reraise. This resolves a crash.

## Steps to test these changes

Go to Sea, summon Ifrit, assault a aern, use Flaming Crush to kill an aern, immediately release when it's hp is 0 and do not crash.
Crash is observed on Linux, at least.

## Special Deployment Considerations

N/A
