### PR TITLE
Fixes mob pets left with leave having odd hate behaviors.

### DIFF
--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -42,7 +42,7 @@ void CPetController::Tick(time_point tick)
 
     if (PPet->shouldDespawn(tick))
     {
-        petutils::DespawnPet(PPet->PMaster);
+        petutils::DetachPet(PPet->PMaster, PPet->isCharmed && tick > PPet->charmTime);
         return;
     }
 

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1502,7 +1502,7 @@ namespace petutils
         }
     }
 
-    void DetachPet(CBattleEntity* PMaster)
+    void DetachPet(CBattleEntity* PMaster, bool petUncharm)
     {
         XI_DEBUG_BREAK_IF(PMaster == nullptr);
         XI_DEBUG_BREAK_IF(PMaster->PPet == nullptr);
@@ -1520,7 +1520,7 @@ namespace petutils
                 PMob->PAI->Disengage();
 
                 // charm time is up, mob attacks player now
-                if (PMob->PEnmityContainer->IsWithinEnmityRange(PMob->PMaster))
+                if (PMob->PEnmityContainer->IsWithinEnmityRange(PMob->PMaster) && petUncharm)
                 {
                     PMob->PEnmityContainer->UpdateEnmity(PChar, 0, 0);
                 }

--- a/src/map/utils/petutils.h
+++ b/src/map/utils/petutils.h
@@ -71,7 +71,7 @@ namespace petutils
 
     void  SpawnPet(CBattleEntity* PMaster, uint32 PetID, bool spawningFromZone);
     void  SpawnMobPet(CBattleEntity* PMaster, uint32 PetID);
-    void  DetachPet(CBattleEntity* PMaster);
+    void  DetachPet(CBattleEntity* PMaster, bool petUncharm = false);
     void  DespawnPet(CBattleEntity* PMaster);
     void  AttackTarget(CBattleEntity* PMaster, CBattleEntity* PTarget);
     void  RetreatToMaster(CBattleEntity* PMaster);


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes mob pets left with leave having odd hate behaviors.

## What does this pull request do? (Please be technical)

This pull request ensures that the agression assignment which occurs when a pet becomes uncharmed only occurs in the specific case where the pet comes uncharmed due to charm time running out.

## Steps to test these changes

Togglegm off
Charm a mob which is non-agressive (lizard in attowha)
Fight the mob on another mob nearby
Use Leave (mob will walk back to spawn)
!hp 0 the mob you are fighting.
Walk back to the non-agressive pet.
It should not hit you

## Special Deployment Considerations
None