### PR TITLE
[Magic] Enfeebling Duration Resistance Checks

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1010,6 +1010,15 @@ xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes, ski
         resist = resist / 2
     end
 
+    -- If we're applying a status effect, < 0.5 should be fail, 0.5 is half duration, 1.0 is full duration
+    if effect ~= nil and resist < 0.5 then
+        resist = 0
+    elseif effect ~= nil and resist == 0.5 then
+        resist = 0.5
+    elseif effect ~= nil and resist > 0.5 then
+        resist = 1
+    end
+
     return resist
 end
 

--- a/scripts/globals/spells/black/bind.lua
+++ b/scripts/globals/spells/black/bind.lua
@@ -29,7 +29,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/bindga.lua
+++ b/scripts/globals/spells/black/bindga.lua
@@ -30,12 +30,12 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
         --Try to erase a weaker bind.
-        elseif (target:addStatusEffect(xi.effect.BIND, target:getSpeed(), 0, resduration)) then
+        elseif target:addStatusEffect(xi.effect.BIND, target:getSpeed(), 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/blind.lua
+++ b/scripts/globals/spells/black/blind.lua
@@ -42,7 +42,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/blind_ii.lua
+++ b/scripts/globals/spells/black/blind_ii.lua
@@ -43,7 +43,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/blindga.lua
+++ b/scripts/globals/spells/black/blindga.lua
@@ -34,11 +34,12 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.ENFEEBLING_MAGIC
     params.bonus = 0
     params.effect = xi.effect.BLINDNESS
-    duration = duration * xi.magic.applyResistanceEffect(caster, target, spell, params)
+    local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if duration >= 60 then --Do it!
+        local resduration = duration * resist
 
-        local resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/break.lua
+++ b/scripts/globals/spells/black/break.lua
@@ -28,7 +28,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/breakga.lua
+++ b/scripts/globals/spells/black/breakga.lua
@@ -28,7 +28,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/gravity.lua
+++ b/scripts/globals/spells/black/gravity.lua
@@ -39,7 +39,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/gravity_ii.lua
+++ b/scripts/globals/spells/black/gravity_ii.lua
@@ -37,7 +37,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poison.lua
+++ b/scripts/globals/spells/black/poison.lua
@@ -33,7 +33,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poison_ii.lua
+++ b/scripts/globals/spells/black/poison_ii.lua
@@ -33,7 +33,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poison_iii.lua
+++ b/scripts/globals/spells/black/poison_iii.lua
@@ -27,8 +27,8 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.tier = 3
 
     if not xi.magic.differentEffect(caster, target, spell, params) then
-       spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-       return params.effect
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        return params.effect
     end
 
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
@@ -36,7 +36,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poisonga.lua
+++ b/scripts/globals/spells/black/poisonga.lua
@@ -33,7 +33,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poisonga_ii.lua
+++ b/scripts/globals/spells/black/poisonga_ii.lua
@@ -33,7 +33,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/poisonga_iii.lua
+++ b/scripts/globals/spells/black/poisonga_iii.lua
@@ -43,7 +43,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist == 1 or resist == 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/sleep.lua
+++ b/scripts/globals/spells/black/sleep.lua
@@ -26,7 +26,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/sleep_ii.lua
+++ b/scripts/globals/spells/black/sleep_ii.lua
@@ -26,7 +26,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/sleepga.lua
+++ b/scripts/globals/spells/black/sleepga.lua
@@ -38,7 +38,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/sleepga_ii.lua
+++ b/scripts/globals/spells/black/sleepga_ii.lua
@@ -26,7 +26,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/stun.lua
+++ b/scripts/globals/spells/black/stun.lua
@@ -34,7 +34,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     else
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/black/virus.lua
+++ b/scripts/globals/spells/black/virus.lua
@@ -28,7 +28,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- effect taken
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/paralyga.lua
+++ b/scripts/globals/spells/white/paralyga.lua
@@ -42,7 +42,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         if resist >= 0.5 then --there are no quarter or less hits, if target resists more than .5 spell is resisted completely
             local resduration = duration * resist
 
-            resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+            resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
             if resduration == 0 then
                 spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/paralyze.lua
+++ b/scripts/globals/spells/white/paralyze.lua
@@ -40,7 +40,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- There are no quarter or less hits, if target resists more than .5 spell is resisted completely
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/paralyze_ii.lua
+++ b/scripts/globals/spells/white/paralyze_ii.lua
@@ -40,7 +40,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/silence.lua
+++ b/scripts/globals/spells/white/silence.lua
@@ -27,7 +27,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/silencega.lua
+++ b/scripts/globals/spells/white/silencega.lua
@@ -37,7 +37,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/slow.lua
+++ b/scripts/globals/spells/white/slow.lua
@@ -46,7 +46,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/slow_ii.lua
+++ b/scripts/globals/spells/white/slow_ii.lua
@@ -40,7 +40,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then --Do it!
         local resduration = duration * resist
 
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/globals/spells/white/slowga.lua
+++ b/scripts/globals/spells/white/slowga.lua
@@ -32,7 +32,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     if resist >= 0.5 then -- Do it!
         local resduration = duration * resist
-        resduration = xi.magic.calculateBuildDuration(target, duration, params.effect, caster)
+        resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
         if resduration == 0 then
             spell:setMsg(xi.msg.basic.NONE)
         elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, 1) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Enfeebling spells will now properly calculate the duration with regards to its resist state (Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
If we're applying a status effect, < 0.5 should be fail, 0.5 is half duration, 1.0 is full duration
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to any high level mob (Yovra for example)
!changejob rdm 75
Make sure you have no gear on
Cast until you land Bind
If it was a half resist you should see the duration cut in half
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
