### PR TITLE
[core] Add some safety to Treasure Pool/Party/Alliance

### DIFF
--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -80,31 +80,15 @@ void CAlliance::dissolveAlliance(bool playerInitiated)
                         WHERE allianceid = %u AND IF(%u = 0 AND %u = 0, true, server_addr = %u AND server_port = %u);",
                    ALLIANCE_LEADER | PARTY_SECOND | PARTY_THIRD, m_AllianceID, map_ip.s_addr, map_port, map_ip.s_addr, map_port);
 
-        // first kick out the third party if it exsists
-        CParty* party = nullptr;
-        if (this->partyList.size() == 3)
+        // Remove all parties. The `delParty` call removes a party from `partyList`.
+        while (partyList.size() > 0)
         {
-            party = this->partyList.at(2);
+            CParty* party = partyList.at(0);
             this->delParty(party);
             party->ReloadParty();
         }
 
-        // kick out the second party
-        if (this->partyList.size() == 2)
-        {
-            party = this->partyList.at(1);
-            this->delParty(party);
-            party->ReloadParty();
-        }
-
-        // kick out the first party
-        if (this->partyList.size() == 1)
-        {
-            party              = this->partyList.at(0);
-            party->m_PAlliance = nullptr;
-            party->ReloadParty();
-        }
-
+        // Clear the party list -- deletion of parties is handled elsewhere if applicable.
         this->partyList.clear();
 
         // TODO: This entire system needs rewriting to both:
@@ -195,9 +179,12 @@ void CAlliance::delParty(CParty* party)
     }
 
     // Delete the party from the alliance list
-    party->m_PAlliance->partyList.erase(
-        std::remove_if(party->m_PAlliance->partyList.begin(), party->m_PAlliance->partyList.end(), [=](CParty* entry)
-                       { return party == entry; }));
+    auto partyToDelete = std::find(party->m_PAlliance->partyList.begin(), party->m_PAlliance->partyList.end(), party);
+
+    if (partyToDelete != party->m_PAlliance->partyList.end())
+    {
+        party->m_PAlliance->partyList.erase(partyToDelete);
+    }
 
     for (auto* entry : party->m_PAlliance->partyList)
     {
@@ -228,6 +215,11 @@ void CAlliance::delParty(CParty* party)
             return;
         }
 
+        if (PChar->PTreasurePool && PChar->PTreasurePool->GetPoolType() == TREASUREPOOL_ZONE)
+        {
+            return;
+        }
+
         PChar->PTreasurePool = new CTreasurePool(TREASUREPOOL_PARTY);
         PChar->PTreasurePool->AddMember(PChar);
         PChar->PTreasurePool->UpdatePool(PChar);
@@ -247,7 +239,20 @@ void CAlliance::delParty(CParty* party)
 
 void CAlliance::addParty(CParty* party)
 {
+    if (std::find(partyList.begin(), partyList.end(), party) != partyList.end())
+    {
+        ShowWarning("CAlliance::addParty - party is already in the alliance list!");
+        return;
+    }
+
+    if (partyList.size() == 3)
+    {
+        ShowWarning("CAlliance::addParty - Alliance party list was full when trying to add a party.");
+        return;
+    }
+
     party->m_PAlliance = this;
+
     partyList.push_back(party);
 
     uint8 newparty = 0;

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -270,70 +270,65 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
     }
     else
     {
-        for (uint32 i = 0; i < members.size(); ++i)
+        auto memberToDelete = std::find(members.begin(), members.end(), PEntity);
+
+        if (memberToDelete != members.end())
         {
-            if (PEntity == members.at(i))
+            if (m_PartyType == PARTY_PCS && PEntity->objtype == TYPE_PC)
             {
-                members.erase(members.begin() + i);
+                CCharEntity* PChar = static_cast<CCharEntity*>(PEntity);
 
-                if (m_PartyType == PARTY_PCS)
+                if (m_PQuarterMaster == PChar)
                 {
-                    CCharEntity* PChar = dynamic_cast<CCharEntity*>(PEntity);
-                    if (PChar)
+                    SetQuarterMaster("");
+                }
+                if (m_PSyncTarget == PChar)
+                {
+                    SetSyncTarget("", 553);
+                    CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
+                    if (sync && sync->GetDuration() == 0)
                     {
-                        if (m_PQuarterMaster == PChar)
+                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                        sync->SetStartTime(server_clock::now());
+                        sync->SetDuration(30000);
+                    }
+                    DisableSync();
+                }
+                if (m_PSyncTarget != nullptr && m_PSyncTarget != PChar)
+                {
+                    if (PChar->status != STATUS_TYPE::DISAPPEAR)
+                    {
+                        CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
+                        if (sync && sync->GetDuration() == 0)
                         {
-                            SetQuarterMaster("");
-                        }
-                        if (m_PSyncTarget == PChar)
-                        {
-                            SetSyncTarget("", 553);
-                            CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
-                            if (sync && sync->GetDuration() == 0)
-                            {
-                                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
-                                sync->SetStartTime(server_clock::now());
-                                sync->SetDuration(30000);
-                            }
-                            DisableSync();
-                        }
-                        if (m_PSyncTarget != nullptr && m_PSyncTarget != PChar)
-                        {
-                            if (PChar->status != STATUS_TYPE::DISAPPEAR)
-                            {
-                                CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
-                                if (sync && sync->GetDuration() == 0)
-                                {
-                                    PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
-                                    sync->SetStartTime(server_clock::now());
-                                    sync->SetDuration(30000);
-                                }
-                            }
-                        }
-                        PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
-
-                        PChar->pushPacket(new CPartyDefinePacket(nullptr));
-                        PChar->pushPacket(new CPartyMemberUpdatePacket(PChar, 0, 0, PChar->getZone()));
-                        PChar->pushPacket(new CCharUpdatePacket(PChar));
-                        PChar->PParty = nullptr;
-
-                        sql->Query("DELETE FROM accounts_parties WHERE charid = %u;", PChar->id);
-
-                        uint8 data[4]{};
-                        ref<uint32>(data, 0) = m_PartyID;
-                        message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
-
-                        if (PChar->PTreasurePool != nullptr && PChar->PTreasurePool->GetPoolType() != TREASUREPOOL_ZONE)
-                        {
-                            PChar->PTreasurePool->DelMember(PChar);
-                            PChar->PTreasurePool = new CTreasurePool(TREASUREPOOL_SOLO);
-                            PChar->PTreasurePool->AddMember(PChar);
-                            PChar->PTreasurePool->UpdatePool(PChar);
+                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                            sync->SetStartTime(server_clock::now());
+                            sync->SetDuration(30000);
                         }
                     }
                 }
-                break;
+                PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
+
+                PChar->pushPacket(new CPartyDefinePacket(nullptr));
+                PChar->pushPacket(new CPartyMemberUpdatePacket(PChar, 0, 0, PChar->getZone()));
+                PChar->pushPacket(new CCharUpdatePacket(PChar));
+                PChar->PParty = nullptr;
+
+                sql->Query("DELETE FROM accounts_parties WHERE charid = %u;", PChar->id);
+
+                uint8 data[4]{};
+                ref<uint32>(data, 0) = m_PartyID;
+                message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+
+                if (PChar->PTreasurePool != nullptr && PChar->PTreasurePool->GetPoolType() != TREASUREPOOL_ZONE)
+                {
+                    PChar->PTreasurePool->DelMember(PChar);
+                    PChar->PTreasurePool = new CTreasurePool(TREASUREPOOL_SOLO);
+                    PChar->PTreasurePool->AddMember(PChar);
+                    PChar->PTreasurePool->UpdatePool(PChar);
+                }
             }
+            members.erase(memberToDelete);
         }
     }
 }
@@ -355,23 +350,34 @@ void CParty::DelMember(CBattleEntity* PEntity)
     }
     else
     {
-        for (uint32 i = 0; i < members.size(); ++i)
+        auto memberToDelete = std::find(members.begin(), members.end(), PEntity);
+
+        if (memberToDelete != members.end())
         {
-            if (PEntity == members.at(i))
+            if (m_PartyType == PARTY_PCS && PEntity->objtype == TYPE_PC)
             {
-                members.erase(members.begin() + i);
+                CCharEntity* PChar = static_cast<CCharEntity*>(PEntity);
 
-                if (m_PartyType == PARTY_PCS)
+                if (m_PQuarterMaster == PChar)
                 {
-                    CCharEntity* PChar = (CCharEntity*)PEntity;
-
-                    if (m_PQuarterMaster == PChar)
+                    SetQuarterMaster("");
+                }
+                if (m_PSyncTarget == PChar)
+                {
+                    SetSyncTarget("", 553);
+                    CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
+                    if (sync && sync->GetDuration() == 0)
                     {
-                        SetQuarterMaster("");
+                        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
+                        sync->SetStartTime(server_clock::now());
+                        sync->SetDuration(30000);
                     }
-                    if (m_PSyncTarget == PChar)
+                    DisableSync();
+                }
+                if (m_PSyncTarget != nullptr && m_PSyncTarget != PChar)
+                {
+                    if (PChar->status != STATUS_TYPE::DISAPPEAR)
                     {
-                        SetSyncTarget("", 553);
                         CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
                         if (sync && sync->GetDuration() == 0)
                         {
@@ -379,42 +385,28 @@ void CParty::DelMember(CBattleEntity* PEntity)
                             sync->SetStartTime(server_clock::now());
                             sync->SetDuration(30000);
                         }
-                        DisableSync();
-                    }
-                    if (m_PSyncTarget != nullptr && m_PSyncTarget != PChar)
-                    {
-                        if (PChar->status != STATUS_TYPE::DISAPPEAR)
-                        {
-                            CStatusEffect* sync = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC);
-                            if (sync && sync->GetDuration() == 0)
-                            {
-                                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 30, 553));
-                                sync->SetStartTime(server_clock::now());
-                                sync->SetDuration(30000);
-                            }
-                        }
-                    }
-                    PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
-
-                    PChar->pushPacket(new CPartyDefinePacket(nullptr));
-                    PChar->pushPacket(new CPartyMemberUpdatePacket(PChar, 0, 0, PChar->getZone()));
-                    PChar->pushPacket(new CCharUpdatePacket(PChar));
-                    PChar->PParty = nullptr;
-
-                    if (PChar->PTreasurePool != nullptr && PChar->PTreasurePool->GetPoolType() != TREASUREPOOL_ZONE)
-                    {
-                        PChar->PTreasurePool->DelMember(PChar);
-                        PChar->PTreasurePool = new CTreasurePool(TREASUREPOOL_SOLO);
-                        PChar->PTreasurePool->AddMember(PChar);
-                        PChar->PTreasurePool->UpdatePool(PChar);
                     }
                 }
-                else
+                PChar->PLatentEffectContainer->CheckLatentsPartyMembers(members.size());
+
+                PChar->pushPacket(new CPartyDefinePacket(nullptr));
+                PChar->pushPacket(new CPartyMemberUpdatePacket(PChar, 0, 0, PChar->getZone()));
+                PChar->pushPacket(new CCharUpdatePacket(PChar));
+                PChar->PParty = nullptr;
+
+                if (PChar->PTreasurePool != nullptr && PChar->PTreasurePool->GetPoolType() != TREASUREPOOL_ZONE)
                 {
-                    PEntity->PParty = nullptr;
+                    PChar->PTreasurePool->DelMember(PChar);
+                    PChar->PTreasurePool = new CTreasurePool(TREASUREPOOL_SOLO);
+                    PChar->PTreasurePool->AddMember(PChar);
+                    PChar->PTreasurePool->UpdatePool(PChar);
                 }
-                break;
             }
+            else
+            {
+                PEntity->PParty = nullptr;
+            }
+            members.erase(memberToDelete);
         }
         this->ReloadParty();
     }
@@ -422,13 +414,13 @@ void CParty::DelMember(CBattleEntity* PEntity)
 
 void CParty::PopMember(CBattleEntity* PEntity)
 {
-    for (uint32 i = 0; i < members.size(); ++i)
+    auto memberToDelete = std::find(members.begin(), members.end(), PEntity);
+
+    if (memberToDelete != members.end())
     {
-        if (PEntity == members.at(i))
-        {
-            members.erase(members.begin() + i);
-        }
+        members.erase(memberToDelete);
     }
+
     // free memory, party will re reinsatiated when they zone back in
     if (members.empty())
     {
@@ -438,12 +430,16 @@ void CParty::PopMember(CBattleEntity* PEntity)
             {
                 m_PAlliance->setMainParty(nullptr);
             }
-            for (std::size_t i = 0; i < m_PAlliance->partyList.size(); ++i)
+
+            auto it = m_PAlliance->partyList.begin();
+            while (it != m_PAlliance->partyList.end())
             {
-                if (this == m_PAlliance->partyList.at(i))
+                if (this == *it)
                 {
-                    m_PAlliance->partyList.erase(m_PAlliance->partyList.begin() + i);
+                    it = m_PAlliance->partyList.erase(it);
+                    continue;
                 }
+                it++;
             }
         }
         delete this; // cpp.sh allow
@@ -523,10 +519,15 @@ void CParty::AddMember(CBattleEntity* PEntity)
         return;
     }
 
-    // If it's a player party, make sure only 6 players can be in it
+    if (std::find(members.begin(), members.end(), PEntity) != members.end())
+    {
+        ShowWarning("CParty::AddMember() - PEntity was already in the member list!");
+        return;
+    }
+
     if (PEntity->objtype == TYPE_PC && m_PartyType == PARTY_PCS && members.size() > 5)
     {
-        // Party is full -- Do nothing
+        ShowWarning("CParty::AddMember() - Party was full when trying to add a member.");
         return;
     }
 
@@ -598,9 +599,9 @@ void CParty::AddMember(uint32 id)
 {
     if (m_PartyType == PARTY_PCS)
     {
-        // Check for full party
         if (members.size() > 5)
         {
+            ShowWarning("CParty::AddMember() - Party was full when trying to add a member from out of zone.");
             return;
         }
 

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -79,6 +79,12 @@ void CTreasurePool::AddMember(CCharEntity* PChar)
         return;
     }
 
+    if (std::find(members.begin(), members.end(), PChar) != members.end())
+    {
+        ShowWarning("CTreasurePool::AddMember() - PChar was already in the members list!");
+        return;
+    }
+
     members.push_back(PChar);
 
     if (m_TreasurePoolType == TREASUREPOOL_SOLO && members.size() > 1)
@@ -112,26 +118,25 @@ void CTreasurePool::DelMember(CCharEntity* PChar)
     {
         if (!m_PoolItems[i].Lotters.empty())
         {
-            for (size_t j = 0; j < m_PoolItems[i].Lotters.size(); j++)
+            auto lotterIterator = m_PoolItems[i].Lotters.begin();
+            while (lotterIterator != m_PoolItems[i].Lotters.end())
             {
                 // remove their lot info
-                if (PChar->id == m_PoolItems[i].Lotters[j].member->id)
+                LotInfo* info = &(*lotterIterator);
+                if (PChar->id == info->member->id)
                 {
-                    m_PoolItems[i].Lotters.erase(m_PoolItems[i].Lotters.begin() + j);
+                    lotterIterator = m_PoolItems[i].Lotters.erase(lotterIterator);
                 }
             }
         }
     }
     //}
 
-    for (uint32 i = 0; i < members.size(); ++i)
+    auto memberToDelete = std::find(members.begin(), members.end(), PChar);
+    if (memberToDelete != members.end())
     {
-        if (PChar == members.at(i))
-        {
-            PChar->PTreasurePool = nullptr;
-            members.erase(members.begin() + i);
-            break;
-        }
+        PChar->PTreasurePool = nullptr;
+        members.erase(memberToDelete);
     }
 
     if ((m_TreasurePoolType == TREASUREPOOL_PARTY || m_TreasurePoolType == TREASUREPOOL_ALLIANCE) && members.size() == 1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Add some Treasure Pool/Party/Alliance safety and fix a crash with Treasure Pools (Wintersolstice)

## What does this pull request do? (Please be technical)

Adds some safety to Treasure Pools, Party and Alliance code.

Mostly replaces suspicious searches to std::find and self modifying loops with syntax that supports doing that and adds a few sanity checks as well as a crucial missing zonewide treasurepool check that could cause crashes if ever used and people d/c or otherwise shutdown and log back in

## Steps to test these changes

Get in a party/alliance, lot items, zone a character out and see no errors
Get in an alliance of two partys with one party with a single member who is the leader of the alliance and /shutdown with no errors
Zone in a party/alliance with no errors
Use a zonewide treasure pool and be able to leave an alliance without creating a new treasure pool briefly (see `CAlliance::delParty`)

## Special Deployment Considerations

N/A
