### PR TITLE
[core] Fix crashing issue with some zones when logging in

### DIFF
--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -38,10 +38,11 @@ CBaseEntity::CBaseEntity()
 , animation(0)
 , animationsub(0)
 , speed(50 + settings::get<int8>("map.SPEED_MOD")) // It is downright dumb to init every entity at PLAYER speed, but until speed is reworked this hack stays.
-, speedsub(50)                                     // Retail does NOT adjust this when speed is adjusted.
+, speedsub(40)                                     // Retail does NOT adjust this when speed is adjusted.
 , namevis(0)
 , allegiance(ALLEGIANCE_TYPE::MOB)
 , updatemask(0)
+, manualConfig(false)
 , isRenamed(false)
 , m_bReleaseTargIDOnDisappear(false)
 , spawnAnimation(SPAWN_ANIMATION::NORMAL)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

N/A

## What does this pull request do? (Please be technical)

Fixes the `manualConfig` boolean.  Originally un-initialized because everything got moved to the initializer list instead of being initialized inside the constructor.

## Steps to test these changes

Zone into South Gustaberg, No crashy

## Special Deployment Considerations

N/A
