### PR TITLE
[core] Set some flags to allow transports to be fixed in place

### DIFF
--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -48,10 +48,15 @@ void Transport_Ship::setVisible(bool visible) const
     if (visible)
     {
         this->npc->status = STATUS_TYPE::NORMAL;
+        // This appears to be some sort of magic bit/flag set. In QSC 0x8001 is observed on the effects that light up the weight on the weighted doors.
+        // The effect of 0x8001 appears to be to "stay in place" and not "stand on top of" things, such as the floor -- most likely fixes positions to the exact X/Y/Z coords supplied in 0x00E.
+        this->npc->loc.p.moving = 0x8007;
     }
     else
     {
         this->npc->status = STATUS_TYPE::DISAPPEAR;
+        // Missing 0x0001 bit here
+        this->npc->loc.p.moving = 0x8006;
     }
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Airships, Boats, barges and the manaclipper will no longer have strange movement once docked. (Wintersolstice)

## What does this pull request do? (Please be technical)


Aligns transports to their cargo holds and/or the position where they stop. They no longer move with the depths of the water.
![Testaroni_2023 05 28_174806](https://github.com/LandSandBoat/server/assets/60417494/c1444475-6a90-4102-b84f-1dbfda5d7ae6)
![Testaroni_2023 05 28_174227](https://github.com/LandSandBoat/server/assets/60417494/cb6a6e4a-238d-459f-b68a-f0d415e859cb)

![Testaroni_2023 05 28_173515](https://github.com/LandSandBoat/server/assets/60417494/a3d6dad6-8ac4-42d6-965b-d08be7f9ba04)
![Testaroni_2023 05 28_173312](https://github.com/LandSandBoat/server/assets/60417494/69ec9203-3eae-4f81-ba47-ff23c96edf63)

![Testaroni_2023 05 28_195330](https://github.com/LandSandBoat/server/assets/60417494/16303f03-c62f-42a7-b7cb-67e190600c30)

## Steps to test these changes

Go to boats and stuff and see nothing obviously wrong, go insane because it was a 2 line fix this whole time

## Special Deployment Considerations

N/A
