### PR TITLE
Event Condition Fix

### DIFF
--- a/scripts/globals/events/starlight_celebrations.lua
+++ b/scripts/globals/events/starlight_celebrations.lua
@@ -16,7 +16,7 @@ function xi.events.starlightCelebration.isStarlightEnabled()
     local month = tonumber(os.date("%m"))
     local day = tonumber(os.date("%d"))
 
-    if month == 12 and day >= 16 or xi.settings.main.STARLIGHT_YEAR_ROUND then -- According to wiki Startlight Festival is December 16 - December 31.
+    if month == 12 and day >= 16 or xi.settings.main.STARLIGHT_YEAR_ROUND == 1 then -- According to wiki Startlight Festival is December 16 - December 31.
         if xi.settings.main.STARLIGHT_2021 == 1 then
             option = 1
         end

--- a/scripts/globals/events/sunbreeze_festival.lua
+++ b/scripts/globals/events/sunbreeze_festival.lua
@@ -10,7 +10,7 @@ xi.events.sunbreeze_festival = xi.events.sunbreeze_festival or {}
 local event = SeasonalEvent:new("SunbreezeFestival")
 
 xi.events.sunbreeze_festival.enabledCheck = function()
-    return tonumber(os.date("%m")) == 8 and xi.settings.main.SUNBREEZE == 1 or xi.settings.main.SUNBREEZE_YEAR_ROUND
+    return tonumber(os.date("%m")) == 8 and xi.settings.main.SUNBREEZE == 1 or xi.settings.main.SUNBREEZE_YEAR_ROUND == 1
 end
 
 event:setEnableCheck(xi.events.sunbreeze_festival.enabledCheck)


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
No player facing changes

## What does this pull request do? (Please be technical)
Fix for events running year round as they were checking for bool - not int

## Steps to test these changes
Enable events normally, and witness they are enabled year round.
