### PR TITLE
Border case fix for Raise in battlefields

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2135,7 +2135,7 @@ void CCharEntity::OnRaise()
             // Player died within a battlefield, reward the battlefield level equivalent EXP
             if (StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
             {
-                expLost = m_LevelRestriction <= 67 ? (charutils::GetExpNEXTLevel(m_LevelRestriction) * 8) / 100 : 2400;
+                expLost = m_LevelRestriction >= 1 && m_LevelRestriction <= 67 ? (charutils::GetExpNEXTLevel(m_LevelRestriction) * 8) / 100 : 2400;
             }
 
             // Exp is enough to level you and (you're not under a level restriction, or the level restriction is higher than your current main level).


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed an issue where if level sync == 0 within a battlefield, players weren't rewarded EXP after dying and being raised.(WinterSolstice)

## What does this pull request do? (Please be technical)
Added a boundary check for an instance where level sync would be 0.
