### PR TITLE
 Smoothly path vertically as well

### DIFF
--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -412,6 +412,7 @@ void CPathFind::StepTo(const position_t& pos, bool run)
 
     float stepDistance = (speed / 10) / 2;
     float distanceTo   = distance(m_POwner->loc.p, pos);
+    float diff_y = pos.y - m_POwner->loc.p.y;
 
     // face point mob is moving towards
     LookAt(pos);
@@ -431,8 +432,21 @@ void CPathFind::StepTo(const position_t& pos, bool run)
             float radians = (1 - (float)m_POwner->loc.p.rotation / 256) * 2 * (float)M_PI;
 
             m_POwner->loc.p.x += cosf(radians) * (distanceTo - m_distanceFromPoint);
-            m_POwner->loc.p.y = pos.y;
             m_POwner->loc.p.z += sinf(radians) * (distanceTo - m_distanceFromPoint);
+            if (abs(diff_y) > .5f)
+            {
+                // Don't step too far vertically by simply utilizing the slope
+                float new_y = m_POwner->loc.p.y + stepDistance * (pos.y - m_POwner->loc.p.y) / distance(m_POwner->loc.p, pos, true);
+                float min_y = (pos.y + m_POwner->loc.p.y - abs(pos.y - m_POwner->loc.p.y)) / 2;
+                float max_y = (pos.y + m_POwner->loc.p.y + abs(pos.y - m_POwner->loc.p.y)) / 2;
+                // clamp new_y between start and end vertical position
+                new_y = new_y < min_y ? min_y : new_y;
+                m_POwner->loc.p.y = new_y > max_y ? max_y : new_y;
+            }
+            else
+            {
+                m_POwner->loc.p.y = pos.y;
+            }
         }
     }
     else
@@ -442,8 +456,21 @@ void CPathFind::StepTo(const position_t& pos, bool run)
         float radians = (1 - (float)m_POwner->loc.p.rotation / 256) * 2 * (float)M_PI;
 
         m_POwner->loc.p.x += cosf(radians) * stepDistance;
-        m_POwner->loc.p.y = pos.y;
         m_POwner->loc.p.z += sinf(radians) * stepDistance;
+        if (abs(diff_y) > .5f)
+        {
+            // Don't step too far vertically by simply utilizing the slope
+            float new_y = m_POwner->loc.p.y + stepDistance * (pos.y - m_POwner->loc.p.y) / distance(m_POwner->loc.p, pos, true);
+            float min_y = (pos.y + m_POwner->loc.p.y - abs(pos.y - m_POwner->loc.p.y)) / 2;
+            float max_y = (pos.y + m_POwner->loc.p.y + abs(pos.y - m_POwner->loc.p.y)) / 2;
+            // clamp new_y between start and end vertical position
+            new_y = new_y < min_y ? min_y : new_y;
+            m_POwner->loc.p.y = new_y > max_y ? max_y : new_y;
+        }
+        else
+        {
+            m_POwner->loc.p.y = pos.y;
+        }
     }
 
     m_POwner->loc.p.moving += (uint16)((0x36 * ((float)m_POwner->speed / 0x28)) - (0x14 * (mode - 1)));

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -412,7 +412,7 @@ void CPathFind::StepTo(const position_t& pos, bool run)
 
     float stepDistance = (speed / 10) / 2;
     float distanceTo   = distance(m_POwner->loc.p, pos);
-    float diff_y = pos.y - m_POwner->loc.p.y;
+    float diff_y       = pos.y - m_POwner->loc.p.y;
 
     // face point mob is moving towards
     LookAt(pos);
@@ -440,7 +440,7 @@ void CPathFind::StepTo(const position_t& pos, bool run)
                 float min_y = (pos.y + m_POwner->loc.p.y - abs(pos.y - m_POwner->loc.p.y)) / 2;
                 float max_y = (pos.y + m_POwner->loc.p.y + abs(pos.y - m_POwner->loc.p.y)) / 2;
                 // clamp new_y between start and end vertical position
-                new_y = new_y < min_y ? min_y : new_y;
+                new_y             = new_y < min_y ? min_y : new_y;
                 m_POwner->loc.p.y = new_y > max_y ? max_y : new_y;
             }
             else
@@ -464,7 +464,7 @@ void CPathFind::StepTo(const position_t& pos, bool run)
             float min_y = (pos.y + m_POwner->loc.p.y - abs(pos.y - m_POwner->loc.p.y)) / 2;
             float max_y = (pos.y + m_POwner->loc.p.y + abs(pos.y - m_POwner->loc.p.y)) / 2;
             // clamp new_y between start and end vertical position
-            new_y = new_y < min_y ? min_y : new_y;
+            new_y             = new_y < min_y ? min_y : new_y;
             m_POwner->loc.p.y = new_y > max_y ? max_y : new_y;
         }
         else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Improve vertical movement for mob pathing (MowFord)

## What does this pull request do? (Please be technical)

This is a PR from MowFord that's in LSB now, this is his text:

When a mob has a list of m_points, it steps towards the points each server tick. Detour decides the points in the list of m_points, and in multi-level zones simply by definition we will end up with points that differ vertically.

Currently, the y (vertical) component of a mob's position is simply snapped to the y component of the next point in m_points during the StepTo function.

This change adds a bit of complexity to setting the mob's pos.y in StepTo by calculating the slope and using stepDistance to smoothly increment the mob's vertical position.

I should note that detour does a great job of creating a list of m_points to smoothly navigate the navmesh, but our current implementation of StepTo was the main reason mobs bounced around in multi-level environments. This change, coupled with m_carefulpathing, makes mobs path beautifully with a good navmesh of the zone.

## Steps to test these changes

Included in [this imgur album](https://imgur.com/a/d3JabnB) is a gif of before and after the change in dyna-jeuno's palace.

The logic is unchanged in perfectly flat terrain, and I hope is clear enough what it does when the next point in `m_points` is more than .5 yalms different vertically.

## Special Deployment Considerations

N/A
