### PR TITLE
Fix phys ws, rng ws, and smn interaction with dmg mods

### DIFF
--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -253,7 +253,9 @@ local attackTypeShields =
 
 xi.summon.physicalSDT = function(attacker, target, damagetype, finalDmg)
     local adjustedDamage = finalDmg
-    adjustedDamage = target:physicalDmgTaken(adjustedDamage, damagetype)
+    -- need to pass in ignoreDmgMods option to physicalDmgTaken otherwise dmg mods are applied both here
+    -- as called by avatarFinalAdjustments and in applyDamageTaken as called by avatarPhysicalMove
+    adjustedDamage = target:physicalDmgTaken(adjustedDamage, damagetype, true)
 
     if damagetype == xi.damageType.BLUNT then
         adjustedDamage = adjustedDamage * target:getMod(xi.mod.IMPACT_SDT) / 1000

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -369,7 +369,9 @@ local function modifyMeleeHitDamage(attacker, target, attackTbl, wsParams, rawDa
     local adjustedDamage = rawDamage
 
     if not wsParams.formless then
-        adjustedDamage = target:physicalDmgTaken(adjustedDamage, attackTbl.damageType)
+        -- need to pass in ignoreDmgMods option to physicalDmgTaken otherwise dmg mods are applied both here
+        -- and in final ws damage by applyDamageTaken
+        adjustedDamage = target:physicalDmgTaken(adjustedDamage, attackTbl.damageType, true)
 
         if attackTbl.weaponType == xi.skill.HAND_TO_HAND then
             adjustedDamage = adjustedDamage * target:getMod(xi.mod.HTH_SDT) / 1000
@@ -829,7 +831,9 @@ xi.weaponskills.doRangedWeaponskill = function(attacker, target, wsID, wsParams,
     attacker:delStatusEffectsByFlag(xi.effectFlag.DETECTABLE)
 
     -- Calculate reductions
-    finaldmg = target:rangedDmgTaken(finaldmg)
+    -- need to pass in ignoreDmgMods option to rangedDmgTaken otherwise dmg mods are applied both here
+    -- and in final ws damage by applyDamageTaken
+    finaldmg = target:rangedDmgTaken(finaldmg, true)
     finaldmg = finaldmg * target:getMod(xi.mod.PIERCE_SDT) / 1000
 
     finaldmg = finaldmg * xi.settings.main.WEAPON_SKILL_POWER -- Add server bonus

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11998,8 +11998,9 @@ int32 CLuaBaseEntity::physicalDmgTaken(double damage, sol::variadic_args va)
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
     DAMAGE_TYPE damageType = va[0].is<uint32>() ? va[0].as<DAMAGE_TYPE>() : DAMAGE_TYPE::NONE;
+    bool ignoreDmgMods = va[1].is<bool>() ? va[1].as<bool>() : false;
 
-    return battleutils::PhysicalDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType);
+    return battleutils::PhysicalDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType, false, ignoreDmgMods);
 }
 
 /************************************************************************
@@ -12030,8 +12031,9 @@ int32 CLuaBaseEntity::rangedDmgTaken(double damage, sol::variadic_args va)
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
     DAMAGE_TYPE damageType = va[0].is<uint32>() ? va[0].as<DAMAGE_TYPE>() : DAMAGE_TYPE::NONE;
+    bool ignoreDmgMods = va[1].is<bool>() ? va[1].as<bool>() : false;
 
-    return battleutils::RangedDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType);
+    return battleutils::RangedDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType, false, ignoreDmgMods);
 }
 
 /************************************************************************

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5471,17 +5471,20 @@ namespace battleutils
         return damage;
     }
 
-    int32 PhysicalDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered)
+    int32 PhysicalDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered, bool ignoreDmgMods)
     {
-        float resist = 1.0f + PDefender->getMod(Mod::DMGPHYS) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
+        if (ignoreDmgMods)
+        {
+            float resist = 1.0f + PDefender->getMod(Mod::DMGPHYS) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
+            resist       = std::max(resist, 0.5f);                  // PDT caps at -50%
+            resist += PDefender->getMod(Mod::DMGPHYS_II) / 10000.f; // Add Burtgang reduction after 50% cap. Extends cap to -68%
+            resist = std::max(resist, 0.32f);                       // Total cap with MDT-% II included is 87.5%
 
-        resist = std::max(resist, 0.5f);                        // PDT caps at -50%
-        resist += PDefender->getMod(Mod::DMGPHYS_II) / 10000.f; // Add Burtgang reduction after 50% cap. Extends cap to -68%
-        resist = std::max(resist, 0.32f);                       // Total cap with MDT-% II included is 87.5%
-
-        resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGPHYS) / 10000.f;
-        resist = std::max(resist, 0.f);
-        damage = (int32)(damage * resist);
+            resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGPHYS) / 10000.f;
+            resist = std::max(resist, 0.f);
+            damage = (int32)(damage * resist);
+            ShowDebug("PhysicalDmgTaken - Resist: %f Damage: %i", resist, damage);
+        }
 
         if (damage > 0 && PDefender->objtype == TYPE_PET && PDefender->getMod(Mod::AUTO_STEAM_JACKET) > 0)
         {
@@ -5519,15 +5522,18 @@ namespace battleutils
         return damage;
     }
 
-    int32 RangedDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered)
+    int32 RangedDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered, bool ignoreDmgMods)
     {
-        float resist = 1.0f + PDefender->getMod(Mod::DMGRANGE) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
+        if (ignoreDmgMods)
+        {
+            float resist = 1.0f + PDefender->getMod(Mod::DMGRANGE) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
 
-        resist = std::max(resist, 0.5f);
+            resist = std::max(resist, 0.5f);
 
-        resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGRANGE) / 10000.f;
-        resist = std::max(resist, 0.f);
-        damage = (int32)(damage * resist);
+            resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGRANGE) / 10000.f;
+            resist = std::max(resist, 0.f);
+            damage = (int32)(damage * resist);
+        }
 
         if (damage > 0 && PDefender->objtype == TYPE_PET && PDefender->getMod(Mod::AUTO_STEAM_JACKET) > 0)
         {

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -212,8 +212,8 @@ namespace battleutils
 
     int32 BreathDmgTaken(CBattleEntity* PDefender, int32 damage);
     int32 MagicDmgTaken(CBattleEntity* PDefender, int32 damage, ELEMENT element);
-    int32 PhysicalDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered = false);
-    int32 RangedDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered = false);
+    int32 PhysicalDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered = false, bool ignoreDmgMods = false);
+    int32 RangedDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered = false, bool ignoreDmgMods = false);
     int32 HandleSteamJacket(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType);
 
     void  HandleIssekiganEnmityBonus(CBattleEntity* PDefender, CBattleEntity* PAttacker);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Weapon skills will now correctly respect physical, ranged, and summon damage taken modifiers (such as on Hpemde with open mouth). (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes an issue whereby certain damage taken modifiers were being considered twice for WSs. Specifically the mod was first considered when getting base hit damage (which is used as a param in WS calculations) and then again in the final adjustments to WS damage. This resulted in cases were some mobs were taking close to 4x+ damage from WS when they should have been taking 2x. 

The issue is fixed by adding a parameter to the function that gets the base hit damage to indicate that these modifiers should be ignored during the base hit calculation. This is done for physical, ranged, and smn damage. Breath and magic damage do not have this issue as far as I can tell.

## Steps to test these changes
Can test on any mobs that have significant damage mods (like UDMGPHYS), for example on Hpemde when their mouths are open.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
