### PR TITLE
Fix many Cerberus issues

### DIFF
--- a/scripts/globals/mobskills/gates_of_hades.lua
+++ b/scripts/globals/mobskills/gates_of_hades.lua
@@ -35,12 +35,12 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffect = xi.effect.BURN
-    local power = 21
+    local power = 30
 
     xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
 
-    local dmgmod = 1.8
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 6, xi.magic.ele.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local dmgmod = 1.0
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getMainLvl() * 12.5, xi.magic.ele.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, nil, nil, nil, 1.0)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
     return dmg

--- a/scripts/globals/mobskills/magma_hoplon.lua
+++ b/scripts/globals/mobskills/magma_hoplon.lua
@@ -20,9 +20,8 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffectOne = xi.effect.STONESKIN
     local typeEffectTwo = xi.effect.BLAZE_SPIKES
-    local randy = math.random(20, 30)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffectOne, 1000, 0, 300))
-    xi.mobskills.mobBuffMove(mob, typeEffectTwo, randy, 0, 180)
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffectOne, 750, 0, 300))
+    xi.mobskills.mobBuffMove(mob, typeEffectTwo, 20, 0, 900)
     local effect1 = mob:getStatusEffect(typeEffectOne)
     effect1:unsetFlag(xi.effectFlag.DISPELABLE)
 

--- a/scripts/globals/mobskills/sulfurous_breath.lua
+++ b/scripts/globals/mobskills/sulfurous_breath.lua
@@ -18,10 +18,21 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 0.75, xi.magic.ele.FIRE, 700)
+    local numhits = 1
+    local accmod = 1
+    local dmgmod = 1
+    local ftp100 = 2.0
+    local ftp200 = 2.5
+    local ftp300 = 3.0
 
-    local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.FIRE)
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT, ftp100, ftp200, ftp300)
+    local conaldmg = utils.conalDamageAdjustment(mob, target, skill, info.dmg, 0.2)
+    local dmg = xi.mobskills.mobFinalAdjustments(conaldmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded * math.random(1, 2))
+
+    if not skill:hasMissMsg() then
+        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
+    end
+
     return dmg
 end
 

--- a/scripts/zones/Mount_Zhayolm/mobs/Cerberus.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Cerberus.lua
@@ -20,8 +20,29 @@ local drawInPos =
 }
 
 entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
-    mob:setMobMod(xi.mobMod.DRAW_IN_CUSTOM_RANGE, 15)
+    mob:setMod(xi.mod.DEF, 486) -- 486 + 50 gives 536 DEF
+    mob:setMod(xi.mod.EVA, 355)
+    mob:setMod(xi.mod.ATT, 804) -- 804 + 66 gives 870 ATT
+    mob:setMod(xi.mod.UDMGMAGIC, -5000)
+    mob:addMod(xi.mod.MDEF, 12) -- 100 + 12 gives 112 MDEF
+end
+
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    -- skills without GoH
+    local mobSkills = { 1785, 1786, 1787, 1788, 1789 }
+    -- if less than 25% HP
+    if mob:getHPP() <= 25 then
+        -- select GoH with 50% probability
+        if math.random() < 0.50 then
+            return 1790
+        -- else select random skill
+        else
+            return mobSkills[math.random(#mobSkills)]
+        end
+    -- else select random skill
+    else
+        return mobSkills[math.random(#mobSkills)]
+    end
 end
 
 entity.onMobFight = function(mob, target)
@@ -31,18 +52,25 @@ entity.onMobFight = function(mob, target)
         mob:setMod(xi.mod.REGAIN, 70)
     end
 
+    -- retail cerb uses weird custom draw-in mechanism to fixed points
     local drawInWait = mob:getLocalVar("DrawInWait")
 
-    if (target:getXPos() < 814 or target:getXPos() > 865) and os.time() > drawInWait then
+    if
+        (target:getXPos() < 305 or target:getXPos() > 340) and
+        os.time() > drawInWait
+    then
         local rot = target:getRotPos()
-        local position = math.random(1,8)
-        target:setPos(drawInPos[position][1],drawInPos[position][2],drawInPos[position][3],rot)
+        local position = math.random(1, 8)
+        target:setPos(drawInPos[position][1], drawInPos[position][2], drawInPos[position][3], rot)
         mob:messageBasic(232, 0, 0, target)
         mob:setLocalVar("DrawInWait", os.time() + 2)
-    elseif (target:getZPos() < 345 or target:getZPos() > 377) and os.time() > drawInWait then
+    elseif
+        (target:getZPos() < -100 or target:getZPos() > -70) and
+        os.time() > drawInWait
+    then
         local rot = target:getRotPos()
-        local position = math.random(1,8)
-        target:setPos(drawInPos[position][1],drawInPos[position][2],drawInPos[position][3],rot)
+        local position = math.random(1, 8)
+        target:setPos(drawInPos[position][1], drawInPos[position][2], drawInPos[position][3], rot)
         mob:messageBasic(232, 0, 0, target)
         mob:setLocalVar("DrawInWait", os.time() + 2)
     end

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -122,7 +122,7 @@ INSERT INTO `mob_pool_mods` VALUES (639,63,25,0); -- DEFP: 25
 INSERT INTO `mob_pool_mods` VALUES (676,160,-50,0); -- DMG: -50
 
 -- Cerberus
-INSERT INTO `mob_pool_mods` VALUES (680,1,322,0);   -- DEF: 322
+INSERT INTO `mob_pool_mods` VALUES (680,59,155,1); -- WEAPON_BONUS: (85+2)*1.55 is 135 base dmg
 INSERT INTO `mob_pool_mods` VALUES (680,31,200,0);  -- MEVA: 200
 INSERT INTO `mob_pool_mods` VALUES (680,251,-50,0); -- STUNRES: -50
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
None (change for ToAU launch)

## What does this pull request do? (Please be technical)
The PR fixes many issues with Cerb:
1. Fix Cerb drawn-in logic so correctly draws into several fixed points near Cerb spawn (as per capture)
2. Fix Cerb attack, evasion, defense, MDT, MDB to match retail capture values (as per Jimmayus)
3. Fix several Cerb family mob skills to match Jimmayus mob skill info
4. Fix the frequency of Gates of Hades (used when cerb <25%) to be 50% (as per [era videos](https://youtu.be/XvCRpEQHV1Y?t=395), was 8/15 mob skills)

## Steps to test these changes
1. Fight cerb and attempt to run away many times, should be drawn-in to one of the random spots
2. Fight cerb and compare to, for example, era video like that linked above
3. Same as point 2 (but can feed tp with !tp 3000)
4. Same as point 3 (but when cerb under 25% and count GoH vs. other moves)

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
