### PR TITLE
Fixes an edge case on bcnm loot calc

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -1106,7 +1106,7 @@ function Battlefield:handleLootRolls(battlefield, lootTable, npc)
                     if type(entry) == 'table' then
                         current = current + entry.droprate
 
-                        if current > roll then
+                        if current >= roll then
                             if entry.itemid == 0 then
                                 break
                             end


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed an edge case where in very rare scenarios, guarenteed BCNM loot pools would not drop.

## What does this pull request do? (Please be technical)

We use `if current > roll then` to gate the drops so consider the following cases:
```
| Item A Weight 50 | Item B Weight 50 |
| 0                |               100|
                   ^                  ^
A roll of 50 gets the 2nd item.
A roll of 100, gets no items.
```

Updated to use `>=` as the logic gate

## Steps to test these changes

The easiest way to test this is spam omega or ultima and make sure the 2 100% drops are there and all expected coins are present.

If testing with GM power I can provide commands to make the process much much faster on request.
Exececution level required.

## Special Deployment Considerations

None - not hot fixable.