### PR TITLE
Magical portions of weaponskills will no longer miss

### DIFF
--- a/scripts/globals/abilities/pets/aerial_blast.lua
+++ b/scripts/globals/abilities/pets/aerial_blast.lua
@@ -25,7 +25,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.WIND
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/aero_ii.lua
+++ b/scripts/globals/abilities/pets/aero_ii.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.WIND
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/aero_iv.lua
+++ b/scripts/globals/abilities/pets/aero_iv.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.WIND
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/blizzard_ii.lua
+++ b/scripts/globals/abilities/pets/blizzard_ii.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.ICE
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/blizzard_iv.lua
+++ b/scripts/globals/abilities/pets/blizzard_iv.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.ICE
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/diamond_dust.lua
+++ b/scripts/globals/abilities/pets/diamond_dust.lua
@@ -26,7 +26,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.ICE
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/earthen_fury.lua
+++ b/scripts/globals/abilities/pets/earthen_fury.lua
@@ -26,7 +26,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.EARTH
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/fire_ii.lua
+++ b/scripts/globals/abilities/pets/fire_ii.lua
@@ -20,7 +20,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.FIRE
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/fire_iv.lua
+++ b/scripts/globals/abilities/pets/fire_iv.lua
@@ -20,7 +20,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.FIRE
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/geocrush.lua
+++ b/scripts/globals/abilities/pets/geocrush.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.EARTH
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     if summoner ~= nil and summoner:isPC() then
         params.tpBonus = summoner:getMerit(xi.merit.GEOCRUSH) -- This was changed to 400 tp/point in 2007. Original value was 320 tp/point

--- a/scripts/globals/abilities/pets/grand_fall.lua
+++ b/scripts/globals/abilities/pets/grand_fall.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.WATER
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     if summoner ~= nil and summoner:isPC() then
         params.tpBonus = summoner:getMerit(xi.merit.GRANDFALL) -- This was changed to 400 tp/point in 2007. Original value was 320 tp/point

--- a/scripts/globals/abilities/pets/heavenly_strike.lua
+++ b/scripts/globals/abilities/pets/heavenly_strike.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.ICE
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     if summoner ~= nil and summoner:isPC() then
         params.tpBonus = summoner:getMerit(xi.merit.HEAVENLY_STRIKE) -- This was changed to 400 tp/point in 2007. Original value was 320 tp/point

--- a/scripts/globals/abilities/pets/howling_moon.lua
+++ b/scripts/globals/abilities/pets/howling_moon.lua
@@ -25,7 +25,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.DARK
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/inferno.lua
+++ b/scripts/globals/abilities/pets/inferno.lua
@@ -25,7 +25,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.FIRE
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/judgment_bolt.lua
+++ b/scripts/globals/abilities/pets/judgment_bolt.lua
@@ -25,7 +25,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.LIGHTNING
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/meteor_strike.lua
+++ b/scripts/globals/abilities/pets/meteor_strike.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.FIRE
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     if summoner ~= nil and summoner:isPC() then
         params.tpBonus = summoner:getMerit(xi.merit.METEOR_STRIKE) -- This was changed to 400 tp/point in 2007. Original value was 320 tp/point

--- a/scripts/globals/abilities/pets/meteorite.lua
+++ b/scripts/globals/abilities/pets/meteorite.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.LIGHT
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     -- TODO: Need to increase ftp a little (roughly 5%)
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)

--- a/scripts/globals/abilities/pets/nether_blast.lua
+++ b/scripts/globals/abilities/pets/nether_blast.lua
@@ -21,7 +21,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.DARK
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
     params.breath = true
     params.netherBlast = true
 

--- a/scripts/globals/abilities/pets/ruinous_omen.lua
+++ b/scripts/globals/abilities/pets/ruinous_omen.lua
@@ -50,7 +50,7 @@ abilityobject.onPetAbility = function(target, pet, skill, summoner)
     params.includemab = true -- This does include magic bonuses
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
     params.omen = damage
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damageTable = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/searing_light.lua
+++ b/scripts/globals/abilities/pets/searing_light.lua
@@ -25,7 +25,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.LIGHT
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/somnolence.lua
+++ b/scripts/globals/abilities/pets/somnolence.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.DARK
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/stone_ii.lua
+++ b/scripts/globals/abilities/pets/stone_ii.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.EARTH
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/stone_iv.lua
+++ b/scripts/globals/abilities/pets/stone_iv.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.EARTH
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/thunder_ii.lua
+++ b/scripts/globals/abilities/pets/thunder_ii.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.LIGHTNING
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/thunder_iv.lua
+++ b/scripts/globals/abilities/pets/thunder_iv.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.LIGHTNING
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/thunderspark.lua
+++ b/scripts/globals/abilities/pets/thunderspark.lua
@@ -20,7 +20,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.LIGHTNING
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/thunderstorm.lua
+++ b/scripts/globals/abilities/pets/thunderstorm.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.LIGHTNING
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     if summoner ~= nil and summoner:isPC() then
         params.tpBonus = summoner:getMerit(xi.merit.THUNDERSTORM) -- This was changed to 400 tp/point in 2007. Original value was 320 tp/point

--- a/scripts/globals/abilities/pets/tidal_wave.lua
+++ b/scripts/globals/abilities/pets/tidal_wave.lua
@@ -25,7 +25,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     params.element = xi.magic.ele.WATER
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/water_ii.lua
+++ b/scripts/globals/abilities/pets/water_ii.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.WATER
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/water_iv.lua
+++ b/scripts/globals/abilities/pets/water_iv.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.WATER
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/abilities/pets/wind_blade.lua
+++ b/scripts/globals/abilities/pets/wind_blade.lua
@@ -19,7 +19,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     params.element = xi.magic.ele.WIND
     params.includemab = true
     params.maccBonus = xi.summon.getSummoningSkillOverCap(pet)
-    params.ignoreStateLock = true
+    params.damageSpell = true
 
     local damage = xi.summon.avatarMagicSkill(pet, target, skill, params)
 

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -844,14 +844,6 @@ xi.magic.applyAbilityResistance = function(player, target, params)
 
     local resist = xi.magic.getMagicResist(p, target, params.element, effectRes, skillchainCount, params.effect, player, utils.ternary(params.damageSpell, true, false))
 
-    if not params.ignoreStateLock then
-        if resist < 0.5 then
-            resist = 0
-        elseif resist < 1 then
-            resist = 0.5
-        end
-    end
-
     if
         params.effect and
         params.chance and
@@ -922,12 +914,12 @@ xi.magic.getMagicHitRate = function(caster, target, skillType, element, effect, 
         dStatAcc = -10 + (bonusDStat / 2)
     elseif dStat > -11 and dStat < 11 then
         dStatAcc = dStat
-    elseif dStat >= 11 then
-        bonusDStat = dStat - 10
-        dStatAcc = 10 + (bonusDStat / 2)
     elseif dStat >= 31 then
         bonusDStat = dStat - 30
         dStatAcc = 20 + (bonusDStat / 4)
+    elseif dStat >= 11 then
+        bonusDStat = dStat - 10
+        dStatAcc = 10 + (bonusDStat / 2)
     end
 
     xi.msg.debugValue(caster, "dStat", dStat)
@@ -1118,8 +1110,7 @@ xi.magic.getMagicResist = function(magicHitRate, target, element, effectRes, ski
         eighthTrigger = true
     end
 
-    -- There are no quarter triggers for players vs mobs (If the target is a player then set to true if conditions are met)
-    if resTriggerPoints[2] and damageSpell and target:isPC() then
+    if resTriggerPoints[2] and damageSpell then
         quarterTrigger = true
     end
 

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -337,6 +337,7 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, f
                 local ftpHybrid = xi.weaponskills.fTP(calcParams.tp, wsParams.ftp100, wsParams.ftp200, wsParams.ftp300) + calcParams.bonusfTP
                 local magicdmg = finaldmg * ftpHybrid
 
+                wsParams.damageSpell = true
                 wsParams.bonus = calcParams.bonusAcc
                 magicdmg = magicdmg * xi.magic.applyAbilityResistance(attacker, target, wsParams)
                 magicdmg = target:magicDmgTaken(magicdmg, wsParams.ele)
@@ -858,6 +859,8 @@ end
 --         ele (xi.magic.ele.FIRE), skill (xi.skill.STAFF)
 
 xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, tp, action, primaryMsg)
+    -- Magical WSs do not resist to 0
+    wsParams.damageSpell = true
     -- Set up conditions and wsParams used for calculating weaponskill damage
     local attack =
     {


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Magical weaponskills and the magical portion of hybrid weaponskills will no longer 100% resist.
The worst case scenario will be a full resist (1/8th)

## What does this pull request do? (Please be technical)

applies the ignoreStateLock flag to magical and hybrid weaponskills

## Steps to test these changes
Toss on a staff
Find an IT
Give yourself regain
Spam earth crusher
_dont_ get 0s

## Special Deployment Considerations
None

Resolves most of https://github.com/HorizonFFXI/HorizonXI-Issues/issues/709
