### PR TITLE
Fixes Mother Globe Pathing Errors when spawning pets

### DIFF
--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Mother_Globe.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Mother_Globe.lua
@@ -110,6 +110,8 @@ local spawnSlaveGlobe = function(mg, slaveGlobe, spawnPos)
     else
         mg:entityAnimationPacket("casm")
         local pPet = slaveGlobe:getID() - 1
+        local pet = GetMobByID(pPet)
+
         mg:timer(3000, function(mob)
             if mob:isAlive() then
                 mob:entityAnimationPacket("shsm")
@@ -117,7 +119,7 @@ local spawnSlaveGlobe = function(mg, slaveGlobe, spawnPos)
                 if pPet == nil then
                     slaveGlobe:pathTo(mob:getXPos() + 0.15, mob:getYPos(), mob:getZPos() + 0.15)
                 else
-                    slaveGlobe:pathTo(pPet:getXPos() + 0.5, pPet:getYPos(), pPet:getZPos() + 0.5)
+                    slaveGlobe:pathTo(pet:getXPos() + 0.5, pet:getYPos(), pet:getZPos() + 0.5)
                 end
             end
         end)


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
N/A
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Fixes an error causing pPet to be nil and causing errors in the map
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
go to mother globe and see no errors in the map
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
