### PR TITLE
Fix dispelable shields

### DIFF
--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -184,9 +184,9 @@ INSERT INTO `status_effects` VALUES (146,'accuracy_down',8405026,0,0,0,0,90,4,0,
 INSERT INTO `status_effects` VALUES (147,'attack_down',8405026,0,0,0,0,91,6,0,0);
 INSERT INTO `status_effects` VALUES (148,'evasion_down',8405026,0,0,0,0,92,2,0,0);
 INSERT INTO `status_effects` VALUES (149,'defense_down',8405026,0,0,0,0,93,3,0,0);
-INSERT INTO `status_effects` VALUES (150,'physical_shield',41,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (150,'physical_shield',40,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (151,'arrow_shield',33,0,0,0,0,0,0,0,0);
-INSERT INTO `status_effects` VALUES (152,'magic_shield',41,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (152,'magic_shield',40,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (153,'damage_spikes',41,34,0,0,0,0,0,0,800);
 INSERT INTO `status_effects` VALUES (154,'shining_ruby',41,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (155,'medicine',0,0,0,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Physical and magic shield status effects of monsters are no longer dispelable. (Tracent)

## What does this pull request do? (Please be technical)
This fixes the above issue by changing the status effect flags of physical and magic shield status effects (these seem to only be used by monsters).

## Steps to test these changes
Fight Ultima under 40% and give TP until it uses Energy Screen (physical shield) and then try to dispel it on both RDM and BRD.

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1106
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/3257
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
