### PR TITLE
Add getEffects command

### DIFF
--- a/scripts/commands/geteffects.lua
+++ b/scripts/commands/geteffects.lua
@@ -1,0 +1,49 @@
+---------------------------------------------------------------------------------------------------
+-- func: geteffects
+-- desc: prints list of all effects
+---------------------------------------------------------------------------------------------------
+require("scripts/globals/status")
+require("scripts/globals/msg")
+
+cmdprops =
+{
+    permission = 3,
+    parameters = ""
+}
+
+local function getEffectName(value)
+    for k, v in pairs(xi.effect) do
+        if v == value then
+            return k
+        end
+    end
+
+    return nil
+end
+
+function onTrigger(player)
+    local target = player:getCursorTarget()
+    if target == nil then
+        player:PrintToPlayer("Target something first.")
+        return
+    end
+
+    local targetType = target:getObjType()
+
+    if targetType == xi.objType.NPC then
+        player:PrintToPlayer("Target something other than an NPC..They don't have effects!")
+        return
+    end
+
+    local targetStatusEffects = target:getStatusEffects()
+
+    if next(targetStatusEffects) ~= nil then
+        player:PrintToPlayer(string.format("Showing Active Effects for: %s", target:getName()), xi.msg.channel.SYSTEM_3)
+        player:PrintToPlayer("[Effect Id] [Name] [Power] [Sub Id] [SubPower]", xi.msg.channel.SYSTEM_3)
+        for _, effect in pairs(targetStatusEffects) do
+            player:PrintToPlayer(string.format("%-5s %s %s %s %s", effect:getType(), getEffectName(effect:getType()), effect:getPower(), effect:getSubType(), effect:getSubPower()), xi.msg.channel.SYSTEM_3)
+        end
+    else
+        player:PrintToPlayer("No active effects found!")
+    end
+end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Non-player impacting.
Adds a gm command to get all status effects on a target.

## What does this pull request do? (Please be technical)
Adds a gm command to get all status effects on a target and display the power and subpower

## Steps to test these changes

target something with buffs
use `!geteffects`

target something without buffs
use `!geteffects`

## Special Deployment Considerations

GM level set to 3
Id like any GM to have access to this for trouble shooting