### PR TITLE
[core] Fix pet weapon auto attack damage to use pre-calculated values

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -415,7 +415,7 @@ int16 CBattleEntity::GetAmmoDelay()
 uint16 CBattleEntity::GetMainWeaponDmg()
 {
     TracyZoneScoped;
-    if (objtype == TYPE_PET || objtype == TYPE_MOB)
+    if ((objtype == TYPE_PET && static_cast<CPetEntity*>(this)->getPetType() == PET_TYPE::JUG_PET) || objtype == TYPE_MOB)
     {
         return mobutils::GetWeaponDamage(static_cast<CMobEntity*>(this), SLOT_MAIN);
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Avatar, Automaton and Wyvern auto attack base weapon damage has been corrected. (Wintersolstice)

## What does this pull request do? (Please be technical)

This will fix auto attack weapon damage from Wyverns, Avatars and Automatons. Jug pets are unaffected as well as avatar BPs. The values were being calculated in petutils.cpp but went unused.

## Steps to test these changes
At level 75:

Summon a wyvern or carbuncle/caitsith, `!exec player:PrintToPlayer(tostring(player:getPet():getWeaponDmg()))` should return 40
Summon any other avatar, `!exec player:PrintToPlayer(tostring(player:getPet():getWeaponDmg()))` should return 47
Jugpets should still be level-3~ (barring AF2 gloves stuff)

## Special Deployment Considerations
N/A