### PR TITLE
Fishing crash fixed

### DIFF
--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -2064,14 +2064,14 @@ namespace fishingutils
             Bait = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_AMMO));
 
             // Players cannot fish using the goldfishing basket outside of the sunbreeze event or goldfishing designated zones
-            if (Rod->getID() == GOLDFISH_BASKET && !settings::get<bool>("main.SUNBREEZE"))
+            if (Rod != nullptr && Rod->getID() == GOLDFISH_BASKET && !settings::get<bool>("main.SUNBREEZE"))
             {
                 PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_CANNOTFISH_MOMENT));
                 PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
                 destroy(PChar->hookedFish);
                 return;
             }
-            else if (Rod->getID() == GOLDFISH_BASKET && zone != 238 && zone != 239 && zone != 241 && zone != 231 && zone != 234 && zone != 235 &&
+            else if (Rod != nullptr && Rod->getID() == GOLDFISH_BASKET && zone != 238 && zone != 239 && zone != 241 && zone != 231 && zone != 234 && zone != 235 &&
                      zone != 247 && zone != 100 && zone != 107 && zone != 116)
             {
                 PChar->pushPacket(new CMessageTextPacket(PChar, MessageOffset + FISHMESSAGEOFFSET_CANNOTFISH_MOMENT));


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
No player facing adjustments

## What does this pull request do? (Please be technical)
Fixed a member access without checking for nullptr
The crash that this issue cause occured when players attempted to fish without using a rod, but with bait. 
This issue was introduced with the initial goldfishing update.
