### PR TITLE
Fixes King Vinegarroon Spawning During any weather

### DIFF
--- a/scripts/zones/Western_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Western_Altepa_Desert/Zone.lua
@@ -17,8 +17,13 @@ zoneObject.onChocoboDig = function(player, precheck)
 end
 
 zoneObject.onInitialize = function(zone)
-    -- NM Persistence
-    xi.mob.nmTODPersistCache(zone, ID.mob.KING_VINEGARROON)
+    -- KV Persistence
+    UpdateNMSpawnPoint(ID.mob.KING_VINEGARROON)
+    DisallowRespawn(GetMobByID(ID.mob.KING_VINEGARROON):getID(), true)
+
+    if os.time() < GetServerVariable("\\[SPAWN\\]17289575") then
+        GetMobByID(ID.mob.KING_VINEGARROON):setRespawnTime(GetServerVariable("\\[SPAWN\\]17289575") - os.time())
+    end
 
     xi.bmt.updatePeddlestox(xi.zone.YUHTUNGA_JUNGLE, ID.npc.PEDDLESTOX)
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Fixes an issue where King Vinegarroon would spawn outside its weather and reset its cooldown (Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Fixes an issue where King Vinegarroon would spawn outside its weather and reset its cooldown 

The nmPersistCache function was resetting its spawn time and forcing it pop after a server crash/reset.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Set KV respawn time to desired time check (one minute)
Kill KV
Check server var for "[SPAWN]17289575" to make sure it saved for 1 min
Crash/restart server
If there is no weather KV should NOT spawn and despawn instantly.

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
