### PR TITLE
Fix Ultima and Proto-Ultima elemental conal spam following Nuclear Waste

### DIFF
--- a/scripts/zones/Sealions_Den/mobs/Ultima.lua
+++ b/scripts/zones/Sealions_Den/mobs/Ultima.lua
@@ -55,7 +55,10 @@ end
 
 entity.onMobWeaponSkill = function(target, mob, skill)
     -- After using Nuclear Waste use a random elemental conal attack
-    if skill:getID() == 1268 then
+    if
+        skill:getID() == 1268 and
+        mob:getLocalVar("nuclearWaste") == 1
+    then
         mob:timer(4000, function(mobArg)
             local ability = math.random(1262, 1267)
             mob:useMobAbility(ability)

--- a/scripts/zones/Temenos/mobs/Proto-Ultima.lua
+++ b/scripts/zones/Temenos/mobs/Proto-Ultima.lua
@@ -55,7 +55,10 @@ end
 
 entity.onMobWeaponSkill = function(target, mob, skill)
     -- After using Nuclear Waste use a random elemental conal attack
-    if skill:getID() == 1268 then
+    if
+        skill:getID() == 1268 and
+        mob:getLocalVar("nuclearWaste") == 1
+    then
         mob:timer(4000, function(mobArg)
             local ability = math.random(1262, 1267)
             mob:useMobAbility(ability)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Ultima and Proto-Ultima will no longer use a number of elemental conal mobskills _per player_ hit by nuclear waste.

## What does this pull request do? (Please be technical)

`entity.onMobWeaponSkill` triggers once per target hit by a mob skill.
This was causing Ultima to use an elemental conal per player hit by nuclear waste instead of the intended one mob skill.
All of the related mob skills already had a nuclear waste gate on them - so I added that to the logic.

## Steps to test these changes

Enter Central Temenos 4th floor with at least 2 characters
Characters (even GMs) who are entering as the non-initiator must have cosmo_cleanse and white_card
Go to proto-ultima
Beat it down under 75% (dissapation is the give away)
Have all players hug ultima
!tp 3000 until it uses nuclear waste and hits multiple players
Count the number of elemental conal TP moves that follow.
It should be 1, not numPlayersHit.

Elemental Conals
```
cryo_jet
flame_thrower
high-tension_discharger
hydro_canon
smoke_discharger
turbofan
```

## Special Deployment Considerations
none