### PR TITLE
[sql] Fix att mods for 1H weapons to work on both hands

### DIFF
--- a/modules/era/sql/item_mods.sql
+++ b/modules/era/sql/item_mods.sql
@@ -20,6 +20,7 @@ REPLACE INTO `item_mods` (`itemid`, `modid`, `value`) VALUES
     (15400,521,10), -- Black Cuisses AUGMENTS_ABSORB: 10
     (15339,521,10); -- Black Sollerets AUGMENTS_ABSORB: 10
 
+-- Set Critical hit rate bonus in main/sub slots to apply only to slot with CRITHITRATE_SLOT mod
 UPDATE item_mods
 SET modId = 1168
 WHERE itemId IN (
@@ -29,15 +30,5 @@ WHERE itemId IN (
     AND skill != 0
     )
 AND modId = 165;
-
-UPDATE item_mods
-SET modId = 1169
-WHERE itemId IN (
-    SELECT itemId
-    FROM item_weapon
-    WHERE skill < 25
-    AND skill != 0
-    )
-AND modId = 23;
 
 UNLOCK TABLES;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Onehand weapons with Attack+ will now effect both hands where applicable. (Wintersolstice)

## What does this pull request do? (Please be technical)

Restores _some_ of my sanity.

## Steps to test these changes

Equip Juggernaut, /checkparam <me> and see both hands have +30 attack.

## Special Deployment Considerations

N/A