### PR TITLE
Vrtra Tuning | Fafnir resistances

### DIFF
--- a/scripts/globals/mobskills/cyclone_wing.lua
+++ b/scripts/globals/mobskills/cyclone_wing.lua
@@ -25,7 +25,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getMobWeaponDmg(xi.slot.MAIN) * 1.5, xi.magic.ele.DARK, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getMainLvl() + 2, xi.magic.ele.DARK, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, 0, 0, 5, 5, 5)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.DARK)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLEEP_I, 1, 0, 60)

--- a/scripts/globals/mobskills/sable_breath.lua
+++ b/scripts/globals/mobskills/sable_breath.lua
@@ -25,7 +25,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.25, xi.magic.ele.DARK, 1400)
+    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.25, xi.magic.ele.DARK, 1150)
     dmgmod = utils.conalDamageAdjustment(mob, target, skill, dmgmod, 0.9)
 
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
@@ -16,6 +16,10 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.DRAW_IN_FRONT, 1)
     mob:setMobMod(xi.mobMod.WEAPON_BONUS, 152)
     mob:setMod(xi.mod.ATT, 489)
+    mob:setMod(xi.mod.STUNRES, 100)
+    mob:setMod(xi.mod.DARK_EEM, 40)
+    mob:setMod(xi.mod.LIGHT_EEM, 40)
+    mob:setMod(xi.mod.SLEEPRESBUILD, 1)
 
     -- Despawn the ???
     GetNPCByID(ID.npc.FAFNIR_QM):setStatus(xi.status.DISAPPEAR)

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
@@ -10,11 +10,20 @@ local entity = {}
 local offsets = { 1, 3, 5, 2, 4, 6 }
 
 entity.onMobSpawn = function(mob)
+    mob:addImmunity(xi.immunity.TERROR)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:setMod(xi.mod.UDMGMAGIC, -5000)
+    mob:setMod(xi.mod.UDMGRANGE, -5000)
+    mob:setMod(xi.mod.UDMGBREATH, -5000)
     mob:setMod(xi.mod.DEF, 466)
     mob:setMod(xi.mod.ATT, 344)
     mob:setMod(xi.mod.EVA, 450)
+    mob:setMod(xi.mod.REGEN, 50) -- Says high very regen
     mob:setMod(xi.mod.UFASTCAST, 50)
-    mob:setMod(xi.mod.DARK_MEVA, 100)
+    mob:setMod(xi.mod.REFRESH, 100)
+    mob:setMod(xi.mod.SLEEPRESBUILD, 1)
+    mob:setMod(xi.mod.LULLABYRESBUILD, 1)
     mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
     mob:setMobMod(xi.mobMod.SIGHT_RANGE, 30)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
@@ -44,7 +53,11 @@ entity.onMobFight = function(mob, target)
         mob:setLocalVar("spawnTime", spawnTime)
     end
 
-    if fifteenBlock > twohourTime and mob:getHPP() <= 85 and mob:canUseAbilities() then
+    if
+        fifteenBlock > twohourTime and
+        mob:getHPP() <= 90 and
+        mob:canUseAbilities()
+    then
         mob:setLocalVar("skill_tp", mob:getTP())
         mob:useMobAbility(710)
         mob:setLocalVar("twohourTime", fifteenBlock + math.random(4, 6))
@@ -72,13 +85,15 @@ entity.onMobFight = function(mob, target)
                         local pos = mob:getPos()
                         pet:setPos(pos.x, pos.y, pos.z)
                         if mob:getTarget() ~= nil then
-                            pet:updateEnmity(target)
+                            pet:updateEnmity(mob:getTarget())
                         end
                     end
                 end)
+
                 break
             end
         end
+
         local random = math.random(40, 45)
         mob:setLocalVar("spawnTime", os.time() + random)
     end
@@ -102,7 +117,7 @@ entity.onMobWeaponSkill = function(target, mob, skill)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENDARK, { power = math.random(45, 90), chance = 10 })
+    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENDARK, { power = math.random(55, 90), chance = 25 })
 end
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Vrtra has been tuned to better reflect era accuracy (Frank)
- Stun resistance and sleep build resistance has been added to Fafnir (Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Vrtra:
Added regen
Added immunities to luas
Added damage modifiers to match other wyrms
Added sleep and lullaby build resistance
Adjusted charm HP threshold to 90% instead of 85
Increased additional effect chance from 10% to 25% Adjusted Cyclone Wing and Sable Breathes damage values

Fafnir:
 Stun resistance and sleep build resistance has been added to Fafnir
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Fight Vrtra...
Get destroyed
<!-- Clear and detailed steps to test your changes here. -->
n/a
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
