### PR TITLE
[bcnm] Allow parties entry to Apocalypse Nigh

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -1313,7 +1313,7 @@ local function checkReqs(player, npc, bfid, registrant)
 
         [1057] = function() -- Quest: Apocalypse Nigh
             return player:hasCompletedQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) or
-                player:getCharVar('ApocalypseNigh') >= 3
+                player:getCharVar("Quest[3][89]Status") >= 3
         end,
 
         [1290] = function() -- NW Apollyon
@@ -1731,7 +1731,7 @@ local function checkSkip(player, bfid)
             return player:hasCompletedQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) or
                 (
                     player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and
-                    player:getCharVar('ApocalypseNigh') > 3
+                    player:getCharVar("Quest[3][89]Status") > 3
                 )
         end,
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Allow parties entry to Apocalypse Nigh (WinterSolstice)

## What does this pull request do? (Please be technical)

Allow parties entry to Apocalypse Nigh
Also allow helping Apocalypse Nigh after finishing the quest

## Steps to test these changes

Be on apocalypse nigh in a party, everyone be able to enter (instead of solo only)
Same as above, except helping with Apocalypse Nigh

## Special Deployment Considerations

N/A