### PR TITLE
Fix Teleporters in Grand Palace to allow bi-directional usage

### DIFF
--- a/scripts/zones/Grand_Palace_of_HuXzoi/Zone.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/Zone.lua
@@ -73,6 +73,7 @@ end
 zoneObject.onEventFinish = function(player, csid, option)
     if csid >= 150 and csid <= 159 then
         xi.teleport.clearEnmityList(player)
+        player:setLocalVar("Hu-Xzoi-TP", 0)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fix Teleporters in Grand Palace of Hu'Xzoi to allow bi-directional usage

## What does this pull request do? (Please be technical)

There was a var being set to prevent CS from trigering upon completion of the previous elevator warp.
The var was not being unset later on.

Ive added back the var unset to the completion of the CS, which appears to prevent the double CS issue - which i think was accidentally snipped out earlier.


## Steps to test these changes

Run back and forth on an elevator in the GPoH

## Special Deployment Considerations

None, can hotfix this if you wanted to