### PR TITLE
Adds consistency to guard calculations through an attack

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -114,34 +114,18 @@ void CAttack::SetCritical(bool value, uint16 slot, bool isGuarded)
 
 /************************************************************************
  *                                                                      *
- *  Sets the guarded flag.                                              *
- *                                                                      *
- ************************************************************************/
-void CAttack::SetGuarded(bool isGuarded)
-{
-    m_isGuarded = isGuarded;
-}
-
-/************************************************************************
- *                                                                      *
  *  Gets the guarded flag.                                              *
  *                                                                      *
  ************************************************************************/
 bool CAttack::IsGuarded()
 {
-    m_isGuarded = attackutils::IsGuarded(m_attacker, m_victim);
-    if (m_isGuarded)
+    if (m_isGuarded.has_value())
     {
-        if (m_damageRatio > 1.0f)
-        {
-            m_damageRatio -= 1.0f;
-        }
-        else
-        {
-            m_damageRatio = 0;
-        }
+        return m_isGuarded.value();
     }
-    return m_isGuarded;
+
+    m_isGuarded.emplace(attackutils::IsGuarded(m_attacker, m_victim));
+    return m_isGuarded.value();
 }
 
 /************************************************************************

--- a/src/map/attack.h
+++ b/src/map/attack.h
@@ -89,7 +89,6 @@ public:
     bool                      IsFirstSwing() const;                           // Returns the isFirstSwing flag.
     void                      SetAsFirstSwing(bool isFirst = true);           // Sets this attack as the first swing.
     float                     GetDamageRatio() const;                         // Gets the damage ratio.
-    void                      SetGuarded(bool);                               // Sets the isGuarded flag.
     bool                      IsGuarded();                                    // Sets the isGuarded flag. Also alters the damage ratio accordingly.
     bool                      IsEvaded() const;                               // Gets the evaded flag.
     void                      SetEvaded(bool value);                          // Sets the evaded flag.
@@ -106,16 +105,16 @@ public:
     void SetAttackType(PHYSICAL_ATTACK_TYPE type); // Sets the attack type.
 
 private:
-    CBattleEntity*            m_attacker;            // The attacker.
-    CBattleEntity*            m_victim;              // The victim.
-    CAttackRound*             m_attackRound;         // Reference to the parent attack round.
-    PHYSICAL_ATTACK_TYPE      m_attackType;          // The attack type (Double, Triple, Zanshin ect).
-    PHYSICAL_ATTACK_DIRECTION m_attackDirection;     // The attack direction (Left, Right).
-    uint8                     m_hitRate{ 0 };        // This attack's hitrate.
-    bool                      m_isCritical{ false }; // Flag: Is this attack a critical attack?
-    bool                      m_isGuarded{ false };  // Flag: Is this attack guarded by the victim?
-    bool                      m_isBlocked{ false };  // Flag: Is this attack blocked by the victim?
-    bool                      m_isEvaded{ false };   // Flag: Is this attack evaded by the victim?
+    CBattleEntity*            m_attacker;                  // The attacker.
+    CBattleEntity*            m_victim;                    // The victim.
+    CAttackRound*             m_attackRound;               // Reference to the parent attack round.
+    PHYSICAL_ATTACK_TYPE      m_attackType;                // The attack type (Double, Triple, Zanshin ect).
+    PHYSICAL_ATTACK_DIRECTION m_attackDirection;           // The attack direction (Left, Right).
+    uint8                     m_hitRate{ 0 };              // This attack's hitrate.
+    bool                      m_isCritical{ false };       // Flag: Is this attack a critical attack?
+    std::optional<bool>       m_isGuarded{ std::nullopt }; // Flag: Is this attack guarded by the victim?
+    bool                      m_isBlocked{ false };        // Flag: Is this attack blocked by the victim?
+    bool                      m_isEvaded{ false };         // Flag: Is this attack evaded by the victim?
     bool                      m_isCountered{ false };
     bool                      m_isCovered{ false }; // Flag: Is someone covering the victim?
     bool                      m_anticipated{ false };


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Guard animations, guard damage reduction, and guard skill up opportunities will now be aligned.
Previously each phase of a guard was disjointed - so it was possible to have an animation with no dmg reduction and no skill up chance, or dmg reduction with no animation or skill up chance.  Or a skill up chance, with neither dmg reduction nor animation.
## What does this pull request do? (Please be technical)

Instead of recalculating if a guard occurs up to 6 times per attack, all independently - calculate once and store for the entire attack.

## Steps to test these changes

Be a mnk - engage a mob.

Give the mob high accuracy `!setmod acc 10000`

Make the mob invulnerable `!immortal`

Can be helpful to load simplelog addon to avoid missing guard procs

## Special Deployment Considerations

None
