### PR TITLE
[LSB] Fix shell effect values in mobskill scripts.

### DIFF
--- a/scripts/globals/mobskills/bubble_armor.lua
+++ b/scripts/globals/mobskills/bubble_armor.lua
@@ -18,9 +18,11 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.SHELL, 20, 0, 60))
+    local typeEffect = xi.effect.SHELL
+    local power      = 5000
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, 180))
 
-    return xi.effect.SHELL
+    return typeEffect
 end
 
 return mobskillObject

--- a/scripts/globals/mobskills/bubble_curtain.lua
+++ b/scripts/globals/mobskills/bubble_curtain.lua
@@ -18,9 +18,11 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.SHELL, 50, 0, 180))
+    local typeEffect = xi.effect.SHELL
+    local power      = 5000
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, 180))
 
-    return xi.effect.SHELL
+    return typeEffect
 end
 
 return mobskillObject

--- a/scripts/globals/mobskills/crystaline_cocoon.lua
+++ b/scripts/globals/mobskills/crystaline_cocoon.lua
@@ -20,9 +20,9 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffect1 = xi.effect.PROTECT
     local typeEffect2 = xi.effect.SHELL
-    local power1 = 50
-    local power2 = 20
-    local duration = 300
+    local power1      = 50
+    local power2      = 2000
+    local duration    = 300
 
     skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect1, power1, 0, duration))
     xi.mobskills.mobBuffMove(mob, typeEffect2, power2, 0, duration)

--- a/scripts/globals/mobskills/unblessed_armor.lua
+++ b/scripts/globals/mobskills/unblessed_armor.lua
@@ -19,7 +19,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffect = xi.effect.SHELL
-    local power = 50
+    local power      = 5000
 
     skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, 180))
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) --> 

Author: [Xaver-DaRed](https://github.com/Xaver-DaRed)
 
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fix shell effect values in mobskill scripts
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Adjusts the magic damage reduction of shell to the correct value of 50%.  Closes #1685HorizonXi
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Cast Stone on Snipper in Valkurm Dunes.
2. Wait for Snipper to use Bubble Curtain ability.
3. Cast Stone again on Snipper.
4. Compare Stone damage numbers.
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
