### PR TITLE
[lua] Fix Charybdis spawning with/after it's placeholder.

### DIFF
--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Charybdis.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Charybdis.lua
@@ -12,27 +12,30 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MULTI_HIT, 5)
 end
 
-entity.onMobSpawn = function(mob)
-    -- Ensure PHs can't respawn while alive
-    local mantaOne = ID.mob.CHARYBDIS - 2
-    local mantaTwo = ID.mob.CHARYBDIS - 4
-    DisallowRespawn(mantaOne, true)
-    DisallowRespawn(mantaTwo, true)
-    DespawnMob(mantaOne)
-    DespawnMob(mantaTwo)
+entity.onMobDeath = function(mob, player, optParams)
+    -- Remove the listener added from xi.mob.phOnDespawn
+    -- This is necessary to use multiple different PH IDs for one NM
+    mob:removeListener("DESPAWN_" .. mob:getID())
+    DisallowRespawn(mob:getID(), true)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
+entity.onMobDespawn = function(mob, player, optParams)
+    -- 8 hour minimum respawn. also a function of xi.mob.phOnDespawn's listener.
+    mob:setLocalVar("pop", os.time() + 28800)
+
     -- Only one Charbydis PH is up at one time
     local chooseManta = math.random(1, 2)
     local mantaOne = ID.mob.CHARYBDIS - 2
     local mantaTwo = ID.mob.CHARYBDIS - 4
+
     if chooseManta == 2 then
+        DisallowRespawn(mantaOne, true)
         DisallowRespawn(mantaTwo, false)
-        GetMobByID(mantaTwo):setRespawnTime(300)
+        GetMobByID(mantaTwo):setRespawnTime(GetMobRespawnTime(mantaTwo))
     elseif chooseManta == 1 then
         DisallowRespawn(mantaOne, false)
-        GetMobByID(mantaOne):setRespawnTime(300)
+        DisallowRespawn(mantaTwo, true)
+        GetMobByID(mantaOne):setRespawnTime(GetMobRespawnTime(mantaOne))
     end
 end
 

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Devil_Manta.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Devil_Manta.lua
@@ -14,21 +14,24 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    -- Only one Charbydis PH is up at one time
-    local chooseManta = math.random(1, 2)
-    local mantaOne = ID.mob.CHARYBDIS - 2
-    local mantaTwo = ID.mob.CHARYBDIS - 4
-    if mob:getID() == mantaOne and chooseManta == 2 then
-        DisallowRespawn(mantaOne, true)
-        DisallowRespawn(mantaTwo, false)
-        GetMobByID(mantaTwo):setRespawnTime(960)
-    elseif mob:getID() == mantaTwo and chooseManta == 1 then
-        DisallowRespawn(mantaOne, false)
-        DisallowRespawn(mantaTwo, true)
-        GetMobByID(mantaOne):setRespawnTime(960)
-    end
+    -- 8 hour minimum, this is also set in the Charbydis script due to the multi-placeholders.
+    -- See the Charbydis script for more.
 
-    xi.mob.phOnDespawn(mob, ID.mob.CHARYBDIS_PH, 10, 28800) -- 8 hour minimum
+    if not xi.mob.phOnDespawn(mob, ID.mob.CHARYBDIS_PH, 10, 28800) then
+        -- Charbydis is not queued to spawn.
+        -- Choose a Charbydis PH randomly to spawn next.
+        local chooseManta = math.random(1, 2)
+        local mantaOne = ID.mob.CHARYBDIS - 2
+        local mantaTwo = ID.mob.CHARYBDIS - 4
+
+        if chooseManta == 2 then
+            DisallowRespawn(mantaOne, true)
+            DisallowRespawn(mantaTwo, false)
+        elseif chooseManta == 1 then
+            DisallowRespawn(mantaOne, false)
+            DisallowRespawn(mantaTwo, true)
+        end
+    end
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Charybdis's placeholder will no longer occasionally erroneously spawn if Charybdis is going to spawn. (Wintersolstice)

## What does this pull request do? (Please be technical)

Due to the nature of this specific mob on ASB wanting two placeholders, the `xi.mob.phOnDespawn` listener was interfering with the Charybdis/Devil Manta scripts. See the following:

```                -- on PH death, replace PH repop with NM repop
                DisallowRespawn(phId, true)
                DisallowRespawn(nmId, false)
                UpdateNMSpawnPoint(nmId)
                nm:setRespawnTime(immediate and 1 or GetMobRespawnTime(phId)) -- if immediate is true, spawn the nm immediately (1ms) else use placeholder's timer

                nm:addListener("DESPAWN", "DESPAWN_" .. nmId, function(m)
                    -- on NM death, replace NM repop with PH repop
                    DisallowRespawn(nmId, true)
                    DisallowRespawn(phId, false)
                    GetMobByID(phId):setRespawnTime(GetMobRespawnTime(phId))
                    m:setLocalVar("pop", os.time() + cooldown)
                    m:removeListener("DESPAWN_" .. nmId)
                end)
```
Thie `DisallowRespawn(phId, false)` call _could_ be stale if the Devil Manta's `onMobDespawn` chose to select the _other_ placeholder to despawn.

That requires removing the `"DESPAWN_" .. mob:getID()` listener when Charybdis dies so it doesn't fire, and we replace it's functionality.

Note that if in theory `xi.mob.phOnDespawn` ever changed internally this would break. I would consider this PR to be an long-term unsafe fix with equivalent functionality.

However, it is possible to make a long term safe fix with the only functionality changed is that the same PH that popped Charybdis will be the same one that respawns on it's death. If you want the long term safe version, please indicate so and I will alter the PR.

## Steps to test these changes

Kill Charybdis repeatedly, don't see the PH spawn before Charybdis.

## Special Deployment Considerations

Drink a whole bottle of vodka after camping Charybdis for 3 hours and find out you were a beta tester all along and lose claim arguably unfairly, but that's the game.
