### PR TITLE
[core] Fixes Barrage feeding the mob 10000 TP

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2300,14 +2300,16 @@ namespace battleutils
                 baseTp = CalculateBaseTP((int16)(delay * 60.0f / 1000.0f / ratio));
             }
 
+            int16 attackerTp = 0;
+
             if (giveTPtoAttacker)
             {
                 if (PAttacker->objtype == TYPE_PC && physicalAttackType == PHYSICAL_ATTACK_TYPE::ZANSHIN)
                 {
                     baseTp += ((CCharEntity*)PAttacker)->PMeritPoints->GetMeritValue(MERIT_IKISHOTEN, (CCharEntity*)PAttacker);
                 }
-
-                PAttacker->addTP((int16)(tpMultiplier * (baseTp * (1.0f + 0.01f * (float)((PAttacker->getMod(Mod::STORETP) + getStoreTPbonusFromMerit(PAttacker)))))));
+                attackerTp = ((tpMultiplier * (baseTp * (1.0f + 0.01f * (float)((PAttacker->getMod(Mod::STORETP) + getStoreTPbonusFromMerit(PAttacker)))))));
+                PAttacker->addTP(attackerTp);
             }
 
             if (giveTPtoVictim)
@@ -2327,9 +2329,9 @@ namespace battleutils
                 }
                 else
                 {
-                    PDefender->addTP((uint16)(tpMultiplier *
-                                              ((baseTp + 30) * sBlowMult *
-                                               (1.0f + 0.01f * (float)PDefender->getMod(Mod::STORETP))))); // subtle blow also reduces the "+30" on mob tp gain
+                    uint16 defenderTp = attackerTp * 1.25 * sBlowMult *
+                                         (1.0f + 0.01f * (float)PDefender->getMod(Mod::STORETP)); // subtle blow also reduces the "+30" on mob tp gain
+                    PDefender->addTP(defenderTp);
                 }
             }
         }
@@ -2446,7 +2448,7 @@ namespace battleutils
             else
             {
                 PDefender->addTP((int16)(tpMultiplier * targetTPMultiplier *
-                                         ((baseTp + 30) * sBlowMult *
+                                         (std::ceil(baseTp * 1.25) * sBlowMult *
                                           (1.0f + 0.01f * (float)PDefender->getMod(Mod::STORETP))))); // subtle blow also reduces the "+30" on mob tp gain
             }
         }


### PR DESCRIPTION
Fixes Barrage feeding the mob 10000 TP

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [ ] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Barrage will no longer feed a mob 3k TP (WinterSoltice, Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Corrects the TP gained from barrage to not give it 3000 TP...
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/105882754/ddeb8c61-8578-4641-8fb5-e7f91a0fb085)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
use barrage on a mob
See that the mob does not gain 3k tp and instead gains the TP of 5 hits.
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
