### PR TITLE
Function: sendMobEmote 

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -16143,6 +16143,48 @@ void CLuaBaseEntity::sendNpcEmote(CLuaBaseEntity* PBaseEntity, sol::object const
     }
 }
 
+/************************************************************************
+*  Function: sendMobEmote()
+*  Purpose : Makes a mob entity emit an emote.
+*  Example : mob:sendMobEmote(target, xi.emote.PANIC, xi.emoteMode.MOTION)
+*  Notes   : Intended only for humanoid mobs that have the
+             same skeletal meshes for animations as players; such as fomor
+************************************************************************/
+
+void CLuaBaseEntity::sendMobEmote(CLuaBaseEntity* PBaseEntity, sol::object const& p0, sol::object const& p1, sol::object const& p2)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+
+    // 1st parameter is optional
+    XI_DEBUG_BREAK_IF(p0 == sol::lua_nil);
+    XI_DEBUG_BREAK_IF(p1 == sol::lua_nil);
+    // 4th parameter is optional
+
+    CMobEntity* PMob        = dynamic_cast<CMobEntity*>(m_PBaseEntity);
+    uint32      EntityId    = 0;
+    uint16      EntityIndex = 0;
+
+    if (PBaseEntity != nullptr)
+    {
+        EntityId    = PBaseEntity->getID();
+        EntityIndex = PBaseEntity->getTargID();
+    }
+
+    uint16 emoteId     = (p0 != sol::lua_nil) ? p0.as<uint16>() : 0;
+    uint16 emoteModeId = (p1 != sol::lua_nil) ? p1.as<uint16>() : 0;
+    uint16 extra       = (p2 != sol::lua_nil) ? p2.as<uint32>() : 0;
+
+    if (PMob)
+    {
+        const Emote     emoteID   = static_cast<Emote>(emoteId);
+        const EmoteMode emoteMode = static_cast<EmoteMode>(emoteModeId);
+
+        PMob->loc.zone->PushPacket(PMob, CHAR_INRANGE,
+                                   new CCharEmotionPacket(PMob, EntityId, EntityIndex, emoteID, emoteMode, extra));
+    }
+}
+
 void CLuaBaseEntity::setDigTable()
 {
     if (m_PBaseEntity != nullptr && m_PBaseEntity->objtype == TYPE_PC)
@@ -17269,6 +17311,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("clearSession", CLuaBaseEntity::clearSession);
     SOL_REGISTER("setSpawnType", CLuaBaseEntity::setSpawnType);
     SOL_REGISTER("sendNpcEmote", CLuaBaseEntity::sendNpcEmote);
+    SOL_REGISTER("sendMobEmote", CLuaBaseEntity::sendMobEmote);
     SOL_REGISTER("restoreNpcLook", CLuaBaseEntity::restoreNpcLook);
     SOL_REGISTER("getTraits", CLuaBaseEntity::getTraits);
     SOL_REGISTER("clearActionQueue", CLuaBaseEntity::clearActionQueue);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -905,6 +905,7 @@ public:
     uint32 getWorldPassRedeemTime();
     uint32 getWorldpassId(uint32 targid);
     void   sendNpcEmote(CLuaBaseEntity* PBaseEntity, sol::object const& p0, sol::object const& p1, sol::object const& p2);
+    void   sendMobEmote(CLuaBaseEntity* PBaseEntity, sol::object const& p0, sol::object const& p1, sol::object const& p2);
     void   clearActionQueue();
     void   clearTimerQueue();
     void   setDigTable();               // Sets PChar Last Dig Table

--- a/src/map/packets/char_emotion.cpp
+++ b/src/map/packets/char_emotion.cpp
@@ -116,3 +116,37 @@ CCharEmotionPacket::CCharEmotionPacket(CNpcEntity* PNpc, uint32 TargetID, uint16
 
     ref<uint8>(0x16) = static_cast<uint8>(emoteMode);
 }
+
+CCharEmotionPacket::CCharEmotionPacket(CMobEntity* PMob, uint32 TargetID, uint16 TargetIndex, Emote EmoteID, EmoteMode emoteMode, uint16 extra)
+{
+    this->setType(0x5A);
+    this->setSize(0x70);
+
+    ref<uint32>(0x04) = PMob->id;
+    ref<uint32>(0x08) = TargetID;
+    ref<uint16>(0x0C) = PMob->targid;
+    ref<uint16>(0x0E) = TargetIndex;
+    ref<uint8>(0x10)  = EmoteID == Emote::JOB ? static_cast<uint8>(EmoteID) + (extra - 0x1F) : static_cast<uint8>(EmoteID);
+
+    if (EmoteID == Emote::SALUTE)
+    {
+        ref<uint16>(0x12) = extra;
+    }
+    else if (EmoteID == Emote::HURRAY)
+    {
+        ref<uint16>(0x12) = extra;
+    }
+    else if (EmoteID == Emote::BELL)
+    {
+        // No emote text for /bell
+        emoteMode = EmoteMode::MOTION;
+
+        ref<uint8>(0x12) = (extra - 0x06);
+    }
+    else if (EmoteID == Emote::JOB)
+    {
+        ref<uint8>(0x12) = (extra - 0x1F);
+    }
+
+    ref<uint8>(0x16) = static_cast<uint8>(emoteMode);
+}

--- a/src/map/packets/char_emotion.h
+++ b/src/map/packets/char_emotion.h
@@ -90,12 +90,14 @@ enum class EmoteMode : uint8
 
 class CCharEntity;
 class CNpcEntity;
+class CMobEntity;
 
 class CCharEmotionPacket : public CBasicPacket
 {
 public:
     CCharEmotionPacket(CCharEntity* PChar, uint32 TargetID, uint16 TargetIndex, Emote EmoteID, EmoteMode emoteMode, uint16 extra);
     CCharEmotionPacket(CNpcEntity* PNpc, uint32 TargetID, uint16 TargetIndex, Emote EmoteID, EmoteMode emoteMode, uint16 extra);
+    CCharEmotionPacket(CMobEntity* PMob, uint32 TargetID, uint16 TargetIndex, Emote EmoteID, EmoteMode emoteMode, uint16 extra);
 };
 
 #endif


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do? (Please be technical)
- Adds a function that allows mobs to use emotes. This function is only intended for mobs with the same skeletal meshes for animations as players.
- Upon testing no errors occur when using it on unintended mobs and only appears to work for humanoid mobs

## Steps to test these changes
!exec target:sendMobEmote(target, 41, 2) will make a humanoid mob use a pickaxe animation
it behaves siimilarily to sendEmote and sendNPCEmote

## Special Deployment Considerations
Don't forget to rebuild when testing changes
