### PR TITLE
Fix sunbreeze clustering issue

### DIFF
--- a/scripts/globals/events/sunbreeze_festival.lua
+++ b/scripts/globals/events/sunbreeze_festival.lua
@@ -10,90 +10,144 @@ xi.events.sunbreeze_festival = xi.events.sunbreeze_festival or {}
 local event = SeasonalEvent:new("SunbreezeFestival")
 
 xi.events.sunbreeze_festival.enabledCheck = function()
-    return tonumber(os.date("%m")) == 8 and xi.settings.main.SUNBREEZE == 1
+    return tonumber(os.date("%m")) == 8 and xi.settings.main.SUNBREEZE == 1 or xi.settings.main.SUNBREEZE_YEAR_ROUND
 end
 
 event:setEnableCheck(xi.events.sunbreeze_festival.enabledCheck)
 
 local sunbreezeNPCEntites =
 {
-    -- Goldfish NPCs
-    17789025, -- Mei (Rabao)
-    17187570, -- Saradorial (West Ronfaure)
-    17216210, -- Fish Eyes (North Gustaberg)
-    17253106, -- Kesha Shopehllok (East Sarutabaruta)
-    -- Bastok Markets (Dancers + Moogle)
-    17740130, 17740035, 17740036, 17740037, 17740038, 17740039,
-    17740040, 17740041, 17740042, 17740043, 17740044, 17740045,
-    17740046, 17740047, 17740048, 17740049, 17740050,
-    -- Windurst Woods (Dancers + Moogle)
-    17764737, 17764707, 17764708, 17764709, 17764710,
-    17764703, 17764704, 17764705, 17764706,
-    -- Northern San d'Oria (Dancers + Moogle)
-    17723724, 17723725, 17723726, 17723727, 17723728, 17723729,
-    17723730, 17723731,
+    [xi.zone.RABAO] =
+    {
+        17789025, -- Mei
+    },
+
+    [xi.zone.WEST_RONFAURE] =
+    {
+        17187570, -- Saradorial
+    },
+
+    [xi.zone.SOUTH_GUSTABERG] =
+    {
+        17216210, -- Fish Eyes
+    },
+
+    [xi.zone.EAST_SARUTABARUTA] =
+    {
+        17253106, -- Kesha Shopehllok
+    },
+
+    [xi.zone.BASTOK_MARKETS] =
+    {
+        -- (Dancers + Moogle)
+        17740130, 17740035, 17740036, 17740037, 17740038, 17740039,
+        17740040, 17740041, 17740042, 17740043, 17740044, 17740045,
+        17740046, 17740047, 17740048, 17740049, 17740050,
+    },
+
+    [xi.zone.WINDURST_WOODS] =
+    {
+        -- (Dancers + Moogle)
+        17764737, 17764707, 17764708, 17764709, 17764710,
+        17764703, 17764704, 17764705, 17764706,
+    },
+
+    [xi.zone.NORTHERN_SAN_DORIA] =
+    {
+        -- (Dancers + Moogle)
+        17723724, 17723725, 17723726, 17723727, 17723728, 17723729,
+        17723730, 17723731, 17723753,
+    },
 }
 
 local sunbreezeDecorations =
 {
-    -- Fireworks
-    17187571, 17191555, 17212131, 17216209, 17244668, 17289818, 17248881,
-    17253105, 17719783, 17727646, 17723770, 17735938, 17740146, 17760486,
-    17744126, 17752456, 17756373, 17764738, 17788993,
-    -- Bastok Markets (Trees)
-    17740051, 17740052, 17740053, 17740054, 17740055, 17740056, 17740057,
-    17740058, 17740059, 17740060, 17740061, 17740121, 17740122, 17740123,
-    17740124, 17740125, 17740126, 17740127, 17740105,
-    -- Port Bastok (Trees)
-    17744084, 17744085, 17744086, 17744087, 17744088, 17744089, 17744090,
-    17744091, 17744092, 17744093, 17744094, 17744095, 17744096, 17744097,
-    17744098, 17744099, 17744100, 17744101, 17744102, 17744103, 17744104,
-    17744105, 17744106, 17744107, 17744108, 17744109, 17744082, 17744083,
-    -- Windurst Woods (Trees)
-    17764711, 17764712, 17764713, 17764714, 17764715, 17764716, 17764717,
-    17764718, 17764719, 17764720, 17764721, 17764722, 17764723,
-    -- Windurst Walls (Trees)
-    17756374, 17756375, 17756376, 17756377, 17756378, 17756379, 17756380,
-    17756381, 17756382, 17756383, 17756384, 17756385,
-    -- Windurst Waters (Trees)
-    17752440, 17752441, 17752442, 17752443, 17752444, 17752445, 17752446,
-    17752447, 17752448, 17752449, 17752450, 17752451, 17752452, 17752453,
-    17752454, 17752455,
-    -- Port Windurst (Trees)
-    17760471, 17760472, 17760473, 17760474, 17760475, 17760476, 17760477,
-    17760478, 17760479, 17760480, 17760481, 17760482, 17760483, 17760484,
-    -- Northern San d'Oria
-    17723732, 17723733, 17723734, 17723735, 17723736, 17723737, 17723738,
-    17723739, 17723740, 17723741, 17723742, 17723743, 17723744, 17723745,
-    17723746, 17723747, 17723748, 17723749, 17723750, 17723751, 17723752,
-    -- Southern San d'Oria
-    17719786, 17719787, 17719788, 17719789, 17719790, 17719791, 17719792,
-    17719793, 17719794, 17719795, 17719796, 17719797, 17719798, 17719799,
-    17719800, 17719801, 17719802, 17719803, 17719804, 17719805, 17719806,
-    17719807, 17719808, 17719809, 17719814, 17719815, 17719816,
+    [0] = -- Fireworks
+    {
+        17187571, 17191555, 17212131, 17216209, 17244668, 17289818, 17248881,
+        17253105, 17719783, 17727646, 17723770, 17735938, 17740146, 17760486,
+        17744126, 17752456, 17756373, 17764738, 17788993,
+    },
+
+    [xi.zone.BASTOK_MARKETS] =
+    {
+        17740051, 17740052, 17740053, 17740054, 17740055, 17740056, 17740057,
+        17740058, 17740059, 17740060, 17740061, 17740121, 17740122, 17740123,
+        17740124, 17740125, 17740126, 17740127, 17740105,
+    },
+
+    [xi.zone.PORT_BASTOK] =
+    {
+        17744084, 17744085, 17744086, 17744087, 17744088, 17744089, 17744090,
+        17744091, 17744092, 17744093, 17744094, 17744095, 17744096, 17744097,
+        17744098, 17744099, 17744100, 17744101, 17744102, 17744103, 17744104,
+        17744105, 17744106, 17744107, 17744108, 17744109, 17744082, 17744083,
+    },
+
+    [xi.zone.WINDURST_WOODS] =
+    {
+        17764711, 17764712, 17764713, 17764714, 17764715, 17764716, 17764717,
+        17764718, 17764719, 17764720, 17764721, 17764722, 17764723,
+    },
+
+    [xi.zone.WINDURST_WALLS] =
+    {
+        17756374, 17756375, 17756376, 17756377, 17756378, 17756379, 17756380,
+        17756381, 17756382, 17756383, 17756384, 17756385,
+    },
+
+    [xi.zone.WINDURST_WATERS] =
+    {
+        17752440, 17752441, 17752442, 17752443, 17752444, 17752445, 17752446,
+        17752447, 17752448, 17752449, 17752450, 17752451, 17752452, 17752453,
+        17752454, 17752455,
+    },
+
+    [xi.zone.PORT_WINDURST] =
+    {
+        17760471, 17760472, 17760473, 17760474, 17760475, 17760476, 17760477,
+        17760478, 17760479, 17760480, 17760481, 17760482, 17760483, 17760484,
+    },
+
+    [xi.zone.NORTHERN_SAN_DORIA] =
+    {
+        17723732, 17723733, 17723734, 17723735, 17723736, 17723737, 17723738,
+        17723739, 17723740, 17723741, 17723742, 17723743, 17723744, 17723745,
+        17723746, 17723747, 17723748, 17723749, 17723750, 17723751, 17723752,
+    },
+
+    [xi.zone.SOUTHERN_SAN_DORIA] =
+    {
+        17719786, 17719787, 17719788, 17719789, 17719790, 17719791, 17719792,
+        17719793, 17719794, 17719795, 17719796, 17719797, 17719798, 17719799,
+        17719800, 17719801, 17719802, 17719803, 17719804, 17719805, 17719806,
+        17719807, 17719808, 17719809, 17719814, 17719815, 17719816,
+    },
 }
 
+-- This table is used in the enabling and disabling of the
+-- fireworks in day / night cycles
 local sunbreezeFireworks =
 {
-    [xi.zone.WEST_RONFAURE]         = { 17187571, },
-    [xi.zone.EAST_RONFAURE]         = { 17191555, },
-    [xi.zone.NORTH_GUSTABERG]       = { 17212131, },
-    [xi.zone.SOUTH_GUSTABERG]       = { 17216209, },
-    [xi.zone.EASTERN_ALTEPA_DESERT] = { 17244668, },
-    [xi.zone.WESTERN_ALTEPA_DESERT] = { 17289818, },
-    [xi.zone.WEST_SARUTABARUTA]     = { 17248881, },
-    [xi.zone.EAST_SARUTABARUTA]     = { 17253105, },
-    [xi.zone.SOUTHERN_SAN_DORIA]    = { 17719783, },
-    [xi.zone.PORT_SAN_DORIA]        = { 17727646, },
-    [xi.zone.NORTHERN_SAN_DORIA]    = { 17723770, },
-    [xi.zone.BASTOK_MINES]          = { 17735938, },
-    [xi.zone.BASTOK_MARKETS]        = { 17740146, },
-    [xi.zone.PORT_BASTOK]           = { 17744126, },
-    [xi.zone.WINDURST_WATERS]       = { 17752456, },
-    [xi.zone.WINDURST_WALLS]        = { 17756373, },
-    [xi.zone.PORT_WINDURST]         = { 17760486, },
-    [xi.zone.WINDURST_WOODS]        = { 17764738, },
-    [xi.zone.RABAO]                 = { 17788993, },
+    [xi.zone.WEST_RONFAURE]         = 17187571,
+    [xi.zone.EAST_RONFAURE]         = 17191555,
+    [xi.zone.NORTH_GUSTABERG]       = 17212131,
+    [xi.zone.SOUTH_GUSTABERG]       = 17216209,
+    [xi.zone.EASTERN_ALTEPA_DESERT] = 17244668,
+    [xi.zone.WESTERN_ALTEPA_DESERT] = 17289818,
+    [xi.zone.WEST_SARUTABARUTA]     = 17248881,
+    [xi.zone.EAST_SARUTABARUTA]     = 17253105,
+    [xi.zone.SOUTHERN_SAN_DORIA]    = 17719783,
+    [xi.zone.PORT_SAN_DORIA]        = 17727646,
+    [xi.zone.NORTHERN_SAN_DORIA]    = 17723770,
+    [xi.zone.BASTOK_MINES]          = 17735938,
+    [xi.zone.BASTOK_MARKETS]        = 17740146,
+    [xi.zone.PORT_BASTOK]           = 17744126,
+    [xi.zone.WINDURST_WATERS]       = 17752456,
+    [xi.zone.WINDURST_WALLS]        = 17756373,
+    [xi.zone.PORT_WINDURST]         = 17760486,
+    [xi.zone.WINDURST_WOODS]        = 17764738,
+    [xi.zone.RABAO]                 = 17788993,
 }
 
 local sunbreezeMusicZones =
@@ -153,48 +207,6 @@ local goldfishRewardTable =
         [115] = { points = 70, item = xi.items.WHITE_BUTTERFLY, amount = 5 },
         [139] = { points = 70, item = xi.items.WHITE_BUTTERFLY, amount = 5 },
         [903] = { points = 70, item = xi.items.BELL_CRICKET,    amount = 5 },
-    },
-}
-
-local moogleVendorStock =
-{
-    [2004] = -- No retail information
-    {
-
-    },
-
-    [2005] =
-    {
-        xi.items.HUME_GILET,           7500,
-        xi.items.HUME_GILET_P1,       10000,
-        xi.items.HUME_TRUNKS,          7500,
-        xi.items.HUME_TRUNKS_P1,      10000,
-        xi.items.HUME_TOP,             7500,
-        xi.items.HUME_TOP_P1,         10000,
-        xi.items.HUME_SHORTS,          7500,
-        xi.items.HUME_SHORTS_P1,      10000,
-        xi.items.ELVAAN_GILET,         7500,
-        xi.items.ELVAAN_GILET_P1,     10000,
-        xi.items.ELVAAN_TRUNKS,        7500,
-        xi.items.ELVAAN_TRUNKS_P1,    10000,
-        xi.items.ELVAAN_TOP,           7500,
-        xi.items.ELVAAN_TOP_P1,       10000,
-        xi.items.ELVAAN_SHORTS,        7500,
-        xi.items.ELVAAN_SHORTS_P1,    10000,
-        xi.items.TARUTARU_MAILLOT,     7500,
-        xi.items.TARUTARU_MAILLOT_P1, 10000,
-        xi.items.TARUTARU_TRUNKS,      7500,
-        xi.items.TARUTARU_TRUNKS_P1,  10000,
-        xi.items.TARUTARU_TOP,         7500,
-        xi.items.TARUTARU_TOP_P1,     10000,
-        xi.items.MITHRA_TOP,           7500,
-        xi.items.MITHRA_TOP_P1,       10000,
-        xi.items.MITHRA_SHORTS,        7500,
-        xi.items.MITHRA_SHORTS_P1,    10000,
-        xi.items.GALKA_GILET,          7500,
-        xi.items.GALKA_GILET_P1,      10000,
-        xi.items.GALKA_TRUNKS,         7500,
-        xi.items.GALKA_TRUNKS_P1,     10000,
     },
 }
 
@@ -311,11 +323,6 @@ xi.events.sunbreeze_festival.goldfishVendorOnEventFinish = function(player, csid
     end
 end
 
-xi.events.sunbreeze_festival.moogleVendorOnTrigger = function(player, npc)
-    player:messageSpecial(zones[player:getZoneID()].text.SUNBREEZE_MOOGLE_VENDOR)
-    xi.shop.general(player, moogleVendorStock[xi.settings.main.SUNBREEZE_VENDOR_ERA])
-end
-
 xi.events.sunbreeze_festival.setMusic = function(flag)
     local sunbreezeMusic = 227
     -- If true, set sunbreeze music
@@ -361,43 +368,90 @@ end
 
 xi.events.sunbreeze_festival.spawnFireworks = function(zone)
     if xi.events.sunbreeze_festival.enabledCheck then
-        for _, firework in pairs(sunbreezeFireworks[zone:getID()]) do
-            local fireworkNPC = GetNPCByID(firework)
-            local hour = VanadielHour()
+        local firework = GetNPCByID(sunbreezeFireworks[zone:getID()])
+        local hour     = VanadielHour()
 
-            if hour <= 6 or hour >= 18 then
-                fireworkNPC:setStatus(xi.status.NORMAL)
-            else
-                fireworkNPC:setStatus(xi.status.INVISIBLE)
+        if hour <= 5 or hour >= 17 then
+            firework:setStatus(xi.status.NORMAL)
+        else
+            firework:setStatus(xi.status.INVISIBLE)
+        end
+    end
+end
+
+xi.events.sunbreeze_festival.showNPCs = function(zoneID)
+    if xi.events.sunbreeze_festival.enabledCheck() then
+        for _, entityID in pairs(sunbreezeNPCEntites[zoneID]) do
+            local npc = GetNPCByID(entityID)
+
+            if npc then
+                npc:setStatus(xi.status.NORMAL)
+            end
+        end
+
+    else
+        for _, entityID in pairs(sunbreezeNPCEntites[zoneID]) do
+            local npc = GetNPCByID(entityID)
+
+            if npc then
+                npc:setStatus(xi.status.DISAPPEAR)
             end
         end
     end
 end
 
-xi.events.sunbreeze_festival.showEntities = function(enabled)
-    -- NPCs for the event
-    for _, entityID in pairs(sunbreezeNPCEntites) do
-        local entity = GetNPCByID(entityID)
+xi.events.sunbreeze_festival.showDecorations = function(zoneID)
+    if xi.events.sunbreeze_festival.enabledCheck() then
+        for _, entityID in pairs(sunbreezeDecorations[zoneID]) do
+            local npc = GetNPCByID(entityID)
 
-        if entity then
-            if enabled then
-                entity:setStatus(xi.status.NORMAL)
-            else
-                entity:setStatus(xi.status.INVISIBLE)
+            if npc then
+                npc:setStatus(xi.status.NORMAL)
+            end
+        end
+
+    else
+        for _, entityID in pairs(sunbreezeDecorations[zoneID]) do
+            local npc = GetNPCByID(entityID)
+
+            if npc then
+                npc:setStatus(xi.status.DISAPPEAR)
+            end
+        end
+    end
+end
+
+-- TODO:
+-- The tabling should not use raw NPC IDs and instead should create
+-- decorations / NPCs dynamically based on tables of NPC information
+xi.events.sunbreeze_festival.enableEntities = function(enabled)
+    -- NPCs for the event
+    for zone, entities in pairs(sunbreezeNPCEntites) do
+        for _, npcID in pairs(entities) do
+            local npc = GetNPCByID(npcID)
+
+            if npc then
+                if enabled then
+                    npc:setStatus(xi.status.NORMAL)
+                else
+                    npc:setStatus(xi.status.INVISIBLE)
+                end
             end
         end
     end
 
-    -- Entities that will always render in
-    for _, entityID in pairs(sunbreezeDecorations) do
-        local entity = GetNPCByID(entityID)
+    -- Decorations that will always render in
+    for zone, entities in pairs(sunbreezeDecorations) do
+        for _, decoID in pairs(entities) do
+            local deco = GetNPCByID(decoID)
 
-        if entity then
-            if enabled then
-                entity:setAlwaysRender(true)
-                entity:setStatus(xi.status.NORMAL)
-            else
-                entity:setStatus(xi.status.INVISIBLE)
+            if deco then
+                if enabled then
+                    deco:setAlwaysRender(true)
+                    deco:setStatus(xi.status.NORMAL)
+                else
+                    deco:setStatus(xi.status.INVISIBLE)
+                end
             end
         end
     end
@@ -405,12 +459,12 @@ end
 
 event:setStartFunction(function()
     xi.events.sunbreeze_festival.setMusic(true)
-    xi.events.sunbreeze_festival.showEntities(true)
+    xi.events.sunbreeze_festival.enableEntities(true)
 end)
 
 event:setEndFunction(function()
     xi.events.sunbreeze_festival.setMusic(false)
-    xi.events.sunbreeze_festival.showEntities(false)
+    xi.events.sunbreeze_festival.enableEntities(false)
 end)
 
 return event

--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -14,6 +14,8 @@ local zoneObject = {}
 zoneObject.onInitialize = function(zone)
     applyHalloweenNpcCostumes(zone:getID())
     xi.events.starlightCelebration.applyStarlightDecorations(zone:getID())
+    xi.events.sunbreeze_festival.showDecorations(zone:getID())
+    xi.events.sunbreeze_festival.showNPCs(zone:getID())
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/East_Sarutabaruta/Zone.lua
+++ b/scripts/zones/East_Sarutabaruta/Zone.lua
@@ -23,9 +23,8 @@ zoneObject.onInitialize = function(zone)
         xi.mob.nmTODPersistCache(zone, ID.mob.DUKE_DECAPOD)
     end
 
-    if xi.events.starlightCelebration.isStarlightEnabled ~= 0 then
-        xi.events.starlightCelebration.applyStarlightDecorations(zone:getID())
-    end
+    xi.events.starlightCelebration.applyStarlightDecorations(zone:getID())
+    xi.events.sunbreeze_festival.showNPCs(zone:getID())
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -25,6 +25,8 @@ zoneObject.onInitialize = function(zone)
 
     applyHalloweenNpcCostumes(zone:getID())
     xi.events.starlightCelebration.applyStarlightDecorations(zone:getID())
+    xi.events.sunbreeze_festival.showDecorations(zone:getID())
+    xi.events.sunbreeze_festival.showNPCs(zone:getID())
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -16,6 +16,7 @@ zoneObject.onInitialize = function(zone)
     zone:registerTriggerArea(2, 53.5, 5, -165.3, 66.5, 6, -72) -- drawbridge area
     xi.conquest.toggleRegionalNPCs(zone)
     xi.events.starlightCelebration.applyStarlightDecorations(zone:getID())
+    xi.events.sunbreeze_festival.showDecorations(zone:getID())
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)

--- a/scripts/zones/Rabao/Zone.lua
+++ b/scripts/zones/Rabao/Zone.lua
@@ -9,6 +9,7 @@ require('scripts/globals/chocobo')
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    xi.events.sunbreeze_festival.showNPCs(zone:getID())
     xi.chocobo.initZone(zone)
 end
 

--- a/scripts/zones/South_Gustaberg/Zone.lua
+++ b/scripts/zones/South_Gustaberg/Zone.lua
@@ -16,9 +16,8 @@ zoneObject.onChocoboDig = function(player, precheck)
 end
 
 zoneObject.onInitialize = function(zone)
-    if xi.events.starlightCelebration.isStarlightEnabled ~= 0 then
-        xi.events.starlightCelebration.applyStarlightDecorations(zone:getID())
-    end
+    xi.events.starlightCelebration.applyStarlightDecorations(zone:getID())
+    xi.events.sunbreeze_festival.showNPCs(zone:getID())
 
     -- NM Persistence
     if xi.settings.main.ENABLE_WOTG == 1 then

--- a/scripts/zones/Southern_San_dOria/Zone.lua
+++ b/scripts/zones/Southern_San_dOria/Zone.lua
@@ -17,8 +17,11 @@ local zoneObject = {}
 zoneObject.onInitialize = function(zone)
     zone:registerTriggerArea(1, -292, -10, 90 , -258, 10, 105)
     quests.ffr.initZone(zone) -- register trigger areas 2 through 6
+
     applyHalloweenNpcCostumes(zone:getID())
     xi.events.starlightCelebration.applyStarlightDecorations(zone:getID())
+    xi.events.sunbreeze_festival.showDecorations(zone:getID())
+
     xi.chocobo.initZone(zone)
     xi.conquest.toggleRegionalNPCs(zone)
 end

--- a/scripts/zones/West_Ronfaure/Zone.lua
+++ b/scripts/zones/West_Ronfaure/Zone.lua
@@ -2,6 +2,7 @@
 -- Zone: West_Ronfaure (100)
 -----------------------------------
 local ID = require('scripts/zones/West_Ronfaure/IDs')
+require('scripts/globals/events/sunbreeze_festival')
 require('scripts/quests/i_can_hear_a_rainbow')
 require('scripts/globals/chocobo_digging')
 require('scripts/globals/conquest')
@@ -15,6 +16,7 @@ end
 
 zoneObject.onInitialize = function(zone)
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
+    xi.events.sunbreeze_festival.showNPCs(zone:getID())
 
     --NM Persistence
     if xi.settings.main.ENABLE_WOTG == 1 then

--- a/scripts/zones/Windurst_Woods/Zone.lua
+++ b/scripts/zones/Windurst_Woods/Zone.lua
@@ -16,6 +16,8 @@ local zoneObject = {}
 zoneObject.onInitialize = function(zone)
     applyHalloweenNpcCostumes(zone:getID())
     xi.events.starlightCelebration.applyStarlightDecorations(zone:getID())
+    xi.events.sunbreeze_festival.showDecorations(zone:getID())
+    xi.events.sunbreeze_festival.showNPCs(zone:getID())
     xi.chocobo.initZone(zone)
     xi.conquest.toggleRegionalNPCs(zone)
 end

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -232,7 +232,7 @@ xi.settings.main =
     STARLIGHT_2021                  = 0,    -- Set to 1 to enable the 2021 version of the Starlight Celebration. Dec. 16 through Dec. 31.
     STARLIGHT_YEAR_ROUND            = 0,    -- Set to 1 to have the Starlight Celebration initialize outside of normal times.
     SUNBREEZE                       = 0,    -- Set to 1 to have the Sunbreeze Festival be active from Aug 1 to Aug 31.
-    SUNBREEZE_VENDOR_ERA            = 2005, -- Set to any value between 2005 - *Undefined*
+    SUNBREEZE_YEAR_ROUND            = 0,    -- Set to 1 to have the Sunbreeze Festival initialize outside of normal times.
     EGGHUNT                         =       -- Egg Hunt Egg-stravanganza
     {
         START                       = { DAY = 6,  MONTH = 4 },


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
No player facing changes

## What does this pull request do? (Please be technical)
Fixed an issue where the sunbreeze event wasn't working as intended on servers that use clustering. 
The changes made force entities to be enabled on each specific's zone initialization, rather than only once on server startup.

## For Reference
The reasoning of splitting decorations and entities into two different tables is that decorations are required to be set as always rendered.