### PR TITLE
[Limbus] Fixes Mix-up in drop tables

### DIFF
--- a/modules/era/sql/era_mob_droplist.sql
+++ b/modules/era/sql/era_mob_droplist.sql
@@ -26393,25 +26393,149 @@ INSERT INTO `mob_droplist` VALUES (3233,0,0,1000,1875,@ALWAYS); -- Ancient Beast
 INSERT INTO `mob_droplist` VALUES (3233,0,0,1000,1875,@VCOMMON); -- Ancient Beastcoin (Very Common, 24%)
 INSERT INTO `mob_droplist` VALUES (3233,0,0,1000,1875,@VCOMMON); -- Ancient Beastcoin (Very Common, 24%)
 
--- ZoneiD: 25 - Orcish Footsoldiers
--- ZoneiD: 25 - Orcish Gladiators
--- ZoneiD: 25 - Orcish Troopers
-INSERT INTO `mob_droplist` VALUES (3234,2,0,1000,750,0); -- Silver Beastcoin (Steal)
-INSERT INTO `mob_droplist` VALUES (3234,2,0,1000,1661,@UNCOMMON); -- Misareaux Garlic (Very Rare, 1%)
+-- ZoneID:  37 - Fire Elemental
+-- ZoneID:  37 - Ice Elemental
+-- ZoneID:  37 - Air Elemental
+-- ZoneID:  37 - Earth Elemental
+-- ZoneID:  37 - Thunder Elemental
+-- ZoneID:  37 - Water Elemental
+-- ZoneID:  37 - Dark Elemental
+-- ZoneID:  37 - Mystic_Avatar
+INSERT INTO `mob_droplist` VALUES (3234,0,0,1000,1875,@ALWAYS); -- Ancient Beastcoin (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3234,0,0,1000,1875,@VCOMMON); -- Ancient Beastcoin (Very Common, 24%)
+INSERT INTO `mob_droplist` VALUES (3234,0,0,1000,1875,@VCOMMON); -- Ancient Beastcoin (Very Common, 24%)
 
--- ZoneiD: 25 - Orcish Bowshooters
-INSERT INTO `mob_droplist` VALUES (3235,2,0,1000,750,0); -- Silver Beastcoin (Steal)
-INSERT INTO `mob_droplist` VALUES (3235,2,0,1000,1661,@UNCOMMON); -- Misareaux Garlic (Uncommon 10%)
-INSERT INTO `mob_droplist` VALUES (3235,0,0,1000,5154,@UNCOMMON);   -- Tavnazian Liver (Uncommon 10%)
+-- ZoneID:  37 - Light Elemental
+-- ZoneID:  37 - Mystic_Avatar (Carbuncle)
+INSERT INTO `mob_droplist` VALUES (3235,0,0,1000,1875,@ALWAYS); -- Ancient Beastcoin (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3235,0,0,1000,1875,@ALWAYS); -- Ancient Beastcoin (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3235,0,0,1000,1875,@ALWAYS); -- Ancient Beastcoin (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3235,0,0,1000,1875,@ALWAYS); -- Ancient Beastcoin (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3235,0,0,1000,1875,@ALWAYS); -- Ancient Beastcoin (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3235,0,0,1000,1875,@ALWAYS); -- Ancient Beastcoin (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3235,0,0,1000,1875,@VCOMMON); -- Ancient Beastcoin (Very Common, 24%)
+INSERT INTO `mob_droplist` VALUES (3235,0,0,1000,1875,@VCOMMON); -- Ancient Beastcoin (Very Common, 24%)
 
--- ZoneiD: 24 - Orcish Beastrider
--- ZoneiD: 24 - Orcish Brawler
--- ZoneiD: 24 - Orcish Footsoldier
--- ZoneiD: 24 - Orcish Nightrider
--- ZoneiD: 24 - Orcish Galdiator
--- ZoneiD: 24 - Orcish Trooper
-INSERT INTO `mob_droplist` VALUES (3236,2,0,1000,750,0); -- Silver Beastcoin (Steal)
-INSERT INTO `mob_droplist` VALUES (3236,0,0,1000,5154,@UNCOMMON);   -- Tavnazian Liver (Uncommon, 10%)
+-- ZoneID:  37 - Grognard Mesmerizer
+-- ZoneID:  37 - Grognard Footsoldier
+-- ZoneID:  37 - Grognard Predator
+-- ZoneID:  37 - Grognard Neckchopper
+-- ZoneID:  37 - Grognard Grappler
+-- ZoneID:  37 - Grognard Impaler
+-- ZoneID:  37 - Star Ruby Quadav
+-- ZoneID:  37 - Whitegold Quadav
+-- ZoneID:  37 - Wootz Quadav
+-- ZoneID:  37 - Star Sapphire Quadav
+-- ZoneID:  37 - Lightsteel Quadav
+-- ZoneID:  37 - Yagudo Archpriest
+-- ZoneID:  37 - Yagudo Disciplinant
+-- ZoneID:  37 - Yagudo Kapellmeister
+-- ZoneID:  37 - Yagudo Knight Templar
+-- ZoneID:  37 - Yagudo Prelatess
+-- ZoneID:  37 - Yagudo Eradicator
+INSERT INTO `mob_droplist` VALUES (3236,0,0,1000,1875,@ALWAYS); -- Ancient Beastcoin (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3236,0,0,1000,1875,@VCOMMON); -- Ancient Beastcoin (Very Common, 24%)
+INSERT INTO `mob_droplist` VALUES (3236,0,0,1000,1875,@VCOMMON); -- Ancient Beastcoin (Very Common, 24%)
+
+-- ZoneID:  37 - Kingslayer_Doggvdegg
+-- ZoneID:  37 - JiGho_Ageless
+-- ZoneID:  37 - Koo_Buzu_the_Theomanic
+-- ZoneID:  37 - Mystic_Avatar
+-- ZoneID:  37 - Enhanced_Koenigstiger
+-- ZoneID:  37 - Enhanced_Pygmaioi
+-- ZoneID:  37 - Enhanced_Kettenkaefer
+-- ZoneID:  37 - Enhanced_Salamander
+-- ZoneID:  37 - Enhanced_Jelly
+-- ZoneID:  37 - Enhanced_Makara
+-- ZoneID:  37 - Enhanced_Akbaba
+INSERT INTO `mob_droplist` VALUES (3237,0,0,1000,1875,@ALWAYS); -- Ancient Beastcoin (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3237,0,0,1000,1875,@ALWAYS); -- Ancient Beastcoin (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3237,0,0,1000,1875,@ALWAYS); -- Ancient Beastcoin (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3237,0,0,1000,1875,@UNCOMMON); -- Ancient Beastcoin (Uncommon, 10%)
+
+-- ZoneID:  135 - Animated Knuckles
+INSERT INTO `mob_droplist` VALUES (3238,0,0,1000,1571,@ALWAYS); -- Mystic Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Dagger
+INSERT INTO `mob_droplist` VALUES (3239,0,0,1000,1572,@ALWAYS); -- Ornate Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Longsword
+INSERT INTO `mob_droplist` VALUES (3240,0,0,1000,1573,@ALWAYS); -- Holy Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Claymore
+INSERT INTO `mob_droplist` VALUES (3241,0,0,1000,1574,@ALWAYS); -- Intricate Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Tabar
+INSERT INTO `mob_droplist` VALUES (3242,0,0,1000,1575,@ALWAYS); -- Runaeic Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Great Axe
+INSERT INTO `mob_droplist` VALUES (3243,0,0,1000,1576,@ALWAYS); -- Seraphic Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Scythe
+INSERT INTO `mob_droplist` VALUES (3244,0,0,1000,1577,@ALWAYS); -- Tenebrous Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Spear
+INSERT INTO `mob_droplist` VALUES (3245,0,0,1000,1578,@ALWAYS); -- Stellar Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Kunai
+INSERT INTO `mob_droplist` VALUES (3246,0,0,1000,1579,@ALWAYS); -- Demoniac Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Tachi
+INSERT INTO `mob_droplist` VALUES (3247,0,0,1000,1580,@ALWAYS); -- Divine Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Hammer
+INSERT INTO `mob_droplist` VALUES (3248,0,0,1000,1581,@ALWAYS); -- Heavenly Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Staff
+INSERT INTO `mob_droplist` VALUES (3249,0,0,1000,1582,@ALWAYS); -- Celestial Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Longbow
+INSERT INTO `mob_droplist` VALUES (3250,0,0,1000,1583,@ALWAYS); -- Snarled Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Horn
+INSERT INTO `mob_droplist` VALUES (3251,0,0,1000,1584,@ALWAYS); -- Mysterial Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Gun
+INSERT INTO `mob_droplist` VALUES (3252,0,0,1000,1585,@ALWAYS); -- Ethereal Fragment (Always, 100%)
+
+-- ZoneID:  135 - Animated Shield
+INSERT INTO `mob_droplist` VALUES (3253,0,0,1000,1822,@ALWAYS); -- Supernal Fragment (Always, 100%)
+
+-- ZoneID: 198 - Wendigo Blm
+INSERT INTO `mob_droplist` VALUES (3254,0,0,1000,880,@VCOMMON); -- Bone Chip (Very Common, 24%)
+INSERT INTO `mob_droplist` VALUES (3254,0,0,1000,4824,@RARE);   -- Scroll Of Gravity (Rare, 5%)
+INSERT INTO `mob_droplist` VALUES (3254,2,0,1000,880,0);        -- Bone Chip (Steal)
+
+-- ZoneID: 25 - Orcish Footsoldiers
+-- ZoneID: 25 - Orcish Gladiators
+-- ZoneID: 25 - Orcish Troopers
+INSERT INTO `mob_droplist` VALUES (3255,2,0,1000,750,0); -- Silver Beastcoin (Steal)
+INSERT INTO `mob_droplist` VALUES (3255,2,0,1000,1661,@UNCOMMON); -- Misareaux Garlic (Uncommon, 10%) http://www.ffxidb.com/items/1661
+
+-- ZoneID: 25 - Orcish Bowshooters
+INSERT INTO `mob_droplist` VALUES (3256,2,0,1000,750,0); -- Silver Beastcoin (Steal)
+INSERT INTO `mob_droplist` VALUES (3256,2,0,1000,1661,@UNCOMMON); -- Misareaux Garlic (Uncommon, 10%)-- http://www.ffxidb.com/items/1661
+INSERT INTO `mob_droplist` VALUES (3256,0,0,1000,5154,@RARE);   -- Tavnazian Liver (Rare 5%) http://www.ffxidb.com/items/5154
+
+-- ZoneID: 24 - Orcish Beastrider
+-- ZoneID: 24 - Orcish Brawler
+-- ZoneID: 24 - Orcish Footsoldier
+-- ZoneID: 24 - Orcish Nightrider
+-- ZoneID: 24 - Orcish Gladiator
+-- ZoneID: 24 - Orcish Trooper
+INSERT INTO `mob_droplist` VALUES (3257,2,0,1000,750,0); -- Silver Beastcoin (Steal)
+INSERT INTO `mob_droplist` VALUES (3257,0,0,1000,5154,@RARE);   -- Tavnazian Liver (Rare, 5%) http://www.ffxidb.com/items/5154
+
+-- ZoneID:123  - Pyuu_the_Spatemaker
+INSERT INTO `mob_droplist` VALUES (3258,0,0,1000,2850,@UNCOMMON);   -- Sahagin Gold (Uncommon, ~10%) http://www.ffxidb.com/zones/123/pyuu-the-spatemaker
+
+-- ZoneID:61  - Fahrafahr the Bloodied
+INSERT INTO `mob_droplist` VALUES (3259,0,0,1000,18872,@COMMON);   -- Lyft Ferule (Common, ~15%) http://www.ffxidb.com/items/18872
+
+------------------------------------------------------------------------------
+-- DO NOT ADD ANY NEW DROPLISTS TO THIS SECTION ABOVE - ONLY EDIT THE DROPS
+------------------------------------------------------------------------------
+
 --------------------------------
 -- ASB Droplists Start at 6000
 --------------------------------

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -880,9 +880,9 @@ INSERT INTO `mob_groups` VALUES (12,2672,24,'Miner_Bee',330,0,1697,0,0,31,34,0);
 INSERT INTO `mob_groups` VALUES (13,3854,24,'Tavnazian_Sheep',330,0,2382,0,0,33,37,0);
 INSERT INTO `mob_groups` VALUES (14,557,24,'Bugard',330,0,371,0,0,34,37,0);
 INSERT INTO `mob_groups` VALUES (15,749,24,'Cluster',330,8,490,0,0,38,40,0);
-INSERT INTO `mob_groups` VALUES (16,6271,24,'Orcish_Brawler',330,0,3236,0,0,35,38,0);
-INSERT INTO `mob_groups` VALUES (17,6269,24,'Orcish_Beastrider',330,0,3236,0,0,35,38,0);
-INSERT INTO `mob_groups` VALUES (18,6270,24,'Orcish_Nightraider',330,0,3236,0,0,35,38,0);
+INSERT INTO `mob_groups` VALUES (16,6271,24,'Orcish_Brawler',330,0,3257,0,0,35,38,0);
+INSERT INTO `mob_groups` VALUES (17,6269,24,'Orcish_Beastrider',330,0,3257,0,0,35,38,0);
+INSERT INTO `mob_groups` VALUES (18,6270,24,'Orcish_Nightraider',330,0,3257,0,0,35,38,0);
 INSERT INTO `mob_groups` VALUES (19,6273,24,'Orcish_Impaler',330,0,283,0,0,35,38,0);
 INSERT INTO `mob_groups` VALUES (20,3083,24,'Padfoot',0,128,1972,3400,0,45,46,0);
 INSERT INTO `mob_groups` VALUES (21,3034,24,'Orcish_Stonelauncher',330,0,1942,0,0,37,40,0);
@@ -921,10 +921,10 @@ INSERT INTO `mob_groups` VALUES (53,277,24,'Atomic_Cluster',330,8,187,0,0,44,46,
 INSERT INTO `mob_groups` VALUES (54,1553,24,'Gigas_Braver',330,0,981,0,0,41,44,0);
 INSERT INTO `mob_groups` VALUES (55,1573,24,'Gigas_Martialist',330,0,981,0,0,41,44,0);
 INSERT INTO `mob_groups` VALUES (56,1555,24,'Gigas_Catapulter',330,0,981,0,0,41,44,0);
-INSERT INTO `mob_groups` VALUES (57,6276,24,'Orcish_Bowshooter',330,0,3235,0,0,41,44,0);
-INSERT INTO `mob_groups` VALUES (58,6278,24,'Orcish_Footsoldier',330,0,3236,0,0,41,44,0);
-INSERT INTO `mob_groups` VALUES (59,3015,24,'Orcish_Gladiator',330,0,3236,0,0,41,44,0);
-INSERT INTO `mob_groups` VALUES (60,3039,24,'Orcish_Trooper',330,0,3236,0,0,41,44,0);
+INSERT INTO `mob_groups` VALUES (57,6276,24,'Orcish_Bowshooter',330,0,3257,0,0,41,44,0);
+INSERT INTO `mob_groups` VALUES (58,6278,24,'Orcish_Footsoldier',330,0,3257,0,0,41,44,0);
+INSERT INTO `mob_groups` VALUES (59,3015,24,'Orcish_Gladiator',330,0,3257,0,0,41,44,0);
+INSERT INTO `mob_groups` VALUES (60,3039,24,'Orcish_Trooper',330,0,3257,0,0,41,44,0);
 INSERT INTO `mob_groups` VALUES (61,1397,24,'Fomor_Thief',330,1,885,0,0,42,44,0);
 INSERT INTO `mob_groups` VALUES (62,2392,24,'Leshachikha',330,0,0,0,0,49,53,0);
 INSERT INTO `mob_groups` VALUES (63,1599,24,'Gigas_Warwolf',330,0,999,0,0,41,44,0);
@@ -983,15 +983,15 @@ INSERT INTO `mob_groups` VALUES (26,6028,25,'Seaboard_Vulture',330,0,427,0,0,83,
 INSERT INTO `mob_groups` VALUES (27,1553,25,'Gigas_Braver',330,0,982,0,0,41,44,0);
 INSERT INTO `mob_groups` VALUES (28,1573,25,'Gigas_Martialist',330,0,991,0,0,41,44,0);
 INSERT INTO `mob_groups` VALUES (29,3034,25,'Orcish_Stonelauncher',330,0,1942,0,0,43,46,0);
-INSERT INTO `mob_groups` VALUES (30,6283,25,'Orcish_Trooper',330,0,3234,0,0,41,44,0);
-INSERT INTO `mob_groups` VALUES (31,6277,25,'Orcish_Bowshooter',330,0,3235,0,0,41,44,0);
+INSERT INTO `mob_groups` VALUES (30,6283,25,'Orcish_Trooper',330,0,3255,0,0,41,44,0);
+INSERT INTO `mob_groups` VALUES (31,6277,25,'Orcish_Bowshooter',330,0,3255,0,0,41,44,0);
 INSERT INTO `mob_groups` VALUES (32,940,25,'Death_Jacket',330,0,584,0,0,37,40,0);
 INSERT INTO `mob_groups` VALUES (33,277,25,'Atomic_Cluster',330,8,187,0,0,44,46,0);
 INSERT INTO `mob_groups` VALUES (34,1599,25,'Gigas_Warwolf',330,0,1000,0,0,41,44,0);
 INSERT INTO `mob_groups` VALUES (35,1555,25,'Gigas_Catapulter',330,0,983,0,0,41,44,0);
-INSERT INTO `mob_groups` VALUES (36,6279,25,'Orcish_Footsoldier',330,0,3234,0,0,41,44,0);
+INSERT INTO `mob_groups` VALUES (36,6279,25,'Orcish_Footsoldier',330,0,3255,0,0,41,44,0);
 INSERT INTO `mob_groups` VALUES (37,1592,25,'Gigass_Sheep',0,128,0,0,0,34,36,0);
-INSERT INTO `mob_groups` VALUES (38,6281,25,'Orcish_Gladiator',330,0,3234,0,0,41,44,0);
+INSERT INTO `mob_groups` VALUES (38,6281,25,'Orcish_Gladiator',330,0,3255,0,0,41,44,0);
 INSERT INTO `mob_groups` VALUES (39,2945,25,'Odqan',0,128,1839,0,0,50,51,0);
 INSERT INTO `mob_groups` VALUES (40,2556,25,'Mantrap',300,0,3077,0,0,45,49,0);
 INSERT INTO `mob_groups` VALUES (41,3073,25,'Overgrown_Rose',330,0,1964,0,0,47,50,0);
@@ -3027,7 +3027,7 @@ INSERT INTO `mob_groups` VALUES (55,5191,61,'Vanasarvik',0,128,0,0,25000,99,99,0
 INSERT INTO `mob_groups` VALUES (56,6751,61,'Elders_Imp',0,128,0,0,0,99,99,0);
 INSERT INTO `mob_groups` VALUES (57,6752,61,'Grand_Grenade',0,128,0,0,0,99,99,0);
 INSERT INTO `mob_groups` VALUES (58,6753,61,'Sarama',0,128,0,0,0,99,99,0);
-INSERT INTO `mob_groups` VALUES (59,6750,61,'Fahrafahr_the_Bloodied',0,32,0,0,0,0,0,0);
+INSERT INTO `mob_groups` VALUES (59,6750,61,'Fahrafahr_the_Bloodied',0,32,3259,0,0,80,80,0);
 
 -- ------------------------------------------------------------
 -- Halvung (Zone 62)
@@ -8774,7 +8774,7 @@ INSERT INTO `mob_groups` VALUES (21,833,123,'Creek_Sahagin',330,0,532,0,0,34,38,
 INSERT INTO `mob_groups` VALUES (22,3373,123,'River_Sahagin',330,0,2105,0,0,34,38,0);
 INSERT INTO `mob_groups` VALUES (23,3788,123,'Stream_Sahagin',330,0,2344,0,0,34,38,0);
 INSERT INTO `mob_groups` VALUES (24,2647,123,'Meww_the_Turtlerider',0,128,1666,4500,10000,47,47,0);
-INSERT INTO `mob_groups` VALUES (25,6845,123,'Pyuu_the_Spatemaker',0,128,3234,9000,10000,73,73,0);
+INSERT INTO `mob_groups` VALUES (25,6845,123,'Pyuu_the_Spatemaker',0,128,3258,9000,10000,73,73,0);
 INSERT INTO `mob_groups` VALUES (26,2491,123,'Makara',330,0,1229,0,0,35,38,0);
 INSERT INTO `mob_groups` VALUES (27,3393,123,'Rose_Garden',0,128,2123,5000,0,50,50,0);
 INSERT INTO `mob_groups` VALUES (28,4252,123,'Voluptuous_Vilma',0,128,2589,6000,0,52,53,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Fixes drop tables in Limbus so they do not drop Tav items! (Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Aligns end up LSBs drop tables with our module
This fixes limbus drop rate issue of the mobs dropping orc and tav items.

Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1339
Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1331
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go do limbus and not get tav livers
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
