### PR TITLE
Tiamat, Jorm and KSNM99 Wyrm Fixes

### DIFF
--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -82,16 +82,13 @@ entity.flight = function(mob)
 end
 
 entity.onMobFight = function(mob, target)
-    local drawInTableNorth =
-    {
-        condition1 = target:getXPos() < -515 and target:getZPos() > 8,
-        position   = { -530.642, -4.013, 6.262, target:getRotPos() },
-    }
-    local drawInTableEast =
-    {
-        condition1 = target:getXPos() > -480 and target:getZPos() > -50,
-        position   = { -481.179, -4, -41.92, target:getRotPos() },
-    }
+    -- Wyrms automatically wake from sleep in the air
+    if
+        hasSleepEffects(mob) and
+        mob:getAnimationSub() == 1
+    then
+        mob:wakeUp()
+    end
 
     -- Gains a large attack boost when health is under 25% which cannot be Dispelled.
     if mob:getHPP() <= 25 and mob:getMod(xi.mod.ATT) <= 800 then
@@ -133,13 +130,16 @@ entity.onMobFight = function(mob, target)
         mob:setMagicCastingEnabled(true)
     end
 
-    -- Wyrms automatically wake from sleep in the air
-    if
-        hasSleepEffects(mob) and
-        mob:getAnimationSub() == 1
-    then
-        mob:wakeUp()
-    end
+    local drawInTableNorth =
+    {
+        condition1 = target:getXPos() < -515 and target:getZPos() > 8,
+        position   = { -530.642, -4.013, 6.262, target:getRotPos() },
+    }
+    local drawInTableEast =
+    {
+        condition1 = target:getXPos() > -480 and target:getZPos() > -50,
+        position   = { -481.179, -4, -41.92, target:getRotPos() },
+    }
 
     -- Tiamat draws in from set boundaries leaving her spawn area
     utils.arenaDrawIn(mob, target, drawInTableNorth)
@@ -170,6 +170,7 @@ entity.onMobDisengage = function(mob)
         mob:delStatusEffect(xi.effect.ALL_MISS)
         mob:setMobSkillAttack(0)
         mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+        mob:resetLocalVars()
     end
 end
 

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -30,7 +30,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.ATT, 398)
     mob:setMod(xi.mod.DEF, 475)
     mob:setMod(xi.mod.EVA, 434)
-    mob:setMod(xi.mod.MATT, 70)
+    mob:setMod(xi.mod.MATT, 0) -- Despite being /BLM it has 0 MATT
     mob:setMod(xi.mod.REGEN, 22)
     mob:setMod(xi.mod.REFRESH, 200)
     mob:setMod(xi.mod.DARK_MEVA, 70)
@@ -74,26 +74,18 @@ entity.flight = function(mob)
     mob:setAnimationSub(1)
     mob:addStatusEffectEx(xi.effect.ALL_MISS, 0, 1, 0, 0)
     mob:setBehaviour(0)
-    mob:setMobSkillAttack(730)
+    mob:setMobSkillAttack(732)
     mob:setLocalVar("changeTime", os.time() + 30)
 end
 
 entity.onMobFight = function(mob, target)
-    local drawInTableNorth =
-    {
-        condition1 = target:getXPos() < -105 and target:getXPos() > -215 and target:getZPos() > 195,
-        position   = { -201.86, -175.66, 189.32, target:getRotPos() },
-    }
-    local drawInTableSouth =
-    {
-        condition1 = target:getXPos() > -250 and target:getXPos() < -212 and target:getZPos() < 55,
-        position   = { -235.62, -175.17, 62.67, target:getRotPos() },
-    }
-    local drawInTableEast =
-    {
-        condition1 = target:getXPos() > -160 and target:getZPos() > 105 and target:getZPos() < 130,
-        position   = { -166.02, -175.89, 119.38, target:getRotPos() },
-    }
+    -- Wyrms automatically wake from sleep in the air
+    if
+        hasSleepEffects(mob) and
+        mob:getAnimationSub() == 1
+    then
+        mob:wakeUp()
+    end
 
     -- Handle flight and ground timer
     if
@@ -131,13 +123,21 @@ entity.onMobFight = function(mob, target)
         mob:setMagicCastingEnabled(true)
     end
 
-    -- Wyrms automatically wake from sleep in the air
-    if
-        hasSleepEffects(mob) and
-        mob:getAnimationSub() == 1
-    then
-        mob:wakeUp()
-    end
+    local drawInTableNorth =
+    {
+        condition1 = target:getXPos() < -105 and target:getXPos() > -215 and target:getZPos() > 195,
+        position   = { -201.86, -175.66, 189.32, target:getRotPos() },
+    }
+    local drawInTableSouth =
+    {
+        condition1 = target:getXPos() > -250 and target:getXPos() < -212 and target:getZPos() < 55,
+        position   = { -235.62, -175.17, 62.67, target:getRotPos() },
+    }
+    local drawInTableEast =
+    {
+        condition1 = target:getXPos() > -160 and target:getZPos() > 105 and target:getZPos() < 130,
+        position   = { -166.02, -175.89, 119.38, target:getRotPos() },
+    }
 
     -- Jorm draws in from set boundaries leaving her spawn area
     utils.arenaDrawIn(mob, target, drawInTableNorth)
@@ -190,6 +190,7 @@ entity.onMobDisengage = function(mob)
         mob:delStatusEffect(xi.effect.ALL_MISS)
         mob:setMobSkillAttack(0)
         mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
+        mob:resetLocalVars()
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Fixes an issue where Jorm and Tiamat would get stuck in their 2hr animation if they are reset (Frank)
- The damage on Jorm as been adjusted to reflect era accuracy (Frank)
- Fixes an issue where the Wyrm inside  KSNM99 fight Early Bird Catches the Wyrm would not reset properly upon wiping/reset of instance. (Frank)
- Fixes an issue where the Wyrm inside  KSNM99 fight Early Bird Catches the Wyrm would use a skill mid-flight animation causing the breathe to hit the entire party accidently (Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
+ Fixes jorm and tia sometimes getting stuck in their 2hr phase when a party wipes
+ Adjusted KSNM99 Wyrm to reset properly on death. It should also no longer use a TP skill when its mid-flying into the air.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to Jorm or Tia -> Let it use its 2h -> !goto yourself and see that it resets its 2hr timer and animation

Enter KSNM99 fight Early Bird Catches the Wyrm
Drag it away from the center -> Get it blow 85% -> give it !tp 3000 during walking to the center
It should wait for it to fly and then use a TP move (Replicated 5 times on local server...will probably break when someone else does it)
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
