### PR TITLE
Dawn Prishe not appearing fix

### DIFF
--- a/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
@@ -21,6 +21,10 @@ entity.onMobInitialize = function(mob)
     end)
 end
 
+entity.onMobSpawn = function(mob)
+    mob:setAllegiance(xi.allegiance.PLAYER)
+end
+
 entity.onMobRoam = function(mob)
     local promathia = ID.mob.PROMATHIA_OFFSET + mob:getBattlefield():getArea()
     if not GetMobByID(promathia):isAlive() then

--- a/scripts/zones/Empyreal_Paradox/mobs/Selhteus.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Selhteus.lua
@@ -16,6 +16,10 @@ entity.onMobInitialize = function(mob)
     mob:setAutoAttackEnabled(false)
 end
 
+entity.onMobSpawn = function(mob)
+    mob:setAllegiance(xi.allegiance.PLAYER)
+end
+
 entity.onMobFight = function(mob, target)
     if target:getTarget() and target:getTarget():getID() ~= mob:getID() then
         local targetPos = target:getPos()

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -1363,8 +1363,8 @@ INSERT INTO `mob_groups` VALUES (7,0,36,'Promathia_htbf',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (8,4820,36,'Metus',0,128,0,0,20000,125,125,0);
 INSERT INTO `mob_groups` VALUES (9,0,36,'Omega',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (10,0,36,'Ultima',0,128,0,0,0,0,0,0);
-INSERT INTO `mob_groups` VALUES (11,3199,36,'Prishe',0,128,0,2200,0,75,75,1); -- ally
-INSERT INTO `mob_groups` VALUES (12,5417,36,'Selhteus',0,128,0,0,0,75,75,1); -- ally
+INSERT INTO `mob_groups` VALUES (11,3199,36,'Prishe',0,128,0,2200,0,75,75,0); -- ally
+INSERT INTO `mob_groups` VALUES (12,5417,36,'Selhteus',0,128,0,0,0,75,75,0); -- ally
 
 -- ------------------------------------------------------------
 -- Temenos (Zone 37)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed an issue where Prishe and Selhteus would sometimes not appear during the battlefield: "Dawn". (Abdiah)

## What does this pull request do? (Please be technical)
I believe the issue stems from BCNMs and instances having issues spawning mobs in with the player allegiance. In my findings with assaults, it worked consistently when switching the allegiance after the mob has spawned.

## Steps to test these changes
Do the Dawn battlefield in Empyreal Paradox
