### PR TITLE
Fix AH ordering of items with no stock

### DIFF
--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -88,9 +88,11 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 AHCategoryID, int8*
 
     std::vector<ahItem*> ItemList;
 
-    const char* fmtQuery = "SELECT item_basic.itemid, item_basic.stackSize, COUNT(*)-SUM(stack), SUM(stack) "
+    const char* fmtQuery = "SELECT item_basic.itemid, item_basic.stackSize, "
+                           "SUM(if(auction_house.buyer_name IS NULL, 1, 0))-SUM(if(auction_house.buyer_name IS NULL, stack, 0)), "
+                           "SUM(if(auction_house.buyer_name IS NULL, stack, 0)) "
                            "FROM item_basic "
-                           "LEFT JOIN auction_house ON item_basic.itemId = auction_house.itemid AND auction_house.buyer_name IS NULL "
+                           "LEFT JOIN auction_house ON item_basic.itemId = auction_house.itemid "
                            "LEFT JOIN item_equipment ON item_basic.itemid = item_equipment.itemid "
                            "LEFT JOIN item_weapon ON item_basic.itemid = item_weapon.itemid "
                            "WHERE aH = %u AND auction_house.itemid IS NOT NULL "
@@ -117,50 +119,6 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 AHCategoryID, int8*
             }
 
             ItemList.push_back(PAHItem);
-        }
-    }
-
-    const char* noQtyQuery = "SELECT item_basic.itemid, item_basic.stackSize "
-                             "FROM item_basic "
-                             "LEFT JOIN auction_house ON item_basic.itemId = auction_house.itemid "
-                             "LEFT JOIN item_equipment ON item_basic.itemid = item_equipment.itemid "
-                             "LEFT JOIN item_weapon ON item_basic.itemid = item_weapon.itemid "
-                             "WHERE aH = %u AND auction_house.itemid IS NOT NULL "
-                             "GROUP BY item_basic.itemid "
-                             "%s";
-
-    int32 noQtyRet = sql->Query(noQtyQuery, AHCategoryID, OrderByString);
-
-    if (noQtyRet != SQL_ERROR && sql->NumRows() != 0)
-    {
-        while (sql->NextRow() == SQL_SUCCESS)
-        {
-            uint16 CurrItemID = sql->GetUIntData(0);
-            bool   itemFound  = false;
-
-            for (ahItem* PAHItem : ItemList)
-            {
-                if (PAHItem->ItemID == CurrItemID)
-                {
-                    itemFound = true;
-                    break;
-                }
-            }
-
-            if (!itemFound)
-            {
-                ahItem* PAHItem       = new ahItem;
-                PAHItem->ItemID       = CurrItemID;
-                PAHItem->SingleAmount = 0;
-                PAHItem->StackAmount  = 0;
-
-                if (sql->GetIntData(1) == 1)
-                {
-                    PAHItem->StackAmount = -1;
-                }
-
-                ItemList.push_back(PAHItem);
-            }
         }
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Out of stock items in AH categories will no longer appear at the bottom of the category list. (Tracent)

## What does this pull request do? (Please be technical)
See above, basically just condenses two SQL queries into a single query so the sort can be applied to both in-stock and out-of-stock items and thus do not need to concatenate the out of stock items to the end of the list.

## Steps to test these changes
Was tested by Hugin on simulated AH on several different categories and the quantities match 

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
