### PR TITLE
Fix several issues

### DIFF
--- a/modules/era/lua_dynamis/mob_spawning_files/dynamis_bastok_mobs.lua
+++ b/modules/era/lua_dynamis/mob_spawning_files/dynamis_bastok_mobs.lua
@@ -249,9 +249,9 @@ xi.dynamis.mobList[zoneID][151].info = {"NM", "Effigy Shield BRD", "Quadav", "BR
 xi.dynamis.mobList[zoneID][152].info = {"NM", "Effigy Shield DRK", "Quadav", "DRK", nil } -- Effigy Shield
 xi.dynamis.mobList[zoneID][153].info = {"NM", "Effigy Shield SAM", "Quadav", "SAM", nil } -- Effigy Shield
 
-xi.dynamis.mobList[zoneID][154].info = {"TE normal", "Vanguard Vindicator", "Quadav", "WAR", nil } -- 10min TE
-xi.dynamis.mobList[zoneID][155].info = {"TE normal", "Vanguard Constable",  "Quadav", "WHM", nil } -- 10min TE
-xi.dynamis.mobList[zoneID][156].info = {"TE normal", "Vanguard Militant",   "Quadav", "MNK", nil } -- 10min TE
+xi.dynamis.mobList[zoneID][154].info = {"Beastmen", "Vanguard Vindicator", "Quadav", "WAR", nil } -- 10min TE
+xi.dynamis.mobList[zoneID][155].info = {"Beastmen", "Vanguard Constable",  "Quadav", "WHM", nil } -- 10min TE
+xi.dynamis.mobList[zoneID][156].info = {"Beastmen", "Vanguard Militant",   "Quadav", "MNK", nil } -- 10min TE
 
 
 ----------------------------------------------------------------------------------------------------

--- a/modules/era/sql/synth_recipes_era.sql
+++ b/modules/era/sql/synth_recipes_era.sql
@@ -1391,6 +1391,7 @@ UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Lt. Steel Shee
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Griffon Leather' AND ID = 44539;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Griffon Leather' AND ID = 44541;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Griffon Leather' AND ID = 44545;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ID = 53007;
 
 -- ------------------------------------------------------------
 -- ToAU Synths
@@ -1607,7 +1608,6 @@ UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'High Healing 
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Stone Bangles' AND ID = 52513;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Macuahuitl' AND ID = 52520;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Beak Necklace' AND ID = 52526;
-UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ID = 53007;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Marid Mittens' AND ID = 53011;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Scapegoat' AND ID = 53013;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Marid Leggings' AND ID = 53018;

--- a/scripts/zones/Sealions_Den/bcnms/one_to_be_feared_helper.lua
+++ b/scripts/zones/Sealions_Den/bcnms/one_to_be_feared_helper.lua
@@ -12,14 +12,17 @@ local oneToBeFeared = {}
 -- Not to be confused with an actual instance.
 
 local function healCharacter(player)
-    player:setHP(player:getMaxHP())
-    player:setMP(player:getMaxMP())
-    player:setTP(0)
-    if player:getPet() ~= nil then
-        local pet = player:getPet()
-        pet:setHP(pet:getMaxHP())
-        pet:setMP(pet:getMaxMP())
-        pet:setTP(0)
+    -- only heal players if alive otherwise bugs out player
+    if player:isAlive() then
+        player:setHP(player:getMaxHP())
+        player:setMP(player:getMaxMP())
+        player:setTP(0)
+        if player:getPet() ~= nil then
+            local pet = player:getPet()
+            pet:setHP(pet:getMaxHP())
+            pet:setMP(pet:getMaxMP())
+            pet:setTP(0)
+        end
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Three 10-minute time extension monsters in Dynamis-Bastok near Zeruhn Mines will now correctly spawn. (Tracent)
- A Pirates Gun can now be crafted. (Tracent)
- Players that die during one of the first two stages of the CoP 6-4 One to be Feared fight can now be raised between stages. (Tracent)

## What does this pull request do? (Please be technical)
Fixes the three issues above

## Steps to test these changes
Self explanatory, you can see the TE mobs as spawning from mob 89 in the [diagram](https://enedin.be/dyna/html/zone/bas.htm).

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/3054
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1660

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
