### PR TITLE
[core] Update Battlefield power if Battlefield exists

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -423,10 +423,20 @@ bool CBattlefield::InsertEntity(CBaseEntity* PEntity, bool enter, BATTLEFIELDMOB
     }
 
     // mob, initiator or ally
-    if (entity && !entity->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD))
+    if (entity)
     {
-        entity->StatusEffectContainer->AddStatusEffect(
-            new CStatusEffect(EFFECT_BATTLEFIELD, EFFECT_BATTLEFIELD, this->GetID(), 0, 0, m_Initiator.id, this->GetArea()), true);
+        CStatusEffect* PBattlefieldEffect = entity->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD);
+        // Update battlefield ID if battlefield effect exists
+        // Tango with a Tracker/Requiem of Sin corner case where NPC IDs are shared between BCs as per retail caps
+        if (PBattlefieldEffect)
+        {
+            PBattlefieldEffect->SetPower(this->GetID());
+        }
+        else
+        {
+            entity->StatusEffectContainer->AddStatusEffect(
+                new CStatusEffect(EFFECT_BATTLEFIELD, EFFECT_BATTLEFIELD, this->GetID(), 0, 0, m_Initiator.id, this->GetArea()), true);
+        }
     }
 
     return true;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes an issue with BCNMs that share mob IDs such as Requiem of Sin and Tango with a Tracker (Wintersolstice)

## What does this pull request do? (Please be technical)

This fixes corner case BCs where mob IDs are shared in battlefields such as the Shikarees in Requiem of Sin & Tango with a Tracker

Should have no effect on other battlefields, as the IDs are static.
## Steps to test these changes

Enter Tango with a Tracker, finish it, Enter Requiem of Sin and be able to fight the mobs and win.

## Special Deployment Considerations

N/A
