### PR TITLE
Fix several issues with Evil Oscar

### DIFF
--- a/modules/era/sql_dynamis/era_dyna_sql.sql
+++ b/modules/era/sql_dynamis/era_dyna_sql.sql
@@ -2267,7 +2267,6 @@ REPLACE INTO `mob_spell_lists` VALUES ('Quieitiel',5002,274,56,255);
 --                        Skill Modifictions                        --
 -- --------------------------------------------------------------------
 -- Dynamis - Valkurm
-UPDATE mob_skills SET mob_skill_distance = 15.00 WHERE mob_skill_id = "1332"; -- Extremely Bad Breath should be 15`
 DELETE FROM mob_skills WHERE mob_skill_id = "1605"; -- Miasmic Breath
 REPLACE INTO mob_skills VALUES (1605,63,'miasmic_breath',4,15.0,2000,1500,4,0,0,0,0,0,0);
 DELETE FROM mob_skills WHERE mob_skill_id = "1607"; -- Fragrant Breath

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1288,7 +1288,7 @@ INSERT INTO `mob_skills` VALUES (1326,988,'final_retribution',1,10.0,2000,1500,4
 INSERT INTO `mob_skills` VALUES (1329,990,'gala_macabre',1,10.0,2000,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1330,910,'hoof_volley',0,7.0,2000,1500,4,0,0,2,0,0,0);
 INSERT INTO `mob_skills` VALUES (1331,437,'counterstance_waughroon_kid',0,7.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1332,63,'extremely_bad_breath',1,10.0,4000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1332,63,'extremely_bad_breath',1,10.0,2000,3500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1333,152,'contagion_transfer',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1334,154,'contamination',1,12.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1335,151,'toxic_pick',0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Evil Oscar now has retail accurate range and readying time for Extremely Bad Breath. (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes several issues with Evil Oscar including fixing Extremely Bad Breath readying time to 3.5 seconds and range to 10 yalms (both retail accurate). Also adds the 1.5 second delay between third filling message and using Extremely Bad Breath and an out of range message if target is not in range when starting Extremely Bad Breath.

## Steps to test these changes
Fight Evil Oscar

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1159
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
