### PR TITLE
Per capture: pets dont generate hate when healing

### DIFF
--- a/scripts/globals/effects/healing.lua
+++ b/scripts/globals/effects/healing.lua
@@ -112,7 +112,11 @@ effectObject.onEffectTick = function(target, effect)
             end
 
             target:addHP(healHP)
-            if target:getHPP() < 100 then
+
+            if
+                target:getHPP() < 100  and
+                target:getMaster() == nil
+            then
                 target:updateEnmityFromCure(target, healHP)
             end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Pets (like bst jug and charmed pets) will no longer generate emnity for hp recovered while healing (stay).

## What does this pull request do? (Please be technical)

Adds a check prior to generating emnity for hp recovered via healing status effect.

https://youtu.be/k9Se4yvhYtc?t=864

## Steps to test these changes

Be Bst.  !godmode yourself (dmg immune, PD - helps with this test)
Summon a jug pet
!immortal the jug pet
!hp 1 the jug pet
Have the jug pet fight something near or greater in level.
Heel the jug pet - let the jug pet take a beating for a bit (this will floor its emnity)
Hit the pet's target once
Stay the jug pet and watch the pets HP
Note that as the jug pet's hp rises, the monster will not go to the jug pet.

## Special Deployment Considerations
None