### PR TITLE
Adds tandem strike via mod

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1034,6 +1034,13 @@ xi.magic.getMagicHitRate = function(caster, target, skillType, element, effect, 
         xi.msg.debugValue(caster, "Skillchain Bonus Magic Accuracy", magicacc)
     end
 
+    -- Apply bonus macc from TandemStrike
+    local tandemBonus = xi.magic.handleTandemStrikeBonus(caster)
+    if tandemBonus > 0 then
+        magicacc = magicacc + tandemBonus
+        xi.msg.debugValue(caster, "Tandem Strike Magic Accuracy Bonus", magicacc)
+    end
+
     magicacc = magicacc + bonusAcc
 
     -- Add macc% from food
@@ -2220,4 +2227,21 @@ xi.magic.calculateMEVAMult = function(tier)
     end
 
     return eemVal
+end
+
+xi.magic.handleTandemStrikeBonus = function(caster)
+    if
+        caster:getMod(xi.mod.TANDEM_STRIKE) > 0 and
+        caster:isTandemValid()
+    then
+        return caster:getMod(xi.mod.TANDEM_STRIKE)
+    elseif
+        (caster:getMaster() ~= nil and
+        caster:getMaster():getMod(xi.mod.TANDEM_STRIKE) > 0) and
+        caster:isTandemValid()
+    then
+        return caster:getMaster():getMod(xi.mod.TANDEM_STRIKE)
+    end
+
+    return 0
 end

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -560,6 +560,13 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
         xi.msg.debugValue(caster, "Skillchain Bonus Magic Accuracy", magicAcc)
     end
 
+    -- Apply bonus macc from TandemStrike
+    local tandemBonus = xi.magic.handleTandemStrikeBonus(caster)
+    if tandemBonus > 0 then
+        magicAcc = magicAcc + tandemBonus
+        xi.msg.debugValue(caster, "Tandem Strike Magic Accuracy Bonus", magicAcc)
+    end
+
     -----------------------------------
     -- magicAcc from Job Points.
     -----------------------------------

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1842,6 +1842,10 @@ xi.mod =
     VIRUS_MEVA                    = 1176, -- Virus MEVA from Barspells
     PETRIFY_MEVA                  = 1177, -- Petrify MEVA from Barspells
 
+    -- New ASB section created per PR comment, starting at 2000
+    TANDEM_STRIKE = 2000, -- Beastmaster trait - provides acc/macc to master and pet when both engage the same target
+    TANDEM_BLOW   = 2001, -- Beastmaster trait - provides subtle blow to master and pet when both engage the same target
+
     -- IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN src/map/modifier.h ASWELL!
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12023,6 +12023,18 @@ void CLuaBaseEntity::uncharm()
 }
 
 /************************************************************************
+ *  Function: isTandemValid()
+ *  Purpose : checks if the entity satifies all conditions of tandem
+ *  Example : player:isTandemValid()
+ *  Notes   : for tandem strike and tandem blow
+ ************************************************************************/
+
+bool CLuaBaseEntity::isTandemValid()
+{
+    return battleutils::IsTandemValid(static_cast<CBattleEntity*>(m_PBaseEntity));
+}
+
+/************************************************************************
  *  Function: addBurden()
  *  Purpose : Adds a Burden to a Target
  *  Example : local overload = target:addBurden(xi.magic.ele.EARTH - 1, burden)
@@ -17031,6 +17043,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("charm", CLuaBaseEntity::charm);
     SOL_REGISTER("charmDuration", CLuaBaseEntity::charmDuration);
     SOL_REGISTER("uncharm", CLuaBaseEntity::uncharm);
+    SOL_REGISTER("isTandemValid", CLuaBaseEntity::isTandemValid);
 
     // PUP
     SOL_REGISTER("addBurden", CLuaBaseEntity::addBurden);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -660,6 +660,7 @@ public:
     void charm(CLuaBaseEntity const* target);                          // applies charm on target
     void charmDuration(CLuaBaseEntity const* target, uint32 duration); // applies charm on target for duration
     void uncharm();                                                    // removes charm on target
+    bool isTandemValid();                                              // verifies that the entity satifies all tandem conditions for tandem blow and tandem strike
 
     uint8 addBurden(uint8 element, uint8 burden);
     uint8 getOverloadChance(uint8 element);

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
   Copyright (c) 2010-2015 Darkstar Dev Teams
   This program is free software: you can redistribute it and/or modify
@@ -970,6 +970,10 @@ enum class Mod
     SILENCE_MEVA           = 1175, // Silence MEVA from Barspells
     VIRUS_MEVA             = 1176, // Virus MEVA from Barspells
     PETRIFY_MEVA           = 1177, // Petrify MEVA from Barspells
+
+    // Per PR comment - New ASB section starting at 2000
+    TANDEM_STRIKE = 2000, // Beastmaster trait - provides acc/macc to master and pet when both engage the same target
+    TANDEM_BLOW   = 2001, // Beastmaster trait - provides subtle blow to master and pet when both engage the same target
 
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/globals/status.lua ASWELL!
 

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -140,6 +140,7 @@ namespace battleutils
     bool IsParalyzed(CBattleEntity* PAttacker);
     bool IsAbsorbByShadow(CBattleEntity* PDefender, CBattleEntity* PAttacker);
     bool IsIntimidated(CBattleEntity* PAttacker, CBattleEntity* PDefender);
+    bool IsTandemValid(CBattleEntity* PAttacker);
 
     int32 GetFSTR(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 SlotID);
     uint8 GetHitRateEx(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber, int8 offsetAccuracy);


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Enables the use of Mod `TANDEM_STRIKE`.
No gameplay changes as current traits and equipment will not apply this mod.

## What does this pull request do? (Please be technical)

Adds Mod 74 and 75.  Tandem Strike and Blow.
Implements core logic to apply acc and macc bonuses when the tandem condition is met.
Note: these values are not visible on checkparam per retail testing - so they must be calculated and added in when applied.
Note2: This does not introduce the actual trait tandem strike yet

## Steps to test these changes
This is fun to test.
Add mod 74 or TANDEM_STRIKE to the player - use a high value.
Make the player weak (say level 30)
Fight a much higher level mob and track if the acc applies
The acc will not apply via checkparam

Do the same for the pet.
Do the same for pet magical abilities like roar

For player magic sub blm or rdm, use the magic debug mod and cast nukes and enfeebles
Swap to sword or scythe and use an elemental or hybrid ws.

## Special Deployment Considerations

None
