### PR TITLE
Fix central temenos and dmg mod calculation

### DIFF
--- a/scripts/battlefields/Temenos/central_temenos_2nd_floor.lua
+++ b/scripts/battlefields/Temenos/central_temenos_2nd_floor.lua
@@ -26,7 +26,7 @@ local content = Limbus:new({
     name             = "CENTRAL_TEMENOS_2ND_FLOOR",
 })
 
-local function weakenCarbuncle(elementalMod, bonusMod, bonusAmount, battlefield, mob, count)
+local function weakenCarbuncle(elementalMod, bonusMods, bonusAmounts, battlefield, mob, count)
     -- Remove the elemental bonus effects
     local zone = mob:getZone()
     local carbuncle = zone:queryEntitiesByName("Mystic_Avatar_Carbuncle")[1]
@@ -34,10 +34,12 @@ local function weakenCarbuncle(elementalMod, bonusMod, bonusAmount, battlefield,
         carbuncle:setMod(elementalMod, 0)
     end
 
-    carbuncle:delMod(bonusMod, bonusAmount)
+    for modIndex, bonusMod in ipairs(bonusMods) do
+        carbuncle:delMod(bonusMod, bonusAmounts[modIndex])
+    end
 end
 
-function content:handleElementalDeath(elementalMod, bonusMod, bonusAmount, weakElemental, battlefield, mob, count)
+function content:handleElementalDeath(elementalMod, bonusMods, bonusAmounts, weakElemental, battlefield, mob, count)
     -- Spawn the Mystic Avatar if this elemental died from morphing
     if mob:getLocalVar("morphed") == 1 then
         local mysticID = mob:getID() + 6
@@ -50,7 +52,7 @@ function content:handleElementalDeath(elementalMod, bonusMod, bonusAmount, weakE
         return
     end
 
-    weakenCarbuncle(elementalMod, bonusMod, bonusAmount, battlefield, mob, count)
+    weakenCarbuncle(elementalMod, bonusMods, bonusAmounts, battlefield, mob, count)
 
     -- Morph the weak elemental into a Mystic Avatar
     local zone = mob:getZone()
@@ -75,11 +77,15 @@ content.groups =
             "Light_Elemental",
         },
 
-        -- NOTE: Elementals take double physical damage because their family resistance is 25% so it totals to 50% resistance
         mods =
         {
-            [xi.mod.UDMGPHYS] = -10000,
-            [xi.mod.UDMGMAGIC] = 5000,
+            -- 50% resist on all damage
+            [xi.mod.DMG] = -5000,
+            -- remove the normal phys down of elementals
+            [xi.mod.PIERCE_SDT] = 1000,
+            [xi.mod.SLASH_SDT] = 1000,
+            [xi.mod.IMPACT_SDT] = 1000,
+            [xi.mod.HTH_SDT] = 1000,
             [xi.mobMod.DETECTION] = xi.detects.HEARING,
         },
     },
@@ -90,14 +96,16 @@ content.groups =
         mobs = { "Mystic_Avatar_Ifrit" },
         mods =
         {
-            [xi.mod.UDMGPHYS] = 2500,
+            [xi.mod.UDMGPHYS] = -2500,
+            [xi.mod.UDMGRANGE] = -2500,
+            [xi.mod.UDMGBREATH] = -2500,
             [xi.mod.FIRE_ABSORB] = 100,
             [xi.mod.FIRE_SDT] = -10000,
-            [xi.mod.ICE_SDT] = 9000,
-            [xi.mod.THUNDER_SDT] = 9000,
-            [xi.mod.EARTH_SDT] = 9000,
-            [xi.mod.WIND_SDT] = 9000,
-            [xi.mod.DARK_SDT] = 9000,
+            [xi.mod.ICE_SDT] = -9000,
+            [xi.mod.THUNDER_SDT] = -9000,
+            [xi.mod.EARTH_SDT] = -9000,
+            [xi.mod.WIND_SDT] = -9000,
+            [xi.mod.DARK_SDT] = -9000,
         },
     },
 
@@ -106,14 +114,16 @@ content.groups =
         mobs = { "Mystic_Avatar_Shiva" },
         mods =
         {
-            [xi.mod.UDMGPHYS] = 2500,
+            [xi.mod.UDMGPHYS] = -2500,
+            [xi.mod.UDMGRANGE] = -2500,
+            [xi.mod.UDMGBREATH] = -2500,
             [xi.mod.ICE_ABSORB] = 100,
             [xi.mod.ICE_SDT] = -10000,
-            [xi.mod.WATER_SDT] = 9000,
-            [xi.mod.THUNDER_SDT] = 9000,
-            [xi.mod.EARTH_SDT] = 9000,
-            [xi.mod.WIND_SDT] = 9000,
-            [xi.mod.DARK_SDT] = 9000,
+            [xi.mod.WATER_SDT] = -9000,
+            [xi.mod.THUNDER_SDT] = -9000,
+            [xi.mod.EARTH_SDT] = -9000,
+            [xi.mod.WIND_SDT] = -9000,
+            [xi.mod.DARK_SDT] = -9000,
         },
     },
 
@@ -122,14 +132,16 @@ content.groups =
         mobs = { "Mystic_Avatar_Garuda" },
         mods =
         {
-            [xi.mod.UDMGPHYS] = 2500,
+            [xi.mod.UDMGPHYS] = -2500,
+            [xi.mod.UDMGRANGE] = -2500,
+            [xi.mod.UDMGBREATH] = -2500,
             [xi.mod.WIND_ABSORB] = 100,
             [xi.mod.WIND_SDT] = -10000,
-            [xi.mod.FIRE_SDT] = 9000,
-            [xi.mod.WATER_SDT] = 9000,
-            [xi.mod.THUNDER_SDT] = 9000,
-            [xi.mod.EARTH_SDT] = 9000,
-            [xi.mod.DARK_SDT] = 9000,
+            [xi.mod.FIRE_SDT] = -9000,
+            [xi.mod.WATER_SDT] = -9000,
+            [xi.mod.THUNDER_SDT] = -9000,
+            [xi.mod.EARTH_SDT] = -9000,
+            [xi.mod.DARK_SDT] = -9000,
         },
     },
 
@@ -138,14 +150,16 @@ content.groups =
         mobs = { "Mystic_Avatar_Titan" },
         mods =
         {
-            [xi.mod.UDMGPHYS] = 2500,
+            [xi.mod.UDMGPHYS] = -2500,
+            [xi.mod.UDMGRANGE] = -2500,
+            [xi.mod.UDMGBREATH] = -2500,
             [xi.mod.EARTH_ABSORB] = 100,
             [xi.mod.EARTH_SDT] = -10000,
-            [xi.mod.ICE_SDT] = 9000,
-            [xi.mod.FIRE_SDT] = 9000,
-            [xi.mod.WATER_SDT] = 9000,
-            [xi.mod.THUNDER_SDT] = 9000,
-            [xi.mod.DARK_SDT] = 9000,
+            [xi.mod.ICE_SDT] = -9000,
+            [xi.mod.FIRE_SDT] = -9000,
+            [xi.mod.WATER_SDT] = -9000,
+            [xi.mod.THUNDER_SDT] = -9000,
+            [xi.mod.DARK_SDT] = -9000,
         },
     },
 
@@ -154,14 +168,16 @@ content.groups =
         mobs = { "Mystic_Avatar_Ramuh" },
         mods =
         {
-            [xi.mod.UDMGPHYS] = 2500,
+            [xi.mod.UDMGPHYS] = -2500,
+            [xi.mod.UDMGRANGE] = -2500,
+            [xi.mod.UDMGBREATH] = -2500,
             [xi.mod.LTNG_ABSORB] = 100,
             [xi.mod.THUNDER_SDT] = -10000,
-            [xi.mod.ICE_SDT] = 9000,
-            [xi.mod.FIRE_SDT] = 9000,
-            [xi.mod.WATER_SDT] = 9000,
-            [xi.mod.WIND_SDT] = 9000,
-            [xi.mod.DARK_SDT] = 9000,
+            [xi.mod.ICE_SDT] = -9000,
+            [xi.mod.FIRE_SDT] = -9000,
+            [xi.mod.WATER_SDT] = -9000,
+            [xi.mod.WIND_SDT] = -9000,
+            [xi.mod.DARK_SDT] = -9000,
         },
     },
 
@@ -170,14 +186,16 @@ content.groups =
         mobs = { "Mystic_Avatar_Leviathan" },
         mods =
         {
-            [xi.mod.UDMGPHYS] = 2500,
+            [xi.mod.UDMGPHYS] = -2500,
+            [xi.mod.UDMGRANGE] = -2500,
+            [xi.mod.UDMGBREATH] = -2500,
             [xi.mod.WATER_ABSORB] = 100,
             [xi.mod.WATER_SDT] = -10000,
-            [xi.mod.FIRE_SDT] = 9000,
-            [xi.mod.ICE_SDT] = 9000,
-            [xi.mod.EARTH_SDT] = 9000,
-            [xi.mod.WIND_SDT] = 9000,
-            [xi.mod.DARK_SDT] = 9000,
+            [xi.mod.FIRE_SDT] = -9000,
+            [xi.mod.ICE_SDT] = -9000,
+            [xi.mod.EARTH_SDT] = -9000,
+            [xi.mod.WIND_SDT] = -9000,
+            [xi.mod.DARK_SDT] = -9000,
         },
     },
 
@@ -191,7 +209,7 @@ content.groups =
             "Mystic_Avatar_Ifrit",
         },
 
-        death = utils.bind(content.handleElementalDeath, content, xi.mod.FIRE_SDT, xi.mod.ATTP, 50, "Ice_Elemental"),
+        death = utils.bind(content.handleElementalDeath, content, xi.mod.FIRE_SDT, { xi.mod.ATTP }, { 50 }, "Ice_Elemental"),
     },
 
     {
@@ -203,7 +221,7 @@ content.groups =
         },
 
         -- TODO: Figure out the bonus modifier
-        death = utils.bind(content.handleElementalDeath, content, xi.mod.ICE_SDT, xi.mod.MATT, 50, "Air_Elemental"),
+        death = utils.bind(content.handleElementalDeath, content, xi.mod.ICE_SDT, { xi.mod.MATT }, { 50 }, "Air_Elemental"),
     },
 
     {
@@ -214,7 +232,7 @@ content.groups =
             "Mystic_Avatar_Garuda",
         },
 
-        death = utils.bind(content.handleElementalDeath, content, xi.mod.WIND_SDT, xi.mod.EVA, 100, "Earth_Elemental"),
+        death = utils.bind(content.handleElementalDeath, content, xi.mod.WIND_SDT, { xi.mod.EVA }, { 100 }, "Earth_Elemental"),
     },
 
     {
@@ -225,7 +243,7 @@ content.groups =
             "Mystic_Avatar_Titan",
         },
 
-        death = utils.bind(content.handleElementalDeath, content, xi.mod.EARTH_SDT, xi.mod.UDMGPHYS, 5000, "Thunder_Elemental"),
+        death = utils.bind(content.handleElementalDeath, content, xi.mod.EARTH_SDT, { xi.mod.UDMGPHYS, xi.mod.UDMGRANGE, xi.mod.UDMGBREATH }, { -5000, -5000, -5000 }, "Thunder_Elemental"),
     },
 
     {
@@ -236,7 +254,7 @@ content.groups =
             "Mystic_Avatar_Ramuh",
         },
 
-        death = utils.bind(content.handleElementalDeath, content, xi.mod.THUNDER_SDT, xi.mod.DOUBLE_ATTACK, 100, "Water_Elemental"),
+        death = utils.bind(content.handleElementalDeath, content, xi.mod.THUNDER_SDT, { xi.mod.DOUBLE_ATTACK }, { 100 }, "Water_Elemental"),
     },
 
     {
@@ -247,12 +265,14 @@ content.groups =
             "Mystic_Avatar_Leviathan",
         },
 
-        death = utils.bind(content.handleElementalDeath, content, xi.mod.WATER_SDT, xi.mod.UDMGMAGIC, 5000, "Fire_Elemental"),
+        death = utils.bind(content.handleElementalDeath, content, xi.mod.WATER_SDT, { xi.mod.UDMGMAGIC }, { -5000 }, "Fire_Elemental"),
     },
 
     {
         mobs = { "Light_Elemental" },
-        death = utils.bind(weakenCarbuncle, content, xi.mod.NONE, xi.mod.DARK_SDT, 2500),
+        death = function(battlefield, mob)
+            weakenCarbuncle(xi.mod.NONE, { xi.mod.DARK_SDT }, { -2500 }, battlefield, mob)
+        end
     },
 
     {
@@ -262,20 +282,21 @@ content.groups =
             "Mystic_Avatar_Carbuncle",
         },
         mobMods = { [xi.mobMod.DETECTION] = xi.detects.HEARING },
-        inParty = true,
+        isParty = true,
+        superlink = true,
     },
 
     {
         mobs = { "Mystic_Avatar_Carbuncle" },
         mods =
         {
-            [xi.mod.FIRE_SDT] = 9000,
-            [xi.mod.ICE_SDT] = 9000,
-            [xi.mod.WIND_SDT] = 9000,
-            [xi.mod.EARTH_SDT] = 9000,
-            [xi.mod.THUNDER_SDT] = 9000,
-            [xi.mod.WATER_SDT] = 9000,
-            [xi.mod.DARK_SDT] = 5000,
+            [xi.mod.FIRE_SDT] = -9000,
+            [xi.mod.ICE_SDT] = -9000,
+            [xi.mod.WIND_SDT] = -9000,
+            [xi.mod.EARTH_SDT] = -9000,
+            [xi.mod.THUNDER_SDT] = -9000,
+            [xi.mod.WATER_SDT] = -9000,
+            [xi.mod.DARK_SDT] = -5000,
         },
 
         setup = function(battlefield, mobs)
@@ -283,9 +304,11 @@ content.groups =
             mob:addMod(xi.mod.ATTP, 50)
             mob:addMod(xi.mod.MATT, 50)
             mob:addMod(xi.mod.EVA, 100)
-            mob:addMod(xi.mod.UDMGPHYS, 5000)
+            mob:addMod(xi.mod.UDMGPHYS, -5000)
+            mob:addMod(xi.mod.UDMGRANGE, -5000)
+            mob:addMod(xi.mod.UDMGBREATH, -5000)
             mob:addMod(xi.mod.DOUBLE_ATTACK, 100)
-            mob:addMod(xi.mod.UDMGMAGIC, 5000)
+            mob:addMod(xi.mod.UDMGMAGIC, -5000)
         end,
 
         death = function(battlefield, mob)

--- a/scripts/globals/damage.lua
+++ b/scripts/globals/damage.lua
@@ -67,9 +67,9 @@ xi.damage.returnDamageTakenMod = function(target, attackType, damageType)
 
     for _, mod in pairs(attMods[attackType]) do
         if mod.min ~= nil then
-            dmgTakenMod = dmgTakenMod + utils.clamp(target:getMod(mod.mod) / 10000, mod.min, mod.max)
+            dmgTakenMod = dmgTakenMod * (1 + utils.clamp(target:getMod(mod.mod) / 10000, mod.min, mod.max))
         else
-            dmgTakenMod = dmgTakenMod + (target:getMod(mod.mod) / 10000)
+            dmgTakenMod = dmgTakenMod * (1 + (target:getMod(mod.mod) / 10000))
         end
     end
 
@@ -82,7 +82,7 @@ xi.damage.returnDamageTakenMod = function(target, attackType, damageType)
     then
         dmgTakenMod = dmgTakenMod * ((target:getMod(dmgMods[damageType])) / 1000)
     elseif damageType and dmgMods[damageType] then -- This is for elemental SDTs only
-        dmgTakenMod = dmgTakenMod + (target:getMod(dmgMods[damageType]) / 10000)
+        dmgTakenMod = dmgTakenMod * (1 + (target:getMod(dmgMods[damageType]) / 10000))
     end
 
     return dmgTakenMod

--- a/scripts/zones/Temenos/mobs/Light_Elemental.lua
+++ b/scripts/zones/Temenos/mobs/Light_Elemental.lua
@@ -7,39 +7,9 @@ local ID = require("scripts/zones/Temenos/IDs")
 local entity = {}
 
 entity.onMobEngaged = function(mob, target)
-    local mobID = mob:getID()
-    if mobID == ID.mob.TEMENOS_C_MOB[2] + 1 then
-        GetMobByID(ID.mob.TEMENOS_C_MOB[2] + 2):updateEnmity(target)
-        GetMobByID(ID.mob.TEMENOS_C_MOB[2]):updateEnmity(target)
-    elseif mobID == ID.mob.TEMENOS_C_MOB[2] + 2 then
-        GetMobByID(ID.mob.TEMENOS_C_MOB[2] + 1):updateEnmity(target)
-        GetMobByID(ID.mob.TEMENOS_C_MOB[2]):updateEnmity(target)
-    end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    if optParams.isKiller or optParams.noKiller then
-        switch (mob:getID()): caseof
-        {
-            [ID.mob.TEMENOS_C_MOB[2] + 1] = function()
-                if
-                    GetMobByID(ID.mob.TEMENOS_C_MOB[2]):isDead() and
-                    GetMobByID(ID.mob.TEMENOS_C_MOB[2] + 2):isDead()
-                then
-                    GetNPCByID(ID.npc.TEMENOS_C_CRATE[2]):setStatus(xi.status.NORMAL)
-                end
-            end,
-
-            [ID.mob.TEMENOS_C_MOB[2] + 2] = function()
-                if
-                    GetMobByID(ID.mob.TEMENOS_C_MOB[2]):isDead() and
-                    GetMobByID(ID.mob.TEMENOS_C_MOB[2] + 1):isDead()
-                then
-                    GetNPCByID(ID.npc.TEMENOS_C_CRATE[2]):setStatus(xi.status.NORMAL)
-                end
-            end,
-        }
-    end
 end
 
 return entity

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -479,6 +479,7 @@ void CLuaBattlefield::addGroups(sol::table groups, bool hasMultipleArenas)
                 if (PMob->PParty != nullptr)
                 {
                     PMob->PParty->RemoveMember(PMob);
+                    PMob->PParty = nullptr;
                 }
 
                 if (party == nullptr)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Monsters in Central Temenos 2nd floor now have the correct resistances and linking behavior. (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes several issues with monsters in Central Temenos 2nd Floor including many monsters having damage mods with the incorrect sign or missing and incorrect mods. Also the damage.lua was adding multiple damage mods incorrectly thus causing behavior such as absorbing damage. Finally the linking behavior of the light elementals and carby was not working due to issues with the isParty keyword and implementation in the limbus system.

## Steps to test these changes
Fight Central Temenos 2nd Floor

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1558
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1518
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1320
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1515
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/511
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
