### PR TITLE
Flash in the Pan Fame Fix

### DIFF
--- a/scripts/quests/bastok/A_Flash_in_the_Pan.lua
+++ b/scripts/quests/bastok/A_Flash_in_the_Pan.lua
@@ -55,7 +55,7 @@ quest.sections =
                         if npc:getLocalVar('tradeCooldown') <= os.time() then
                             return quest:progressEvent(219)
                         else
-                            return quest:progressEvent(218)
+                            return quest:event(218)
                         end
                     end
                 end,
@@ -64,15 +64,13 @@ quest.sections =
             onEventFinish =
             {
                 [219] = function(player, csid, option, npc)
+                    if player:hasCompletedQuest(quest.areaId, quest.questId) then
+                        quest.reward.fame = 15
+                    end
+
                     if quest:complete(player) then
                         player:confirmTrade()
                         GetNPCByID(bastokMarketsID.npc.AQUILLINA):setLocalVar('tradeCooldown', os.time() + 900)
-                    end
-                end,
-
-                [218] = function(player, csid, option, npc)
-                    if quest:complete(player) then
-                        player:confirmTrade(false)
                     end
                 end,
             },

--- a/scripts/quests/bastok/A_Flash_in_the_Pan.lua
+++ b/scripts/quests/bastok/A_Flash_in_the_Pan.lua
@@ -73,6 +73,10 @@ quest.sections =
                         GetNPCByID(bastokMarketsID.npc.AQUILLINA):setLocalVar('tradeCooldown', os.time() + 900)
                     end
                 end,
+
+                [218] = function(player, csid, option, npc)
+                    player:tradeComplete(false)
+                end,
             },
         },
     },


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Removed a line that always allowed players to complete the quest Flash in the Pan regardless of the NPC's timers.

## What does this pull request do? (Please be technical)
Removed ghost code that was completing the quest when it shouldn't have done so.
Reduced fame for recompletion of the quest.
