### PR TITLE
9-2 Heir to the Light Fix

### DIFF
--- a/scripts/zones/QuBia_Arena/Globals.lua
+++ b/scripts/zones/QuBia_Arena/Globals.lua
@@ -45,10 +45,14 @@ global.phaseEventFinish = function(player, csid)
             SpawnMob(ID.mob.HEIR_TO_THE_LIGHT_OFFSET + 14 * (bfArea - 1) + i)
         end
 
-        local trion = battlefield:insertEntity(75, true, true)
-        trion:setSpawn(unpack(phaseInfo[bfArea][1]))
-        trion:spawn()
-        player:setPos(unpack(phaseInfo[bfArea][2]))
+        if battlefield:getLocalVar("trionSpawned") == 0 then
+            battlefield:setLocalVar("trionSpawned", 1)
+
+            local trion = battlefield:insertEntity(75, true, true)
+            trion:setSpawn(unpack(phaseInfo[bfArea][1]))
+            trion:spawn()
+            player:setPos(unpack(phaseInfo[bfArea][2]))
+        end
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed multiple Trion from spawning in the 9-2 mission "Heir to the Light" battlefield (Abdiah)

## What does this pull request do? (Please be technical)
Adds a safety variable to the battlefield to ensure that Trion is only spawned once. This comes with multiple sources of reports where Trion has spawned 3+ copies.

Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1490
Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1432

## Steps to test these changes
Run 9-2 Heir to the Light with a full party
