### PR TITLE
Reap What You Sow Fix

### DIFF
--- a/scripts/quests/windurst/Reap_What_You_Sow.lua
+++ b/scripts/quests/windurst/Reap_What_You_Sow.lua
@@ -15,6 +15,7 @@ local quest = Quest:new(xi.quest.log_id.WINDURST, xi.quest.id.windurst.REAP_WHAT
 
 quest.reward =
 {
+    item = xi.items.STATIONERY_SET,
     gil = 700,
     fame = 75,
     fameArea = xi.quest.fame_area.WINDURST,
@@ -23,8 +24,12 @@ quest.reward =
 quest.sections =
 {
     {
+        -- Players can only start the quest if they are below rank 4 fame
+        -- else they must complete let sleeping dogs lie
         check = function(player, status, vars)
-            return status == QUEST_AVAILABLE
+            return status == QUEST_AVAILABLE and
+            (player:getFameLevel(xi.quest.fame_area.WINDURST) < 4 or
+            player:hasCompletedQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LET_SLEEPING_DOGS_LIE))
         end,
 
         [xi.zone.WINDURST_WATERS] =
@@ -53,7 +58,7 @@ quest.sections =
 
     {
         check = function(player, status, vars)
-            return status == QUEST_AVAILABLE
+            return status == QUEST_ACCEPTED
         end,
 
         [xi.zone.WINDURST_WATERS] =
@@ -84,14 +89,13 @@ quest.sections =
                 [475] = function(player, csid, option, npc)
                     if npcUtil.giveItem(player, xi.items.STATIONERY_SET) then
                         player:confirmTrade()
-                        player:addGil(500)
+                        npcUtil.giveCurrency(player, 'gil', 500)
                     end
                 end,
 
                 [477] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, xi.items.STATIONERY_SET) then
+                    if quest:complete() then
                         player:confirmTrade()
-                        quest:complete(player)
                     end
                 end,
             },


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed players being unable to interact with the "Reap What You Sow" quest. (Abdiah)

## What does this pull request do? (Please be technical)
Fixes incorrect variable checking of quest progress, which was previously blocking entire access to this quest.

Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/819
Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/883
