### PR TITLE
Waking the Beast Key Item Fix

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -696,12 +696,12 @@ local function checkReqs(player, npc, bfid, registrant)
         end,
 
         [226] = function() -- Quest: Waking the Beast (Fullmoon Fountain)
-            return player:hasKeyItem(xi.ki.WHISPER_OF_FLAMES) and
-                player:hasKeyItem(xi.ki.WHISPER_OF_TREMORS) and
-                player:hasKeyItem(xi.ki.WHISPER_OF_STORMS) and
-                player:hasKeyItem(xi.ki.WHISPER_OF_FROST) and
-                player:hasKeyItem(xi.ki.WHISPER_OF_GALES) and
-                player:hasKeyItem(xi.ki.WHISPER_OF_TIDES)
+            return player:hasKeyItem(xi.ki.EYE_OF_FLAMES) and
+                player:hasKeyItem(xi.ki.EYE_OF_TREMORS) and
+                player:hasKeyItem(xi.ki.EYE_OF_STORMS) and
+                player:hasKeyItem(xi.ki.EYE_OF_FROST) and
+                player:hasKeyItem(xi.ki.EYE_OF_GALES) and
+                player:hasKeyItem(xi.ki.EYE_OF_TIDES)
         end,
 
         [256] = function() -- ZM8: Return to Delkfutt's Tower
@@ -767,7 +767,7 @@ local function checkReqs(player, npc, bfid, registrant)
 
         [419] = function() -- Quest: Waking the Beast (Cloister of Gales)
             return player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) and
-                not player:hasKeyItem(xi.ki.WHISPER_OF_GALES)
+                not player:hasKeyItem(xi.ki.EYE_OF_GALES)
         end,
 
         [420] = function() -- ASA4: Sugar-coated Directive
@@ -789,7 +789,7 @@ local function checkReqs(player, npc, bfid, registrant)
 
         [451] = function() -- Quest: Waking the Beast (Cloister of Storms)
             return player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) and
-                not player:hasKeyItem(xi.ki.WHISPER_OF_STORMS)
+                not player:hasKeyItem(xi.ki.EYE_OF_STORMS)
         end,
 
         [452] = function() -- ASA4: Sugar-coated Directive
@@ -811,7 +811,7 @@ local function checkReqs(player, npc, bfid, registrant)
 
         [483] = function() -- Quest: Waking the Beast (Cloister of Frost)
             return player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) and
-                not player:hasKeyItem(xi.ki.WHISPER_OF_FROST)
+                not player:hasKeyItem(xi.ki.EYE_OF_FROST)
         end,
 
         [484] = function() -- ASA4: Sugar-coated Directive
@@ -865,7 +865,7 @@ local function checkReqs(player, npc, bfid, registrant)
 
         [546] = function() -- Quest: Waking the Beast (Cloister of Flames)
             return player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) and
-                not player:hasKeyItem(xi.ki.WHISPER_OF_FLAMES)
+                not player:hasKeyItem(xi.ki.EYE_OF_FLAMES)
         end,
 
         [547] = function() -- ASA4: Sugar-coated Directive
@@ -887,7 +887,7 @@ local function checkReqs(player, npc, bfid, registrant)
 
         [579] = function() -- Quest: Waking the Beast (Cloister of Tremors)
             return player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) and
-                not player:hasKeyItem(xi.ki.WHISPER_OF_TREMORS)
+                not player:hasKeyItem(xi.ki.EYE_OF_TREMORS)
         end,
 
         [580] = function() -- ASA4: Sugar-coated Directive
@@ -905,7 +905,7 @@ local function checkReqs(player, npc, bfid, registrant)
 
         [610] = function() -- Quest: Waking the Beast (Cloister of Tides)
             return player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) and
-                not player:hasKeyItem(xi.ki.WHISPER_OF_TIDES)
+                not player:hasKeyItem(xi.ki.EYE_OF_TIDES)
         end,
 
         [611] = function() -- ASA4: Sugar-coated Directive
@@ -1144,12 +1144,12 @@ local function checkReqs(player, npc, bfid, registrant)
     local enterReqs =
     {
         [226] = function() -- Quest: Waking the Beast (Fullmoon Fountain)
-            return player:hasKeyItem(xi.ki.WHISPER_OF_FLAMES) and
-                player:hasKeyItem(xi.ki.WHISPER_OF_TREMORS) and
-                player:hasKeyItem(xi.ki.WHISPER_OF_STORMS) and
-                player:hasKeyItem(xi.ki.WHISPER_OF_FROST) and
-                player:hasKeyItem(xi.ki.WHISPER_OF_GALES) and
-                player:hasKeyItem(xi.ki.WHISPER_OF_TIDES)
+            return player:hasKeyItem(xi.ki.EYE_OF_FLAMES) and
+                player:hasKeyItem(xi.ki.EYE_OF_TREMORS) and
+                player:hasKeyItem(xi.ki.EYE_OF_STORMS) and
+                player:hasKeyItem(xi.ki.EYE_OF_FROST) and
+                player:hasKeyItem(xi.ki.EYE_OF_GALES) and
+                player:hasKeyItem(xi.ki.EYE_OF_TIDES)
         end,
 
         [419] = function() -- Quest: Waking the Beast (Cloister of Gales)

--- a/scripts/zones/Cloister_of_Flames/bcnms/waking_the_beast.lua
+++ b/scripts/zones/Cloister_of_Flames/bcnms/waking_the_beast.lua
@@ -36,7 +36,7 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 and player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) then
-        npcUtil.giveKeyItem(player, xi.ki.WHISPER_OF_FLAMES)
+        npcUtil.giveKeyItem(player, xi.ki.EYE_OF_FLAMES)
     end
 end
 

--- a/scripts/zones/Cloister_of_Frost/bcnms/waking_the_beast.lua
+++ b/scripts/zones/Cloister_of_Frost/bcnms/waking_the_beast.lua
@@ -36,7 +36,7 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 and player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) then
-        npcUtil.giveKeyItem(player, xi.ki.WHISPER_OF_FROST)
+        npcUtil.giveKeyItem(player, xi.ki.EYE_OF_FROST)
     end
 end
 

--- a/scripts/zones/Cloister_of_Gales/bcnms/waking_the_beast.lua
+++ b/scripts/zones/Cloister_of_Gales/bcnms/waking_the_beast.lua
@@ -36,7 +36,7 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 and player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) then
-        npcUtil.giveKeyItem(player, xi.ki.WHISPER_OF_GALES)
+        npcUtil.giveKeyItem(player, xi.ki.EYE_OF_GALES)
     end
 end
 

--- a/scripts/zones/Cloister_of_Storms/bcnms/waking_the_beast.lua
+++ b/scripts/zones/Cloister_of_Storms/bcnms/waking_the_beast.lua
@@ -36,7 +36,7 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 and player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) then
-        npcUtil.giveKeyItem(player, xi.ki.WHISPER_OF_STORMS)
+        npcUtil.giveKeyItem(player, xi.ki.EYE_OF_STORMS)
     end
 end
 

--- a/scripts/zones/Cloister_of_Tides/bcnms/waking_the_beast.lua
+++ b/scripts/zones/Cloister_of_Tides/bcnms/waking_the_beast.lua
@@ -36,7 +36,7 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 and player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) then
-        npcUtil.giveKeyItem(player, xi.ki.WHISPER_OF_TIDES)
+        npcUtil.giveKeyItem(player, xi.ki.EYE_OF_TIDES)
     end
 end
 

--- a/scripts/zones/Cloister_of_Tremors/bcnms/waking_the_beast.lua
+++ b/scripts/zones/Cloister_of_Tremors/bcnms/waking_the_beast.lua
@@ -36,7 +36,7 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 and player:hasKeyItem(xi.ki.RAINBOW_RESONATOR) then
-        npcUtil.giveKeyItem(player, xi.ki.WHISPER_OF_TREMORS)
+        npcUtil.giveKeyItem(player, xi.ki.EYE_OF_TREMORS)
     end
 end
 


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Players will now be rewarded the proper key item from the battlefields during the quest: "Waking the Beast" (Abdiah)

## What does this pull request do? (Please be technical)
Adjusted improper checking and rewarding of key items surrounding the quest: "Waking the Beast". Previously used whipers instead of eyes during quest progress.
