### PR TITLE
Restore multihit ftp, remove zanshin check on weaponskills

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -596,9 +596,13 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
     -- store bonus damage for first hit, for use after other calculations are done
     local firstHitBonus = (finaldmg * attacker:getMod(xi.mod.ALL_WSDMG_FIRST_HIT)) / 100
 
-    local hitsDone = 1
+    -- Reset fTP if it's not supposed to carry over across all hits for this WS
+    -- We'll recalculate our mainhand damage after doing offhand
+    if not wsParams.multiHitfTP then
+        ftp = 1
+    end
 
-    ftp = 1 + calcParams.bonusfTP
+    local hitsDone = 1
 
     base = (calcParams.weaponDamage[1] + wsMods) * ftp
 
@@ -641,7 +645,6 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
         calcParams.critRate = calcParams.critRate + mainSlotCritBonus - subSlotCritBonus
     end
 
-    -- Reset fTP if it's not supposed to carry over across all hits for this WS
     calcParams.tpHitsLanded = calcParams.hitsLanded -- Store number of TP hits that have landed thus far
     calcParams.hitsLanded = 0 -- Reset counter to start tracking additional hits (from WS or Multi-Attacks)
 

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -323,7 +323,7 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, f
     if
         (missChance <= calcParams.hitRate or
         calcParams.guaranteedHit or
-        (calcParams.melee and (math.random() < attacker:getMod(xi.mod.ZANSHIN) / 100))) and
+        calcParams.melee) and
         not calcParams.mustMiss
     then
         if not shadowAbsorb(target) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

As intended, Zanshin no longer works on weaponskills (Wintersolstice)
WS gorget .1 fTP bonus no longer applies to hits after the first on weaponskills unless fTP mirrors on that weaponskill. (Wintersolstice)

## What does this pull request do? (Please be technical)

Restores multiHitfTP ws param from LSB, which fixes a huge oversight with WS gorget fTP applying to hits beyond the first when the WS doesn't mirror fTP.

Zanshin check on weaponskills is now removed, as it doesn't work that way.

## Steps to test these changes

Use weaponskills with gorget, don't get extra fTP on hits past the first.
See zanshin not silently re-roll misses on weaponskills.

## Special Deployment Considerations

N/A, though check if all weaponskills that should have multiHitfTP do.
