### PR TITLE
Fixes Power Attack for jug pets.  Power Attack (beelte) now crits)

### DIFF
--- a/scripts/globals/mobskills/power_attack_beetle.lua
+++ b/scripts/globals/mobskills/power_attack_beetle.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Power Attack
--- Deals damage based off TP.
+-- Single target critical damage
 -- 100% TP: ??? / 250% TP: ??? / 300% TP: ???
 -----------------------------------
 require("scripts/globals/settings")
@@ -17,11 +17,13 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 1
     local dmgmod = 1
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 1.5, 2)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.HTH, info.hitslanded)
+    -- In testing lvl 60 blu vs lvl 25-28 beetles (Diving Beetles) - 50 out of 50 power attacks hit for similar damage as a critical hit
+    local crit = 1 -- mobPhysicalMove does not actually caclulate CRIT_VARIES, crit param required
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.CRIT_VARIES, 1, 1.5, 2, crit)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
     if not skill:hasMissMsg() then
-        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.HTH)
+        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     end
 
     return dmg

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -559,7 +559,7 @@ INSERT INTO `abilities` VALUES (703,'numbshroom',9,25,257,2,102,0,0,0,2000,0,6,1
 INSERT INTO `abilities` VALUES (704,'shakeshroom',9,25,257,2,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (705,'silence_gas',9,25,257,3,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (706,'dark_spore',9,25,257,3,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
-INSERT INTO `abilities` VALUES (707,'power_attack',9,25,257,1,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
+INSERT INTO `abilities` VALUES (707,'power_attack_beetle',9,25,257,1,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (708,'hi-freq_field',9,25,257,2,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (709,'rhino_attack',9,25,257,1,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (710,'rhino_guard',9,25,257,1,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Jug Pet beetle pets will no longer use gigas power attack instead of beetle power attack.
Power Attack (beetle) is now a crit tp move.

## What does this pull request do? (Please be technical)

Adds crit param for beetle power attack.
Changes skill name lookup in abilities.sql to correctly map 707 (ready: power attack) to power_attack_beetle

## Testing on Retail:
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/105882290/67d5d25e-3c84-4473-b8f5-e8e5beeaedd1)
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/105882290/26f457d7-610b-4825-b23f-39b0183f2886)

Over two sessions - brought 4 Diving beetles (level 25-28) down to sub 25% and let them beat upon a level 60 blu/25 whm.
Single auto attacks from the beetles ranged from single digits to max 16 dmg.  Crits were mid 20s - low 30s dmg.
Rhino attack consistiently landed for single digit damage.
Every single Power Attack always hit for mid 20s or higher on 50+ usages.
This implies that power attack either has a unique floor on dmg or that every single power attack was a crit.

## Steps to test these changes

Summon a beetle jug pet and have it use power attack
It should **not** turn into a submarine and dive through the ground, then pop up and smack the target.
Instead, it should look how power attack always looks.

From a mob change perspecitive, could replicate the test done above or just fight beetles and note that you get crit hit dmg whenever power attack lands.

## Special Deployment Considerations

normal deployment should handle the abilities.sql update
