### PR TITLE
Fix dawn ally issues

### DIFF
--- a/scripts/zones/Empyreal_Paradox/IDs.lua
+++ b/scripts/zones/Empyreal_Paradox/IDs.lua
@@ -28,7 +28,7 @@ zones[xi.zone.EMPYREAL_PARADOX] =
     },
     mob =
     {
-        PROMATHIA_OFFSET = 16924672,
+        PROMATHIA_OFFSET = 16924671,
     },
     npc =
     {

--- a/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
+++ b/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
@@ -16,7 +16,8 @@ local battlefieldObject = {}
 battlefieldObject.onBattlefieldInitialise = function(battlefield)
     battlefield:setLocalVar("phaseChange", 1)
     battlefield:setLocalVar("instantKick", 1)
-    local baseID = ID.mob.PROMATHIA_OFFSET + battlefield:getArea()
+    -- Need to multiply getArea by 2 due to the two Promathia versions
+    local baseID = ID.mob.PROMATHIA_OFFSET + (battlefield:getArea() * 2)
     local pos = GetMobByID(baseID):getSpawnPos()
 
     local prishe = battlefield:insertEntity(11, true, true)

--- a/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
@@ -22,11 +22,11 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setAllegiance(xi.allegiance.PLAYER)
 end
 
 entity.onMobRoam = function(mob)
-    local promathia = ID.mob.PROMATHIA_OFFSET + mob:getBattlefield():getArea()
+    -- Need to multiply getArea by 2 due to the two Promathia versions
+    local promathia = ID.mob.PROMATHIA_OFFSET + (mob:getBattlefield():getArea() * 2)
     if not GetMobByID(promathia):isAlive() then
         promathia = promathia + 1
     end

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
@@ -20,7 +20,8 @@ end
 
 entity.onMobSpawn = function(mob)
     local battlefield = mob:getBattlefield()
-    if GetMobByID(ID.mob.PROMATHIA_OFFSET + battlefield:getArea()):isDead() then
+    -- Need to multiply getArea by 2 due to the two Promathia versions
+    if GetMobByID(ID.mob.PROMATHIA_OFFSET + (battlefield:getArea() * 2)):isDead() then
         battlefield:setLocalVar("phaseChange", 0)
     end
 end
@@ -74,6 +75,7 @@ entity.onMobFight = function(mob, target)
         else
             mob:castSpell(218, target)
         end
+
         mob:setLocalVar("spellWait", os.time() + 66)
     end
 end

--- a/scripts/zones/Empyreal_Paradox/mobs/Selhteus.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Selhteus.lua
@@ -17,7 +17,6 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setAllegiance(xi.allegiance.PLAYER)
 end
 
 entity.onMobFight = function(mob, target)

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -1363,8 +1363,8 @@ INSERT INTO `mob_groups` VALUES (7,0,36,'Promathia_htbf',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (8,4820,36,'Metus',0,128,0,0,20000,125,125,0);
 INSERT INTO `mob_groups` VALUES (9,0,36,'Omega',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (10,0,36,'Ultima',0,128,0,0,0,0,0,0);
-INSERT INTO `mob_groups` VALUES (11,3199,36,'Prishe',0,128,0,2200,0,75,75,0); -- ally
-INSERT INTO `mob_groups` VALUES (12,5417,36,'Selhteus',0,128,0,0,0,75,75,0); -- ally
+INSERT INTO `mob_groups` VALUES (11,3199,36,'Prishe',0,128,0,2200,0,75,75,1); -- ally
+INSERT INTO `mob_groups` VALUES (12,5417,36,'Selhteus',0,128,0,0,0,75,75,1); -- ally
 
 -- ------------------------------------------------------------
 -- Temenos (Zone 37)

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1273,7 +1273,7 @@ Usage:
         fire_meva, ice_meva, wind_meva, earth_meva, lightning_meva, water_meva, light_meva, dark_meva, \
         Element, mob_pools.familyid, name_prefix, entityFlags, animationsub, \
         (mob_family_system.HP / 100), (mob_family_system.MP / 100), hasSpellScript, spellList, mob_groups.poolid, \
-        allegiance, namevis, aggro, mob_pools.skill_list_id, mob_pools.true_detection, mob_family_system.detects, \
+        allegiance, namevis, aggro, mob_pools.skill_list_id, mob_pools.true_detection, mob_family_system.detects \
         FROM mob_groups INNER JOIN mob_pools ON mob_groups.poolid = mob_pools.poolid \
         INNER JOIN mob_resistances ON mob_pools.resist_id = mob_resistances.resist_id \
         INNER JOIN mob_family_system ON mob_pools.familyid = mob_family_system.familyID \


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Prishe and Selh'teus in the Dawn mission fight will now appear. (Tracent)

## What does this pull request do? (Please be technical)
This fixes two issues with the allies in the dawn fight, firstly an extra comma in the SQL querying for allies and secondly an issue with the calculation of Promathia offsets for the three possible areas of the battlefield.

## Steps to test these changes
On two separate characters:
- !addmission 6 840
- !exec player:setCharVar('Mission[6][840]Status', 2)
- !zone 36
Have the first enter Dawn fight, have the second character enter a separate Dawn fight, notice that in both fights the allies appear and fight the correct promathias, defeat promathia and get win on both chars

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
