### PR TITLE
[core] Retrigger all latents after an equip packet is sent

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -219,6 +219,8 @@ CCharEntity::CCharEntity()
     PRecastContainer       = std::make_unique<CCharRecastContainer>(this);
     PLatentEffectContainer = new CLatentEffectContainer(this);
 
+    retriggerLatentsAfterPacketParsing = false;
+
     resetPetZoningInfo();
     petZoningInfo.petID = 0;
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -481,6 +481,7 @@ public:
     bool           MeritMode; // If true then player is meriting
 
     CLatentEffectContainer* PLatentEffectContainer;
+    bool                    retriggerLatentsAfterPacketParsing; // used to retrigger all latent effects after packet parsing is done in map.cpp
 
     CItemContainer* PGuildShop;                   // текущий магазин гильдии, в котором персонаж производит закупки
     CItemContainer* getStorage(uint8 LocationID); // получение указателя на соответствующее хранилище

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -57,6 +57,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #include "ai/controllers/automaton_controller.h"
 #include "daily_system.h"
+#include "latent_effect_container.h"
 #include "packets/basic.h"
 #include "packets/chat_message.h"
 #include "utils/battleutils.h"
@@ -788,6 +789,19 @@ int32 parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t*
                         SmallPD_Size, PChar->GetName());
         }
     }
+
+    if (PChar->retriggerLatentsAfterPacketParsing)
+    {
+        for (uint8 equipSlotID = 0; equipSlotID < 16; ++equipSlotID)
+        {
+            if (PChar->equip[equipSlotID] != 0)
+            {
+                PChar->PLatentEffectContainer->CheckLatentsEquip(equipSlotID);
+            }
+        }
+        PChar->retriggerLatentsAfterPacketParsing = false; // reset for next packet parse
+    }
+
     map_session_data->client_packet_id = SmallPD_Code;
 
     // Google Translate:

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3625,6 +3625,7 @@ void SmallPacket0x050(map_session_data_t* const PSession, CCharEntity* const PCh
     charutils::SaveCharLook(PChar);
     luautils::CheckForGearSet(PChar); // check for gear set on gear change
     PChar->UpdateHealth();
+    PChar->retriggerLatentsAfterPacketParsing = true; // retrigger all latents after all equip packets are parsed
 }
 
 /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

All equipped latents will now be re-triggered to check if they are active after changing gear. (Wintersolstice)

## What does this pull request do? (Please be technical)

This will fix race conditions with latents that do not activate on equip in their sequence of equips but would activate after the entire set is equipped, like retail.

## Steps to test these changes

Equip a minstrel's ring but the latent should only activate after your entire equip set, and have it activate after the entire set, instantly.

For example, if your hp% set to activate minstrel's ring requires back, waist, legs, feet (default equip order), it would only activate a second or two later before this patch, because Minstrel's Ring is equipped before the last few slots. Caveat -- luashitacast, gearswap, etc could change equip order and fix this by equipping minstrel's ring last.

## Special Deployment Considerations

N/A
