### PR TITLE
Heaven Cent Quest Fixes

### DIFF
--- a/scripts/quests/windurst/Heaven_Cent.lua
+++ b/scripts/quests/windurst/Heaven_Cent.lua
@@ -236,6 +236,7 @@ quest.sections =
                         quest:setVar(player, 'Coin', 1)
                     end
                 end,
+
                 [50] = function(player, csid, option, npc)
                     if option == 2 and npcUtil.giveItem(player, xi.items.SHELLING_PIECE) then
                         quest:setVar(player, 'Coin', 1)
@@ -248,11 +249,13 @@ quest.sections =
                         npcUtil.giveItem(player, xi.items.SHELLING_PIECE)
                     end
                 end,
+
                 [47] = function(player, csid, option, npc)
                     if option == 2 then
                         npcUtil.giveItem(player, xi.items.SHELLING_PIECE)
                     end
                 end,
+
                 [51] = function(player, csid, option, npc)
                     if option == 2 then
                         npcUtil.giveItem(player, xi.items.SHELLING_PIECE)

--- a/scripts/quests/windurst/Heaven_Cent.lua
+++ b/scripts/quests/windurst/Heaven_Cent.lua
@@ -139,6 +139,12 @@ quest.sections =
                         return quest:progressEvent(41)
                     end
                 end,
+
+                onTrigger = function(player, npc)
+                    if player:getPos().x >= 248 then
+                        return quest:progressEvent(42)
+                    end
+                end,
             },
 
             -- Chests
@@ -160,7 +166,7 @@ quest.sections =
                             return quest:progressEvent(46)
                         end
                     else
-                        player:messageSpecial(ID.text.CHEST_EMPTY)
+                        return quest:messageSpecial(ID.text.CHEST_EMPTY)
                     end
                 end,
             },
@@ -183,7 +189,7 @@ quest.sections =
                             return quest:progressEvent(48)
                         end
                     else
-                        player:messageSpecial(ID.text.CHEST_EMPTY)
+                        return quest:messageSpecial(ID.text.CHEST_EMPTY)
                     end
                 end,
             },
@@ -206,7 +212,7 @@ quest.sections =
                             return quest:progressEvent(50)
                         end
                     else
-                        player:messageSpecial(ID.text.CHEST_EMPTY)
+                        return quest:messageSpecial(ID.text.CHEST_EMPTY)
                     end
                 end,
             },
@@ -220,18 +226,18 @@ quest.sections =
 
                 -- Correct coin (Flag correct coin)
                 [46] = function(player, csid, option, npc)
-                    if option == 2 and npcUtil.giveItem(xi.items.SHELLING_PIECE) then
+                    if option == 2 and npcUtil.giveItem(player, xi.items.SHELLING_PIECE) then
                         quest:setVar(player, 'Coin', 1)
                     end
                 end,
 
                 [48] = function(player, csid, option, npc)
-                    if option == 2 and npcUtil.giveItem(xi.items.SHELLING_PIECE) then
+                    if option == 2 and npcUtil.giveItem(player, xi.items.SHELLING_PIECE) then
                         quest:setVar(player, 'Coin', 1)
                     end
                 end,
                 [50] = function(player, csid, option, npc)
-                    if option == 2 and npcUtil.giveItem(xi.items.SHELLING_PIECE) then
+                    if option == 2 and npcUtil.giveItem(player, xi.items.SHELLING_PIECE) then
                         quest:setVar(player, 'Coin', 1)
                     end
                 end,
@@ -239,17 +245,17 @@ quest.sections =
                 -- Inorrect coin
                 [49] = function(player, csid, option, npc)
                     if option == 2 then
-                        npcUtil.giveItem(xi.items.SHELLING_PIECE)
+                        npcUtil.giveItem(player, xi.items.SHELLING_PIECE)
                     end
                 end,
                 [47] = function(player, csid, option, npc)
                     if option == 2 then
-                        npcUtil.giveItem(xi.items.SHELLING_PIECE)
+                        npcUtil.giveItem(player, xi.items.SHELLING_PIECE)
                     end
                 end,
                 [51] = function(player, csid, option, npc)
                     if option == 2 then
-                        npcUtil.giveItem(xi.items.SHELLING_PIECE)
+                        npcUtil.giveItem(player, xi.items.SHELLING_PIECE)
                     end
                 end,
             },


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixes the quest: "Heaven Cent" to be functional as well as added more functionality that was missing from the quest. (Abdiah)

## What does this pull request do? (Please be technical)
Adds functionality to allow players to leave the room if they don't have any other means of warp / escape
Fixes shelling piece not actually being given to the players

Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/882
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/2378
