### PR TITLE
Fix KV draw-in logic

### DIFF
--- a/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
@@ -35,7 +35,10 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDisengage = function(mob, weather)
-    if not (mob:getWeather() == xi.weather.DUST_STORM or mob:getWeather() == xi.weather.SAND_STORM) then
+    if
+        not (mob:getWeather() == xi.weather.DUST_STORM or
+        mob:getWeather() == xi.weather.SAND_STORM)
+    then
         DespawnMob(mob:getID())
     end
 end
@@ -48,12 +51,15 @@ entity.onMobWeaponSkill = function(target, mob, skill)
     local nextDrawIn = mob:getLocalVar("[Draw-In]WaitTime")
 
     -- Every time KV performs a TP move, he will draw in either his target or the entire alliance randomly
-    if (skill:getID() == 354 or skill:getID() == 355 or skill:getID() == 722 or skill:getID() == 723) and os.time() > nextDrawIn then
+    if
+        (skill:getID() == 354 or skill:getID() == 355 or skill:getID() == 722 or skill:getID() == 723) and
+        os.time() > nextDrawIn
+    then
         local chance = math.random(1, 2)
         if chance == 1 then
-            mob:triggerDrawIn(mob, true, 1, 35, target)
+            mob:triggerDrawIn(mob, true, 1, nil, target, true)
         else
-            mob:triggerDrawIn(mob, false, 1, 35, target)
+            mob:triggerDrawIn(mob, false, 1, nil, target, true)
         end
 
         -- KV always does an AOE TP move followed by a single target TP move
@@ -87,7 +93,10 @@ end
 entity.onMobRoam = function(mob)
     updateRegen(mob)
 
-    if not (mob:getWeather() == xi.weather.DUST_STORM or mob:getWeather() == xi.weather.SAND_STORM) then
+    if
+        not (mob:getWeather() == xi.weather.DUST_STORM or
+        mob:getWeather() == xi.weather.SAND_STORM)
+    then
         DespawnMob(mob:getID())
     end
 end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15258,7 +15258,7 @@ void CLuaBaseEntity::useMobAbility(sol::variadic_args va)
  *  Note    : Params can assume a default value by passing nil
  *          : e.g. triggerDrawIn(true) to pull in a party/alliance
  ************************************************************************/
-inline int32 CLuaBaseEntity::triggerDrawIn(CLuaBaseEntity* PMobEntity, sol::object const& includePt, sol::object const& drawRange, sol::object const& maxReach, sol::object const& target)
+inline int32 CLuaBaseEntity::triggerDrawIn(CLuaBaseEntity* PMobEntity, sol::object const& includePt, sol::object const& drawRange, sol::object const& maxReach, sol::object const& target, sol::object const& incDeadAndMount)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
@@ -15267,10 +15267,11 @@ inline int32 CLuaBaseEntity::triggerDrawIn(CLuaBaseEntity* PMobEntity, sol::obje
     CBattleEntity* PTarget = PMob->GetBattleTarget();
 
     // Default values
-    uint8  drawInRange  = PMob->GetMeleeRange() * 2;
-    uint16 maximumReach = 0xFFFF;
-    bool   includeParty = false;
-    float  offset       = PMob->GetMeleeRange() - 0.2f;
+    uint8  drawInRange         = PMob->GetMeleeRange() * 2;
+    uint16 maximumReach        = 0xFFFF;
+    bool   includeParty        = false;
+    float  offset              = PMob->GetMeleeRange() - 0.2f;
+    bool   includeDeadAndMount = false;
 
     if ((drawRange != sol::lua_nil) && drawRange.is<uint8>())
     {
@@ -15293,10 +15294,15 @@ inline int32 CLuaBaseEntity::triggerDrawIn(CLuaBaseEntity* PMobEntity, sol::obje
         includeParty = includePt.as<bool>();
     }
 
+    if (incDeadAndMount != sol::lua_nil)
+    {
+        includeDeadAndMount = incDeadAndMount.as<bool>();
+    }
+
     if (PTarget)
     {
         // Draw in requires a target
-        battleutils::DrawIn(PTarget, PMob, offset, drawInRange, maximumReach, includeParty);
+        battleutils::DrawIn(PTarget, PMob, offset, drawInRange, maximumReach, includeParty, includeDeadAndMount);
     }
 
     return 0;

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -855,10 +855,10 @@ public:
 
     bool actionQueueEmpty(); // returns whether the action queue is empty or not
 
-    void  castSpell(sol::object const& spell, sol::object entity);                                                                                                       // forces a mob to cast a spell (parameter = spell ID, otherwise picks a spell from its list)
-    void  useJobAbility(uint16 skillID, sol::object const& pet);                                                                                                         // forces a job ability use (players/pets only)
-    void  useMobAbility(sol::variadic_args va);                                                                                                                          // forces a mob to use a mobability (parameter = skill ID)
-    int32 triggerDrawIn(CLuaBaseEntity* PMobEntity, sol::object const& includePt, sol::object const& drawRange, sol::object const& maxReach, sol::object const& target); // forces a mob to draw in target
+    void  castSpell(sol::object const& spell, sol::object entity);                                                                                                                                           // forces a mob to cast a spell (parameter = spell ID, otherwise picks a spell from its list)
+    void  useJobAbility(uint16 skillID, sol::object const& pet);                                                                                                                                             // forces a job ability use (players/pets only)
+    void  useMobAbility(sol::variadic_args va);                                                                                                                                                              // forces a mob to use a mobability (parameter = skill ID)
+    int32 triggerDrawIn(CLuaBaseEntity* PMobEntity, sol::object const& includePt, sol::object const& drawRange, sol::object const& maxReach, sol::object const& target, sol::object const& incDeadAndMount); // forces a mob to draw in target
     bool  hasTPMoves();
 
     void weaknessTrigger(uint8 level);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -6200,7 +6200,7 @@ namespace battleutils
         }
     }
 
-    bool DrawIn(CBattleEntity* PTarget, CMobEntity* PMob, float offset, uint8 drawInRange, uint16 maximumReach, bool includeParty)
+    bool DrawIn(CBattleEntity* PTarget, CMobEntity* PMob, float offset, uint8 drawInRange, uint16 maximumReach, bool includeParty, bool includeDeadAndMount)
     {
         if (std::chrono::time_point_cast<std::chrono::seconds>(server_clock::now()).time_since_epoch().count() - PMob->GetLocalVar("DrawInTime") < 2)
         {
@@ -6240,11 +6240,12 @@ namespace battleutils
         //     return false;
         // }
 
-        std::function<void(CBattleEntity*)> drawInFunc = [PMob, drawInRange, maximumReach, &nearEntity, &success](CBattleEntity* PMember)
+        std::function<void(CBattleEntity*)> drawInFunc = [PMob, drawInRange, maximumReach, includeDeadAndMount, &nearEntity, &success](CBattleEntity* PMember)
         {
             float pDistance = distance(PMob->loc.p, PMember->loc.p);
             if (PMob->loc.zone == PMember->loc.zone && pDistance > drawInRange && pDistance < maximumReach &&
-                PMember->status != STATUS_TYPE::CUTSCENE_ONLY && !PMember->isDead() && !PMember->isMounted())
+                PMember->status != STATUS_TYPE::CUTSCENE_ONLY &&
+                (includeDeadAndMount || (!PMember->isDead() && !PMember->isMounted())))
             // if (PMob->loc.zone == PMember->loc.zone && dist > drawInRange && dist < maximumReach &&
             //     PMember->status != STATUS_TYPE::STATUS_CUTSCENE_ONLY && !PMember->isDead() && !PMember->isMounted())
             {

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -248,7 +248,7 @@ namespace battleutils
     WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar);
     WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar, uint16 zoneWeather);
     bool    WeatherMatchesElement(WEATHER weather, uint8 element);
-    bool    DrawIn(CBattleEntity* PTarget, CMobEntity* PMob, float offset, uint8 drawInRange, uint16 maximumReach, bool includeParty);
+    bool    DrawIn(CBattleEntity* PTarget, CMobEntity* PMob, float offset, uint8 drawInRange, uint16 maximumReach, bool includeParty, bool includeDeadAndMount = false);
     void    DoWildCardToEntity(CCharEntity* PCaster, CCharEntity* PTarget, uint8 roll);
     void    AddTraits(CBattleEntity* PEntity, TraitList_t* TraitList, uint8 level, bool mobSubJobCheck = false);
     bool    HasClaim(CBattleEntity* PEntity, CBattleEntity* PTarget);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
King Vinegarroon now draws in players across the entire zone and also draws in dead players and mounted players (on chocobo). (Tracent)

## What does this pull request do? (Please be technical)
This fixes KV by making the draw-in more retail accurate as described above. The main remaining issue is that players drawn-in on chocobo are not damaged by KV mob skills that occur just after the draw-in (as this requires more in depth core changes).

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/3255
## Steps to test these changes
Fight KV with two characters with one on other side of the zone, repeatedly give KV 3000 tp and wait for alli draw-in (happens 50% of the time), repeat with a dead and a mounted player.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
