### PR TITLE
[lua] Adjust scaling for physical SDT in damage.lua

### DIFF
--- a/scripts/globals/damage.lua
+++ b/scripts/globals/damage.lua
@@ -80,7 +80,7 @@ xi.damage.returnDamageTakenMod = function(target, attackType, damageType)
         dmgMods[damageType] <= xi.mod.HTH_SDT and
         dmgMods[damageType] >= xi.mod.SLASH_SDT
     then
-        dmgTakenMod = dmgTakenMod + ((target:getMod(dmgMods[damageType]) - 1000) / 10000)
+        dmgTakenMod = dmgTakenMod * ((target:getMod(dmgMods[damageType])) / 1000)
     elseif damageType and dmgMods[damageType] then -- This is for elemental SDTs only
         dmgTakenMod = dmgTakenMod + (target:getMod(dmgMods[damageType]) / 10000)
     end


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Mob TP moves and jug pet TP moves now properly scale with Blunt/Slashing/Piercing resistance/weakness.

## What does this pull request do? (Please be technical)

This fixes mob/jugpet TP moves to have proper damage reduction, physical SDT scaling starts at 1000 by default as 1.0.

## Steps to test these changes

Fight Jailer of Temperance with any jugpet, have temperance take 0 damage when previously it would not.

## Special Deployment Considerations

Find more ways to nerf BST
