### PR TITLE
Fix double counting of many damage mods

### DIFF
--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -710,7 +710,7 @@ xi.job_utils.dragoon.useDamageBreath = function(wyvern, target, skill, action, d
     local element = damageType - xi.damageType.ELEMENTAL
 
     -- "Breath accuracy is directly affected by a wyvern's current HP", but no data exists.
-    local resist              = xi.spells.damage.calculateResist(wyvern, target,  nil, 0, element, 0, bonusMacc)
+    local resist              = xi.spells.damage.calculateResist(wyvern, target,  nil, 0, element, 0, bonusMacc, element)
     local sdt                 = xi.spells.damage.calculateSDT(wyvern, target, nil, element)
     local magicBurst          = xi.spells.damage.calculateIfMagicBurst(wyvern, target,  0, element)
     local nukeAbsorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(wyvern, target, nil, element)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -545,13 +545,6 @@ xi.mobskills.mobBreathMove = function(mob, target, percent, base, element, cap)
         return math.floor(damage * liement)
     end
 
-    -- The values set for this modifiers are base 10000.
-    -- -2500 in item_mods.sql means -25% damage recived.
-    -- 2500 would mean 25% ADDITIONAL damage taken.
-    -- The effects of the "Shell" spells are also included in this step. The effect also aplies a negative value.
-
-    damage = xi.damage.applyDamageTaken(target, damage, xi.attackType.BREATH)
-
     if
         target:hasStatusEffect(xi.effect.ALL_MISS) and
         target:getStatusEffect(xi.effect.ALL_MISS):getPower() > 1

--- a/scripts/globals/mobskills/spirits_within.lua
+++ b/scripts/globals/mobskills/spirits_within.lua
@@ -32,7 +32,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     dmg = math.floor(hp * (math.floor(0.016 * tp) + 16) / 256)
 
-    dmg = target:breathDmgTaken(dmg)
+    dmg = target:breathDmgTaken(dmg, true)
 
     -- Handling phalanx
     dmg = dmg - target:getMod(xi.mod.PHALANX)

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -270,15 +270,9 @@ local attackTypeShields =
 
 xi.summon.physicalSDT = function(attacker, target, damagetype, finalDmg)
     local adjustedDamage = finalDmg
-    adjustedDamage = target:physicalDmgTaken(adjustedDamage, damagetype)
-
-    if damagetype == xi.damageType.BLUNT then
-        adjustedDamage = adjustedDamage * target:getMod(xi.mod.IMPACT_SDT) / 1000
-    elseif damagetype == xi.damageType.PIERCING then
-        adjustedDamage = adjustedDamage * target:getMod(xi.mod.PIERCE_SDT) / 1000
-    elseif damagetype == xi.damageType.SLASHING then
-        adjustedDamage = adjustedDamage * target:getMod(xi.mod.SLASH_SDT) / 1000
-    end
+    -- need to pass in ignoreDmgMods option to physicalDmgTaken otherwise dmg mods are applied both here
+    -- as called by avatarFinalAdjustments and in applyDamageTaken as called by avatarPhysicalMove
+    adjustedDamage = target:physicalDmgTaken(adjustedDamage, damagetype, true)
 
     return adjustedDamage
 end

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -382,23 +382,9 @@ local function modifyMeleeHitDamage(attacker, target, attackTbl, wsParams, rawDa
     local adjustedDamage = rawDamage
 
     if not wsParams.formless then
-        adjustedDamage = target:physicalDmgTaken(adjustedDamage, attackTbl.damageType)
-
-        if attackTbl.weaponType == xi.skill.HAND_TO_HAND then
-            adjustedDamage = adjustedDamage * target:getMod(xi.mod.HTH_SDT) / 1000
-        elseif
-            attackTbl.weaponType == xi.skill.DAGGER or
-            attackTbl.weaponType == xi.skill.POLEARM
-        then
-            adjustedDamage = adjustedDamage * target:getMod(xi.mod.PIERCE_SDT) / 1000
-        elseif
-            attackTbl.weaponType == xi.skill.CLUB or
-            attackTbl.weaponType == xi.skill.STAFF
-        then
-            adjustedDamage = adjustedDamage * target:getMod(xi.mod.IMPACT_SDT) / 1000
-        else
-            adjustedDamage = adjustedDamage * target:getMod(xi.mod.SLASH_SDT) / 1000
-        end
+        -- need to pass in ignoreDmgMods option to physicalDmgTaken otherwise dmg mods are applied both here
+        -- and in final ws damage by applyDamageTaken
+        adjustedDamage = target:physicalDmgTaken(adjustedDamage, attackTbl.damageType, true)
     end
 
     -- Scarlet Delirium
@@ -860,8 +846,9 @@ xi.weaponskills.doRangedWeaponskill = function(attacker, target, wsID, wsParams,
     attacker:delStatusEffectsByFlag(xi.effectFlag.DETECTABLE)
 
     -- Calculate reductions
-    finaldmg = target:rangedDmgTaken(finaldmg)
-    finaldmg = finaldmg * target:getMod(xi.mod.PIERCE_SDT) / 1000
+    -- need to pass in ignoreDmgMods option to rangedDmgTaken otherwise dmg mods are applied both here
+    -- and in final ws damage by applyDamageTaken
+    finaldmg = target:rangedDmgTaken(finaldmg, xi.damageType.NONE, true)
 
     finaldmg = finaldmg * xi.settings.main.WEAPON_SKILL_POWER -- Add server bonus
     calcParams.finalDmg = finaldmg
@@ -946,7 +933,9 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
         -- Calculate magical bonuses and reductions
         dmg = xi.magic.addBonusesAbility(attacker, wsParams.element, target, dmg, wsParams)
         dmg = dmg * xi.magic.applyAbilityResistance(attacker, target, wsParams)
-        dmg = target:magicDmgTaken(dmg, wsParams.element)
+        -- need to pass in ignoreDmgMods option to magicDmgTaken otherwise dmg mods are applied both here
+        -- and in final ws damage by applyDamageTaken
+        dmg = target:magicDmgTaken(dmg, wsParams.element, true)
 
         if dmg < 0 then
             calcParams.finalDmg = dmg

--- a/scripts/globals/weaponskills/atonement.lua
+++ b/scripts/globals/weaponskills/atonement.lua
@@ -82,7 +82,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
         end
 
         dmg = utils.clamp(dmg, 0, player:getMainLvl() * 10) -- Damage is capped to player's level * 10, before WS damage mods
-        damage = target:breathDmgTaken(dmg)
+        damage = target:breathDmgTaken(dmg, true)
         if player:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID) > 0 then
             damage = damage * (100 + player:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID)) / 100
         end

--- a/scripts/globals/weaponskills/spirits_within.lua
+++ b/scripts/globals/weaponskills/spirits_within.lua
@@ -57,7 +57,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
         end
     end
 
-    local damage = target:breathDmgTaken(wsc)
+    local damage = target:breathDmgTaken(wsc, true)
     if damage > 0 then
         if player:getOffhandDmg() > 0 then
             calcParams.tpHitsLanded = 2

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12314,9 +12314,10 @@ int32 CLuaBaseEntity::physicalDmgTaken(double damage, sol::variadic_args va)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
-    DAMAGE_TYPE damageType = va[0].is<uint32>() ? va[0].as<DAMAGE_TYPE>() : DAMAGE_TYPE::NONE;
+    DAMAGE_TYPE damageType    = va[0].is<uint32>() ? va[0].as<DAMAGE_TYPE>() : DAMAGE_TYPE::NONE;
+    bool        ignoreDmgMods = va[1].is<bool>() ? va[1].as<bool>() : false;
 
-    return battleutils::PhysicalDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType);
+    return battleutils::PhysicalDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType, false, ignoreDmgMods);
 }
 
 /************************************************************************
@@ -12330,9 +12331,10 @@ int32 CLuaBaseEntity::magicDmgTaken(double damage, sol::variadic_args va)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
-    ELEMENT elementType = va[0].is<uint32>() ? va[0].as<ELEMENT>() : ELEMENT_NONE;
+    ELEMENT elementType   = va[0].is<uint32>() ? va[0].as<ELEMENT>() : ELEMENT_NONE;
+    bool    ignoreDmgMods = va[1].is<bool>() ? va[1].as<bool>() : false;
 
-    return battleutils::MagicDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), elementType);
+    return battleutils::MagicDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), elementType, ignoreDmgMods);
 }
 
 /************************************************************************
@@ -12346,9 +12348,10 @@ int32 CLuaBaseEntity::rangedDmgTaken(double damage, sol::variadic_args va)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
-    DAMAGE_TYPE damageType = va[0].is<uint32>() ? va[0].as<DAMAGE_TYPE>() : DAMAGE_TYPE::NONE;
+    DAMAGE_TYPE damageType    = va[0].is<uint32>() ? va[0].as<DAMAGE_TYPE>() : DAMAGE_TYPE::NONE;
+    bool        ignoreDmgMods = va[1].is<bool>() ? va[1].as<bool>() : false;
 
-    return battleutils::RangedDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType);
+    return battleutils::RangedDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), damageType, false, ignoreDmgMods);
 }
 
 /************************************************************************
@@ -12358,11 +12361,13 @@ int32 CLuaBaseEntity::rangedDmgTaken(double damage, sol::variadic_args va)
  *  Notes   : Passes argument to BreathDmgTaken member of battleutils
  ************************************************************************/
 
-int32 CLuaBaseEntity::breathDmgTaken(double damage)
+int32 CLuaBaseEntity::breathDmgTaken(double damage, sol::variadic_args va)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
-    return battleutils::BreathDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage));
+    bool ignoreDmgMods = va[0].is<bool>() ? va[0].as<bool>() : false;
+
+    return battleutils::BreathDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage), ignoreDmgMods);
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -678,7 +678,7 @@ public:
     int32 physicalDmgTaken(double damage, sol::variadic_args va);
     int32 magicDmgTaken(double damage, sol::variadic_args va);
     int32 rangedDmgTaken(double damage, sol::variadic_args va);
-    int32 breathDmgTaken(double damage);
+    int32 breathDmgTaken(double damage, sol::variadic_args va);
     void  handleAfflatusMiseryDamage(double damage);
 
     bool   isWeaponTwoHanded();

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5474,15 +5474,18 @@ namespace battleutils
         PChar->PClaimedMob = nullptr;
     }
 
-    int32 BreathDmgTaken(CBattleEntity* PDefender, int32 damage)
+    int32 BreathDmgTaken(CBattleEntity* PDefender, int32 damage, bool ignoreDmgMods)
     {
-        float resist = 1.0f + PDefender->getMod(Mod::DMGBREATH) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
+        if (!ignoreDmgMods)
+        {
+            float resist = 1.0f + PDefender->getMod(Mod::DMGBREATH) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
 
-        resist = std::max(resist, 0.5f); // assuming if its floored at .5f its capped at 1.5f but who's stacking +dmgtaken equip anyway???
+            resist = std::max(resist, 0.5f); // assuming if its floored at .5f its capped at 1.5f but who's stacking +dmgtaken equip anyway???
 
-        resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGBREATH) / 10000.f;
-        resist = std::max(resist, 0.f);
-        damage = (int32)(damage * resist);
+            resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGBREATH) / 10000.f;
+            resist = std::max(resist, 0.f);
+            damage = (int32)(damage * resist);
+        }
 
         if (xirand::GetRandomNumber(100) < PDefender->getMod(Mod::ABSORB_DMG_CHANCE))
         {
@@ -5502,7 +5505,7 @@ namespace battleutils
         return damage;
     }
 
-    int32 MagicDmgTaken(CBattleEntity* PDefender, int32 damage, ELEMENT element)
+    int32 MagicDmgTaken(CBattleEntity* PDefender, int32 damage, ELEMENT element, bool ignoreDmgMods)
     {
         Mod absorb[8]    = { Mod::FIRE_ABSORB, Mod::ICE_ABSORB, Mod::WIND_ABSORB, Mod::EARTH_ABSORB,
                              Mod::LTNG_ABSORB, Mod::WATER_ABSORB, Mod::LIGHT_ABSORB, Mod::DARK_ABSORB };
@@ -5517,16 +5520,19 @@ namespace battleutils
             return (int32)(damage * liement);
         }
 
-        float resist = 1.0f + PDefender->getMod(Mod::DMGMAGIC) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
+        if (!ignoreDmgMods)
+        {
+            float resist = 1.0f + PDefender->getMod(Mod::DMGMAGIC) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
 
-        resist = std::max(resist, 0.5f);
+            resist = std::max(resist, 0.5f);
 
-        resist += PDefender->getMod(Mod::DMGMAGIC_II) / 10000.f;
-        resist = std::max(resist, 0.125f); // Total cap with MDT-% II included is 87.5%
+            resist += PDefender->getMod(Mod::DMGMAGIC_II) / 10000.f;
+            resist = std::max(resist, 0.125f); // Total cap with MDT-% II included is 87.5%
 
-        resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGMAGIC) / 10000.f;
-        resist = std::max(resist, 0.f);
-        damage = (int32)(damage * resist);
+            resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGMAGIC) / 10000.f;
+            resist = std::max(resist, 0.f);
+            damage = (int32)(damage * resist);
+        }
 
         if (damage > 0 && PDefender->objtype == TYPE_PET && PDefender->getMod(Mod::AUTO_STEAM_JACKET) > 1)
         {
@@ -5559,17 +5565,20 @@ namespace battleutils
         return damage;
     }
 
-    int32 PhysicalDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered)
+    int32 PhysicalDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered, bool ignoreDmgMods)
     {
-        float resist = 1.0f + PDefender->getMod(Mod::DMGPHYS) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
+        if (!ignoreDmgMods)
+        {
+            float resist = 1.0f + PDefender->getMod(Mod::DMGPHYS) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
 
-        resist = std::max(resist, 0.5f);                        // PDT caps at -50%
-        resist += PDefender->getMod(Mod::DMGPHYS_II) / 10000.f; // Add Burtgang reduction after 50% cap. Extends cap to -68%
-        resist = std::max(resist, 0.32f);                       // Total cap with MDT-% II included is 87.5%
+            resist = std::max(resist, 0.5f);                        // PDT caps at -50%
+            resist += PDefender->getMod(Mod::DMGPHYS_II) / 10000.f; // Add Burtgang reduction after 50% cap. Extends cap to -68%
+            resist = std::max(resist, 0.32f);                       // Total cap with MDT-% II included is 87.5%
 
-        resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGPHYS) / 10000.f;
-        resist = std::max(resist, 0.f);
-        damage = (int32)(damage * resist);
+            resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGPHYS) / 10000.f;
+            resist = std::max(resist, 0.f);
+            damage = (int32)(damage * resist);
+        }
 
         if (damage > 0 && PDefender->objtype == TYPE_PET && PDefender->getMod(Mod::AUTO_STEAM_JACKET) > 0)
         {
@@ -5607,15 +5616,18 @@ namespace battleutils
         return damage;
     }
 
-    int32 RangedDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered)
+    int32 RangedDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered, bool ignoreDmgMods)
     {
-        float resist = 1.0f + PDefender->getMod(Mod::DMGRANGE) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
+        if (!ignoreDmgMods)
+        {
+            float resist = 1.0f + PDefender->getMod(Mod::DMGRANGE) / 10000.f + PDefender->getMod(Mod::DMG) / 10000.f;
 
-        resist = std::max(resist, 0.5f);
+            resist = std::max(resist, 0.5f);
 
-        resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGRANGE) / 10000.f;
-        resist = std::max(resist, 0.f);
-        damage = (int32)(damage * resist);
+            resist += PDefender->getMod(Mod::UDMG) + PDefender->getMod(Mod::UDMGRANGE) / 10000.f;
+            resist = std::max(resist, 0.f);
+            damage = (int32)(damage * resist);
+        }
 
         if (damage > 0 && PDefender->objtype == TYPE_PET && PDefender->getMod(Mod::AUTO_STEAM_JACKET) > 0)
         {

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -212,10 +212,10 @@ namespace battleutils
     void DirtyExp(CBattleEntity* PDefender, CBattleEntity* PAttacker);
     void RelinquishClaim(CCharEntity* PDefender);
 
-    int32 BreathDmgTaken(CBattleEntity* PDefender, int32 damage);
-    int32 MagicDmgTaken(CBattleEntity* PDefender, int32 damage, ELEMENT element);
-    int32 PhysicalDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered = false);
-    int32 RangedDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered = false);
+    int32 BreathDmgTaken(CBattleEntity* PDefender, int32 damage, bool ignoreDmgMods = false);
+    int32 MagicDmgTaken(CBattleEntity* PDefender, int32 damage, ELEMENT element, bool ignoreDmgMods = false);
+    int32 PhysicalDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered = false, bool ignoreDmgMods = false);
+    int32 RangedDmgTaken(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType, bool IsCovered = false, bool ignoreDmgMods = false);
     int32 HandleSteamJacket(CBattleEntity* PDefender, int32 damage, DAMAGE_TYPE damageType);
 
     void  HandleIssekiganEnmityBonus(CBattleEntity* PDefender, CBattleEntity* PAttacker);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Weapon skills will now correctly interact with damage reduction and damage bonus modifiers (for example physical weapon skills on elementals like air elemental). (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes many instances where damage modifiers were being applied twice.

## Steps to test these changes
Can test for example by using weapon skills on elemental mobs. Also can be test locally by adding debug printing to each function that applies a modifier and then using varying skills, spells, abilities, and such and making sure they are applied only once.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
