### PR TITLE
Fix issue with removal of Ronfaure rotten supplies

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -214,7 +214,7 @@ local function areSuppliesRotten(player, npc, guardType)
     local rotten  = false
     local text    = zones[player:getZoneID()].text
 
-    if region > 0 and fresh <= os.time() then
+    if fresh ~= 0 and fresh <= os.time() then
         rotten = true
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Players will now be able to get rid of expired conquest supplies for Ronfaure by talking to the appropriate conquest overseer. (Tracent)

## What does this pull request do? (Please be technical)
This fixes an issue that prevented conquest overseers from removing expired Ronfaure supplies due to an invalid >0 check. The check does not work because Ronfaure has region id of 0, and thus the supplies were never being removed.

## Steps to test these changes
Get supplies for Ronfaure and try to turn them in after the conquest deadline. They should be removed by the conquest overseer npc.

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/3192
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
