### PR TITLE
BRD AF3: Fixed Bugaboo ID

### DIFF
--- a/scripts/quests/jeuno/BRD_AF3_The_Circle_of_Time.lua
+++ b/scripts/quests/jeuno/BRD_AF3_The_Circle_of_Time.lua
@@ -13,7 +13,8 @@ require('scripts/globals/npc_util')
 require('scripts/globals/quests')
 require('scripts/globals/interaction/quest')
 -----------------------------------
-local ID = require("scripts/zones/Xarcabard/IDs")
+local xarcabardID = require("scripts/zones/Xarcabard/IDs")
+local monasticID = require("scripts/zones/Monastic_Cavern/IDs")
 -----------------------------------
 
 local quest = Quest:new(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_CIRCLE_OF_TIME)
@@ -130,7 +131,7 @@ quest.sections =
                     elseif os.time() > quest:getVar(player, 'ringBuried') then
                         return quest:progressEvent(2)
                     else
-                        return quest:messageSpecial(ID.text.PERENNIAL_SNOW_WAIT, 225)
+                        return quest:messageSpecial(xarcabardID.text.PERENNIAL_SNOW_WAIT, 225)
                     end
                 end,
             },
@@ -203,7 +204,7 @@ quest.sections =
                     then
                         if
                             quest:getVar(player, 'Prog') == 7 and
-                            npcUtil.popFromQM(player, npc, ID.mob.BUGABOO, { hide = 0 })
+                            npcUtil.popFromQM(player, npc, monasticID.mob.BUGABOO, { hide = 0 })
                         then
                             return quest:noAction()
                         elseif  quest:getVar(player, 'Prog') == 8 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed a bug where Bugaboo would not spawn for BRD AF3 quest.
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
1. Added a new local variable 'monasticID' for monastic cavern IDs
- Changed the variable used to spawn Bugaboo to direct to the correct ID
2. Change the previous variable ID to be 'xarcabardID' for easy identification
Note: Closes #3194 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Accept the quest The Circle of Time and progress it to the point you need to select the altar to spawn Bugaboo.
<!-- Clear and detailed steps to test your changes here. -->
