### PR TITLE
Set Ghrah EEM via script.

### DIFF
--- a/scripts/mixins/families/empty.lua
+++ b/scripts/mixins/families/empty.lua
@@ -9,7 +9,10 @@ g_mixins = g_mixins or {}
 
 local setModel = function(mob, skin)
     -- Strays in Vahzl can also spawn as Weeper and Seether models
-    if mob:getZone():getID() == xi.zone.PROMYVION_VAHZL and mob:getName() == "Stray" then
+    if
+        mob:getZone():getID() == xi.zone.PROMYVION_VAHZL and
+        mob:getName() == "Stray"
+    then
         local chance = math.random(1, 10)
         if chance == 1 then -- Weeper
             mob:setLocalVar("strayType", 1)
@@ -36,22 +39,37 @@ local setModel = function(mob, skin)
     end
 
     -- Set model depending on mob family
-    if mob:getFamily() == 255 or (mob:getFamily() == 499 and mob:getLocalVar("strayType") == 3) then -- Wanderer/Stray
+    if
+        mob:getFamily() == 255 or
+        (mob:getFamily() == 499 and
+        mob:getLocalVar("strayType") == 3)
+    then -- Wanderer/Stray
         if model == 4 then
             model = model + 1
         end
+
         mob:setModelId(1105 + model)
-    elseif mob:getFamily() == 256 or (mob:getFamily() == 499 and mob:getLocalVar("strayType") == 1) then -- Weeper / Stray
+    elseif
+        mob:getFamily() == 256 or
+        (mob:getFamily() == 499 and
+        mob:getLocalVar("strayType") == 1)
+    then -- Weeper / Stray
         mob:setModelId(1111 + model)
-    elseif mob:getFamily() == 220 or (mob:getFamily() == 499 and mob:getLocalVar("strayType") == 2) then -- Seether / Stray
+    elseif
+        mob:getFamily() == 220 or
+        (mob:getFamily() == 499 and
+        mob:getLocalVar("strayType") == 2)
+    then -- Seether / Stray
         if model > 1 then
             model = model + 1
         end
+
         mob:setModelId(1116 + model)
     elseif mob:getFamily() == 241 then -- Thinker
         if model > 2 then
             model = model + 1
         end
+
         mob:setModelId(1122 + model)
     elseif mob:getFamily() == 137 or mob:getFamily() == 138 then -- Gorger
         mob:setModelId(1128 + model)
@@ -59,6 +77,7 @@ local setModel = function(mob, skin)
         if model > 2 then
             model = model + 1
         end
+
         mob:setModelId(1133 + model)
     end
 end
@@ -130,61 +149,58 @@ g_mixins.families.empty = function(emptyMob)
             mob:setAnimationSub(1)
         end
 
+        -- TODO: Merge with Ghrah mixin
         -- Temporary solution until mods on spawn issue is corrected
         local buffed = mob:getLocalVar("buffed")
+        if buffed == 0 then
+            -- return EEM to neutral, overriding DB
+            mob:setMod(xi.mod.FIRE_EEM, 100)
+            mob:setMod(xi.mod.ICE_EEM, 100)
+            mob:setMod(xi.mod.WIND_EEM, 100)
+            mob:setMod(xi.mod.EARTH_EEM, 100)
+            mob:setMod(xi.mod.THUNDER_EEM, 100)
+            mob:setMod(xi.mod.WATER_EEM, 100)
+            mob:setMod(xi.mod.LIGHT_EEM, 100)
+            mob:setMod(xi.mod.DARK_EEM, 100)
+        end
+
         if skin == 1 and buffed == 0 then -- Dark
-            mob:setMod(xi.mod.DARK_MEVA, 99)
-            mob:setMod(xi.mod.SLEEPRES, 90)
-            mob:setMod(xi.mod.LIGHT_MEVA, -27)
+            mob:setMod(xi.mod.DARK_EEM, 5)
+            mob:setMod(xi.mod.LIGHT_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 2 and buffed == 0 then -- Water
-            mob:setMod(xi.mod.FIRE_MEVA, 80)
-            mob:setMod(xi.mod.WATER_MEVA, 99)
-            mob:setMod(xi.mod.POISONRES, 90)
-            mob:setMod(xi.mod.THUNDER_MEVA, -27)
+            mob:setMod(xi.mod.FIRE_EEM, 5)
+            mob:setMod(xi.mod.WATER_EEM, 5)
+            mob:setMod(xi.mod.THUNDER_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 3 and buffed == 0 then -- Lightning
-            mob:setMod(xi.mod.WATER_MEVA, 80)
-            mob:setMod(xi.mod.POISONRES, 90)
-            mob:setMod(xi.mod.THUNDER_MEVA, 99)
-            mob:setMod(xi.mod.STUNRES, 90)
-            mob:setMod(xi.mod.EARTH_MEVA, -27)
+            mob:setMod(xi.mod.WATER_EEM, 5)
+            mob:setMod(xi.mod.THUNDER_EEM, 5)
+            mob:setMod(xi.mod.EARTH_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 4 and buffed == 0 then -- Earth
-            mob:setMod(xi.mod.THUNDER_MEVA, 80)
-            mob:setMod(xi.mod.STUNRES, 90)
-            mob:setMod(xi.mod.EARTH_MEVA, 99)
-            mob:setMod(xi.mod.SLOWRES, 90)
-            mob:setMod(xi.mod.WIND_MEVA, -27)
+            mob:setMod(xi.mod.THUNDER_EEM, 5)
+            mob:setMod(xi.mod.EARTH_EEM, 5)
+            mob:setMod(xi.mod.WIND_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 5 and buffed == 0 then -- Light
-            mob:setMod(xi.mod.LIGHT_MEVA, 99)
-            mob:setMod(xi.mod.LULLABYRES, 90)
-            mob:setMod(xi.mod.DARK_MEVA, -27)
+            mob:setMod(xi.mod.LIGHT_EEM, 5)
+            mob:setMod(xi.mod.DARK_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 6 and buffed == 0 then -- Fire
-            mob:setMod(xi.mod.ICE_MEVA, 80)
-            mob:setMod(xi.mod.PARALYZERES, 90)
-            mob:setMod(xi.mod.BINDRES, 90)
-            mob:setMod(xi.mod.FIRE_MEVA, 99)
-            mob:setMod(xi.mod.WATER_MEVA, -27)
+            mob:setMod(xi.mod.ICE_EEM, 5)
+            mob:setMod(xi.mod.FIRE_EEM, 5)
+            mob:setMod(xi.mod.WATER_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 7 and buffed == 0 then -- Ice
-            mob:setMod(xi.mod.WIND_MEVA, 80)
-            mob:setMod(xi.mod.GRAVITYRES, 90)
-            mob:setMod(xi.mod.SILENCERES, 90)
-            mob:setMod(xi.mod.ICE_MEVA, 99)
-            mob:setMod(xi.mod.PARALYZERES, 90)
-            mob:setMod(xi.mod.BINDRES, 90)
-            mob:setMod(xi.mod.FIRE_MEVA, -27)
+            mob:setMod(xi.mod.WIND_EEM, 5)
+            mob:setMod(xi.mod.ICE_EEM, 5)
+            mob:setMod(xi.mod.FIRE_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif buffed == 0 then -- Wind
-            mob:setMod(xi.mod.EARTH_MEVA, 80)
-            mob:setMod(xi.mod.SLOWRES, 90)
-            mob:setMod(xi.mod.WIND_MEVA, 99)
-            mob:setMod(xi.mod.GRAVITYRES, 90)
-            mob:setMod(xi.mod.SILENCERES, 90)
-            mob:setMod(xi.mod.ICE_MEVA, -27)
+            mob:setMod(xi.mod.EARTH_EEM, 5)
+            mob:setMod(xi.mod.WIND_EEM, 5)
+            mob:setMod(xi.mod.ICE_EEM, 150)
             mob:setLocalVar("buffed", 1)
         end
     end)

--- a/scripts/mixins/families/ghrah.lua
+++ b/scripts/mixins/families/ghrah.lua
@@ -1,7 +1,8 @@
 require("scripts/globals/mixins")
 require("scripts/globals/status")
------------------------------------
-
+------------------------------------------
+-- Currently only used by Aw and Eo Grahs
+------------------------------------------
 g_mixins = g_mixins or {}
 
 g_mixins.families.ghrah = function(ghrahMob)
@@ -14,6 +15,7 @@ g_mixins.families.ghrah = function(ghrahMob)
         else
             mob:setLocalVar("form2", 3)
         end
+
         local skin = math.random(1161, 1168)
         mob:setLocalVar("skin", skin)
         mob:setModelId(skin)
@@ -99,70 +101,67 @@ g_mixins.families.ghrah = function(ghrahMob)
             mob:delMod(xi.mod.ATTP, 50)
         end
 
+        -- TODO: Merge with Empty mixin
         -- Temporary solution until mods on spawn issue is corrected
         local skin = mob:getLocalVar("skin")
         local buffed = mob:getLocalVar("buffed")
+        if buffed == 0 then
+            -- return EEM to neutral, overriding DB
+            mob:setMod(xi.mod.FIRE_EEM, 100)
+            mob:setMod(xi.mod.ICE_EEM, 100)
+            mob:setMod(xi.mod.WIND_EEM, 100)
+            mob:setMod(xi.mod.EARTH_EEM, 100)
+            mob:setMod(xi.mod.THUNDER_EEM, 100)
+            mob:setMod(xi.mod.WATER_EEM, 100)
+            mob:setMod(xi.mod.LIGHT_EEM, 100)
+            mob:setMod(xi.mod.DARK_EEM, 100)
+        end
+
         if skin == 1161 and buffed == 0 then -- Fire
             mob:setSpellList(484)
-            mob:setMod(xi.mod.ICE_MEVA, 80)
-            mob:setMod(xi.mod.PARALYZERES, 99)
-            mob:setMod(xi.mod.BINDRES, 99)
-            mob:setMod(xi.mod.FIRE_MEVA, 100)
-            mob:setMod(xi.mod.WATER_MEVA, -27)
+            mob:setMod(xi.mod.ICE_EEM, 5)
+            mob:setMod(xi.mod.FIRE_EEM, 5)
+            mob:setMod(xi.mod.WATER_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 1162 and buffed == 0 then -- Ice
             mob:setSpellList(479)
-            mob:setMod(xi.mod.WIND_MEVA, 80)
-            mob:setMod(xi.mod.GRAVITYRES, 99)
-            mob:setMod(xi.mod.SILENCERES, 99)
-            mob:setMod(xi.mod.ICE_MEVA, 100)
-            mob:setMod(xi.mod.PARALYZERES, 100)
-            mob:setMod(xi.mod.BINDRES, 100)
-            mob:setMod(xi.mod.FIRE_MEVA, -27)
+            mob:setMod(xi.mod.WIND_EEM, 5)
+            mob:setMod(xi.mod.ICE_EEM, 5)
+            mob:setMod(xi.mod.FIRE_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 1163 and buffed == 0 then -- Wind
             mob:setSpellList(480)
-            mob:setMod(xi.mod.EARTH_MEVA, 80)
-            mob:setMod(xi.mod.SLOWRES, 99)
-            mob:setMod(xi.mod.WIND_MEVA, 100)
-            mob:setMod(xi.mod.GRAVITYRES, 100)
-            mob:setMod(xi.mod.SILENCERES, 100)
-            mob:setMod(xi.mod.ICE_MEVA, -27)
+            mob:setMod(xi.mod.EARTH_EEM, 5)
+            mob:setMod(xi.mod.WIND_EEM, 5)
+            mob:setMod(xi.mod.ICE_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 1164 and buffed == 0 then -- Earth
             mob:setSpellList(481)
-            mob:setMod(xi.mod.THUNDER_MEVA, 80)
-            mob:setMod(xi.mod.STUNRES, 99)
-            mob:setMod(xi.mod.EARTH_MEVA, 100)
-            mob:setMod(xi.mod.SLOWRES, 100)
-            mob:setMod(xi.mod.WIND_MEVA, -27)
+            mob:setMod(xi.mod.THUNDER_EEM, 5)
+            mob:setMod(xi.mod.EARTH_EEM, 5)
+            mob:setMod(xi.mod.WIND_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 1165 and buffed == 0 then -- Lightning
             mob:setSpellList(482)
-            mob:setMod(xi.mod.WATER_MEVA, 80)
-            mob:setMod(xi.mod.POISONRES, 99)
-            mob:setMod(xi.mod.THUNDER_MEVA, 100)
-            mob:setMod(xi.mod.STUNRES, 100)
-            mob:setMod(xi.mod.EARTH_MEVA, -27)
+            mob:setMod(xi.mod.WATER_EEM, 5)
+            mob:setMod(xi.mod.THUNDER_EEM, 5)
+            mob:setMod(xi.mod.EARTH_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 1166 and buffed == 0 then -- Water
             mob:setSpellList(483)
-            mob:setMod(xi.mod.FIRE_MEVA, 80)
-            mob:setMod(xi.mod.WATER_MEVA, 100)
-            mob:setMod(xi.mod.POISONRES, 100)
-            mob:setMod(xi.mod.THUNDER_MEVA, -27)
+            mob:setMod(xi.mod.FIRE_EEM, 5)
+            mob:setMod(xi.mod.WATER_EEM, 5)
+            mob:setMod(xi.mod.THUNDER_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 1167 and buffed == 0 then -- Light
             mob:setSpellList(478)
-            mob:setMod(xi.mod.LIGHT_MEVA, 100)
-            mob:setMod(xi.mod.LULLABYRES, 100)
-            mob:setMod(xi.mod.DARK_MEVA, -27)
+            mob:setMod(xi.mod.LIGHT_EEM, 5)
+            mob:setMod(xi.mod.DARK_EEM, 150)
             mob:setLocalVar("buffed", 1)
         elseif skin == 1168 and buffed == 0 then -- Dark
             mob:setSpellList(477)
-            mob:setMod(xi.mod.DARK_MEVA, 100)
-            mob:setMod(xi.mod.SLEEPRES, 100)
-            mob:setMod(xi.mod.LIGHT_MEVA, -27)
+            mob:setMod(xi.mod.DARK_EEM, 5)
+            mob:setMod(xi.mod.LIGHT_EEM, 150)
             mob:setLocalVar("buffed", 1)
         end
     end)


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixes Ghrah EEM values - Ghrahs of all elements will no longer be immune to dark based sleeps.
Applies to Aw and Eo grah only.
## What does this pull request do? (Please be technical)

For better or worse - all grahs are only split up in the data base by type (ix, aw, eo)

so per type, they are all built identically.
This includes the "relatively" new values of EEM (elemental evasion)

When a grah spwans - scripts randomize the grah's element and align the mob's model, spell list and resists - particularly setting some elemental based resists and some status based resists.

But the scripts didnt account for EEM.
And Grah's base EEM was as low as it gets for dark.  i.e. basically it just says immune. (dark_eem  = 5)

For now, I am resetting the ghrah's dark eem and then assiging eem 5 to the opposite element of the ghrah

## Steps to test these changes

Kill and respawn ghrahs over and over (aw and eo)
use !getmod <element>_eem
A value of 5 is hard resist
A value of 100 is neutral
A value over 100 is weak

## Special Deployment Considerations

Server bounce since its a mixin
