### PR TITLE
Add checks before petentity casting

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13625,12 +13625,19 @@ bool CLuaBaseEntity::charmPet(CLuaBaseEntity const* target)
 void CLuaBaseEntity::petAttack(CLuaBaseEntity* PEntity)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
-    CPetEntity* pet = static_cast<CPetEntity*>(static_cast<CBattleEntity*>(m_PBaseEntity)->PPet);
-    if (pet != nullptr)
+
+    CBattleEntity* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity)->PPet;
+    if (PBattle != nullptr)
     {
-        // A temporary fix until we move the spirit controller to lua.
-        if (pet->m_PetID >= PETID::PETID_AIRSPIRIT && pet->m_PetID <= PETID::PETID_DARKSPIRIT)
-            static_cast<CSpiritController*>(pet->PAI->GetController())->setMagicCooldowns();
+        if (PBattle->objtype == TYPE_PET)
+        {
+            CPetEntity* Pet = static_cast<CPetEntity*>(PBattle);
+            // A temporary fix until we move the spirit controller to lua.
+            if (Pet->getPetType() == PET_TYPE::AVATAR && Pet->m_PetID <= PETID::PETID_DARKSPIRIT)
+            {
+                static_cast<CSpiritController*>(Pet->PAI->GetController())->setMagicCooldowns();
+            }
+        }
 
         petutils::AttackTarget(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<CBattleEntity*>(PEntity->GetBaseEntity()));
     }
@@ -13659,15 +13666,22 @@ void CLuaBaseEntity::petRetreat()
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
-    auto*       PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
-    CPetEntity* pet     = static_cast<CPetEntity*>(PBattle->PPet);
-    if (pet != nullptr)
-    {
-        // A temporary fix until we move the spirit controller to lua.
-        if (pet->m_PetID >= PETID::PETID_AIRSPIRIT && pet->m_PetID <= PETID::PETID_DARKSPIRIT)
-            static_cast<CSpiritController*>(pet->PAI->GetController())->setMagicCooldowns();
+    CBattleEntity* PBattleMaster = static_cast<CBattleEntity*>(m_PBaseEntity);
+    CBattleEntity* PBattlePet    = PBattleMaster->PPet;
 
-        petutils::RetreatToMaster(PBattle);
+    if (PBattlePet != nullptr)
+    {
+        if (PBattlePet->objtype == TYPE_PET)
+        {
+            CPetEntity* Pet = static_cast<CPetEntity*>(PBattlePet);
+            // A temporary fix until we move the spirit controller to lua.
+            if (Pet->getPetType() == PET_TYPE::AVATAR && Pet->m_PetID <= PETID::PETID_DARKSPIRIT)
+            {
+                static_cast<CSpiritController*>(Pet->PAI->GetController())->setMagicCooldowns();
+            }
+        }
+
+        petutils::RetreatToMaster(PBattleMaster);
     }
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
None

## What does this pull request do? (Please be technical)
This fixes an issue with casting to PetEntity whereby there should be checks to make sure the type is pet rather than mob.

## Steps to test these changes
As a SMN/BST charm mobs and fight and heel, and then cast spirits and use assault and retreat.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
