### PR TITLE
Fix convert dmg to mp for all sources

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -680,6 +680,15 @@ int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullp
         this->SetLocalVar("weaponskillHit", 0);
     }
 
+    if (getMod(Mod::ABSORB_DMG_TO_MP) > 0)
+    {
+        int16 absorbedMP = (int16)(amount * getMod(Mod::ABSORB_DMG_TO_MP) / 100);
+        if (absorbedMP > 0)
+        {
+            addMP(absorbedMP);
+        }
+    }
+
     return addHP(-amount);
 }
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -680,8 +680,6 @@ int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullp
         this->SetLocalVar("weaponskillHit", 0);
     }
 
-    // if attack has master, if it has a master -> if its a PC and the enmity containter holds the mob
-
     return addHP(-amount);
 }
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5392,12 +5392,7 @@ namespace battleutils
         }
         else
         {
-            damage           = HandleSevereDamage(PDefender, damage, false);
-            int16 absorbedMP = (int16)(damage * PDefender->getMod(Mod::ABSORB_DMG_TO_MP) / 100);
-            if (absorbedMP > 0)
-            {
-                PDefender->addMP(absorbedMP);
-            }
+            damage = HandleSevereDamage(PDefender, damage, false);
         }
 
         // When set mob will only take 0 or 1 damage
@@ -5453,12 +5448,7 @@ namespace battleutils
         }
         else
         {
-            damage           = HandleSevereDamage(PDefender, damage, false);
-            int16 absorbedMP = (int16)(damage * PDefender->getMod(Mod::ABSORB_DMG_TO_MP) / 100);
-            if (absorbedMP > 0)
-            {
-                PDefender->addMP(absorbedMP);
-            }
+            damage = HandleSevereDamage(PDefender, damage, false);
         }
 
         // When set mob will only take 0 or 1 damage
@@ -7169,9 +7159,6 @@ namespace battleutils
         {
             dmgToMPMods += PDefender->getMod(Mod::COVER_TO_MP);
         }
-
-        // Get ABSORB_DMG_TO_MP mod
-        dmgToMPMods += PDefender->getMod(Mod::ABSORB_DMG_TO_MP);
 
         // Get ABSORB_PHYSDMG_TO_MP mod
         dmgToMPMods += PDefender->getMod(Mod::ABSORB_PHYSDMG_TO_MP);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Converts Damage to MP % will now work on magic damage taken and mob TP moves. (Wintersolstice)

## What does this pull request do? (Please be technical)

Cherry picked commit from LSB, with a commit to remove an orphaned comment to non-existent code to allow the cherry pick.

ABSORB_DMG_TO_MP mod will now work from all damage sources that eventually call takeDamage in C++, negative addhp and/or delhp calls will not proc this.

Abdiah:
Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1434
## Steps to test these changes

`!setmod ABSORB_DMG_TO_MP 100`
take damage from autoattacks and get 1:1 mp back conversion
take damage from spells and get 1:1 mp back conversion (used to be broken)
take damage from mob abilities and get 1:1 mp back conversion (used to be broken)

`!setmod REGEN_DOWN 100` and do not get any MP conversion
absorb element via ${ELEMENT}_ABSORB mod, do not get any MP conversion
absorb phys damage via PHYS_ABSORB mod, do not get any MP conversion

do not get MP conversion with stoneskin/phalanx absorbing all damage

## Special Deployment Considerations

N/A