### PR TITLE
[search] Fix uint16 wrapping bug for party/alliance leaders

### DIFF
--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -493,7 +493,7 @@ std::list<SearchEntity*> CDataLoader::GetPlayersList(search_req sr, int* count)
  *                                                                       *
  ************************************************************************/
 
-std::list<SearchEntity*> CDataLoader::GetPartyList(uint16 PartyID, uint16 AllianceID)
+std::list<SearchEntity*> CDataLoader::GetPartyList(uint32 PartyID, uint32 AllianceID)
 {
     std::list<SearchEntity*> PartyList;
 

--- a/src/search/data_loader.h
+++ b/src/search/data_loader.h
@@ -89,7 +89,7 @@ public:
     uint32 GetPlayersCount(const search_req& sr);
 
     std::vector<ahHistory*>  GetAHItemHystory(uint16 ItemID, bool stack);
-    std::list<SearchEntity*> GetPartyList(uint16 PartyID, uint16 AllianceID);
+    std::list<SearchEntity*> GetPartyList(uint32 PartyID, uint32 AllianceID);
     std::list<SearchEntity*> GetLinkshellList(uint32 LinkshellID);
     std::list<SearchEntity*> GetPlayersList(search_req sr, int* count);
     std::string              GetSearchComment(uint32 playerId);

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -487,8 +487,8 @@ void HandleGroupListRequest(CTCPRequestPacket& PTCPRequest)
 {
     uint8* data = PTCPRequest.GetData();
 
-    uint16 partyid      = ref<uint16>(data, 0x10);
-    uint16 allianceid   = ref<uint16>(data, 0x14);
+    uint32 partyid      = ref<uint32>(data, 0x10);
+    uint32 allianceid   = ref<uint32>(data, 0x14);
     uint32 linkshellid1 = ref<uint32>(data, 0x18);
     uint32 linkshellid2 = ref<uint32>(data, 0x1C);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Player IDs above 65535 will now be able to be a party leader and get proper results in "Member List" requests from the menu (Wintersolstice)

## What does this pull request do? (Please be technical)

Cherry-picked commit from LSB:

This fixes search for alliance/party IDs above 65535.
The IDs are mapped to player IDs and needed to be widened.

## Steps to test these changes

Make a character a party leader/alliance leader who has a character ID above 65535 and be able to use "Member List" and get results.

## Special Deployment Considerations

N/A