### PR TITLE
Fix WS damage mods part two

### DIFF
--- a/scripts/globals/mobskills/spirits_within.lua
+++ b/scripts/globals/mobskills/spirits_within.lua
@@ -32,7 +32,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     dmg = math.floor(hp * (math.floor(0.016 * tp) + 16) / 256)
 
-    dmg = target:breathDmgTaken(dmg, true)
+    dmg = target:breathDmgTaken(dmg)
 
     -- Handling phalanx
     dmg = dmg - target:getMod(xi.mod.PHALANX)

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -270,9 +270,15 @@ local attackTypeShields =
 
 xi.summon.physicalSDT = function(attacker, target, damagetype, finalDmg)
     local adjustedDamage = finalDmg
-    -- need to pass in ignoreDmgMods option to physicalDmgTaken otherwise dmg mods are applied both here
-    -- as called by avatarFinalAdjustments and in applyDamageTaken as called by avatarPhysicalMove
-    adjustedDamage = target:physicalDmgTaken(adjustedDamage, damagetype, true)
+    adjustedDamage = target:physicalDmgTaken(adjustedDamage, damagetype)
+
+    if damagetype == xi.damageType.BLUNT then
+        adjustedDamage = adjustedDamage * target:getMod(xi.mod.IMPACT_SDT) / 1000
+    elseif damagetype == xi.damageType.PIERCING then
+        adjustedDamage = adjustedDamage * target:getMod(xi.mod.PIERCE_SDT) / 1000
+    elseif damagetype == xi.damageType.SLASHING then
+        adjustedDamage = adjustedDamage * target:getMod(xi.mod.SLASH_SDT) / 1000
+    end
 
     return adjustedDamage
 end
@@ -361,7 +367,11 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
     -- Calculate Blood Pact Damage before stoneskin
     dmg = dmg + dmg * mob:getMod(xi.mod.BP_DAMAGE) / 100
 
-    dmg = xi.damage.applyDamageTaken(target, dmg, skilltype, damagetype)
+    -- if magic then apply magic mods here
+    -- (physical mods are applied in physicalSDT)
+    if skilltype == xi.attackType.MAGICAL then
+        dmg = xi.damage.applyDamageTaken(target, dmg, skilltype, damagetype)
+    end
 
     -- handle One For All, Liement
 

--- a/scripts/globals/weaponskills/atonement.lua
+++ b/scripts/globals/weaponskills/atonement.lua
@@ -82,7 +82,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
         end
 
         dmg = utils.clamp(dmg, 0, player:getMainLvl() * 10) -- Damage is capped to player's level * 10, before WS damage mods
-        damage = target:breathDmgTaken(dmg, true)
+        damage = target:breathDmgTaken(dmg)
         if player:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID) > 0 then
             damage = damage * (100 + player:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID)) / 100
         end

--- a/scripts/globals/weaponskills/spirits_within.lua
+++ b/scripts/globals/weaponskills/spirits_within.lua
@@ -57,7 +57,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
         end
     end
 
-    local damage = target:breathDmgTaken(wsc, true)
+    local damage = target:breathDmgTaken(wsc)
     if damage > 0 then
         if player:getOffhandDmg() > 0 then
             calcParams.tpHitsLanded = 2


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Weapon skills will now correctly interact with damage reduction and damage bonus modifiers (for example physical weapon skills on elementals like air elemental). (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes many instances where damage modifiers were being applied twice, unlike the previous PR (that this builds upon) this deals with multi-hit WSes by not using damage.lua for WSs.

NOTE that this PR depends on the [earlier PR](https://github.com/AirSkyBoat/AirSkyBoat/pull/3195), thus need to pull both the original then this to horizon or need to unrevert the revert of the earlier PR on Horizon.

## Steps to test these changes
Fight mobs with different modifiers such as PDT, SDT, etc. and use WS, SMN bloodpacts, Pet skills, etc.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
