### PR TITLE
Fix Go! Go! Gobmuffin! Reward

### DIFF
--- a/scripts/quests/otherAreas/Go_Go_Gobmuffin.lua
+++ b/scripts/quests/otherAreas/Go_Go_Gobmuffin.lua
@@ -16,7 +16,7 @@ local ID = require('scripts/zones/Riverne-Site_B01/IDs')
 
 local quest = Quest:new(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.GO_GO_GOBMUFFIN)
 
-quest.rewards =
+quest.reward =
 {
     keyItem = xi.ki.MAP_OF_CAPE_RIVERNE,
 }


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed an issue where Go! Go! Gobmuffin! was not granting the Map of Cape Riverne upon completion (Public)

## What does this pull request do? (Please be technical)

Fixes an issue where Go! Go! Gobmuffin! was not correctly granting the Map of Cape Riverne key item upon completion.

## Steps to test these changes

Do the quest and get a map
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/140564555/fa6a5f84-fb73-412d-928e-6a063af6b39f)

## Special Deployment Considerations

N/A

Fixes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1542
