### PR TITLE
Adds Dockerfile, scripts, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ As AirSkyBoat is a derivative of LandSandBoat, please use all of their guides fo
 
 A [quick start guide](https://github.com/LandSandBoat/server/wiki/Quick-Start-Guide), the [frequently asked questions](https://github.com/LandSandBoat/server/wiki/Frequently-Asked-Questions), and a table of "[what works](https://github.com/LandSandBoat/server/wikis/What-Works)" are all available on [LSB's wiki](https://github.com/LandSandBoat/server/wiki).
 
+Optionally, you can run your server in Docker by following the guide at [docker.md](docker.md).
+
 ## Interacting with AirSkyBoat
 
 ### Crashes, bugs, obvious gameplay issues etc

--- a/docker.md
+++ b/docker.md
@@ -1,0 +1,51 @@
+# Docker
+
+Managing ASB in Docker
+
+# Prereq
+
+You must have Docker installed. Follow the appropriate guide for your operating system.
+
+# Build Docker image
+
+Before you can launch the Docker container you must build the image. The image is built from [Dockerfile](Dockerfile). You can build the image using [docker_build.sh](docker_build.sh).
+
+# Compile executables
+
+Before you run the container you must build the server binaries. The container mounts the local source directory and will output the compiled binaries to your local source directory. We compile with this step rather than the build step because it is faster for development to not rebuild the entire container.
+
+If you make changes to the source you must also recompile.
+
+Compile the binaries using [docker_compile.sh](docker_compile.sh)
+
+# Setup database and other database related tasks
+
+If this is a new server, you must first setup the database. ASB documentation refers you to [LandSandBoat Quickstart](https://github.com/LandSandBoat/server/wiki/Quick-Start-Guide) but the jist is to run
+
+```
+mysql_secure_installation
+sudo mysql -u root -p -e \
+    "CREATE USER 'XI_USER'@'localhost' IDENTIFIED BY 'XI_PASSWORD'; \
+     CREATE DATABASE xidb; \
+     USE xidb; \
+     GRANT ALL PRIVILEGES ON xidb.* TO 'XI_USER'@'localhost';"
+python3 tools/dbtool.py
+```
+
+To open a db console use [docker_dbtool.sh](docker_dbtool.sh). If the `xidb` database does not exist it will give you a shell which you can use to run the above commands. If the database does exist it will give you a `dbtool.py` shell.
+
+The database is stored in a docker volume `asb_mysql_data` which persists between restarts.
+
+To take a database backup, simple use `docker_dbtool.sh` and the backup will be created in `sql/backups`.
+
+# Running your container
+
+To run your container use [docker_run.sh](docker_run.sh). To stop your container use [docker_stop.sh](docker_stop.sh). When the container is started it runs [docker_entrypoint.sh](docker_entrypoint.sh). Use [docker_logs.sh](docker_logs.sh) to follow the server process logs. Finally, use [docker_stop.sh](docker_stop.sh) to stop the container.
+
+A restart of the server would look like this.
+```
+./docker_stop.sh
+./docker_start.sh
+```
+
+The server TCP and UDP ports are forwarded to the docker host.

--- a/docker.md
+++ b/docker.md
@@ -36,7 +36,7 @@ To open a db console use [docker_dbtool.sh](docker_dbtool.sh). If the `xidb` dat
 
 The database is stored in a docker volume `asb_mysql_data` which persists between restarts.
 
-To take a database backup, simple use `docker_dbtool.sh` and the backup will be created in `sql/backups`.
+To take a database backup, simply use `docker_dbtool.sh` and the `dbtool.py` console it launches. The backup will be created in `sql/backups` on the host.
 
 # Running your container
 
@@ -45,6 +45,7 @@ To run your container use [docker_run.sh](docker_run.sh). To stop your container
 A restart of the server would look like this.
 ```
 ./docker_stop.sh
+# possible ./docker_dbtool.sh
 ./docker_start.sh
 ```
 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,1 @@
+docker build -t asb .

--- a/docker_compile.sh
+++ b/docker_compile.sh
@@ -1,0 +1,9 @@
+docker run \
+    --rm \
+    --name asb_compile \
+    --mount type=bind,source=/mnt/d/HorizonXI/Server/AirSkyBoat,target=/asb \
+    -v asb_mysql_data:/var/lib/mysql \
+    --entrypoint "" \
+    -w /asb -it asb \
+    /bin/bash -c 'mkdir -p build && cd build && \
+    cmake .. && make clean && make -j $(nproc)'

--- a/docker_dbtool.sh
+++ b/docker_dbtool.sh
@@ -1,0 +1,10 @@
+docker run \
+    --rm \
+    --name asb_dbtool \
+    --mount type=bind,source=/mnt/d/HorizonXI/Server/AirSkyBoat,target=/asb \
+    -v asb_mysql_data:/var/lib/mysql \
+    --entrypoint "" \
+    -w /asb -it asb \
+    /bin/bash -c "service mariadb start && \
+    /usr/bin/python3 /asb/tools/dbtool.py || \
+    /bin/bash"

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+service mariadb start
+screen -dmS xi_map bash -c "/asb/xi_map"
+screen -dmS xi_world bash -c "/asb/xi_world"
+screen -dmS xi_search bash -c "/asb/xi_search"
+screen -dmS xi_connect bash -c "/asb/xi_connect"
+
+tail -f /asb/log/*

--- a/docker_logs.sh
+++ b/docker_logs.sh
@@ -1,0 +1,1 @@
+docker logs -f $(docker ps -aq --filter name=asb)

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,7 +1,9 @@
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 docker run \
     --rm \
     --name asb \
-    --mount type=bind,source=/mnt/d/HorizonXI/Server/AirSkyBoat,target=/asb \
+    --mount type=bind,source=$SCRIPT_DIR,target=/asb \
     -v asb_mysql_data:/var/lib/mysql \
     -p 8080:8080 \
     -p 3306:3306 \

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,14 @@
+docker run \
+    --rm \
+    --name asb \
+    --mount type=bind,source=/mnt/d/HorizonXI/Server/AirSkyBoat,target=/asb \
+    -v asb_mysql_data:/var/lib/mysql \
+    -p 8080:8080 \
+    -p 3306:3306 \
+    -p 54230:54230 \
+    -p 54001:54001 \
+    -p 54231:54231 \
+    -p 51220:51220 \
+    -p 54002:54002 \
+    -p 54003:54003 \
+    -d asb

--- a/docker_stop.sh
+++ b/docker_stop.sh
@@ -1,0 +1,1 @@
+docker stop $(docker ps -aq --filter name=asb)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Added Dockerfile, scripts, and documentation.

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)

Added Dockerfile, scripts, and documentation. Allows server owners and developers to run ASB in a docker container. SQL data is preserved across restarts.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Read `docker.md` and try running

```
./docker_build.sh
./docker_compile.sh
./docker_dbtool.sh
./docker_run.sh
./docker_logs.sh
./docker_stop.sh
```

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

Docker will expose the relevant ports to the Docker host, so you must not run another server outside of Docker on the same host. However, you connect to the server as if it were running on the host.

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
