### PR TITLE
Mark Brazen Bones as WOTG

### DIFF
--- a/modules/era/sql/era_mob_groups.sql
+++ b/modules/era/sql/era_mob_groups.sql
@@ -954,6 +954,7 @@ UPDATE mob_groups SET minLevel = 52, maxLevel = 58 WHERE name = "Bloodsucker_fis
 -- Toraimarai_Canal (Zone 169)
 -- ------------------------------------------------------------
 
+UPDATE mob_groups SET content_tag='WOTG' WHERE name='Brazen_Bones' AND groupid='40' AND zoneid='169';
 UPDATE mob_groups SET content_tag='ABYSSEA' WHERE name='Blackwater_Pugil' AND groupid='24' AND zoneid='169';
 UPDATE mob_groups SET content_tag='ABYSSEA' WHERE name='Plunderer_Crab' AND groupid='25' AND zoneid='169';
 UPDATE mob_groups SET content_tag='ABYSSEA' WHERE name='Deviling_Bats' AND groupid='28' AND zoneid='169';


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Brazen Bones has been tagged as WOTG and will no longer spawn for servers set to earlier eras.
NM was added in 2009
https://wiki.ffo.jp/html/18182.html

## What does this pull request do? (Please be technical)

leverages era_mob_groups sql to flag brazen bones as WOTG

## Steps to test these changes

Run update, restart server, go see if brazen bones spawns

## Special Deployment Considerations

execution of era_mob_groups.sql
