### PR TITLE
Waking the Beast Crash Fix

### DIFF
--- a/scripts/mixins/wtb_prime.lua
+++ b/scripts/mixins/wtb_prime.lua
@@ -4,8 +4,9 @@ require("scripts/globals/mixins")
 g_mixins = g_mixins or {}
 
 g_mixins.wtb_prime = function(prime)
-    prime:addListener("TAKE_DAMAGE", "PRIME_TAKE_DAMAGE", function(mob, amount, attacker)
-        if amount > mob:getHP() then
+    prime:addListener("DEATH", "PRIME_DEATH", function(mob, killer)
+        if mob:getLocalVar("control") == 0 then
+            mob:setLocalVar("control", 1)
             local bf = mob:getBattlefield()
             local phase = bf:getLocalVar("phase")
             local bfNum = bf:getArea()
@@ -14,12 +15,12 @@ g_mixins.wtb_prime = function(prime)
 
             if bf:getLocalVar("primesDead") >= phase then
                 -- Respawn Carbuncle
-                SpawnMob(ID.primes[1][bfNum]):updateEnmity(attacker)
+                SpawnMob(ID.primes[1][bfNum]):updateEnmity(killer)
                 bf:setLocalVar("phase", bf:getLocalVar("phase") + 1)
 
                 if bf:getLocalVar("phase") >= 4 then
                     for i = 1, 4 do
-                        SpawnMob(ID.primes[1][bfNum] + i):updateEnmity(attacker)
+                        SpawnMob(ID.primes[1][bfNum] + i):updateEnmity(killer)
                     end
                 end
             end

--- a/scripts/zones/Full_Moon_Fountain/bcnms/waking_the_beast_fullmoon.lua
+++ b/scripts/zones/Full_Moon_Fountain/bcnms/waking_the_beast_fullmoon.lua
@@ -25,6 +25,7 @@ local loot =
 
 battlefieldObject.onBattlefieldInitialise = function(battlefield)
     battlefield:setLocalVar("carbuncleHP", 20000)
+    battlefield:setLocalVar("lootSpawned", 1)
     battlefield:setLocalVar("phase", 1)
 end
 

--- a/scripts/zones/Full_Moon_Fountain/mobs/Carbuncle_Prime.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Carbuncle_Prime.lua
@@ -32,14 +32,14 @@ local spawnPrime = function(mob, target)
 
         -- Assure the same avatar isn't summoned more than once
         while control do
-            local random = math.random(2,7)
+            local random = math.random(2, 7)
 
             if bf:getLocalVar(avatars[random]) == 0 then
                 bf:setLocalVar(avatars[random], 1)
                 local prime = ID.primes[random][bf:getArea()]
 
                 SpawnMob(prime):updateEnmity(target)
-                GetMobByID(prime):setPos(pos.x + math.random(-3,3), pos.y, pos.z + math.random(-3, 3), pos.rot)
+                GetMobByID(prime):setPos(pos.x + math.random(-3, 3), pos.y, pos.z + math.random(-3, 3), pos.rot)
                 control = false
             end
         end
@@ -80,7 +80,7 @@ entity.onMobFight = function(mob, target)
     if hp < 10 and bf:getLocalVar("2hrControl") == 0 then
         bf:setLocalVar("2hrControl", 1)
         for i = 0, 4 do
-            local carby = GetMobByID(ID.primes[1][bf:getArea()]+i)
+            local carby = GetMobByID(ID.primes[1][bf:getArea()] + i)
 
             if carby:isAlive() then
                 carby:useMobAbility(912)
@@ -90,6 +90,25 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
+    local bf = mob:getBattlefield()
+    local flag = true
+
+    for i = 0, 4 do
+        local carby = GetMobByID(ID.primes[1][bf:getArea()] + i)
+
+        if carby:isAlive() then
+            flag = false
+        end
+    end
+
+    -- Only complete the battlefield if the final carbuncle is killed in phase 4
+    if
+        bf:getLocalVar("phase") >= 4 and
+        optParams.isKiller and
+        flag
+    then
+        bf:setLocalVar("lootSpawned", 0)
+    end
 end
 
 return entity


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed a crash the final battlefield in Waking the Beast that would occur when two players deal a killing blow to an avatar at the same time. (Abdiah)

## What does this pull request do? (Please be technical)
- Fixed variable incrementation behavior to ensure proper behavior and fix crashes

Fixes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1598
