### PR TITLE
[login] Allow characters above id 65535 to login

### DIFF
--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -198,10 +198,12 @@ int32 lobbydata_parse(int32 fd)
                         uint8  charIdExtra = (charId >> 16) & 0xFF;
 
                         // uList is sent through data socket (to bootloader)
-                        ref<uint32>(uList, 16 * (i + 1)) = contentId;
-                        ref<uint16>(uList, 20 * (i + 1)) = charIdMain;
-                        ref<uint8>(uList, 22 * (i + 1))  = worldId;
-                        ref<uint8>(uList, 23 * (i + 1))  = charIdExtra;
+                        uint32 uListOffset = 16 * (i + 1);
+
+                        ref<uint32>(uList, uListOffset) = contentId;
+                        ref<uint16>(uList, uListOffset + 4) = charIdMain;
+                        ref<uint8>(uList, uListOffset + 6)  = worldId;
+                        ref<uint8>(uList, uListOffset + 7)  = charIdExtra;
 
                         // CharList is sent through view socket (to the FFXI client)
                         uint32 charListOffset = 32 + i * 140;

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -200,7 +200,7 @@ int32 lobbydata_parse(int32 fd)
                         // uList is sent through data socket (to bootloader)
                         uint32 uListOffset = 16 * (i + 1);
 
-                        ref<uint32>(uList, uListOffset) = contentId;
+                        ref<uint32>(uList, uListOffset)     = contentId;
                         ref<uint16>(uList, uListOffset + 4) = charIdMain;
                         ref<uint8>(uList, uListOffset + 6)  = worldId;
                         ref<uint8>(uList, uListOffset + 7)  = charIdExtra;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3268,8 +3268,8 @@ bool CLuaBaseEntity::gotoPlayer(std::string const& playerName)
         char buf[30];
         memset(&buf[0], 0, sizeof(buf));
 
-        ref<uint16>(&buf, 0) = sql->GetUIntData(0); // target char
-        ref<uint16>(&buf, 4) = m_PBaseEntity->id;   // warping to target char, their server will send us a zoning message with their pos
+        ref<uint32>(&buf, 0) = sql->GetUIntData(0); // target char
+        ref<uint32>(&buf, 4) = m_PBaseEntity->id;   // warping to target char, their server will send us a zoning message with their pos
 
         message::send(MSG_SEND_TO_ZONE, &buf[0], sizeof(buf), nullptr);
         found = true;
@@ -3297,8 +3297,8 @@ bool CLuaBaseEntity::bringPlayer(std::string const& playerName)
         char buf[30];
         memset(&buf[0], 0, sizeof(buf));
 
-        ref<uint16>(&buf, 0)  = sql->GetUIntData(0); // target char
-        ref<uint16>(&buf, 4)  = 0;                   // wanting to bring target char here so wont give our id
+        ref<uint32>(&buf, 0)  = sql->GetUIntData(0); // target char
+        ref<uint32>(&buf, 4)  = 0;                   // wanting to bring target char here so wont give our id
         ref<uint16>(&buf, 8)  = m_PBaseEntity->getZone();
         ref<uint16>(&buf, 10) = static_cast<uint16>(m_PBaseEntity->loc.p.x);
         ref<uint16>(&buf, 14) = static_cast<uint16>(m_PBaseEntity->loc.p.y);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Allow characters above id 65535 to login with new loader (Wintersolstice)

## What does this pull request do? (Please be technical)

Adjusts some bad offsets in login, opens up some zmq messaging to use 32 bit integers.

## Steps to test these changes

REQUIRES xiloader from https://github.com/LandSandBoat/xiloader/pull/11 if your character ID is above 65535. The xiloader is not needed for character IDs 65535 and below.

Create a character with character ID above 65535 (easily done by breakpointing in lobby_createchar in lobby.cpp and adjusting char ID after the fact.)
Login as normal.

## Special Deployment Considerations

Update xiloader for clients when required (character ID > 65535)
