### PR TITLE
Fix enter Reqs for Tango with a Tracker

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -1257,7 +1257,8 @@ local function checkReqs(player, npc, bfid, registrant)
         end,
 
         [677] = function() -- Quest: Tango with a Tracker
-            return player:hasKeyItem(xi.ki.LETTER_FROM_SHIKAREE_X)
+            return player:hasKeyItem(xi.ki.LETTER_FROM_SHIKAREE_X) or
+                player:hasCompletedQuest(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.TANGO_WITH_A_TRACKER)
         end,
 
         [678] = function() -- Quest: Requiem of Sin
@@ -2000,7 +2001,6 @@ xi.bcnm.onTrigger = function(player, npc)
         if player:getGMLevel() > 0 and player:checkNameFlags(0x04000000) then
             mask = 268435455
         end
-
 
         -- mask = 268435455 -- uncomment to open menu with all possible battlefields
         if mask ~= 0 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Players who have completed Tango with a Tracker can now enter the BCNM to help others who are doing the BCNM for the first time.

## What does this pull request do? (Please be technical)

changes pre-reqs for enter based on https://ffxiclopedia.fandom.com/wiki/Tango_with_a_Tracker

## Steps to test these changes

have a player with KI start the fight and have someone in a pt who does not have KI and has completed the quest

## Special Deployment Considerations
none