### PR TITLE
Mob Roam Regen Behaviour

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1242,6 +1242,7 @@ bool CMobController::Disengage()
     PMob->animation = ANIMATION_NONE;
     // https://www.bluegartr.com/threads/108198-Random-Facts-Thread-Traits-and-Stats-(Player-and-Monster)?p=5670209&viewfull=1#post5670209
     PMob->m_THLvl = 0;
+    m_ResetTick = m_Tick;
 
     return CController::Disengage();
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed mobs from immediately regenerating after disengaging. (Abdiah)

## What does this pull request do? (Please be technical)
What was happening was a mob's roam regen was tied to m_tick > m_resetTick +10. After engaging, this m_resetTick doesn't get updated when the mob disengages. Therefore, the mob would immediately begin regenerating. What this PR does it updates m_resetTick once the mob disengages. Giving a 10 second window before the mob begins to regenerate after they disengage.

Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1499

## Steps to test these changes
Damage a mob and disengage. Witness a 10 second gap before they begin to passively regen while roaming
