### PR TITLE
Enable Goblin bomb_toss_suicide and prevent multiple mobSkillChecks

### DIFF
--- a/scripts/globals/mobskills/bomb_toss.lua
+++ b/scripts/globals/mobskills/bomb_toss.lua
@@ -9,17 +9,6 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local suicideCheck = math.random(0, 100)
-
-    if
-        not mob:isNM() and
-        not mob:isInDynamis() and
-        suicideCheck <= 15 -- 15% chance to use bomb_toss_suicide if bomb_toss is picked (50%)
-    then
-        mob:useMobAbility(592)
-        return 1
-    end
-
     return 0
 end
 

--- a/scripts/globals/mobskills/bomb_toss_suicide.lua
+++ b/scripts/globals/mobskills/bomb_toss_suicide.lua
@@ -2,6 +2,7 @@
 -- Bomb Toss - Suicide
 -- Throws a bomb at an enemy. Sometimes backfires (bomb_toss.lua)
 -- This needs to be set to do 1/3 of the mob's current HP.
+-- 15% chance to use bomb_toss_suicide if bomb_toss is picked (50%)
 -----------------------------------
 require("scripts/globals/mobskills")
 require("scripts/globals/settings")
@@ -10,12 +11,35 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- notorious monsters shouldn't explode, nor dynamis
-    if mob:isMobType(xi.mobskills.mobType.NOTORIOUS) or mob:isInDynamis() then
-        return 1
+    --[[
+    BombToss Suicide should happen approx 15% of the time a goblin throws a bomb
+    goblin_rush and bomb_toss are assumed to be close to 50/50 activation rate
+    This nets a roughly 7.5% activation rate.
+
+    To achieve a 7.5% activation we have to consider how a mob skill is chosen.
+    The entire skill list is shuffled and then checked starting from the first element.
+    In this scenario we have 3 skills to consider resulting in a ~33% chance for each
+    .: we should set bomb_toss_suicide's threshold to be 23%.  33% * 23% = ~7.5%
+    This gives us a roughly 46% goblin_rush rate and a combined ~54% bomb_toss rate
+    Not exactly 50% goblin_rush 35% bomb_toss and 15% bomb_toss_suicide
+
+    A more involved fix is one of the following:
+    - Changing the mob skill list to support weighting (we currently do this mob by mob in OnMobWeaponSkillPrepare)
+    - Changing OnMobWeaponSkillPrepare to support a family level check (perhaps loading a family mixin file and looking for OnMobWeaponSkillPrepare)
+    - Adding a mixin (and a lua file) for every goblin in vanadiel (there are a lot of goblins. lets not do that)
+    Its worth nothing that I am only aware of two families which would make use of this.  Goblins and Moblins
+    ]]
+
+    local suicideCheck = math.random(0, 100)
+    if
+        not mob:isNM() and
+        not mob:isInDynamis() and -- Campaign too eventually
+        suicideCheck <= 23
+    then
+        return 0
     end
 
-    return 0
+    return 1
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -514,6 +514,7 @@ INSERT INTO `mob_skill_lists` VALUES ('Gnole',132,2175);
 INSERT INTO `mob_skill_lists` VALUES ('Gnole',132,2176);
 INSERT INTO `mob_skill_lists` VALUES ('Goblin',133,590);
 INSERT INTO `mob_skill_lists` VALUES ('Goblin',133,591);
+INSERT INTO `mob_skill_lists` VALUES ('Goblin',133,592);
 INSERT INTO `mob_skill_lists` VALUES ('God',134,1491);
 INSERT INTO `mob_skill_lists` VALUES ('God',134,1492);
 INSERT INTO `mob_skill_lists` VALUES ('God',134,1493);

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -400,8 +400,8 @@ bool CMobController::MobSkill(int wsList)
         }
 
         PActionTarget = luautils::OnMobSkillTarget(PActionTarget, PMob, PMobSkill);
-
-        if (PActionTarget && !PMobSkill->isAstralFlow() && luautils::OnMobSkillCheck(PActionTarget, PMob, PMobSkill) == 0) // A script says that the move in question is valid
+        // A script says that the move in question is valid
+        if (PActionTarget && !PMobSkill->isAstralFlow() && luautils::OnMobSkillCheck(PActionTarget, PMob, PMobSkill) == 0)
         {
             float currentDistance = distance(PMob->loc.p, PActionTarget->loc.p);
 
@@ -693,7 +693,7 @@ void CMobController::DoCombatTick(time_point tick)
     {
         return;
     }
-    else if (m_Tick >= m_LastMobSkillTime && xirand::GetRandomNumber(1, 10000) <= PMob->TPUseChance() && MobSkill())
+    else if (PMob->PAI->CanChangeState() && xirand::GetRandomNumber(1, 10000) <= PMob->TPUseChance() && MobSkill())
     {
         return;
     }


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Enables goblin bomb toss suicides at a rate of 15% of bomb tosses (or 7.5%).
First person to open a bug report for seeing back to back suicides or not seeing a suicide in 20 tries gets a ban.

## What does this pull request do? (Please be technical)

Four changes:
1. Removes the mobskill queuing from bomb_toss onMobSkillCheck.  This was causing the double bomb toss issue.
1. Adds bomb_toss_suicide into the goblin mob_skill_list
1. Adds gating checks to bomb_toss_suicide including a perctage activate gate.  See comments in file for rationale on values
1. Adds a gating check to prepareing a mob skill based on the mob AI state.  This will prevent mobs from spamming onMobSkillCheck 2x a second while prepareing weaponskills.

## Steps to test these changes

!zone bibikiBay
!speed 255 and run past the docs - there is a ~73 Hobgoblin
!immortal the goblin
voke the gobbo
!tp 3000 the goblin until it blows itself up
note that you take 1/3 mob current hp dmg - 1.4kish from the hobgoblin

Repeat as much as you want - ideally with the logs addon and grepping the text files vs counting

## Special Deployment Considerations

normal sql update should catch the mob_skill_list change
