### PR TITLE
Fix pet skills which are not using skill:getTP()

### DIFF
--- a/scripts/globals/abilities/pets/healing_ruby.lua
+++ b/scripts/globals/abilities/pets/healing_ruby.lua
@@ -13,9 +13,9 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill)
-    local base = 14 + target:getMainLvl() + pet:getTP() / 12
+    local base = 14 + target:getMainLvl() + skill:getTP() / 120
     if pet:getMainLvl() > 30 then
-        base = 44 + 3 * (pet:getMainLvl() - 30) + pet:getTP() / 12 * (pet:getMainLvl() * 0.075 - 1)
+        base = 44 + 3 * (pet:getMainLvl() - 30) + skill:getTP() / 120 * (pet:getMainLvl() * 0.075 - 1)
     end
 
     if target:getHP() + base > target:getMaxHP() then

--- a/scripts/globals/abilities/pets/sonic_buffet.lua
+++ b/scripts/globals/abilities/pets/sonic_buffet.lua
@@ -16,7 +16,7 @@ end
 -- http://wiki.ffo.jp/html/37931.html
 abilityObject.onPetAbility = function(target, pet, petskill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp   = pet:getTP()
+    local tp   = petskill:getTP()
 
     xi.job_utils.summoner.onUseBloodPact(pet:getMaster(), pet, target, petskill)
 

--- a/scripts/globals/abilities/pets/spring_water.lua
+++ b/scripts/globals/abilities/pets/spring_water.lua
@@ -14,7 +14,7 @@ end
 
 abilityObject.onPetAbility = function(target, pet, skill)
     local base = 47 + pet:getMainLvl() * 3
-    local tp   = pet:getTP()
+    local tp   = skill:getTP()
 
     if tp < 1000 then
         tp = 1000

--- a/scripts/globals/abilities/pets/tornado_ii.lua
+++ b/scripts/globals/abilities/pets/tornado_ii.lua
@@ -16,7 +16,7 @@ end
 -- Modeling this on the known formula for magical Merit BPs of the same level with a merit level of 0
 abilityObject.onPetAbility = function(target, pet, petskill)
     local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp     = pet:getTP() / 10
+    local tp     = petskill:getTP() / 10
     local master = pet:getMaster()
 
     if tp > 300 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed a bug preventing the following pet skills from scaling with TP:
- Healing Ruby
- Spring Water (ASB)
- Sonic Buffer (ASB)
- Tornado II (ASB)
Fixed a bug with the scaling of Healing Ruby to be era accurate (tp scaling reduced by a factor of 10)

Previous TP scaling at 75
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/105882290/b5266237-5e03-49b6-98f6-41614dd3e9ac)

New corrected TP scaling at 75
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/105882290/eea2e0e6-6614-4b80-a643-8a640fc21e00)

credit to @TracentEden for the nice graphs

## What does this pull request do? (Please be technical)
uses `skill:getTP()` instead of `pet:getTP()`.
`pet:getTP()` will always be during skill execution.

## Steps to test these changes

Be a smn 75
Be immortal
!setmod refresh 1000
!setmod regen -100
This will let you keep carby out and also get the log to display any heal.
Summon carby
/pet "Healing Ruby" <me>
Note the heal, carby had 0 tp. - 179
!reset
Target carby !tp 3000
/pet "Healing Ruby" <me>
Note the heal, carby had 3k tp. - 294.65 (295)

Can test the other skills as well.

## Special Deployment Considerations

None