### PR TITLE
LSB cherrypicks - Mobskill tp loss mechanics on stun/petrify etc

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -151,7 +151,7 @@ end
 xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod, dmgmod, tpeffect, ftp100, ftp200, ftp300, critperc, attmod)
     local returninfo = { }
     local fStr = 0
-    local tp = mob:getTP()
+    local tp = skill:getTP()
     -- Leaving this in here in case Jimmayus info says otherwise
     -- if wSCdex == nil then
     --     wSCdex = 0
@@ -229,9 +229,9 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
 
     local paramsRanged = { atk100 = 1, atk200 = 1, atk300 = 1 }
     -- Getting PDIF
-    local pdifTable = xi.weaponskills.cMeleeRatio(mob, target, params, 0, mob:getTP(), xi.slot.MAIN)
+    local pdifTable = xi.weaponskills.cMeleeRatio(mob, target, params, 0, tp, xi.slot.MAIN)
     if tpeffect == xi.mobskills.physicalTpBonus.RANGED then
-        pdifTable = xi.weaponskills.cRangedRatio(mob, target, paramsRanged, 0, mob:getTP())
+        pdifTable = xi.weaponskills.cRangedRatio(mob, target, paramsRanged, 0, tp)
     end
 
     local pdif = pdifTable[1]
@@ -277,7 +277,7 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
 
     while hitsdone < numberofhits do
         chance = math.random()
-        pdifTable = xi.weaponskills.cMeleeRatio(mob, target, params, 0, mob:getTP(), xi.slot.main)
+        pdifTable = xi.weaponskills.cMeleeRatio(mob, target, params, 0, tp, xi.slot.main)
         pdif = pdifTable[1]
         pdifcrit = pdifTable[2]
 
@@ -352,7 +352,7 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
 
     --get all the stuff we need
     local resist = 1
-    local tp = mob:getTP()
+    local tp = skill:getTP()
 
     -- This needs to be taken out - to not cause Nil errors leave and set to damage
     if tpeffect == xi.mobskills.magicalTpBonus.DMG_BONUS then

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -124,7 +124,7 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, wsParams, tp)
     calcParams.skill = skill
     calcParams.fSTR = xi.summon.getAvatarfSTR(avatar:getStat(xi.mod.STR), target:getStat(xi.mod.VIT), avatar)
     calcParams.melee = true
-    calcParams.tp = avatar:getTP()
+    calcParams.tp = skill:getTP()
     calcParams.alpha = xi.weaponskills.getAlpha(avatar:getMainLvl())
 
     -- https://forum.square-enix.com/ffxi/threads/45365?p=534537#post534537
@@ -437,7 +437,7 @@ xi.summon.calculateMagicBloodPactParams = function(avatar, target, skill, wsPara
     params.melee = false
     params.skill = skill
     params.dStat = utils.ternary(wsParams.breath, 0, xi.summon.dStat(avatar, target, xi.mod.INT))
-    params.tp = avatar:getTP() + wsParams.tpBonus
+    params.tp = skill:getTP() + wsParams.tpBonus
     params.alpha = xi.weaponskills.getAlpha(avatar:getMainLvl())
     return params
 end

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -172,7 +172,10 @@ void CMobSkillState::Cleanup(time_point tick)
         // But lose 25% at < 2900 TP.
         // Testing was done via charm on a steelshell, methodology was the following on BST/DRK with a scythe
         // charm -> build tp -> leave -> stun -> interrupt TP move with weapon bash -> charm and check TP. Note that weapon bash incurs damage and thus adds TP.
-        if (m_PEntity->StatusEffectContainer && m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT::EFFECT_STUN))
+        // Note: this is very incomplete. Further testing shows that other statuses also reduce TP but in addition it seems that specific mobskills may reduce TP more or less than these numbers
+        // Thus while incomplete, is better than nothing.
+        if (m_PEntity->StatusEffectContainer &&
+            m_PEntity->StatusEffectContainer->HasStatusEffect({ EFFECT::EFFECT_STUN, EFFECT::EFFECT_TERROR, EFFECT::EFFECT_PETRIFICATION, EFFECT::EFFECT_SLEEP, EFFECT::EFFECT_SLEEP_II, EFFECT::EFFECT_LULLABY }))
         {
             int16 tp = m_spentTP;
             if (tp >= 2900)

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -74,6 +74,7 @@ CMobSkillState::CMobSkillState(CMobEntity* PEntity, uint16 targid, uint16 wsid)
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, new CActionPacket(action));
     }
     m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
+    SpendCost();
 }
 
 CMobSkill* CMobSkillState::GetSkill()
@@ -121,7 +122,6 @@ bool CMobSkillState::Update(time_point tick)
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
         auto delay   = std::chrono::milliseconds(m_PSkill->getAnimationTime());
         m_finishTime = tick + delay;
-        SpendCost();
         Complete();
     }
     if (IsCompleted() && tick > m_finishTime)

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -167,5 +167,22 @@ void CMobSkillState::Cleanup(time_point tick)
         actionTarget.reaction        = REACTION::HIT;
 
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, new CActionPacket(action));
+
+        // On retail testing, mobs lose 33% of their TP at 2900 or higher TP
+        // But lose 25% at < 2900 TP.
+        // Testing was done via charm on a steelshell, methodology was the following on BST/DRK with a scythe
+        // charm -> build tp -> leave -> stun -> interrupt TP move with weapon bash -> charm and check TP. Note that weapon bash incurs damage and thus adds TP.
+        if (m_PEntity->StatusEffectContainer && m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT::EFFECT_STUN))
+        {
+            int16 tp = m_spentTP;
+            if (tp >= 2900)
+            {
+                m_PEntity->health.tp = std::floor(std::round(0.333333f * tp));
+            }
+            else
+            {
+                m_PEntity->health.tp = std::floor(0.25f * tp);
+            }
+        }
     }
 }

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -521,6 +521,8 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
 
         m_StatusEffectSet.insert(PStatusEffect);
 
+        ApplyStateAlteringEffects(PStatusEffect);
+
         luautils::OnEffectGain(m_POwner, PStatusEffect);
         m_POwner->PAI->EventHandler.triggerListener("EFFECT_GAIN", CLuaBaseEntity(m_POwner), CLuaStatusEffect(PStatusEffect));
 
@@ -752,6 +754,40 @@ void CStatusEffectContainer::KillAllStatusEffect()
     m_POwner->UpdateHealth();
 }
 
+// Apply any state alterations for the effect if applicable.
+void CStatusEffectContainer::ApplyStateAlteringEffects(CStatusEffect* StatusEffect)
+{
+    EFFECT effect = StatusEffect->GetStatusID();
+
+    if (m_POwner->isAlive())
+    {
+        // this should actually go into a char charm AI
+        if (m_POwner->objtype == TYPE_PC)
+        {
+            if (effect == EFFECT_CHARM || effect == EFFECT_CHARM_II)
+            {
+                if (m_POwner->PPet != nullptr)
+                {
+                    petutils::DespawnPet(m_POwner);
+                }
+            }
+        }
+
+        if (effect == EFFECT_SLEEP || effect == EFFECT_SLEEP_II || effect == EFFECT_STUN || effect == EFFECT_PETRIFICATION || effect == EFFECT_TERROR ||
+            effect == EFFECT_LULLABY || effect == EFFECT_PENALTY)
+        {
+            // change icon of sleep II and lullaby. Apparently they don't stop player movement.
+            if (effect == EFFECT_SLEEP_II || effect == EFFECT_LULLABY)
+            {
+                StatusEffect->SetIcon(EFFECT_SLEEP);
+            }
+            if (!m_POwner->PAI->IsCurrentState<CInactiveState>())
+            {
+                m_POwner->PAI->Inactive(0ms, false);
+            }
+        }
+    }
+}
 /************************************************************************
  *                                                                       *
  *  Удаляем все эффекты с указанными иконками                            *
@@ -1584,37 +1620,6 @@ void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
     StatusEffect->SetName(name);
     StatusEffect->SetFlag(effects::EffectsParams[effect].Flag);
     StatusEffect->SetType(effects::EffectsParams[effect].Type);
-
-    // todo: find a better place to put this?
-    if (m_POwner->isAlive())
-    {
-        // this should actually go into a char charm AI
-        if (m_POwner->objtype == TYPE_PC)
-        {
-            if (effect == EFFECT_CHARM || effect == EFFECT_CHARM_II)
-            {
-                if (m_POwner->PPet != nullptr)
-                {
-                    petutils::DespawnPet(m_POwner);
-                }
-            }
-        }
-
-        if (effect == EFFECT_SLEEP || effect == EFFECT_SLEEP_II || effect == EFFECT_STUN || effect == EFFECT_PETRIFICATION || effect == EFFECT_TERROR ||
-            effect == EFFECT_LULLABY || effect == EFFECT_PENALTY)
-        {
-            // change icon of sleep II and lullaby. Apparently they don't stop player movement.
-            if (effect == EFFECT_SLEEP_II || effect == EFFECT_LULLABY)
-            {
-                StatusEffect->SetIcon(EFFECT_SLEEP);
-            }
-
-            if (!m_POwner->PAI->IsCurrentState<CInactiveState>())
-            {
-                m_POwner->PAI->Inactive(0ms, false);
-            }
-        }
-    }
 }
 
 /************************************************************************

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -55,6 +55,7 @@ public:
     void DelStatusEffectsByType(uint16 Type);
     bool DelStatusEffectByTier(EFFECT StatusID, uint16 power);
     void KillAllStatusEffect();
+    void ApplyStateAlteringEffects(CStatusEffect* StatusEffect);
 
     bool HasStatusEffect(EFFECT StatusID);               // проверяем наличие эффекта
     bool HasStatusEffect(EFFECT StatusID, uint16 SubID); // проверяем наличие эффекта с уникальным subid


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Interrupting a mob skill with Break, Lullaby, Sleep, Stun, or Terror will now reduce the TP the mob has. (Wintersolstice)

## What does this pull request do? (Please be technical)

Does what it says on the tin, add TP retention of interrupted mobskills that were stunned. These values were taken from retail testing. This implementation is incomplete but is critical for gameplay, otherwise mobs will not lose TP remotely correctly.

## Steps to test these changes

!tp 3000 a mob at 100%
stun/sleep/lullaby
!exec print(tostring(target:getTP()) is now 1/3 of their starting TP when using the moves

## Special Deployment Considerations

N/A