### PR TITLE
Fix conal mob abilities on no turn mobs

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -724,6 +724,15 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
             {
                 angle = 45.0f;
             }
+
+            // for mobs that do not turn to face the target
+            if (m_Behaviour & BEHAVIOUR_NO_TURN)
+            {
+                // need to always add the single main target as otherwise player can interrupt cone skill
+                // by spinning around the mob which should not be possible
+                PAI->TargetFind->findSingleTarget(PTarget, findFlags);
+            }
+
             if (PSkill->m_Aoe == 6) // Conal from center of mob
             {
                 PAI->TargetFind->findWithinCone(PTarget, AOE_RADIUS::ATTACKER, distance, angle, findFlags, 0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Conal abilities from certain monsters (such as Dragon Breath from Fafnir) will no longer be interrupted due to certain positionings. (Tracent)

## What does this pull request do? (Please be technical)
This fixes an issue where conal abilities from no turn mobs would be interrupted in certain positions because the abilities are correctly usable under a very wide cone (wyrms for example always do either spike flail or dragon breath) yet damage (to secondary targets) only applies under a smaller frontal cone. The issue is that the main target was only being searched for in this smaller frontal cone (thus causing no target interruptions) when the actual retail behavior is that the main target should always be valid (no matter relation to these cones). In other words, after the monster starts readying the abilities the main target should never be able to interrupt the move by spinning around the mob (to be outside of cone).

## Steps to test these changes
Fight Fafnir (`!spawnmob 17408018` and `!gotoid 17408018`) and use `!exec target:useMobAbility(953)` to spam dragon breath under different positions relative to the frontal cone.

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1270
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
