### PR TITLE
Fix Miscellaneous Mobskill Poison Damage

### DIFF
--- a/scripts/globals/mobskills/acid_spray.lua
+++ b/scripts/globals/mobskills/acid_spray.lua
@@ -12,7 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = math.min(1, (mob:getMainLvl() / 10)) * 2
+    local power = math.max(1, (mob:getMainLvl() / 10)) * 2
 
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, 60)
 

--- a/scripts/globals/mobskills/plague_breath.lua
+++ b/scripts/globals/mobskills/plague_breath.lua
@@ -17,7 +17,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = math.min(1, mob:getMainLvl() / 10)
+    local power = math.max(1, mob:getMainLvl() / 10)
 
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, 60)
 

--- a/scripts/globals/mobskills/venom.lua
+++ b/scripts/globals/mobskills/venom.lua
@@ -19,7 +19,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffect = xi.effect.POISON
-    local power = math.min(1, (mob:getMainLvl() - 3) / 2)
+    local power = math.max(1, (mob:getMainLvl() - 3) / 2)
 
     xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
 


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Corrected the poison tick damage for Acid Spray, Plaguebreath, and Venom (Public)

## What does this pull request do? (Please be technical)

Fix an issue where poison mobskills are using the min instead of max, which allows for values of 0 when one of the two values is 0.

## Steps to test these changes

!tp 3000
Get poisoned

## Special Deployment Considerations

N/A

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/2584