### PR TITLE
Fix Vrtra timers after a disengage and reengage

### DIFF
--- a/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
@@ -30,6 +30,8 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobEngaged = function(mob, target)
+    mob:setLocalVar("twohourTime", 0)
+    mob:setLocalVar("spawnTime", 0)
 end
 
 entity.onMobFight = function(mob, target)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Vrtra will now have the correct timing for add spawning and charming after disengaging and then reengaging (for example after an alliance wipe and then second attempt). (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes an issue whereby local variables for determining when vrtra should spawn adds and charm were not reset if Vrtra disengaged and then reengaged (such as a party wipe).

## Steps to test these changes
Fight Vrtra for like 5 mins and then !goto charname to allow vrtra to disengage, then start fighting vrtra again and notice that he spawns adds as normal about every one min.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
