### PR TITLE
Fix several issues

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -117,6 +117,18 @@ xi.additionalEffect.calcDamage = function(attacker, element, defender, damage, a
         params.skillType = item:getSkillType()
         params.damageSpell = true
         params.includemab = true
+    -- need to also specify skill and params for bloody bolts
+    elseif
+        addType == xi.additionalEffect.procType.HP_DRAIN and
+        element == xi.magic.ele.DARK and
+        item:getSkillType() == xi.skill.MARKSMANSHIP
+    then
+        params.element = xi.magic.ele.DARK
+        params.attribute = xi.mod.INT
+        params.skillType = item:getSkillType()
+    -- need to also specify the skill for any other bolts
+    elseif item:getSkillType() == xi.skill.MARKSMANSHIP then
+        params.skillType = item:getSkillType()
     end
 
     damage = xi.magic.addBonusesAbility(attacker, element, defender, damage, params)

--- a/scripts/quests/windurst/Waking_Dreams.lua
+++ b/scripts/quests/windurst/Waking_Dreams.lua
@@ -50,7 +50,6 @@ quest.sections =
             ['Kerutoto'] =
             {
                 onTrigger = function(player, npc)
-                    -- TODO: Options still appear even if player has the item or spell
                     if player:hasKeyItem(xi.ki.WHISPER_OF_DREAMS) then
                         local availRewards = 0
                             + (player:hasItem(xi.items.DIABOLOSS_POLE) and 1 or 0)    -- Diabolos's Pole
@@ -64,9 +63,27 @@ quest.sections =
                             xi.items.DIABOLOSS_EARRING,
                             xi.items.DIABOLOSS_RING,
                             xi.items.DIABOLOSS_TORQUE,
-                            { availRewards })
+                            0, 0, 0, availRewards)
                     end
                 end,
+            },
+
+            onEventUpdate =
+            {
+                [920] = function(player, csid, option, npc)
+                    local availRewards = 0
+                        + (player:hasItem(xi.items.DIABOLOSS_POLE) and 1 or 0)    -- Diabolos's Pole
+                        + (player:hasItem(xi.items.DIABOLOSS_EARRING) and 2 or 0) -- Diabolos's Earring
+                        + (player:hasItem(xi.items.DIABOLOSS_RING) and 4 or 0)    -- Diabolos's Ring
+                        + (player:hasItem(xi.items.DIABOLOSS_TORQUE) and 8 or 0)  -- Diabolos's Torque
+                        + (player:hasSpell(304) and 32 or 16) -- Pact or gil
+
+                    player:updateEvent(xi.items.DIABOLOSS_POLE,
+                        xi.items.DIABOLOSS_EARRING,
+                        xi.items.DIABOLOSS_RING,
+                        xi.items.DIABOLOSS_TORQUE,
+                        0, 0, 0, availRewards)
+                end
             },
 
             onEventFinish =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- The reward selection menu for the quest Waking Dreams should now work correctly. (Tracent)
- Bloody bolts now use marksmanship skill level (rather than main hand skill level) for determining HP drain resists. (Tracent)

## What does this pull request do? (Please be technical)
This PR fixes several issues as described above, the changes are mainly self-explanatory.

## Steps to test these changes
- !zone Windurst Waters and !pos 13 -5 -157, !addquest 2 93 and !addkeyitem whisper_of_dreams, talk to Kerutoto until you can get the reward selection menu, you should only see items/options that you do not already have, then attempt to view a reward then select Wait!, when you return to the selection menu you should Diabolos's Pole at the top still (rather than the viewed item)

- Fire bloody bolts with low versus high marksmanship skill on like DC mobs and see the different in drain resists

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2768
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1377
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1284
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1234
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
