### PR TITLE
Fix dynamis level entry check

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis.lua
@@ -715,7 +715,7 @@ local function checkEntryReqs(player, zoneId)
     end
 
     if
-        player:getMainLvl() <= dynamis_min_lvl or
+        player:getMainLvl() < dynamis_min_lvl or
         (xi.dynamis.entryInfoEra[zoneId].csBit >= 7 and not player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.DARKNESS_NAMED))
     then
         return false


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

The level entry requirement check for Dynamis been fixed and players at level 65 can now enter. (Wintersolstice)

## What does this pull request do? (Please be technical)

`<=` -> `<`

## Steps to test these changes

enter dynamis at 65

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
