### PR TITLE
Prevent damage immune Proto Ultima. Change Armor Buster to Light.

### DIFF
--- a/scripts/globals/mobskills/armor_buster.lua
+++ b/scripts/globals/mobskills/armor_buster.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Armor_Buster
+-- Armor Buster
 -- Description:
--- Type: Magical
+-- Type: Magical Light Damage
 -- additional effect: WEIGHT
 -----------------------------------
 require("scripts/globals/mobskills")
@@ -10,20 +10,16 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getLocalVar("citadelBuster") == 0 then
-        return 0
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2.5
-    local info   = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.magic.ele.WATER, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
-    local dmg    = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+    local info   = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.magic.ele.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
+    local dmg    = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
     xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.WEIGHT, 20, 3, 45)
-    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WATER)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.LIGHT)
 
     return dmg
 end

--- a/scripts/globals/mobskills/energy_screen.lua
+++ b/scripts/globals/mobskills/energy_screen.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Energy_Screen
+-- Energy Screen
 -- Description: Invincible
 -----------------------------------
 require("scripts/globals/mobskills")
@@ -9,11 +9,14 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getLocalVar("citadelBuster") == 0 then
-        return 0
+    if
+        mob:getStatusEffect(xi.effect.PHYSICAL_SHIELD) or
+        mob:getStatusEffect(xi.effect.MAGIC_SHIELD)
+    then
+        return 1
     end
 
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/mana_screen.lua
+++ b/scripts/globals/mobskills/mana_screen.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Mana_Screen
+-- Mana Screen
 -- Description: Magic Shield
 -----------------------------------
 require("scripts/globals/mobskills")
@@ -9,11 +9,14 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getLocalVar("citadelBuster") == 0 then
-        return 0
+    if
+        mob:getStatusEffect(xi.effect.PHYSICAL_SHIELD) or
+        mob:getStatusEffect(xi.effect.MAGIC_SHIELD)
+    then
+        return 1
     end
 
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Proto Ultima will no longer be able to have both Energy Screen (physical immunity) and Mana Screen (magical immunity) active at the same time.  Please note that this brings Proto Ultima more in line with retail behavior (read: Armor Buster spam).  Armor Buster has been corrected to be Light elemental, not Water elemental.

## What does this pull request do? (Please be technical)

Adds logical gates to prevent the usage of screen abilities if either screen effect is active on Proto Ultima.
Changes dmg type on Armor Buster.

## Steps to test these changes

Fight Proto Ultima
Reduce to 19% or less tp.
Spam !tp 3000.
Note that Proto Ultima will only ever use Mana or Energy Screen when it does not have phys or mag immunity.
Note that Proto Ultima will happily spam Armor Buster.

To test the element - i guess track resists - then throw up barwater? Equip Genbu's Kabuto and Seiryu's sword.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
