### PR TITLE
Reap What You Sow Fix

### DIFF
--- a/scripts/quests/windurst/Reap_What_You_Sow.lua
+++ b/scripts/quests/windurst/Reap_What_You_Sow.lua
@@ -87,14 +87,12 @@ quest.sections =
             onEventFinish =
             {
                 [475] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, xi.items.STATIONERY_SET) then
-                        player:confirmTrade()
-                        npcUtil.giveCurrency(player, 'gil', 500)
-                    end
+                    player:confirmTrade()
+                    npcUtil.giveCurrency(player, 'gil', 500)
                 end,
 
                 [477] = function(player, csid, option, npc)
-                    if quest:complete() then
+                    if quest:complete(player) then
                         player:confirmTrade()
                     end
                 end,


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do? (Please be technical)
Fixed reward stationary set when players weren't completing the quest.
Fixed players being unable to complete the quest by adding the player param to quest:complete(player)

