### PR TITLE
Adds nation param to THF AF3.

### DIFF
--- a/scripts/quests/windurst/Hitting_the_Marquisate.lua
+++ b/scripts/quests/windurst/Hitting_the_Marquisate.lua
@@ -180,7 +180,7 @@ quest.sections =
                         npcUtil.tradeHasExactly(trade, xi.items.PICKAXE) and
                         quest:getVar(player, 'nanaaProg') == 1
                     then
-                        return quest:progressEvent(119, 0, xi.items.ROGUES_POULAINES, 0, xi.items.PICKAXE)
+                        return quest:progressEvent(119, 0, xi.items.ROGUES_POULAINES, player:getNation(), xi.items.PICKAXE)
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

The CS for THF AF3 will now correctly identify the player's nation of allegience.

## What does this pull request do? (Please be technical)
Adds player:getNation() to the correct param for the CS

## Steps to test these changes
Run Thf AF3 up to the CS

## Special Deployment Considerations
None

## Notes
We still need a capture of someone investigating the ??? which you trade the pickaxe to in the following scenarios:
- without the quest active
- multiple times with the quest active ready to trade the pick axe
- after completing the quest

This is the section of the client where thf af3 strings live.
From [this video](https://ffxiclopedia.fandom.com/wiki/Hitting_the_Marquisate/Plot_Details?file=%C2%ABFFXI-Movie%C2%BB_0110_THF_3_-_Hitting_the_Marquisate) I can see that 7499 and 7500 are used in the CS.
I believe I remember 7498 preceeding the CS - but its been years.
I assume 7494 is the default
7495 is on first examine
7496 on second examine - providing pickaxe item id to param 3
7497 is likely post quest.
But need some confirmation
```
    <field name="index">7494</field>
    <field name="text">There is nothing out of the ordinary here.≺Prompt≻

    <field name="index">7495</field>
    <field name="text">Something about this patch of ground alerts your thief instincts.≺Prompt≻

    <field name="index">7496</field>
    <field name="text">You need ≺Possible Special Code: 01≻≺Possible Special Code: 01≻≺Possible Special Code: 01≻ 

    <field name="index">7497</field>
    <field name="text">There is nothing else of interest here.≺Prompt≻

    <field name="index">7498</field>
    <field name="text">(dig...dig...dig...dig)≺Prompt≻

    <field name="index">7499</field>
    <field name="text">You find an old chest!≺Prompt≻

    <field name="index">7500</field>
    <field name="text">However, your ≺Possible Special Code: 01≻≺Possible Special Code: 05≻#ｃ≺BAD CHAR: 80≻≺BAD CHAR: 80≻ breaks.≺Prompt≻
```