### PR TITLE
Goldfish Reward Fix

### DIFF
--- a/scripts/globals/events/sunbreeze_festival.lua
+++ b/scripts/globals/events/sunbreeze_festival.lua
@@ -212,29 +212,37 @@ local goldfishRewardTable =
 
 local fishValue =
 {
-    [xi.items.TINY_GOLDFISH]    = 1,
-    [xi.items.BLACK_BUBBLE_EYE] = 2,
-    [xi.items.LIONHEAD]         = 10,
-    [xi.items.PEARLSCALE]       = 30,
-    [xi.items.CALICO_COMET]     = 30,
+    [xi.items.TINY_GOLDFISH]    = { amount = 1,  isStackable = true  },
+    [xi.items.BLACK_BUBBLE_EYE] = { amount = 2,  isStackable = true  },
+    [xi.items.LIONHEAD]         = { amount = 10, isStackable = false },
+    [xi.items.PEARLSCALE]       = { amount = 30, isStackable = false },
+    [xi.items.CALICO_COMET]     = { amount = 30, isStackable = false },
 }
 
 xi.events.sunbreeze_festival.goldfishVendorOnTrade = function(player, npc, trade, csid)
-    local hasBasket = player:hasItem(xi.items.GOLDFISH_BASKET) and 1 or 0
-    local points    = 0
+    local hasBasket  = player:hasItem(xi.items.GOLDFISH_BASKET) and 1 or 0
+    local tradedFish = {}
+    local points     = 0
     local itemQty
     local itemID
+    local fish
 
     -- Manually handles the trade in order to calculate the points rewarded
     for i = 0, trade:getSlotCount() - 1 do
         itemID  = trade:getItemId(i)
         itemQty = trade:getItemQty(itemID)
+        tradedFish[itemID] = itemQty
+        fish = fishValue[itemID]
 
-        if fishValue[itemID] == nil then
-            break
+        if fish.amount == nil then
+            return
         else
             trade:confirmItem(itemID, itemQty)
-            points = points + fishValue[itemID] * itemQty
+            if fish.isStackable then
+                points = points + fish.amount * tradedFish[itemID]
+            else
+                points = points + fish.amount
+            end
         end
     end
 

--- a/scripts/zones/South_Gustaberg/npcs/Fish_Eyes.lua
+++ b/scripts/zones/South_Gustaberg/npcs/Fish_Eyes.lua
@@ -18,7 +18,7 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
-    xi.events.sunbreeze_festival.goldfishVendorOnEventUpdate(player, csid, event)
+    xi.events.sunbreeze_festival.goldfishVendorOnEventUpdate(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
No player facing changes

## What does this pull request do? (Please be technical)
Fixes an issue where reward modifier for non-stackable goldfish was being applied to each fish. Ex. 6 non-stackable fish were traded, the reward amount for each fish was multiplied by 6