### PR TITLE
Kirin Trade Spam Fix

### DIFF
--- a/modules/era/lua/era_HNM_system.lua
+++ b/modules/era/lua/era_HNM_system.lua
@@ -4,7 +4,6 @@
 require("modules/module_utils")
 require("scripts/globals/conquest")
 require("scripts/globals/zone")
-require("settings/main")
 
 -----------------------------------
 -- ID Requires

--- a/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm2.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm2.lua
@@ -9,12 +9,8 @@ require("scripts/globals/npc_util")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if
-        npc:getStatus() == xi.status.NORMAL and
-        npcUtil.tradeHas(trade, { 1404, 1405, 1406, 1407 })
-    then
+    if npcUtil.tradeHas(trade, { 1404, 1405, 1406, 1407 }) then
         player:startEvent(101)
-        player:confirmTrade()
     end
 end
 
@@ -26,9 +22,11 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 101 then
-        SpawnMob(ID.mob.KIRIN):updateClaim(player)
-        GetNPCByID(ID.npc.KIRIN_QM):setStatus(xi.status.DISAPPEAR)
+    if
+        npcUtil.popFromQM(player, GetNPCByID(ID.npc.KIRIN_QM), ID.mob.KIRIN, { claim = true }) and
+        csid == 101
+    then
+        player:confirmTrade()
     end
 end
 


### PR DESCRIPTION




<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed players losing their Kirin pop items when traded at the same time as another player.

## What does this pull request do? (Please be technical)
This fix was achieved by making use of the npcUtil popFromQM. Wherein this function will return false if the mob is already spawned, preventing players from losing their pop items. Should the player successfully spawn the mob, only then will it consume their items.

Bonus fix: removed a require in era_HNM_system that wasn't needed (This was causing an error in map every time map was booted up

