### PR TITLE
[core] Correctly iterate over when deleting members in treasure pool

### DIFF
--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -126,7 +126,9 @@ void CTreasurePool::DelMember(CCharEntity* PChar)
                 if (PChar->id == info->member->id)
                 {
                     lotterIterator = m_PoolItems[i].Lotters.erase(lotterIterator);
+                    continue;
                 }
+                lotterIterator++;
             }
         }
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

N/A please don't kill me

## What does this pull request do? (Please be technical)

Actually iterate over treasure pool correctly on deleting members from treasure pool

## Steps to test these changes

Have a 3+ person party, lot on a bunch of items (but leave some gaps in lots) and not have an infinite recursion :)

## Special Deployment Considerations

N/A
