### PR TITLE
PLD af2 fixes

### DIFF
--- a/scripts/quests/sandoria/PLD_AF2_A_Boys_Dream.lua
+++ b/scripts/quests/sandoria/PLD_AF2_A_Boys_Dream.lua
@@ -93,7 +93,7 @@ quest.sections =
                     elseif questProgress == 4 then
                         return quest:event(60) -- During Quest "A Boy's Dream" (after trading bug) madame ?
                     elseif questProgress == 5 then
-                        return quest:progressEvent(47) -- During Quest "A Boy's Dream" (after trading odontotyrannus)
+                        return quest:messageSpecial(ID.text.AILBECHE_TRADE_FISH)
                     elseif questProgress == 6 then
                         return quest:progressEvent(25) -- During Quest "A Boy's Dream" (after Zaldon CS)
                     end
@@ -168,7 +168,7 @@ quest.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        quest:getVar(player, 'Prog') == 4 and
+                        quest:getVar(player, 'Prog') >= 4 and
                         npcUtil.tradeHasExactly(trade, xi.items.ODONTOTYRANNUS)
                     then
                         return quest:progressEvent(85)

--- a/scripts/zones/Northern_San_dOria/IDs.lua
+++ b/scripts/zones/Northern_San_dOria/IDs.lua
@@ -109,6 +109,7 @@ zones[xi.zone.NORTHERN_SAN_DORIA] =
         FLYER_ALREADY                 = 12072, -- This person already has a flyer.
         MOGHOUSE_EXIT                 = 12371, -- You have learned your way through the back alleys of San d'Oria! Now you can exit to any area from your residence.
         AILBECHE_WHEN_FISHING         = 12391, -- Oh, when will my father take me fishing...
+        AILBECHE_TRADE_FISH           = 12456, -- What? You caught the big one? Amazing! I doubt I could have done the same.
         OH_I_WANT_MY_ITEM             = 12630, -- Oh, I want my <item>.
         GAUDYLOX_SHOP_DIALOG          = 12631, -- <Phssshooooowoooo> You never see Goblinshhh from underworld? Me no bad. Me sell chipshhh. You buy. Use with shhhtone heart. You get lucky!
         MILLECHUCA_CLOSED_DIALOG      = 12632, -- I've been trying to import goods from Vollbow, but it's so hard to get items from areas that aren't under San d'Orian control.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Addresses issue where if players skipped optional CS, were unable to progress turning in the fished item to Selbina NPC.
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Changed the var req for Zaldon to accept the fished Item to >= 4 and adjusted a dialog to match accordingly.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
