### PR TITLE
Fix leave command to give short neutral state

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1378,6 +1378,23 @@ void CMobController::TapDeclaimTime()
     m_DeclaimTime = m_Tick;
 }
 
+void CMobController::TapNeutralTimeForLeave()
+{
+    // get tick as unix time
+    auto controllerTick = std::chrono::duration_cast<std::chrono::milliseconds>(m_Tick.time_since_epoch()).count();
+
+    // if controller was just initilized (and thus m_Tick is 0) then use container tick value
+    // subtract 4 seconds to give 6 seconds of neutral time
+    if (controllerTick == 0)
+    {
+        m_NeutralTime = PMob->PAI->getTick() - 4s;
+    }
+    else
+    {
+        m_NeutralTime = m_Tick - 4s;
+    }
+}
+
 bool CMobController::Cast(uint16 targid, SpellID spellid)
 {
     TracyZoneScoped;

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -48,6 +48,7 @@ public:
     bool         CanAggroTarget(CBattleEntity*);
     void         TapDeaggroTime();
     void         TapDeclaimTime();
+    void         TapNeutralTimeForLeave();
     virtual bool Cast(uint16 targid, SpellID spellid) override;
 
 protected:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
After a Beastmaster uses Leave the former pet will not be aggressive or link for a short period of time. (Tracent)

## What does this pull request do? (Please be technical)
This PR adds a short neutral time (no aggro or link) of 6 seconds to a mob after a beastmaster uses leave on that mob. 

## Steps to test these changes
Charm an aggressive mob and then use leave.

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1655
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
