### PR TITLE
[core] Don't reset Pet Zoning Info when zoning into a town

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -441,8 +441,6 @@ void SmallPacket0x00C(map_session_data_t* const PSession, CCharEntity* const PCh
 
         PChar->resetPetZoningInfo();
     }
-    // Reset the petZoning info
-    PChar->resetPetZoningInfo();
 }
 
 /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Player pets will no longer reset when zoning into town (WinterSolstice)

## What does this pull request do? (Please be technical)

At some point, it seems there may have been a bad merge from LSB;

This aligns with era/retail behavior where if you zone into town then immediately back out your pet will return. This also fixes the same issue when zoning through Hall of the Gods or other non-city non-field areas where pets aren't allowed.

## Steps to test these changes

Call wyvern outside of town, zone into town, zone out of town and your wyvern should persist.

## Special Deployment Considerations

N/A