### PR TITLE
Dynamis Pet fixes and Charm fixes

### DIFF
--- a/modules/era/commands/dynaspawnnm.lua
+++ b/modules/era/commands/dynaspawnnm.lua
@@ -54,5 +54,5 @@ function onTrigger(player, zoneName, mobIndex)
     end
 
     xi.dynamis.nmDynamicSpawn(mobIndex, nil, true, zone:getID())
-    player:PrintToPlayer(string.format("[DynaSetWave] Spawned Notorious Monster %n", mobIndex))
+    player:PrintToPlayer(string.format("[DynaSetWave] Spawned Notorious Monster %s", mobIndex))
 end

--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -1612,8 +1612,8 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
             },
             ["Dagourmarche"] =
             {
-                ["onMobFight"] = { function(mob, target) end },
-                ["onMobRoam"] = { function(mob) end },
+                ["onMobFight"] = { function(mob, target) xi.dynamis.onFightMultiPet(mob, target) end },
+                ["onMobRoam"] = { function(mob) xi.dynamis.onRoamMultiPet(mob) end },
                 ["mixins"] = {  require("scripts/mixins/families/avatar"), },
             },
             ["Normal"] =
@@ -1627,8 +1627,8 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
         {
             ["Dagourmarche"] =
             {
-                ["onMobFight"] = { function(mob, target) end },
-                ["onMobRoam"] = { function(mob) end },
+                ["onMobFight"] = { function(mob, target) xi.dynamis.onFightMultiPet(mob, target) end },
+                ["onMobRoam"] = { function(mob) xi.dynamis.onRoamMultiPet(mob) end },
                 ["mixins"] = {   },
             },
             ["Normal"] =
@@ -1648,8 +1648,8 @@ xi.dynamis.spawnDynamicPet =function(target, oMob, mobJob)
             },
             ["Dagourmarche"] =
             {
-                ["onMobFight"] = { function(mob, target) end },
-                ["onMobRoam"] = { function(mob) end },
+                ["onMobFight"] = { function(mob, target) xi.dynamis.onFightMultiPet(mob, target) end },
+                ["onMobRoam"] = { function(mob) xi.dynamis.onRoamMultiPet(mob) end },
                 ["mixins"] = {   },
             },
             ["Normal"] =

--- a/modules/era/lua_dynamis/mobskills/era_pet_skills.lua
+++ b/modules/era/lua_dynamis/mobskills/era_pet_skills.lua
@@ -13,6 +13,9 @@ require("scripts/globals/msg")
 ---------------------------------------------
 local m = Module:new("era_pet_skills")
 
+xi = xi or {}
+xi.dynamis = xi.dynamis or {}
+
 xi.dynamis.onFightApocDRG = function(mob, target)
     if not mob:getMaster() or mob:getMaster():getHP() == 0 then
         DespawnMob(mob:getID())
@@ -33,6 +36,21 @@ xi.dynamis.onRoamApocDRG = function(mob)
     end
 
     if mob:getMaster() and (os.time() >= mob:getMaster():getLocalVar("next2hrTime")) then
+        DespawnMob(mob:getID())
+    end
+end
+
+-- For mobs with multiple pets - we are at risk for unxpected behavior due to pet AI relying on master's AI state
+-- Most if not all core actions assume a single pet and take action only on the single known pet
+-- As an interim fix - despawn pets when the master is dead.
+xi.dynamis.onFightMultiPet = function(mob, target)
+    if not mob:getMaster() or mob:getMaster():isDead() then
+        DespawnMob(mob:getID())
+    end
+end
+
+xi.dynamis.onRoamMultiPet = function(mob)
+    if not mob:getMaster() or mob:getMaster():isDead() then
         DespawnMob(mob:getID())
     end
 end

--- a/scripts/mixins/job_special.lua
+++ b/scripts/mixins/job_special.lua
@@ -183,6 +183,7 @@ local charmList =
     "Eurymedon",
     "Nephiyl Moatfiller",
     "Ophion",
+    "Skadi",
 }
 
 xi.mix.jobSpecial.config = function(mob, params)
@@ -320,14 +321,23 @@ g_mixins.job_special = function(jobSpecialMob)
             end
 
             -- Certain mobs should Charm instead of Familiar if their pet is dead
-            for _,v in pairs(charmList) do
-                if mob:getName() == v and not mob:hasPet() then
+            for _, v in pairs(charmList) do
+                if
+                    mob:getName() == v and
+                    not (mob:hasPet() and
+                    mob:getPet():isAlive())
+                then
                     ability = 710
                     break
                 end
             end
 
-            if mob:isInDynamis() and mob:getMainJob() == xi.job.BST and not mob:hasPet() then
+            if
+                mob:isInDynamis() and
+                mob:getMainJob() == xi.job.BST and
+                not (mob:hasPet() and
+                mob:getPet():isAlive())
+            then
                 ability = 710 -- Charm
             end
 


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Dagourmarche will no longer crash Dyna Beauce when despawning.
Dynamis BSTs and certain BST NMs will now charm players when their pets are dead.  Previously they would only charm after the pet had comepletely despawned.
Skadi (Temenos Gigas BST NM) will now use charm instead of familiar - it does not have a pet at all.

## What does this pull request do? (Please be technical)

Dagourmarche's pets will now despawn when he is defeated.
Dynamis BSTs now check if they have a pet and if the pet is alive before choosing their 2 hour ability.
Added Skadi (Temenos Gigas BST NM) to the charm list.

## Steps to test these changes

Enter Beauce
!dynaspawnnm BEAUCEDINE 158
Kill the NM
Spawn them
Kill them again
Spawn them
Kill their pets then kill them

Run around Beauce until you get a bst mob
Quickly !hp 0 the pet
Quickly !hp 500 the bst mob
Boom, get charmed

!spawnmob `16928781`
!gotoid `16928781`
Hit skadi to get aggro
!hp 500 the mob
He will charm you

## Special Deployment Considerations

nope
