### PR TITLE
Fix several SMN issues

### DIFF
--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -386,7 +386,6 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
 
     if dmg > 0 then
         target:updateEnmityFromDamage(mob, dmg)
-        target:addEnmity(mob:getMaster(), 1, 0)
         target:handleAfflatusMiseryDamage(dmg)
     end
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1528,27 +1528,6 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
                 auto PPetTarget = PTarget->targid;
                 if (PAbility->getID() >= ABILITY_HEALING_RUBY && PAbility->getID() <= ABILITY_PERFECT_DEFENSE)
                 {
-                    // Blood Pact mp cost stored in animation ID
-                    float mpCost = PAbility->getAnimationID();
-
-                    if (StatusEffectContainer->HasStatusEffect(EFFECT_APOGEE))
-                    {
-                        mpCost *= 1.5f;
-                        StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_BLOODPACT);
-                    }
-
-                    // Blood Boon (does not affect Astral Flow BPs)
-                    if ((PAbility->getAddType() & ADDTYPE_ASTRAL_FLOW) == 0)
-                    {
-                        int16 bloodBoonRate = getMod(Mod::BLOOD_BOON);
-                        if (xirand::GetRandomNumber(100) < bloodBoonRate)
-                        {
-                            mpCost *= xirand::GetRandomNumber(8.f, 16.f) / 16.f;
-                        }
-                    }
-
-                    addMP((int32)-mpCost);
-
                     if (PAbility->getValidTarget() == TARGET_SELF)
                     {
                         PPetTarget = PPet->targid;

--- a/src/map/mobskill.cpp
+++ b/src/map/mobskill.cpp
@@ -42,6 +42,7 @@ CMobSkill::CMobSkill(uint16 id)
     m_HP                  = 0;
     m_HPP                 = 0;
     m_knockback           = 0;
+    m_bloodPactAbilityID  = 0;
 }
 
 bool CMobSkill::hasMissMsg() const
@@ -422,4 +423,14 @@ void CMobSkill::setSecondarySkillchain(uint8 skillchain)
 void CMobSkill::setTertiarySkillchain(uint8 skillchain)
 {
     m_tertiarySkillchain = skillchain;
+}
+
+uint16 CMobSkill::getBloodPactAbilityID() const
+{
+    return m_bloodPactAbilityID;
+}
+
+void CMobSkill::setBloodPactAbilityID(uint16 bloodPactAbilityID)
+{
+    m_bloodPactAbilityID = bloodPactAbilityID;
 }

--- a/src/map/mobskill.h
+++ b/src/map/mobskill.h
@@ -75,6 +75,7 @@ public:
     uint8  getPrimarySkillchain() const;
     uint8  getSecondarySkillchain() const;
     uint8  getTertiarySkillchain() const;
+    uint16 getBloodPactAbilityID() const;
 
     bool isDamageMsg() const;
 
@@ -96,6 +97,7 @@ public:
     void setPrimarySkillchain(uint8 skillchain);
     void setSecondarySkillchain(uint8 skillchain);
     void setTertiarySkillchain(uint8 skillchain);
+    void setBloodPactAbilityID(uint16 bloodPactAbilityID);
 
     const std::string& getName();
     void               setName(const std::string& name);
@@ -120,6 +122,7 @@ private:
     uint8  m_primarySkillchain; // weaponskill ID of skillchain properties
     uint8  m_secondarySkillchain;
     uint8  m_tertiarySkillchain;
+    uint16 m_bloodPactAbilityID;
 
     std::string m_name;
 };

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -208,6 +208,8 @@ namespace battleutils
 
         if (ret != SQL_ERROR && sql->NumRows() != 0)
         {
+            // get SMN abilities so can setAbilityID for bloodpacts
+            std::vector<CAbility*> AbilitiesList = ability::GetAbilities(JOB_SMN);
             while (sql->NextRow() == SQL_SUCCESS)
             {
                 CMobSkill* PMobSkill = new CMobSkill(sql->GetIntData(0));
@@ -225,6 +227,18 @@ namespace battleutils
                 PMobSkill->setSecondarySkillchain(sql->GetUIntData(12));
                 PMobSkill->setTertiarySkillchain(sql->GetUIntData(13));
                 PMobSkill->setMsg(185); // standard damage message. Scripters will change this.
+
+                // Need to set the ability ID (for bloodpacts) so that info (such as MP) can be accessed
+                // in mobentity when the actual bloodpact completes (and MP is deducted)
+                for (auto PAbility : AbilitiesList)
+                {
+                    if (PAbility->getMobSkillID() == PMobSkill->getID())
+                    {
+                        PMobSkill->setBloodPactAbilityID(PAbility->getID());
+                        break;
+                    }
+                }
+
                 g_PMobSkillList[PMobSkill->getID()] = PMobSkill;
 
                 auto filename = fmt::format("./scripts/globals/mobskills/{}.lua", PMobSkill->getName());


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Blood pacts will now consume MP when the blood pact successfully completes and players will not lose MP if the blood pact is interrupted (for example, if the Avatar is asleep). (Tracent)
- AoE blood pacts will now give the summoner enmity only on the monster specifically targeted by the blood pact, note that accordingly these blood pacts will apply treasure hunter only to the mob targeted by the blood pact. (Tracent)

## What does this pull request do? (Please be technical)
The PR fixes several SMN issues mentioned above. The blood pact MP change requires a new variable to link the player ability and the mob skill for a blood pact, this is because when the blood pact completes the code function only has access to the mob skill while the player ability has the MP cost and so forth. While the AoE blood pact fix just removes a call that added 1 CE to all such moves.

Completes Issues 2 and 5 in https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1620

## Steps to test these changes
Summon an avatar and use a blood pact to see that MP is removed only when the blood pact completes (rather than when the player initiates the pact). Then target the avatar and use `!exec target:addStatusEffect(2, 1, 0, 20)` to put the avatar to sleep for 20 seconds, then use a blood pact and see MP is not removed as the pact does not complete.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
