### PR TITLE
Fix Hpemde issue with wait and inactive states

### DIFF
--- a/scripts/mixins/families/hpemde.lua
+++ b/scripts/mixins/families/hpemde.lua
@@ -40,8 +40,17 @@ local function openMouth(mob)
     mob:setMod(xi.mod.UDMGMAGIC, 10000)
     mob:setMod(xi.mod.UDMGBREATH, 10000)
     mob:setLocalVar("[hpemde]closeMouthHP", mob:getHP() - math.ceil(mob:getMaxHP() / 3))
+    mob:setAutoAttackEnabled(false)
+    mob:setMobAbilityEnabled(false)
+    mob:setLocalVar("changingState", 1)
     mob:setAnimationSub(3)
-    mob:wait(2000)
+    mob:timer(2000, function(mobArg)
+        if mobArg:isAlive() then
+            mobArg:setAutoAttackEnabled(true)
+            mobArg:setMobAbilityEnabled(true)
+            mobArg:setLocalVar("changingState", 0)
+        end
+    end)
 end
 
 local function closeMouth(mob)
@@ -51,8 +60,17 @@ local function closeMouth(mob)
     mob:setMod(xi.mod.UDMGMAGIC, 0)
     mob:setMod(xi.mod.UDMGBREATH, 0)
     mob:setLocalVar("[hpemde]changeTime", mob:getBattleTime() + 30)
+    mob:setAutoAttackEnabled(false)
+    mob:setMobAbilityEnabled(false)
+    mob:setLocalVar("changingState", 1)
     mob:setAnimationSub(6)
-    mob:wait(2000)
+    mob:timer(2000, function(mobArg)
+        if mobArg:isAlive() then
+            mobArg:setAutoAttackEnabled(true)
+            mobArg:setMobAbilityEnabled(true)
+            mobArg:setLocalVar("changingState", 0)
+        end
+    end)
 end
 
 g_mixins.families.hpemde = function(hpemdeMob)
@@ -96,12 +114,14 @@ g_mixins.families.hpemde = function(hpemdeMob)
         else
             if
                 mob:getAnimationSub() == 6 and
-                mob:getBattleTime() > mob:getLocalVar("[hpemde]changeTime")
+                mob:getBattleTime() > mob:getLocalVar("[hpemde]changeTime") and
+                mob:getLocalVar("changingState") == 0
             then
                 openMouth(mob)
             elseif
                 mob:getAnimationSub() == 3 and
-                mob:getHP() <  mob:getLocalVar("[hpemde]closeMouthHP")
+                mob:getHP() < mob:getLocalVar("[hpemde]closeMouthHP") and
+                mob:getLocalVar("changingState") == 0
             then
                 closeMouth(mob)
             end
@@ -109,7 +129,10 @@ g_mixins.families.hpemde = function(hpemdeMob)
     end)
 
     hpemdeMob:addListener("CRITICAL_TAKE", "HPEMDE_CRITICAL_TAKE", function(mob)
-        if mob:getAnimationSub() == 3 then
+        if
+            mob:getAnimationSub() == 3 and
+            mob:getLocalVar("changingState") == 0
+        then
             closeMouth(mob)
         end
     end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Hpemde monsters will stay asleep or bound even after changing states (open or closed mouth) or if sleep or bind land while changing states. (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes an issue where Hpemde mobs used the wait function which caused the mob to go to the inactive state for two seconds. If sleep or other spell had previously put the mob into an inactive state then this new inactive would incorrectly overwrite the old state thus waking the mob up, Additionally if sleep landed during the 2 second inactive state it would not overwrite (due to a condition check) thus the mob would continue auto-attacking after the 2 second despite having the sleep status effect (and thus could not be reslept). I think PR this also fixes an issue with Hpemde incorrectly using multiple RP moves in a row.

## Steps to test these changes
Fight and sleep normal Hpemde monsters.

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1287
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1210
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
