### PR TITLE
Treat dmg additional effects as dmg for resist calcs

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -105,6 +105,7 @@ xi.additionalEffect.calcDamage = function(attacker, element, defender, damage, a
     local params = {}
     params.bonusmab   = 0
     params.includemab = false
+    params.damageSpell = true
 
     if
         addType == xi.additionalEffect.procType.DAMAGE and


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Treat dmg additional effects as dmg for resist calcs
Per BG wiki additional effects are subject to at most 1/8 resists
https://www.bg-wiki.com/ffxi/Additional_Effect#:~:text=Additional%20effects%20are%20effects%20that,one%20effect%20on%20each%20hit.

Note: There are claims on wiki that [sirocco ](https://ffxiclopedia.fandom.com/wiki/Talk:Sirocco_Kukri)and [boreas ](https://ffxiclopedia.fandom.com/wiki/Boreas_Cesti)can both hit for 0
So which one is right?
Well, if you get a 1/8 resist and and a day effect goes against you, it can drag down hits to 0.

## What does this pull request do? (Please be technical)

added `params.damageSpell = true`  for additional effects which are determining damage

## Steps to test these changes

Use boreas/sirocco to ensure 100% additional effct.
Now go hit something and dont get 0s.

## Special Deployment Considerations

None