### PR TITLE
Displacement enmity reset fix

### DIFF
--- a/scripts/zones/Misareaux_Coast/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/Spatial_Displacement.lua
@@ -28,6 +28,12 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 551 and option == 2 then
         player:setPos(729.749, -20.319, 407.153, 90, 29) -- Go to Riverne #B01 (R)
     end
+
+    if csid > 0 then
+        for _, entry in pairs(player:getNotorietyList()) do
+            entry:clearEnmity(player) -- reset hate on player after teleporting
+        end
+    end
 end
 
 return entity

--- a/scripts/zones/Riverne-Site_A01/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Riverne-Site_A01/npcs/Spatial_Displacement.lua
@@ -36,6 +36,12 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 32003 then
         xi.bcnm.onEventFinish(player, csid, option)
     end
+
+    if csid > 0 then
+        for _, entry in pairs(player:getNotorietyList()) do
+            entry:clearEnmity(player) -- reset hate on player after teleporting
+        end
+    end
 end
 
 return entity


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed spatial displacements in Riverne-Site A and B not wiping enmity when going through them. (Abdiah)

## What does this pull request do? (Please be technical)
Adds a check for each spatial displacement that wipes enmity on the player if they go through a portal.
Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1570

## Steps to test these changes
Get hate and go through a displacement in any Rivernse Site

