### PR TITLE
Fix several KV spawning issues

### DIFF
--- a/scripts/zones/Western_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Western_Altepa_Desert/Zone.lua
@@ -19,11 +19,13 @@ end
 zoneObject.onInitialize = function(zone)
     -- KV Persistence
     UpdateNMSpawnPoint(ID.mob.KING_VINEGARROON)
-    DisallowRespawn(GetMobByID(ID.mob.KING_VINEGARROON):getID(), true)
 
-    if os.time() < GetServerVariable("\\[SPAWN\\]17289575") then
-        GetMobByID(ID.mob.KING_VINEGARROON):setRespawnTime(GetServerVariable("\\[SPAWN\\]17289575") - os.time())
+    if os.time() < GetServerVariable("\\[SPAWN\\]" .. tostring(ID.mob.KING_VINEGARROON)) then
+        GetMobByID(ID.mob.KING_VINEGARROON):setRespawnTime(GetServerVariable("\\[SPAWN\\]" .. tostring(ID.mob.KING_VINEGARROON)) - os.time())
     end
+
+    -- need DisallowRespawn after setRespawnTime because setRespawnTime sets allowRespawn to true
+    DisallowRespawn(ID.mob.KING_VINEGARROON, true)
 
     xi.bmt.updatePeddlestox(xi.zone.YUHTUNGA_JUNGLE, ID.npc.PEDDLESTOX)
 end
@@ -86,26 +88,48 @@ zoneObject.onZoneWeatherChange = function(weather)
         end
     end
 
-    local kingV = GetMobByID(ID.mob.KING_VINEGARROON)
-    local kvre = GetServerVariable("\\[SPAWN\\]17289575")
+    local zone = GetZone(xi.zone.WESTERN_ALTEPA_DESERT)
     if
-        not kingV:isSpawned() and
-        os.time() > kvre and
-        weather == xi.weather.DUST_STORM
-    then
-        -- 10% chance for KV pop at start of single earth weather
-        local chance = math.random(1, 10)
-        if chance == 1 then
-            DisallowRespawn(kingV:getID(), false)
-            SpawnMob(ID.mob.KING_VINEGARROON)
-        end
-    elseif
-        not kingV:isSpawned() and
-        os.time() > kvre and
+        weather == xi.weather.DUST_STORM or
         weather == xi.weather.SAND_STORM
     then
-        DisallowRespawn(kingV:getID(), false)
-        SpawnMob(ID.mob.KING_VINEGARROON)
+        zone:setLocalVar("NeedToCheckKV", 1)
+    else
+        zone:setLocalVar("NeedToCheckKV", 0)
+    end
+end
+
+zoneObject.onZoneTick = function(zone)
+    -- Need to check KV because of weather
+    if zone:getLocalVar("NeedToCheckKV") == 1 then
+        local kvre = GetServerVariable("\\[SPAWN\\]" .. tostring(ID.mob.KING_VINEGARROON))
+        -- Cannot set NeedToCheckKV to 0 until after this condition
+        -- in case window opens during this weather
+        if os.time() > kvre then
+            local weather = zone:getWeather()
+            local kingV = GetMobByID(ID.mob.KING_VINEGARROON)
+
+            if
+                not kingV:isSpawned() and
+                weather == xi.weather.DUST_STORM
+            then
+                -- 10% chance for KV pop at start of single earth weather
+                local chance = math.random(1, 10)
+                if chance == 1 then
+                    DisallowRespawn(ID.mob.KING_VINEGARROON, false)
+                    SpawnMob(ID.mob.KING_VINEGARROON)
+                end
+            elseif
+                not kingV:isSpawned() and
+                weather == xi.weather.SAND_STORM
+            then
+                DisallowRespawn(ID.mob.KING_VINEGARROON, false)
+                SpawnMob(ID.mob.KING_VINEGARROON)
+            end
+
+            -- did a full check during this weather
+            zone:setLocalVar("NeedToCheckKV", 0)
+        end
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
King Vinegarroon now spawns correctly after zone restart and when earth weather is already present when the spawn window opens. (Tracent)

## What does this pull request do? (Please be technical)
This fixes two spawn corner cases described above. 

The first issue was occurring because setRespawnTime was being called after DisallowRespawn, and setRespawnTime actually sets the mobs internal allowRespawn variable to true, thus negating the DisallowRespawn function call. The order of these calls was now switched.

The second issue was occurring because the KV spawn check was in an onWeatherChange function, thus if the KV window opened when there was, for example, already on-going double earth weather, KV would not spawn during that weather. Thus the spawn check was moved to onZoneTick so KV will spawn in such cases.

## Steps to test these changes
Can go to KV spawn area and set the window time to a few minutes into the future 
!exec SetServerVariable("[SPAWN]17289575", os.time()+120)
Then !setweather 9 to start double earth weather like 1 min before the window time
Wait and watch KV spawn as the window opens 

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
