### PR TITLE
Fix a bug causing RSE Satchets to have a very low drop rate.  Adds co…

### DIFF
--- a/scripts/zones/Gusgen_Mines/npcs/qm1.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/qm1.lua
@@ -29,7 +29,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_FLY):addListener("ITEM_DROPS", "ITEM_DROPS_RSE", function(mob, loot)
-            loot:addItemFixed(item, xi.loot.rate.UNCOMMON)
+            loot:addItem(item, xi.loot.rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???

--- a/scripts/zones/Maze_of_Shakhrami/npcs/qm1.lua
+++ b/scripts/zones/Maze_of_Shakhrami/npcs/qm1.lua
@@ -28,7 +28,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_CRAWLER):addListener("ITEM_DROPS", "ITEM_DROPS_RSE", function(mob, loot)
-            loot:addItemFixed(item, xi.loot.rate.UNCOMMON)
+            loot:addItem(item, xi.loot.rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???

--- a/scripts/zones/Ordelles_Caves/npcs/qm1.lua
+++ b/scripts/zones/Ordelles_Caves/npcs/qm1.lua
@@ -28,7 +28,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_LEECH):addListener("ITEM_DROPS", "ITEM_DROPS_RSE", function(mob, loot)
-            loot:addItemFixed(item, xi.loot.rate.UNCOMMON)
+            loot:addItem(item, xi.loot.rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???

--- a/src/map/lua/lua_loot.cpp
+++ b/src/map/lua/lua_loot.cpp
@@ -49,6 +49,7 @@ CLuaLootContainer::CLuaLootContainer(LootContainer* loot)
  *  Purpose : Adds an item to the loot container
  *  Example : loot:addItem(xi.items.ANCIENT_BEASTCOIN, xi.loot.rate.GUARENTEED, 2);
  *  Notes   : Last parameter, quantity, is optional and defaults to 1
+ *            rate must be a valid value for RATE_PERCENTAGES
  ************************************************************************/
 
 void CLuaLootContainer::addItem(uint16 item, uint16 rate, sol::variadic_args va)
@@ -74,6 +75,7 @@ void CLuaLootContainer::addGroup(uint16 groupRate, sol::table items)
  *  Example : loot:addItemFixed(xi.items.ANCIENT_BEASTCOIN, 500, 2);
  *  Notes   : Last parameter, quantity, is optional and defaults to 1
  *            Fixed drop rate is 0-1000.
+ *            Does not support RATE_PERCENTAGES
  ************************************************************************/
 
 void CLuaLootContainer::addItemFixed(uint16 item, uint16 rate, sol::variadic_args va)


### PR DESCRIPTION
…mments.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes a bug causing a lower than expected drop rate for RSE Satchets.

## What does this pull request do? (Please be technical)

This pr changes from using addItemFixed to addItem for loot added to the Aroma NMs.
addItemFixed does not support the RATE_PERCENTAGES which were being passed to the functions - resulting in setting the drop rate to enum value.
addItem already supports RATE_PERCENTAGES via a lookup.
Additionally, I see no evidence that these drops should be Fixed vs Allow for TH - not that portion of the code base is implemented yet.  However once it is implemented, these drops should and will continue to add TH.

Lastly, I added a comment on each of the lua_loot functions calling out that RATE_PERCENTAGES are either required or not supported.  This _may_ help in the future.

## Steps to test these changes

Without instrumentation - we have invoke large sample sizes.
Without modifying the lua to ignore RSE week - we need the correct char at the correct time.

Disclaimer: My local testing involved both instrumentation and modifying the lua to allow any race to pop the NMs - so I was able to see the exact loot table and rates, TH application, and rolls at time of death.

1. Be the right race and gender where applicable for the RSE week.
2. Zone into one of the 3 zones and use the corresponding command:
Gusgen: `!npchere 17580347`
Ordelles: `!npchere 17568147`
Maze: `!npchere 17588711`
3. The ??? will be pulled to your feet and now be visible.  take a few steps back and F8
4. Pop the NM however many times you need to determine if the drop rate is 10%, affected by TH or if the drop rate is closer to say 5/1000 (also affected by TH)

## Special Deployment Considerations

The important parts (lua) can be hot fixed.
