### PR TITLE
Fix issue with hate bouncing with enmity ties

### DIFF
--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -426,6 +426,15 @@ CBattleEntity* CEnmityContainer::GetHighestEnmity()
             auto* POwner = PEnmityObject.PEnmityOwner;
             if (!POwner || (POwner->allegiance != m_EnmityHolder->allegiance))
             {
+                // Deal with ties by preferring current battle target
+                // Check if there is a tie, the current highest entity is valid, the mob has a battle target,
+                if (Enmity == HighestEnmity && highest != m_EnmityList.end() && m_EnmityHolder->GetBattleTargetID() != 0 &&
+                    // the current highest entity is the current battle target
+                    highest->second.PEnmityOwner && highest->second.PEnmityOwner->targid == m_EnmityHolder->GetBattleTargetID())
+                {
+                    continue;
+                }
+
                 active        = PEnmityObject.active;
                 HighestEnmity = Enmity;
                 highest       = it;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Monsters will no longer change their battle target in cases where alternative targets have equal enmity to the current target (for example in cases of SMN and their pet). (Tracent)

## What does this pull request do? (Please be technical)
This PR enforces the logic that in cases of equal enmity between several entities an aggressive mob will prefer the entity that is the current battle target (rather than simply the last entity in the enmity list, as this can cause bouncing). The retail behavior in such tie cases is unclear but the current system (of preferring last entity on enmity list) is arbitrary with no retail basis as far as I can tell. Thus this alternative is more logical and predictable for players and seems to better align with, for example, the general hate bouncing behavior of retail SMN.

## Steps to test these changes
As SMN fight a mob with carby like 10 levels higher than the SMN, specifically:
- Assault the mob (gives carby active enmity and puts carby on enmity list first then the player second)
- Then retreat (so carby loses enmity faster as carby loses from taking damage but does not gain from attacks)
- Then cast a enmity generating spell (not dia) on the mob (gives player active enmity, now both carby and player have active enmity)
- The mob should attack the player for a hit or two (and player should go to 0 total enmity) and carby should auto-attack the mob
- Now the mob should stay on carby as long as player does nothing (despite the player being second on the enmity list and thus hate would normally bounce back and forth between player and carby)

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
