### PR TITLE
Add in Fellows Zone Miscs (Again)

### DIFF
--- a/modules/era/sql/era_zone_settings.sql
+++ b/modules/era/sql/era_zone_settings.sql
@@ -37,4 +37,7 @@ UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 126; -- Qufim Island
 UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 127; -- Behemoth's Dominion
 UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 128; -- Valley of Sorrows
 
+-- Add fellows in proper areas if not already there
+UPDATE zone_settings SET misc = misc + 2 WHERE misc & ~2 and zoneid IN (2, 4, 5, 7, 11, 12, 24, 25, 51, 52, 68, 79, 81, 82, 83, 84, 88, 89, 90, 91, 95, 96, 97, 98, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 141, 142, 143, 145, 147, 149, 151, 153, 157, 158, 159, 160, 161, 162, 164, 166, 167, 171, 172, 173, 174, 175, 176, 184, 190, 191, 192, 193, 194, 195, 196, 197, 198, 200, 204, 205, 208, 212, 213);
+
 UNLOCK TABLES;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixing Fellows Zone Misc values to a module after being wiped out in LOS Mesh merge

## What does this pull request do? (Please be technical)

Fixing Fellows Zone Misc values to a module after being wiped out in LOS Mesh merge

## Steps to test these changes

Enable Fellows and attempt to summon one

## Special Deployment Considerations

Make sure you run zone_settings.lua once to update to LOS mesh values
