### PR TITLE
Fix mob subjob trait issue

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -6425,7 +6425,7 @@ namespace battleutils
         return bonus;
     }
 
-    void AddTraits(CBattleEntity* PEntity, TraitList_t* traitList, uint8 level)
+    void AddTraits(CBattleEntity* PEntity, TraitList_t* traitList, uint8 level, bool mobSubJobCheck)
     {
         CCharEntity* PChar = PEntity->objtype == TYPE_PC ? static_cast<CCharEntity*>(PEntity) : nullptr;
 
@@ -6484,6 +6484,16 @@ namespace battleutils
                     {
                         add = false;
                     }
+                }
+
+                // Mobs SJ level is equal to their MJ level, however certain SJ traits (like double attack)
+                // are gained as if mobs SJ level was half their MJ level (like players),
+                // thus we need check for these special traits
+                if (mobSubJobCheck && PEntity->objtype == TYPE_MOB &&
+                    (PTrait->getID() == TRAIT_DOUBLE_ATTACK || PTrait->getID() == TRAIT_TRIPLE_ATTACK) &&
+                    std::max(static_cast<int>(std::floor(level / 2)), 1) < PTrait->getLevel())
+                {
+                    add = false;
                 }
 
                 if (add)

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -250,7 +250,7 @@ namespace battleutils
     bool    WeatherMatchesElement(WEATHER weather, uint8 element);
     bool    DrawIn(CBattleEntity* PTarget, CMobEntity* PMob, float offset, uint8 drawInRange, uint16 maximumReach, bool includeParty);
     void    DoWildCardToEntity(CCharEntity* PCaster, CCharEntity* PTarget, uint8 roll);
-    void    AddTraits(CBattleEntity* PEntity, TraitList_t* TraitList, uint8 level);
+    void    AddTraits(CBattleEntity* PEntity, TraitList_t* TraitList, uint8 level, bool mobSubJobCheck = false);
     bool    HasClaim(CBattleEntity* PEntity, CBattleEntity* PTarget);
 
     uint32 CalculateSpellCastTime(CBattleEntity*, CMagicState*, uint16 spellid);

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -539,7 +539,8 @@ namespace mobutils
 
         // add traits for sub and main
         battleutils::AddTraits(PMob, traits::GetTraits(mJob), mLvl);
-        battleutils::AddTraits(PMob, traits::GetTraits(PMob->GetSJob()), PMob->GetSLevel());
+        // pass in bool param to stop from adding certain traits to mobs that should not be added
+        battleutils::AddTraits(PMob, traits::GetTraits(PMob->GetSJob()), PMob->GetSLevel(), true);
 
         // Max [HP/MP] Boost traits
         PMob->UpdateHealth();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Monsters under level 50 with non-warrior main job and warrior subjob will no longer have the double attack trait. (Tracent)

## What does this pull request do? (Please be technical)
The PR handles a special case with mob subjob traits whereby mobs under level 50 with non-warrior main job and warrior subjob should not have double attack trait (despite mobs having subjob level equal to main job level).

## Steps to test these changes
Use !gettraits on mobs with war subjob above and below level 50 and also mobs with war main job > 25.

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1383
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
