### PR TITLE
King Behemoth EEM Values

### DIFF
--- a/modules/era/sql/era_mob_elemental_evasion.sql
+++ b/modules/era/sql/era_mob_elemental_evasion.sql
@@ -1049,6 +1049,7 @@ UPDATE `mob_pools` SET `ele_eva_id` = 312 WHERE `poolid` = 2224; -- Khroma Quada
 UPDATE `mob_pools` SET `ele_eva_id` = 340 WHERE `poolid` = 2223; -- Khromasoul Bhurborlor
 UPDATE `mob_pools` SET `ele_eva_id` = 159 WHERE `poolid` = 6619; -- Kindred Dark Knight
 UPDATE `mob_pools` SET `ele_eva_id` = 35 WHERE `poolid` = 2247; -- Kindred's Wyvern
+UPDATE `mob_pools` SET `ele_eva_id` = 252 WHERE `poolid` = 2255; -- King Behemoth
 UPDATE `mob_pools` SET `ele_eva_id` = 110 WHERE `poolid` = 2256; -- King Buffalo
 UPDATE `mob_pools` SET `ele_eva_id` = 336 WHERE `poolid` = 2257; -- King Goldemar
 UPDATE `mob_pools` SET `ele_eva_id` = 322 WHERE `poolid` = 2265; -- Kirin


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Fixes an issue where King Behemoth had the wrong EEM values assigned to it. (Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
King behemoths EEM values were defaulted to 164 ele id which is 100 flat EEM for all resistances. It should be id 256 which is 70 for all.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to King Behemoth
!getmod FIRE_EEM
You should see a value of 70
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
