### PR TITLE
Fix for Extra EXP gained in battlefields

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2153,6 +2153,12 @@ void CCharEntity::OnRaise()
 
             uint16 xpNeededToLevel = charutils::GetExpNEXTLevel(jobs.job[GetMJob()]) - jobs.exp[GetMJob()];
 
+            // Player died within a battlefield, reward the battlefield level equivalent EXP
+            if (StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
+            {
+                expLost = m_LevelRestriction <= 67 ? (charutils::GetExpNEXTLevel(m_LevelRestriction) * 8) / 100 : 2400;
+            }
+
             // Exp is enough to level you and (you're not under a level restriction, or the level restriction is higher than your current main level).
             if (xpNeededToLevel < expLost && (m_LevelRestriction == 0 || GetMLevel() < m_LevelRestriction))
             {


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed a bug where players would regain their original level's exp when being raised within a level sync'ed battlefield. (Abdiah)

## What does this pull request do? (Please be technical)
Added a check in onRaise to determine if a player is in a battlefield or not. If so, the exp returned is equivalent to that what they lost upon death

## Steps to test these changes
Don't forget to rebuild when testing changes as it's a cpp change
