### PR TITLE
Applies roamflags and SuperFamilyID to Dynamic Entities

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1450,7 +1450,8 @@ Usage:
         mob_groups.allegiance, namevis, aggro, mob_pools.skill_list_id, mob_pools.true_detection, mob_family_system.detects, \
         mob_family_system.charmable, \
         mob_ele_evasion.fire_eem, mob_ele_evasion.ice_eem, mob_ele_evasion.wind_eem, mob_ele_evasion.earth_eem, \
-        mob_ele_evasion.lightning_eem, mob_ele_evasion.water_eem, mob_ele_evasion.light_eem, mob_ele_evasion.dark_eem \
+        mob_ele_evasion.lightning_eem, mob_ele_evasion.water_eem, mob_ele_evasion.light_eem, mob_ele_evasion.dark_eem, \
+        mob_pools.roamflag, mob_family_system.superFamilyID \
         FROM mob_groups \
         INNER JOIN mob_pools ON mob_groups.poolid = mob_pools.poolid \
         INNER JOIN mob_resistances ON mob_pools.resist_id = mob_resistances.resist_id \
@@ -1581,6 +1582,8 @@ Usage:
                 PMob->setMobMod(MOBMOD_DETECTION, sql->GetUIntData(69));
 
                 PMob->setMobMod(MOBMOD_CHARMABLE, sql->GetUIntData(70));
+                PMob->m_roamFlags   = sql->GetUIntData(79);
+                PMob->m_SuperFamily = sql->GetUIntData(80);
                 // Overwrite base family charmables depending on mob type. Disallowed mobs which should be charmable
                 // can be set in mob_spawn_mods or in their onInitialize
                 if (PMob->m_Type & MOBTYPE_EVENT || PMob->m_Type & MOBTYPE_FISHED || PMob->m_Type & MOBTYPE_BATTLEFIELD ||


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Dynamic Entiry Worms will now follow correct worm behavior - moving like a worm and not casting spells on targets within melee range.
Dynamic Entities will now link per normal family and super family rules, rather than always linking with all dynamic entities,

## What does this pull request do? (Please be technical)

When instantiating a dynamic entitiy, the family_system superFamilyID and the pool roamFlags will now be applied.

## Steps to test these changes

Find a DE worm (Mineral Eater in K Highlands).
Voke one while in melee range - should not cast.
Watch one for a long time - it should move.
**Note** testing worm movement requires navmesh to be installed.  Check a known non-DE worm for movement before checking a DE worm - so you dont waste 2 hours and question your own sanity.

For DE linking - go to Cape Terrigan at night, in the NE corner.
There are Arid Lizards and Dust Bats.
Ensure Lizard links Lizard and Bat links Bat - but lizard does not link bat.
Find a lizard somwhere else in the cape terrigan zone (by OP).
Drag a lizard up to the NE, note that it links with the DE lizards too.

## Special Deployment Considerations
none
