### PR TITLE
Castle Zvahl Teleporters

### DIFF
--- a/scripts/zones/Castle_Zvahl_Keep/IDs.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/IDs.lua
@@ -50,6 +50,16 @@ zones[xi.zone.CASTLE_ZVAHL_KEEP] =
     npc =
     {
         TREASURE_CHEST = 17441088,
+        TELEPORTERS =
+        {
+            17441070, -- Center tele
+            17441071, -- North west tele
+            17441072, -- South west tele
+            17441073, -- North east tele
+            17441074, -- South east tele
+            17441076, -- North final tele
+            17441077, -- South final tele
+        },
     },
 }
 

--- a/scripts/zones/Castle_Zvahl_Keep/Zone.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/Zone.lua
@@ -49,11 +49,51 @@ local teleportEventsByArea =
     [7] = 7, -- Teleports player to position G-8 on map 2
 }
 
+local teleportPortalByArea =
+{
+    [1] = 17441070, -- Center
+    [2] = 17441073, -- NE
+    [3] = 17441074, -- SE
+    [4] = 17441071, -- NW
+    [5] = 17441072, -- SW
+    [6] = 17441076, -- N
+    [7] = 17441077, -- S
+}
+
+zoneObject.onZoneTick = function(zone)
+    if zone:getLocalVar("tele_timer") < os.time() then
+        local randTele = math.random(1, #ID.npc.TELEPORTERS)
+
+        -- Ensure the same portal isn't selected twice in a row
+        while randTele == zone:getLocalVar("last_tele") do
+            randTele = math.random(1, #ID.npc.TELEPORTERS)
+        end
+
+        zone:setLocalVar("last_tele", randTele)
+
+        local tele = GetNPCByID(ID.npc.TELEPORTERS[randTele])
+
+        tele:openDoor(10)
+        tele:setLocalVar("isOpen", 1)
+        tele:timer(10000, function(teleArg)
+            teleArg:setLocalVar("isOpen", 0)
+        end)
+
+        zone:setLocalVar("tele_timer", os.time() + 5)
+    end
+end
+
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     local areaId = triggerArea:GetTriggerAreaID()
 
-    if teleportEventsByArea[areaId] then
+    if
+        GetNPCByID(teleportPortalByArea[areaId]):getLocalVar("isOpen") == 1 and
+        teleportEventsByArea[areaId]
+    then
         player:startCutscene(teleportEventsByArea[areaId])
+        for _, entry in pairs(player:getNotorietyList()) do
+            entry:clearEnmity(player) -- reset hate on player after teleporting
+        end
     end
 end
 


### PR DESCRIPTION
Implements the teleporters in Castle Zvahl Keep

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Implemented the functionality of the teleporters in Castle Zvahl Keep (Abdiah)

## What does this pull request do? (Please be technical)
The following was based on 2 hours of retail capture:

Teleporters stay open for 10 seconds each time they're triggered.
- There appears to be no pattern in which the portals are triggered.
- Portals trigger in rapid succession, sometimes seconds after another, and other times it can be inactive for a while
- To achieve this, a random portal is selected every 5 - 10 seconds and is triggered for 10 seconds each time
- No portal is chosen twice in a row
- Portals will only be enterable if the animation is triggered.

Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/984

