### PR TITLE
Fixes Message when enfeeble duration is 0

### DIFF
--- a/scripts/globals/spells/black/bind.lua
+++ b/scripts/globals/spells/black/bind.lua
@@ -31,10 +31,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        --Try to erase a weaker bind.
-        elseif target:addStatusEffect(params.effect, target:getSpeed(), 0 , resduration) then
+        if target:addStatusEffect(params.effect, target:getSpeed(), 0 , resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/bindga.lua
+++ b/scripts/globals/spells/black/bindga.lua
@@ -32,10 +32,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        --Try to erase a weaker bind.
-        elseif target:addStatusEffect(xi.effect.BIND, target:getSpeed(), 0, resduration) then
+        if target:addStatusEffect(xi.effect.BIND, target:getSpeed(), 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/blind.lua
+++ b/scripts/globals/spells/black/blind.lua
@@ -44,9 +44,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/blind_ii.lua
+++ b/scripts/globals/spells/black/blind_ii.lua
@@ -45,9 +45,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/break.lua
+++ b/scripts/globals/spells/black/break.lua
@@ -30,9 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, 1, 0, resduration) then
+        if target:addStatusEffect(params.effect, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/breakga.lua
+++ b/scripts/globals/spells/black/breakga.lua
@@ -30,9 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, 1, 0, duration * resist) then
+        if target:addStatusEffect(params.effect, 1, 0, duration * resist) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/gravity.lua
+++ b/scripts/globals/spells/black/gravity.lua
@@ -41,9 +41,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/gravity_ii.lua
+++ b/scripts/globals/spells/black/gravity_ii.lua
@@ -39,9 +39,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison.lua
+++ b/scripts/globals/spells/black/poison.lua
@@ -35,9 +35,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison_ii.lua
+++ b/scripts/globals/spells/black/poison_ii.lua
@@ -35,9 +35,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison_iii.lua
+++ b/scripts/globals/spells/black/poison_iii.lua
@@ -38,9 +38,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poisonga.lua
+++ b/scripts/globals/spells/black/poisonga.lua
@@ -35,9 +35,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poisonga_ii.lua
+++ b/scripts/globals/spells/black/poisonga_ii.lua
@@ -35,9 +35,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/sleep.lua
+++ b/scripts/globals/spells/black/sleep.lua
@@ -28,9 +28,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, 1, 0, resduration) then
+        if target:addStatusEffect(params.effect, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/sleep_ii.lua
+++ b/scripts/globals/spells/black/sleep_ii.lua
@@ -28,9 +28,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, 2, 0, resduration) then
+        if target:addStatusEffect(params.effect, 2, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/sleepga.lua
+++ b/scripts/globals/spells/black/sleepga.lua
@@ -40,9 +40,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, 1, 0, resduration) then
+        if target:addStatusEffect(params.effect, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect

--- a/scripts/globals/spells/black/sleepga_ii.lua
+++ b/scripts/globals/spells/black/sleepga_ii.lua
@@ -28,9 +28,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, 2, 0, resduration) then
+        if target:addStatusEffect(params.effect, 2, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/virus.lua
+++ b/scripts/globals/spells/black/virus.lua
@@ -30,9 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(effect, 5, 3, duration) then
+        if target:addStatusEffect(effect, 5, 3, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/paralyga.lua
+++ b/scripts/globals/spells/white/paralyga.lua
@@ -44,9 +44,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
             resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-            if resduration == 0 then
-                spell:setMsg(xi.msg.basic.NONE)
-            elseif target:addStatusEffect(xi.effect.PARALYSIS, potency, 0, resduration) then
+            if target:addStatusEffect(xi.effect.PARALYSIS, potency, 0, resduration) then
                 spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
             else
                 -- no effect

--- a/scripts/globals/spells/white/paralyze.lua
+++ b/scripts/globals/spells/white/paralyze.lua
@@ -42,9 +42,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, potency, 0, duration * resist, 0, params.tier) then
+        if target:addStatusEffect(params.effect, potency, 0, duration * resist, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             -- no effect

--- a/scripts/globals/spells/white/paralyze_ii.lua
+++ b/scripts/globals/spells/white/paralyze_ii.lua
@@ -42,9 +42,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/silence.lua
+++ b/scripts/globals/spells/white/silence.lua
@@ -29,9 +29,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect , 1, 0, resduration) then
+        if target:addStatusEffect(params.effect , 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/white/silencega.lua
+++ b/scripts/globals/spells/white/silencega.lua
@@ -39,9 +39,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(effectType, 1, 0, resduration) then
+        if target:addStatusEffect(effectType, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/white/slow.lua
+++ b/scripts/globals/spells/white/slow.lua
@@ -48,9 +48,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/slow_ii.lua
+++ b/scripts/globals/spells/white/slow_ii.lua
@@ -42,9 +42,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
+        if target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/slowga.lua
+++ b/scripts/globals/spells/white/slowga.lua
@@ -33,9 +33,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist >= 0.5 then -- Do it!
         local resduration = duration * resist
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
-        if resduration == 0 then
-            spell:setMsg(xi.msg.basic.NONE)
-        elseif target:addStatusEffect(params.effect, power, 0, resduration, 0, 1) then
+        if target:addStatusEffect(params.effect, power, 0, resduration, 0, 1) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Fixes the type of message shown when an enfeebling duration hits 0 due to build resistance. (Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Fixes Message when enfeeble duration is 0.

When it hits 0 because of build resistance it should just wear off immediately and apply the same normal message
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Sleep Fafnir until the duration hits 0
See the same message and it falling off immediately 
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
