### PR TITLE
[Conquest] Grant Titles on Item Purchase

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -11,6 +11,7 @@ require("scripts/globals/npc_util")
 require("scripts/globals/settings")
 require("scripts/globals/garrison")
 require("scripts/globals/status")
+require("scripts/globals/titles")
 require("scripts/globals/zone")
 -----------------------------------
 xi = xi or {}
@@ -927,6 +928,49 @@ local overseerInvNation =
     },
 }
 
+local titlesGranted =
+{
+    [0] = -- San d'Oria
+    {
+        [1]  = xi.title.ROYAL_ARCHER,
+        [2]  = xi.title.ROYAL_SPEARMAN,
+        [3]  = xi.title.ROYAL_SQUIRE,
+        [4]  = xi.title.ROYAL_SWORDSMAN,
+        [5]  = xi.title.ROYAL_CAVALIER,
+        [6]  = xi.title.ROYAL_GUARD,
+        [7]  = xi.title.GRAND_KNIGHT_OF_THE_REALM,
+        [8]  = xi.title.GRAND_TEMPLE_KNIGHT,
+        [9]  = xi.title.RESERVE_KNIGHT_CAPTAIN,
+        [10] = xi.title.ELITE_ROYAL_GUARD,
+    },
+    [1] = -- Bastok
+    {
+        [1]  = xi.title.LEGIONNAIRE,
+        [2]  = xi.title.DECURION,
+        [3]  = xi.title.CENTURION,
+        [4]  = xi.title.JUNIOR_MUSKETEER,
+        [5]  = xi.title.SENIOR_MUSKETEER,
+        [6]  = xi.title.MUSKETEER_COMMANDER,
+        [7]  = xi.title.GOLD_MUSKETEER,
+        [8]  = xi.title.PRAEFECTUS,
+        [9]  = xi.title.SENIOR_GOLD_MUSKETEER,
+        [10] = xi.title.PRAEFECTUS_CASTRORUM,
+    },
+    [2] = -- Windurst
+    {
+        [1]  = xi.title.FREESWORD,
+        [2]  = xi.title.MERCENARY,
+        [3]  = xi.title.MERCENARY_CAPTAIN,
+        [4]  = xi.title.COMBAT_CASTER,
+        [5]  = xi.title.TACTICIAN_MAGICIAN,
+        [6]  = xi.title.WISE_WIZARD,
+        [7]  = xi.title.PATRIARCH_PROTECTOR,
+        [8]  = xi.title.CASTER_CAPTAIN,
+        [9]  = xi.title.MASTER_CASTER,
+        [10] = xi.title.MERCENARY_MAJOR,
+    },
+}
+
 local function getStock(player, guardNation, option)
     local r = overseerInvCommon[option]
     if r == nil then
@@ -1399,6 +1443,9 @@ xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, 
             end
 
             player:delCP(price)
+            if stock.rank ~= nil then
+                player:setTitle(titlesGranted[guardNation][stock.rank])
+            end
         end
     end
 end


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Added titles to Conquest Point purchases (Public)

## What does this pull request do? (Please be technical)

Adds titles to Conquest Point purchases.

## Steps to test these changes

Set nation to any of the three starting nations.
Update rank to allow purchase of items from different ranks.
Purchase item from one rank. Check title has updated.
Purchase item from another rank. Check title has updated.
Purchase item from common tab. Check title has not updated.
Purchase item from another rank. Check title has updated.
Change nation and repeat until all nations have been tested.
Change title at Title Change NPC.

## Special Deployment Considerations

N/A

Cherry-pick of https://github.com/LandSandBoat/server/commit/7da77ef1f5590eac8f35df36386651fb55b55b4d

Fixes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1641
