### PR TITLE
Immersion updates (QSC weighted doors, fog in Al'Taieu, dust cloud in gusgen mines doors)

### DIFF
--- a/scripts/zones/AlTaieu/Zone.lua
+++ b/scripts/zones/AlTaieu/Zone.lua
@@ -33,4 +33,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option)
 end
 
+zoneObject.afterZoneIn = function(player)
+    player:entityVisualPacket("on00", player) -- Fog effect on zone in
+end
+
 return zoneObject

--- a/scripts/zones/Gusgen_Mines/npcs/_5ga.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5ga.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 6):setAnimation(8) --open door C (_5g0)
-        GetNPCByID(lever - 5):setAnimation(9) --close door B (_5g1)
-        GetNPCByID(lever - 4):setAnimation(9) --close door A (_5g2)
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 6):setAnimation(8) --open door C (_5g0)
+            GetNPCByID(lever - 5):setAnimation(9) --close door B (_5g1)
+            GetNPCByID(lever - 4):setAnimation(9) --close door A (_5g2)
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Gusgen_Mines/npcs/_5gb.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5gb.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 7):setAnimation(9) --close door C
-        GetNPCByID(lever - 6):setAnimation(8) --open door B
-        GetNPCByID(lever - 5):setAnimation(9) --close door A
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 7):setAnimation(9) --close door C
+            GetNPCByID(lever - 6):setAnimation(8) --open door B
+            GetNPCByID(lever - 5):setAnimation(9) --close door A
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Gusgen_Mines/npcs/_5gc.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5gc.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 8):setAnimation(9) -- close door C
-        GetNPCByID(lever - 7):setAnimation(9) -- close door B
-        GetNPCByID(lever - 6):setAnimation(8) -- open door A
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 8):setAnimation(9) -- close door C
+            GetNPCByID(lever - 7):setAnimation(9) -- close door B
+            GetNPCByID(lever - 6):setAnimation(8) -- open door A
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Gusgen_Mines/npcs/_5gd.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5gd.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 6):setAnimation(8) -- open door F
-        GetNPCByID(lever - 5):setAnimation(9) -- close door E
-        GetNPCByID(lever - 4):setAnimation(9) -- close door D
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 6):setAnimation(8) -- open door F
+            GetNPCByID(lever - 5):setAnimation(9) -- close door E
+            GetNPCByID(lever - 4):setAnimation(9) -- close door D
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Gusgen_Mines/npcs/_5ge.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5ge.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 7):setAnimation(9) -- close door F
-        GetNPCByID(lever - 6):setAnimation(8) -- open door E
-        GetNPCByID(lever - 5):setAnimation(9) -- close door D
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 7):setAnimation(9) -- close door F
+            GetNPCByID(lever - 6):setAnimation(8) -- open door E
+            GetNPCByID(lever - 5):setAnimation(9) -- close door D
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Gusgen_Mines/npcs/_5gf.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5gf.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 8):setAnimation(9) -- close door F
-        GetNPCByID(lever - 7):setAnimation(9) -- close door E
-        GetNPCByID(lever - 6):setAnimation(8) -- open door D
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 8):setAnimation(9) -- close door F
+            GetNPCByID(lever - 7):setAnimation(9) -- close door E
+            GetNPCByID(lever - 6):setAnimation(8) -- open door D
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Quicksand_Caves/Zone.lua
+++ b/scripts/zones/Quicksand_Caves/Zone.lua
@@ -22,9 +22,9 @@ zoneObject.onInitialize = function(zone)
     zone:registerTriggerArea(13, -820, 5, -380, 0, 0, 0)
     zone:registerTriggerArea(15, -260, 5, 740, 0, 0, 0)
     zone:registerTriggerArea(17, -340, 5, 660, 0, 0, 0)
-    zone:registerTriggerArea(19, -420, 5, 740, 0, 0, 0)
-    zone:registerTriggerArea(21, -340, 5, 820, 0, 0, 0)
-    zone:registerTriggerArea(23, -409, 5, 800, 0, 0, 0)
+    zone:registerTriggerArea(19, -340, 5, 820, 0, 0, 0)
+    zone:registerTriggerArea(21, -409, 5, 800, 0, 0, 0)
+    zone:registerTriggerArea(23, -420, 5, 740, 0, 0, 0)
     zone:registerTriggerArea(25, -400, 5, 670, 0, 0, 0)
 
     -- Hole in the Sand
@@ -64,7 +64,7 @@ end
 local function getWeight(player)
     local race = player:getRace()
 
-    if race == xi.race.GALKA then
+    if race == xi.race.GALKA or player:hasKeyItem(xi.ki.LOADSTONE) then
         return 3
     elseif race == xi.race.TARU_M or race == xi.race.TARU_F then
         return 1
@@ -77,7 +77,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     local triggerAreaID = triggerArea:GetTriggerAreaID()
 
     -- holes in the sand
-    if triggerAreaID >= 30 then
+    if player and triggerAreaID >= 30 then
         switch (triggerAreaID): caseof
         {
             [30] = function()
@@ -107,12 +107,34 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
         local plate = GetNPCByID(ID.npc.ORNATE_DOOR_OFFSET + triggerAreaID)
 
         local totalWeight = plate:getLocalVar("weight")
-        totalWeight = totalWeight + getWeight(player)
-        plate:setLocalVar("weight", totalWeight)
+        if player then
+            totalWeight = totalWeight + getWeight(player)
+            plate:setLocalVar("weight", totalWeight)
+        end
 
-        if player:hasKeyItem(xi.ki.LOADSTONE) or totalWeight >= 3 then
-            door:openDoor(15) -- open door with a 15 second time delay.
-            plate:setAnimation(xi.anim.OPEN_DOOR) -- this is supposed to light up the platform but it's not working. Tried other values too.
+        if
+            totalWeight >= 3 and
+            plate:getLocalVar("opening") == 0 and
+            door:getAnimation() == xi.anim.CLOSE_DOOR
+        then
+            SendEntityVisualPacket(plate:getID(), "unlc") -- Play the light animation
+            plate:setLocalVar("opening", 1)
+
+            -- wait 5 seconds to open the door
+            door:timer(5000, function(doorArg)
+                doorArg:openDoor(10) -- open door with a 10 second time delay.
+            end)
+
+            -- allow door to retrigger 17 seconds from now
+            plate:timer(17000, function(plateArg)
+                plateArg:setLocalVar("opening", 0)
+
+                -- retrigger if weight is still enough to do so
+                if plateArg:getLocalVar("weight") >= 3 then
+                    -- retrigger, with nil as player arg, player is not necessary to re-open the door if weight is >= 3.
+                    zoneObject.onTriggerAreaEnter(nil, triggerArea)
+                end
+            end)
         end
     end
 end
@@ -121,16 +143,11 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     local triggerAreaID = triggerArea:GetTriggerAreaID()
 
     if triggerAreaID < 30 then
-        -- local door = GetNPCByID(ID.npc.ORNATE_DOOR_OFFSET + triggerAreaID - 1)
         local plate = GetNPCByID(ID.npc.ORNATE_DOOR_OFFSET + triggerAreaID)
 
         local totalWeight = plate:getLocalVar("weight")
         totalWeight = totalWeight - getWeight(player)
         plate:setLocalVar("weight", totalWeight)
-
-        if plate:getAnimation() == xi.anim.OPEN_DOOR and totalWeight < 3 then
-            plate:setAnimation(xi.anim.CLOSE_DOOR)
-        end
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

The weighted doors in Quicksand Caves now play their animations and have correct timings. (Wintersolstice)
Al'Taieu's retail fog effect has been implemented. (Wintersolstice)
The levered doors in Gusgen Mines now have their correct timings and a previously missing dust cloud effect. (Wintersolstice)

## What does this pull request do? (Please be technical)

See player-facing descriptions

## Steps to test these changes

Open levered door in Gusgen mines, see a slight delay to the door opening and a dust cloud effect.
Go into Sea and notice a fog effect that appears shortly after zoning in.
Use the weighted doors in QSC and see their animations + timings + retriggering if you stand on the weighted trigger with enough weight.

## Special Deployment Considerations

N/A