### PR TITLE
Fix buying robber rigs from guild

### DIFF
--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -71,8 +71,10 @@ local testItemsByNPC =
     ["Cheupirudaux"]   = {    22,    23, 17354, 17348, 17053, 17156, 17054,    56, 17101, 18884 },
 }
 
+-- need to have robber rig here because it uses the same logic
 local hqCrystals =
 {
+    [0] = { id = xi.items.ROBBER_RIG,       cost = 1500 },
     [1] = { id = xi.items.INFERNO_CRYSTAL,  cost = 200 },
     [2] = { id = xi.items.GLACIER_CRYSTAL,  cost = 200 },
     [3] = { id = xi.items.CYCLONE_CRYSTAL,  cost = 200 },
@@ -483,7 +485,7 @@ xi.crafting.unionRepresentativeTriggerFinish = function(player, option, target, 
                 end
             end
         end
-    elseif category == 0 and option ~= 1073741824 then -- HQ crystal
+    elseif category == 0 and option ~= 1073741824 then -- HQ crystal or robber rig
         local i = hqCrystals[bit.band(bit.rshift(option, 5), 15)]
         local quantity = bit.rshift(option, 9)
         local cost = quantity * i.cost


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Players may now purchase Robber Rigs from fishing guild item merchants. (Tracent)

## What does this pull request do? (Please be technical)
Adds robber rigs to the HQ crystal array as their logic follows the same math.

## Steps to test these changes
Buy various amounts of robber rigs

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/725
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
