### PR TITLE
[core] Move out RNG impl into specialized files

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -99,6 +99,18 @@ CPMAddPackage(
     GIT_TAG v3.11.2
 ) # defines: nlohmann_json::nlohmann_json
 
+CPMAddPackage(
+    NAME pcg-cpp
+    GITHUB_REPOSITORY imneme/pcg-cpp
+    GIT_TAG 428802d1a5634f96bcd0705fab379ff0113bcf13
+) # defines: pcg-cpp
+
+# pcg-cpp does not include cmake
+if(pcg-cpp_ADDED)
+    add_library(pcg-cpp INTERFACE)
+    target_include_directories(pcg-cpp SYSTEM INTERFACE ${pcg-cpp_SOURCE_DIR}/include/)
+endif()
+
 set(EXTERNAL_LIBS
     concurrentqueue
     mariadbclient
@@ -111,6 +123,7 @@ set(EXTERNAL_LIBS
     jthread-lite
     httplib::httplib
     nlohmann_json::nlohmann_json
+    pcg-cpp
 )
 
 if (WIN32)

--- a/src/common/rng/mersennetwister.h
+++ b/src/common/rng/mersennetwister.h
@@ -1,0 +1,86 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2023 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#ifndef _MERSENNETWISTER_H_
+#define _MERSENNETWISTER_H_
+
+#include <array>
+#include <random>
+
+class xirand
+{
+public:
+    static std::mt19937& rng()
+    {
+        static thread_local std::mt19937 e{};
+        return e;
+    }
+
+    static void seed()
+    {
+        ShowInfo("Seeding Mersenne Twister 32 bit RNG");
+
+        std::array<uint32_t, std::mt19937::state_size> seed_data;
+
+        // Certain systems were noted to have bad seeding via only std::random_device,
+        // the following indicated how we could mix in std::random_device with other seed sources
+        // https://stackoverflow.com/a/68382489
+        for (auto it = seed_data.begin(); it != seed_data.end(); ++it)
+        {
+            // start with a C++ equivalent of time(NULL) - UNIX time in seconds
+            *it = std::chrono::duration_cast<std::chrono::seconds>(
+                      std::chrono::system_clock::now().time_since_epoch())
+                      .count();
+
+            // mix with a high precision time in microseconds
+            *it ^= std::chrono::duration_cast<std::chrono::microseconds>(
+                       std::chrono::high_resolution_clock::now().time_since_epoch())
+                       .count();
+
+            // *it ^= more_external_random_stuff;
+        }
+        std::seed_seq seq(seed_data.cbegin(), seed_data.cend());
+        rng().seed(seq);
+    }
+
+    /*
+        declarations for RNG methods implemented in xirand.h.
+    */
+    template <typename T>
+    static inline typename std::enable_if<std::is_integral<T>::value, T>::type GetRandomNumber(T min, T max);
+
+    template <typename T>
+    static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type GetRandomNumber(T min, T max);
+
+    template <typename T>
+    static inline T GetRandomNumber(T max);
+
+    template <typename T>
+    static inline typename T::value_type GetRandomElement(T* container);
+
+    template <typename T>
+    static inline typename T::value_type GetRandomElement(T& container);
+
+    template <typename T>
+    static inline T GetRandomElement(std::initializer_list<T> list);
+};
+
+#endif // _MERSENNETWISTER_H_

--- a/src/common/rng/pcg.h
+++ b/src/common/rng/pcg.h
@@ -1,0 +1,89 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2023 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#ifndef _PCG_H_
+#define _PCG_H_
+
+// https://github.com/imneme/pcg-cpp
+#include "pcg_random.hpp"
+
+#include <array>
+#include <random>
+
+class xirand
+{
+public:
+    static pcg32& rng()
+    {
+        static thread_local pcg32 e{};
+        return e;
+    }
+
+    static void seed()
+    {
+        ShowInfo("Seeding PCG32 RNG");
+
+        std::array<uint32_t, sizeof(pcg32::state_type) / 4> seed_data; // get enough data to seed an N byte state with sets of 32 bit ints
+
+        // Certain systems were noted to have bad seeding via only std::random_device,
+        // the following indicated how we could mix in std::random_device with other seed sources
+        // https://stackoverflow.com/a/68382489
+        for (auto it = seed_data.begin(); it != seed_data.end(); ++it)
+        {
+            // start with a C++ equivalent of time(NULL) - UNIX time in seconds
+            *it = std::chrono::duration_cast<std::chrono::seconds>(
+                      std::chrono::system_clock::now().time_since_epoch())
+                      .count();
+
+            // mix with a high precision time in microseconds
+            *it ^= std::chrono::duration_cast<std::chrono::microseconds>(
+                       std::chrono::high_resolution_clock::now().time_since_epoch())
+                       .count();
+
+            // *it ^= more_external_random_stuff;
+        }
+        std::seed_seq seq(seed_data.cbegin(), seed_data.cend());
+        rng().seed(seq);
+    }
+
+    /*
+        declarations for RNG methods implemented in xirand.h.
+    */
+    template <typename T>
+    static inline typename std::enable_if<std::is_integral<T>::value, T>::type GetRandomNumber(T min, T max);
+
+    template <typename T>
+    static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type GetRandomNumber(T min, T max);
+
+    template <typename T>
+    static inline T GetRandomNumber(T max);
+
+    template <typename T>
+    static inline typename T::value_type GetRandomElement(T* container);
+
+    template <typename T>
+    static inline typename T::value_type GetRandomElement(T& container);
+
+    template <typename T>
+    static inline T GetRandomElement(std::initializer_list<T> list);
+};
+
+#endif // _PCG_H_

--- a/src/common/rng/pcg64.h
+++ b/src/common/rng/pcg64.h
@@ -1,0 +1,89 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2023 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#ifndef _PCG64_H_
+#define _PCG64_H_
+
+// https://github.com/imneme/pcg-cpp
+#include "pcg_random.hpp"
+
+#include <array>
+#include <random>
+
+class xirand
+{
+public:
+    static pcg64& rng()
+    {
+        static thread_local pcg64 e{};
+        return e;
+    }
+
+    static void seed()
+    {
+        ShowInfo("Seeding PCG64 RNG");
+
+        std::array<uint32_t, sizeof(pcg64::state_type) / 4> seed_data; // get enough data to seed an N byte state with sets of 32 bit ints
+
+        // Certain systems were noted to have bad seeding via only std::random_device,
+        // the following indicated how we could mix in std::random_device with other seed sources
+        // https://stackoverflow.com/a/68382489
+        for (auto it = seed_data.begin(); it != seed_data.end(); ++it)
+        {
+            // start with a C++ equivalent of time(NULL) - UNIX time in seconds
+            *it = std::chrono::duration_cast<std::chrono::seconds>(
+                      std::chrono::system_clock::now().time_since_epoch())
+                      .count();
+
+            // mix with a high precision time in microseconds
+            *it ^= std::chrono::duration_cast<std::chrono::microseconds>(
+                       std::chrono::high_resolution_clock::now().time_since_epoch())
+                       .count();
+
+            // *it ^= more_external_random_stuff;
+        }
+        std::seed_seq seq(seed_data.cbegin(), seed_data.cend());
+        rng().seed(seq);
+    }
+
+    /*
+        declarations for RNG methods implemented in xirand.h.
+    */
+    template <typename T>
+    static inline typename std::enable_if<std::is_integral<T>::value, T>::type GetRandomNumber(T min, T max);
+
+    template <typename T>
+    static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type GetRandomNumber(T min, T max);
+
+    template <typename T>
+    static inline T GetRandomNumber(T max);
+
+    template <typename T>
+    static inline typename T::value_type GetRandomElement(T* container);
+
+    template <typename T>
+    static inline typename T::value_type GetRandomElement(T& container);
+
+    template <typename T>
+    static inline T GetRandomElement(std::initializer_list<T> list);
+};
+
+#endif // _PCG_H_

--- a/src/common/xirand.h
+++ b/src/common/xirand.h
@@ -86,7 +86,7 @@ public:
     template <typename T>
     static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type GetRandomNumber(T min, T max)
     {
-        if (min == max || min > max)
+        if (min >= max)
         {
             return min;
         }

--- a/src/common/xirand.h
+++ b/src/common/xirand.h
@@ -23,119 +23,118 @@
 #ifndef _XIRAND_H_
 #define _XIRAND_H_
 
-#include <array>
-#include <random>
+// You can choose an RNG by commenting/uncommenting this line. The default is Mersenne Twister in 32 bit.
+#include "rng/mersennetwister.h"
+// #include "rng/pcg.h"
+// #include "rng/pcg64.h"
 
-class xirand
+// RNG template is as follows:
+// The RNG must comply with the CPP standard UniformRandomBitGenerator ( see https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator )
+//
+// The RNG must return a static thread local instance of the RNG with "rng()" as the accessor, such as:
+// static std::mt19937& rng()
+//
+// The RNG must have a seed function declared as follows:
+//
+// static void seed()
+//
+// The RNG must have the following boilerplate templated function declarations
+/*
+    template <typename T>
+    static inline typename std::enable_if<std::is_integral<T>::value, T>::type GetRandomNumber(T min, T max);
+
+    template <typename T>
+    static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type GetRandomNumber(T min, T max);
+
+    template <typename T>
+    static inline T GetRandomNumber(T max);
+
+    template <typename T>
+    static inline typename T::value_type GetRandomElement(T* container);
+
+    template <typename T>
+    static inline typename T::value_type GetRandomElement(T& container);
+
+    template <typename T>
+    static inline T GetRandomElement(std::initializer_list<T> list);
+*/
+// See the latest revision of src/common/RNG/mersennetwister.h for an example.
+
+//
+// The following functions are not meant to be edited by the end user. Change at your own risk -- you will receive no support.
+//
+
+// Generates a random number in the half-open interval [min, max)
+// @param min
+// @param max
+// @returns result
+//
+// Do note that max is subtracted by one as per an inconsistency in the standard, see
+// https://bugs.llvm.org/show_bug.cgi?id=18767#c1
+// this change results in both real and integer templates having the same min/max range
+template <typename T>
+inline typename std::enable_if<std::is_integral<T>::value, T>::type xirand::GetRandomNumber(T min, T max)
 {
-public:
-    static std::mt19937& mt()
+    if (min == max - 1 || max == min || min > max)
     {
-        static thread_local std::mt19937 e{};
-        return e;
+        return min;
     }
+    std::uniform_int_distribution<T> dist(min, max - 1);
+    return dist(rng());
+}
 
-    static void seed(void)
+template <typename T>
+inline typename std::enable_if<std::is_floating_point<T>::value, T>::type xirand::GetRandomNumber(T min, T max)
+{
+    if (min >= max)
     {
-        std::array<uint32_t, std::mt19937::state_size> seed_data;
-        std::random_device                             rd;
-
-        // Certain systems were noted to have bad seeding via only std::random_device,
-        // the following indicated how we could mix in std::random_device with other seed sources
-        // https://stackoverflow.com/a/68382489
-        for (auto it = seed_data.begin(); it != seed_data.end(); ++it)
-        {
-            // read from std::random_device
-            *it = rd();
-
-            // mix with a C++ equivalent of time(NULL) - UNIX time in seconds
-            *it ^= std::chrono::duration_cast<std::chrono::seconds>(
-                       std::chrono::system_clock::now().time_since_epoch())
-                       .count();
-
-            // mix with a high precision time in microseconds
-            *it ^= std::chrono::duration_cast<std::chrono::microseconds>(
-                       std::chrono::high_resolution_clock::now().time_since_epoch())
-                       .count();
-
-            //*it ^= more_external_random_stuff;
-        }
-        std::seed_seq seq(seed_data.cbegin(), seed_data.cend());
-        mt().seed(seq);
+        return min;
     }
+    std::uniform_real_distribution<T> dist(min, max);
+    return dist(rng());
+}
 
-    // Generates a random number in the half-open interval [min, max)
-    // @param min
-    // @param max
-    // @returns result
-    //
-    // Do note that max is subtracted by one as per an inconsistency in the standard, see
-    // https://bugs.llvm.org/show_bug.cgi?id=18767#c1
-    // this change results in both real and integer templates having the same min/max range
-    template <typename T>
-    static inline typename std::enable_if<std::is_integral<T>::value, T>::type GetRandomNumber(T min, T max)
-    {
-        if (min == max - 1 || max == min || min > max)
-        {
-            return min;
-        }
-        std::uniform_int_distribution<T> dist(min, max - 1);
-        return dist(mt());
-    }
+// Generates a random number in the half-open interval [0, max)
+// @param min
+// @param max
+// @returns result
+//
+// Do note that max is subtracted by one as per an inconsistency in the standard, see
+// https://bugs.llvm.org/show_bug.cgi?id=18767#c1
+// this change results in both real and integer templates having the same min/max range
+template <typename T>
+inline T xirand::GetRandomNumber(T max)
+{
+    return GetRandomNumber<T>(0, max);
+}
 
-    template <typename T>
-    static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type GetRandomNumber(T min, T max)
-    {
-        if (min >= max)
-        {
-            return min;
-        }
-        std::uniform_real_distribution<T> dist(min, max);
-        return dist(mt());
-    }
+// Gets a random element from the given stl-like container (container must have members: at() and size()).
+// @param container
+// @returns result
+template <typename T>
+inline typename T::value_type xirand::GetRandomElement(T* container)
+{
+    // NOTE: the specialisation for integral types uses: dist(min, max - 1), so no need to offset container->size()
+    return container->at(GetRandomNumber<std::size_t>(0U, container->size()));
+}
 
-    // Generates a random number in the half-open interval [0, max)
-    // @param min
-    // @param max
-    // @returns result
-    //
-    // Do note that max is subtracted by one as per an inconsistency in the standard, see
-    // https://bugs.llvm.org/show_bug.cgi?id=18767#c1
-    // this change results in both real and integer templates having the same min/max range
-    template <typename T>
-    static inline T GetRandomNumber(T max)
-    {
-        return GetRandomNumber<T>(0, max);
-    }
+// Gets a random element from the given stl-like container (container must have members: at() and size()).
+// @param container
+// @returns result
+template <typename T>
+inline typename T::value_type xirand::GetRandomElement(T& container)
+{
+    return GetRandomElement(&container);
+}
 
-    // Gets a random element from the given stl-like container (container must have members: at() and size()).
-    // @param container
-    // @returns result
-    template <typename T>
-    static inline typename T::value_type GetRandomElement(T* container)
-    {
-        // NOTE: the specialisation for integral types uses: dist(min, max - 1), so no need to offset container->size()
-        return container->at(GetRandomNumber<std::size_t>(0U, container->size()));
-    }
-
-    // Gets a random element from the given stl-like container (container must have members: at() and size()).
-    // @param container
-    // @returns result
-    template <typename T>
-    static inline typename T::value_type GetRandomElement(T& container)
-    {
-        return GetRandomElement(&container);
-    }
-
-    // Gets a random element from the given initializer_list.
-    // @param initializer_list
-    // @returns result
-    template <typename T>
-    static inline T GetRandomElement(std::initializer_list<T> list)
-    {
-        std::vector<T> container(list);
-        return GetRandomElement(container);
-    }
-};
+// Gets a random element from the given initializer_list.
+// @param initializer_list
+// @returns result
+template <typename T>
+inline T xirand::GetRandomElement(std::initializer_list<T> list)
+{
+    std::vector<T> container(list);
+    return GetRandomElement(container);
+}
 
 #endif // _XIRAND_H_

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -367,7 +367,7 @@ bool CMobController::MobSkill(int wsList)
         return false;
     }
 
-    std::shuffle(skillList.begin(), skillList.end(), xirand::mt());
+    std::shuffle(skillList.begin(), skillList.end(), xirand::rng());
     CBattleEntity* PActionTarget{ nullptr };
 
     for (auto skillid : skillList)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

_You read the patch note, but it turns out there was nothing all along. It was an illusion._ (Wintersolstice)
## What does this pull request do? (Please be technical)

cherry picked commits from LSB;

* Remove random_device from RNG seeding
* Add PCG32 RNG & PCG64 that can be uncommented to be used instead of Mersenne Twister.

Default RNG is still Mersenne Twister 32 bit

## Steps to test these changes
play game, see random numbers

## Special Deployment Considerations
N/A
