### PR TITLE
QUEST [COR AF3} Aligns quest name convention

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -112,11 +112,11 @@ zoneObject.onEventFinish = function(player, csid, option)
         player:setCharVar("gotitallCS", 6)
         player:setPos(60, 0, -71, 38)
     elseif csid == 797 then
-        player:setCharVar("AgainstAllOdds", 1) -- Set For Corsair BCNM
+        player:setCharVar("Quest[6][26]Prog", 1) -- Set For Corsair BCNM
         player:addQuest(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.AGAINST_ALL_ODDS) -- Start of af 3 not completed yet
         player:addKeyItem(xi.ki.LIFE_FLOAT) -- BCNM KEY ITEM TO ENTER BCNM
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.LIFE_FLOAT)
-        player:setCharVar("AgainstAllOddsTimer", getMidnight())
+        player:setCharVar("Quest[6][26]Timer", getMidnight())
     end
 
     xi.moghouse.exitJobChangeFinish(player, csid, option)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
@@ -15,10 +15,10 @@ end
 
 entity.onTrigger = function(player, npc)
     if
-        player:getCharVar("AgainstAllOdds") == 2 and
+        player:getCharVar("Quest[6][26]Prog") == 2 and
         (
-            player:getCharVar("AgainstAllOddsTimer") < os.time() or
-            player:getCharVar("AgainstAllOddsTimer") == 0
+            player:getCharVar("Quest[6][26]Timer") < os.time() or
+            player:getCharVar("Quest[6][26]Timer") == 0
         )
     then
         player:startEvent(604) -- reacquire life float, account for chars on quest previously without a var
@@ -33,7 +33,7 @@ end
 entity.onEventFinish = function(player, csid, option)
     if csid == 604 then
         npcUtil.giveKeyItem(player, xi.ki.LIFE_FLOAT)
-        player:setCharVar("AgainstTimer", getMidnight())
+        player:setCharVar("Quest[6][26]Timer", getMidnight())
     end
 end
 

--- a/scripts/zones/Arrapago_Reef/Zone.lua
+++ b/scripts/zones/Arrapago_Reef/Zone.lua
@@ -25,7 +25,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 
     if
         prevZone == xi.zone.THE_ASHU_TALIF and
-        player:getCharVar("AgainstAllOdds") == 3
+        player:getCharVar("Quest[6][26]Prog") == 3
     then
         cs = 238
     elseif prevZone == xi.zone.ILRUSI_ATOLL then
@@ -43,7 +43,7 @@ end
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     if
         player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.AGAINST_ALL_ODDS) == QUEST_ACCEPTED and
-        player:getCharVar("AgainstAllOdds") == 1
+        player:getCharVar("Quest[6][26]Prog") == 1
     then
         player:startEvent(237)
     end
@@ -60,9 +60,9 @@ zoneObject.onEventFinish = function(player, csid, option)
     elseif csid == 237 then
         player:startEvent(240)
     elseif csid == 238 then
-        npcUtil.completeQuest(player, xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.AGAINST_ALL_ODDS, { item = 15266, var = "AgainstAllOdds" })
+        npcUtil.completeQuest(player, xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.AGAINST_ALL_ODDS, { item = xi.items.CORSAIRS_TRICORNE, var = "Quest[6][26]Prog" })
     elseif csid == 240 then
-        player:setCharVar("AgainstAllOdds", 2)
+        player:setCharVar("Quest[6][26]Prog", 2)
     end
 end
 

--- a/scripts/zones/The_Ashu_Talif/instances/against_all_odds.lua
+++ b/scripts/zones/The_Ashu_Talif/instances/against_all_odds.lua
@@ -10,7 +10,7 @@ local instanceObject = {}
 
 instanceObject.registryRequirements = function(player)
     return player:hasKeyItem(xi.ki.LIFE_FLOAT) and
-        player:getCharVar("AgainstAllOdds") == 2
+        player:getCharVar("Quest[6][26]Prog") == 2
 end
 
 instanceObject.entryRequirements = function(player)
@@ -55,9 +55,9 @@ end
 instanceObject.onInstanceComplete = function(instance)
     local chars = instance:getChars()
     for i, v in pairs(chars) do
-        if v:getCharVar("AgainstAllOdds") == 2 then
-            v:setCharVar("AgainstAllOdds", 3)
-            v:setCharVar("AgainstAllOddsTimer", 0)
+        if v:getCharVar("Quest[6][26]Prog") == 2 then
+            v:setCharVar("Quest[6][26]Prog", 3)
+            v:setCharVar("Quest[6][26]Timer", 0)
         end
 
         v:startEvent(102)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
NONE
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Aligned quest vars in line with IF conventions. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
