### PR TITLE
Ensure Race Runner can cast and use abilities on spawn

### DIFF
--- a/scripts/zones/Boneyard_Gully/mobs/Race_Runner.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Race_Runner.lua
@@ -49,6 +49,8 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.UDMGMAGIC, -4000)
     mob:setMod(xi.mod.REGAIN, 1000)
     mob:setSpeed(70)
+    mob:setMagicCastingEnabled(true)
+    mob:setMobAbilityEnabled(true)
 
     mob:addListener("TAKE_DAMAGE", "RUNNER_TAKE_DAMAGE", function(mobArg, amount, attacker, attackType, damageType)
         if amount > 0 and not attacker:isPet() then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed a bug which would cause Race Runner from Like The Wind ENM to spawn in a state where it could not cast and could not use abilities.

## What does this pull request do? (Please be technical)

Resets `setMagicCastingEnabled` and `setMobAbilityEnabled` on spawn.

## Steps to test these changes

This is fun to test.
1. Enter like the wind.
1. Note the mobID
1. Trigger Race Runner to run by hitting them enough times with a non -pet.
1. While Race Runner is running, !hp 0 it.
1. win the bcnm, pop the chest.
1. Re-Enter like the wind.
1. verify mobID is the same mob you just fought.
1. Provoke or flash (non-dmg aggo) and see if the mob is using spells and abilities.

## Special Deployment Considerations

None - hot fixable.