### PR TITLE
hotfix for PLD quests

### DIFF
--- a/scripts/quests/sandoria/A_Knights_Test.lua
+++ b/scripts/quests/sandoria/A_Knights_Test.lua
@@ -82,8 +82,8 @@ quest.sections =
             ['Baunise'] =
             {
                 onTrigger = function(player, npc)
-                    if player:hasKeyItem (xi.ki.KNIGHTS_SOUL) then
-                        return quest:event(634)
+                    if not player:hasKeyItem (xi.ki.BOOK_OF_THE_WEST) then
+                        return quest:progressEvent(634)
                     elseif player:hasKeyItem (xi.ki.BOOK_OF_THE_WEST) then
                         return quest:messageSpecial(ID.text.TRIAL_IS_DIFFICULT)
                     end
@@ -93,8 +93,8 @@ quest.sections =
             ['Cahaurme'] =
             {
                 onTrigger = function(player, npc)
-                    if player:hasKeyItem (xi.ki.KNIGHTS_SOUL) then
-                        player:startEvent(633)
+                    if not player:hasKeyItem (xi.ki.BOOK_OF_THE_EAST) then
+                        quest:progressEvent(633)
                     elseif player:hasKeyItem (xi.ki.BOOK_OF_THE_EAST) then
                         return quest:messageSpecial(ID.text.WAY_OF_THE_SWORD)
                     end

--- a/scripts/quests/sandoria/A_Squires_Test.lua
+++ b/scripts/quests/sandoria/A_Squires_Test.lua
@@ -54,6 +54,7 @@ quest.sections =
                         quest:setVar(player, 'Refuse', 1)
                     elseif option == 0 then
                         quest:begin(player)
+                        quest:setVar(player, 'Prog', 1)
                     end
                 end,
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Addresses a couple issues where players wouldn't be able to finish the Squires Test or Knights test questslines.
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Fixed a couple of var placements. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
