### PR TITLE
Fix Job Ability Line of Sight Crash

### DIFF
--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -323,7 +323,7 @@ bool CPlayerController::CanUseAbility(uint16 targid, uint16 abilityid)
             PChar->pushPacket(new CMessageBasicPacket(PChar, PTarget, 0, 0, MSGBASIC_TOO_FAR_AWAY));
             return false;
         }
-        if (!PChar->PAI->TargetFind->canSee(&PTarget->loc.p))
+        if (!PChar->CanSeeTarget(PTarget, false))
         {
             errMsg = std::make_unique<CMessageBasicPacket>(PChar, PTarget, PAbility->getID(), 0, MSGBASIC_CANNOT_PERFORM_ACTION);
             PChar->HandleErrorMessage(errMsg);

--- a/src/map/los/los_tree.cpp
+++ b/src/map/los/los_tree.cpp
@@ -41,15 +41,15 @@ LosTree::LosTree(Triangle* elements, int elementCount)
 
     root = new LosTreeNode(this->elements, boundingBoxes, this->elementNexts, indices, 0, elementCount - 1, 100, 1, 5, true);
 
-    delete[] boundingBoxes;
-    delete[] indices;
+    destroy_arr(boundingBoxes);
+    destroy_arr(indices);
 }
 
 LosTree::~LosTree()
 {
-    delete root;
-    delete[] elements;
-    delete[] elementNexts;
+    destroy(root);
+    destroy_arr(elements);
+    destroy_arr(elementNexts);
 }
 
 LosTreeNodeStats LosTree::GetStats()

--- a/src/map/los/los_tree_node.cpp
+++ b/src/map/los/los_tree_node.cpp
@@ -172,8 +172,8 @@ LosTreeNode::LosTreeNode(
 
 LosTreeNode::~LosTreeNode()
 {
-    delete left;
-    delete right;
+    destroy(left);
+    destroy(right);
 }
 
 void LosTreeNode::SetElements(Triangle* elements, int* elementNexts, int* elementIndices, int indexStart, int indexEnd)


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed an issue where using job abilities in town would crash the server (Public)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes an issue where using job abilities in town would cause a line of sight null pointer.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
Use a job ability in town.

## Special Deployment Considerations

N/A
