### PR TITLE
Fix pet enmity loss on auto attacks and leaving

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2216,12 +2216,22 @@ namespace battleutils
                     {
                         ((CPetEntity*)PDefender)
                             ->loc.zone->UpdateEntityPacket(PDefender, ENTITY_UPDATE, UPDATE_COMBAT);
-                    }
 
+                        if (PAttacker->objtype == TYPE_MOB)
+                        {
+                            // charmed mob should lose enmity from normal attacks
+                            ((CMobEntity*)PAttacker)->PEnmityContainer->UpdateEnmityFromAttack(PDefender, damage);
+                        }
+                    }
                     break;
 
                 case TYPE_PET:
                     ((CPetEntity*)PDefender)->loc.zone->UpdateEntityPacket(PDefender, ENTITY_UPDATE, UPDATE_COMBAT);
+                    if (PAttacker->objtype == TYPE_MOB)
+                    {
+                        // pets should lose enmity from normal attacks
+                        ((CMobEntity*)PAttacker)->PEnmityContainer->UpdateEnmityFromAttack(PDefender, damage);
+                    }
                     break;
                 case TYPE_PC:
                     if (PAttacker->objtype == TYPE_MOB)

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -53,6 +53,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../ai/states/ability_state.h"
 
 #include "../mob_modifier.h"
+#include "../notoriety_container.h"
 #include "../packets/char_abilities.h"
 #include "../packets/char_sync.h"
 #include "../packets/char_update.h"
@@ -1555,6 +1556,25 @@ namespace petutils
             PMob->PMaster    = nullptr;
 
             PMob->PAI->SetController(std::make_unique<CMobController>(PMob));
+
+            // clear all enmity towards a charmed mob when it is released
+            // use two loops to avoid modifying the container while iterating over it
+            auto&                  notorietyContainer = PMob->PNotorietyContainer;
+            std::list<CMobEntity*> mobsToPacify;
+
+            // first collect the mobs with hate towards the formerly charmed mob
+            for (auto* entityWithEnmity : *notorietyContainer)
+            {
+                if (entityWithEnmity->objtype == TYPE_MOB)
+                {
+                    mobsToPacify.push_back(static_cast<CMobEntity*>(entityWithEnmity));
+                }
+            }
+            // then remove the formerly charmed mob from those mobs enmity containers
+            for (auto* mobToPacify : mobsToPacify)
+            {
+                mobToPacify->PEnmityContainer->Clear(PMob->id);
+            }
         }
         else if (PPet->objtype == TYPE_PET)
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Pets now lose some enmity when taking damage from normal attacks (similar to players). (Tracent)

When charmed monsters become uncharmed they now lose enmity from other all monsters (for example including the monsters the charmed mob was fighting). (Tracent) (maybe exclude from notes if too technical for players)

## What does this pull request do? (Please be technical)
The PR fixes an issue whereby pets were not losing enmity from auto attacks due to a missing function call. Looking at the code history through git blame the code evolved significantly and was reorganized such that easy to miss such a call. Additionally the PR fixes an issue wherein when charmed mobs become uncharmed they were not being removed from the enmity lists of other mobs.

## Steps to test these changes
Fight with pets and check CE by targeting mob and using the following command
!exec player:PrintToPlayer(target:getCE(player:getPet()))

Fight with a charmed mob against another mob then leave and then recharm. The aggressive mob should go right after the player (not the recharmed mob) since the enmity list of the aggressive mob no longer has the charmed mob.

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1555
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
