### PR TITLE
[magic] Fixes day elements using incorrect enums for mobskills

### DIFF
--- a/scripts/globals/abilities/elemental_siphon.lua
+++ b/scripts/globals/abilities/elemental_siphon.lua
@@ -50,7 +50,7 @@ abilityObject.onUseAbility = function(player, target, ability)
     local weather         = player:getWeather()
 
     -- Day bonus/penalty
-    if dayElement == xi.magic.dayStrong[spiritEle] then
+    if dayElement == spiritEle then
         weatherDayBonus = weatherDayBonus + 0.1
     elseif dayElement == xi.magic.dayWeak[spiritEle] then
         weatherDayBonus = weatherDayBonus - 0.1

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -9,10 +9,37 @@ xi = xi or {}
 xi.magic = xi.magic or {}
 
 -----------------------------------
+-- Day to Element Mapping
+-----------------------------------
+
+xi.magic.dayElement =
+{
+    [xi.day.FIRESDAY]     = xi.magic.element.FIRE,
+    [xi.day.ICEDAY]       = xi.magic.element.ICE,
+    [xi.day.WINDSDAY]     = xi.magic.element.WIND,
+    [xi.day.EARTHSDAY]    = xi.magic.element.EARTH,
+    [xi.day.LIGHTNINGDAY] = xi.magic.element.THUNDER,
+    [xi.day.WATERSDAY]    = xi.magic.element.WATER,
+    [xi.day.LIGHTSDAY]    = xi.magic.element.LIGHT,
+    [xi.day.DARKSDAY]     = xi.magic.element.DARK,
+}
+
+-----------------------------------
 -- Tables by element
 -----------------------------------
 
-xi.magic.dayStrong             = { xi.day.FIRESDAY,              xi.day.ICEDAY,               xi.day.WINDSDAY,               xi.day.EARTHSDAY,              xi.day.LIGHTNINGDAY,               xi.day.WATERSDAY,               xi.day.LIGHTSDAY,           xi.day.DARKSDAY           }
+xi.magic.dayWeak =
+{
+    xi.magic.dayElement[xi.day.WATERSDAY],
+    xi.magic.dayElement[xi.day.FIRESDAY],
+    xi.magic.dayElement[xi.day.ICEDAY],
+    xi.magic.dayElement[xi.day.WINDSDAY],
+    xi.magic.dayElement[xi.day.EARTHSDAY],
+    xi.magic.dayElement[xi.day.LIGHTNINGDAY],
+    xi.magic.dayElement[xi.day.DARKSDAY],
+    xi.magic.dayElement[xi.day.LIGHTSDAY]
+}
+
 xi.magic.singleWeatherStrong   = { xi.weather.HOT_SPELL,         xi.weather.SNOW,             xi.weather.WIND,               xi.weather.DUST_STORM,         xi.weather.THUNDER,                xi.weather.RAIN,                xi.weather.AURORAS,         xi.weather.GLOOM          }
 xi.magic.doubleWeatherStrong   = { xi.weather.HEAT_WAVE,         xi.weather.BLIZZARDS,        xi.weather.GALES,              xi.weather.SAND_STORM,         xi.weather.THUNDERSTORMS,          xi.weather.SQUALL,              xi.weather.STELLAR_GLARE,   xi.weather.DARKNESS       }
 xi.magic.elementalObi          = { xi.mod.FORCE_FIRE_DWBONUS,    xi.mod.FORCE_ICE_DWBONUS,    xi.mod.FORCE_WIND_DWBONUS,     xi.mod.FORCE_EARTH_DWBONUS,    xi.mod.FORCE_LIGHTNING_DWBONUS,    xi.mod.FORCE_WATER_DWBONUS,     xi.mod.FORCE_LIGHT_DWBONUS, xi.mod.FORCE_DARK_DWBONUS }
@@ -27,7 +54,6 @@ local nullMod                  = { xi.mod.FIRE_NULL,             xi.mod.ICE_NULL
 local blmMerit                 = { xi.merit.FIRE_MAGIC_POTENCY,  xi.merit.ICE_MAGIC_POTENCY,  xi.merit.WIND_MAGIC_POTENCY,   xi.merit.EARTH_MAGIC_POTENCY,  xi.merit.LIGHTNING_MAGIC_POTENCY,  xi.merit.WATER_MAGIC_POTENCY                                                          }
 local rdmMerit                 = { xi.merit.FIRE_MAGIC_ACCURACY, xi.merit.ICE_MAGIC_ACCURACY, xi.merit.WIND_MAGIC_ACCURACY,  xi.merit.EARTH_MAGIC_ACCURACY, xi.merit.LIGHTNING_MAGIC_ACCURACY, xi.merit.WATER_MAGIC_ACCURACY                                                         }
 xi.magic.barSpell              = { xi.effect.BARFIRE,            xi.effect.BARBLIZZARD,       xi.effect.BARAERO,             xi.effect.BARSTONE,            xi.effect.BARTHUNDER,              xi.effect.BARWATER                                                                    }
-xi.magic.dayWeak               = { xi.day.WATERSDAY,             xi.day.FIRESDAY,             xi.day.ICEDAY,                 xi.day.WINDSDAY,               xi.day.EARTHSDAY,                  xi.day.LIGHTNINGDAY,            xi.day.DARKSDAY,            xi.day.LIGHTSDAY          }
 xi.magic.singleWeatherWeak     = { xi.weather.RAIN,              xi.weather.HOT_SPELL,        xi.weather.SNOW,               xi.weather.WIND,               xi.weather.DUST_STORM,             xi.weather.THUNDER,             xi.weather.GLOOM,           xi.weather.AURORAS        }
 xi.magic.doubleWeatherWeak     = { xi.weather.SQUALL,            xi.weather.HEAT_WAVE,        xi.weather.BLIZZARDS,          xi.weather.GALES,              xi.weather.SAND_STORM,             xi.weather.THUNDERSTORMS,       xi.weather.DARKNESS,        xi.weather.STELLAR_GLARE  }
 xi.magic.eemStatus             = { xi.effect.FIRE_EEM_MOD,       xi.effect.ICE_EEM_MOD,       xi.effect.WIND_EEM_MOD,        xi.effect.EARTH_EEM_MOD,       xi.effect.THUNDER_EEM_MOD,         xi.effect.WATER_EEM_MOD,        xi.effect.LIGHT_EEM_MOD,    xi.effect.DARK_EEM_MOD    }

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -444,6 +444,7 @@ end
 xi.mobskills.mobAddBonuses = function(caster, target, dmg, ele, ignoreres) -- used for SMN magical bloodpacts and all mob magical skills
     local ignore = ignoreres or false
     local magicDefense = xi.magic.getElementalDamageReduction(target, ele)
+    local dayElement    = VanadielDayElement()
 
     if not ignore then
         dmg = math.floor(dmg * magicDefense)
@@ -469,11 +470,11 @@ xi.mobskills.mobAddBonuses = function(caster, target, dmg, ele, ignoreres) -- us
         end
     end
 
-    if VanadielDayElement() == xi.magic.dayStrong[ele] then
+    if dayElement == ele then
         if math.random() < 0.33 then
             dayWeatherBonus = dayWeatherBonus + 0.10
         end
-    elseif VanadielDayElement() == xi.magic.dayWeak[ele] then
+    elseif dayElement == xi.magic.dayWeak[ele] then
         if math.random() < 0.33 then
             dayWeatherBonus = dayWeatherBonus - 0.10
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixes an issue where mobskills were incorrectly using the wrong enum values for calculating damage based on the day. (Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
The enums for days were never mapped to the correct elements. This was causing strong/weak elements to work on the incorrect days for mobskills

`xi.magic.dayElement` is to prep for LSB Magic PR

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!spawnmob 16797969
!gotoid 16797969
Attack Jorm and let it fly
Use !time to change the day to Firesday
You should see the base damage of the autos in the air should be reduced by 10% about 33% of the time.

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
