### PR TITLE
Fix Antique Collector Quest Reward

### DIFF
--- a/scripts/quests/jeuno/The_Antique_Collector.lua
+++ b/scripts/quests/jeuno/The_Antique_Collector.lua
@@ -22,7 +22,7 @@ quest.reward =
 {
     fame     = 30,
     fameArea = xi.quest.fame_area.JEUNO,
-    keyitem  = xi.ki.MAP_OF_DELKFUTTS_TOWER,
+    keyItem  = xi.ki.MAP_OF_DELKFUTTS_TOWER,
     title    = xi.title.TRADER_OF_ANTIQUITIES,
 }
 


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed an issue where The Antique Collector did not give the Delkfutt's Tower map on completion (Public)

## What does this pull request do? (Please be technical)

Fix the reward for the quest The Antique Collector to correctly give the Map of Delkfutt's Tower key item when completing the quest.

## Steps to test these changes

Do the quest and get the map

## Special Deployment Considerations

N/A

Fixes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1658
