### PR TITLE
Fix Razon Self-Destruct Damage

### DIFF
--- a/scripts/globals/mobskills/self-destruct_2.lua
+++ b/scripts/globals/mobskills/self-destruct_2.lua
@@ -13,19 +13,18 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
         return 1
     end
 
-    mob:setLocalVar("HPSelfDestruct", mob:getHP())
     return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local selfDestHPP = mob:getLocalVar("HPSelfDestruct") / 6
+    local damage = skill:getMobHP() / 6
 
     -- Razon - ENM: Fire in the Sky
     if mob:getHPP() <= 33 and mob:getPool() == 3333 then
-        selfDestHPP = 0
+        damage = 0
     end
 
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, selfDestHPP, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.MAB_BONUS, 1, 0, 1, 1.1, 1.2)
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.MAB_BONUS, 1, 0, 1, 1.1, 1.2)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     mob:setAnimationSub(6)

--- a/scripts/globals/mobskills/self-destruct_3.lua
+++ b/scripts/globals/mobskills/self-destruct_3.lua
@@ -13,19 +13,18 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
         return 1
     end
 
-    mob:setLocalVar("HPSelfDestruct", mob:getHP())
     return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local selfDestHPP = mob:getLocalVar("HPSelfDestruct") / 9
+    local damage = skill:getMobHP() / 9
 
     -- Razon - ENM: Fire in the Sky
     if mob:getHPP() <= 66 and mob:getPool() == 3333 then
-        selfDestHPP = 0
+        damage = 0
     end
 
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, selfDestHPP, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.MAB_BONUS, 1, 0, 1, 1.1, 1.2)
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.MAB_BONUS, 1, 0, 1, 1.1, 1.2)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     mob:setAnimationSub(5)


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes an issue where Fire in the Sky NM Razon was dealing incorrect damage for Self-Destruct (Public)

## What does this pull request do? (Please be technical)

Razon bypasses the mob skill check and never sets the local variable for HP, causing self-destruct to do 0 damage. Most of these similar style checks were fixed in https://github.com/AirSkyBoat/AirSkyBoat/pull/2491, but it seems like these two were missed.

## Steps to test these changes

!addkeyitem monarch_beard
!zone Monarch Linn
Enter Fire in the Sky
Cast different elemental magic until Razon self-destructs
Note damage

## Special Deployment Considerations

N/A

Fixes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1696