### PR TITLE
Fix dyna statue fully resisting physical damage

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -1984,7 +1984,7 @@ xi.dynamis.setStatueStats = function(mob, mobIndex)
     mob:addStatusEffect(xi.effect.BATTLEFIELD, 1, 0, 0, true)
     mob:setMobMod(xi.mobMod.CHECK_AS_NM, 2)
     mob:setMobLevel(math.random(82,84))
-    mob:setMod(xi.mod.UDMG, -5000)
+    mob:setMod(xi.mod.DMG, -5000)
     -- if an eye then does not have slow movement speed and has lower HP in xarc
     if mob:getFamily() == 4 then
         -- base hp of eyes is 2600 for beauc, xarc eyes have about 1040


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
None (This is formalization of a hotfix)

## What does this pull request do? (Please be technical)
Fixes an issue with using the wrong mod on dynamis statues and eyes. UDMG has a different scale and probably should not be used at all until it is changed, thus use DMG instead if looking to reduce all damage by 50% or less.

## Steps to test these changes
Fight dyna statues and eyes

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
