### PR TITLE
[FIX] Corrects H2H Handling for Mobs and Pets in Core

### DIFF
--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -176,6 +176,10 @@ bool CAttackRound::IsH2H()
     {
         return weapon->getSkillType() == SKILL_HAND_TO_HAND;
     }
+    else if ((m_attacker->objtype == TYPE_PET || m_attacker->objtype == TYPE_MOB) && (m_attacker->GetMJob() == JOB_MNK || m_attacker->GetSJob() == JOB_MNK))
+    {
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Corrects an issue where mobs and pets with the Monk job didn't attack properly. Also fixes [#739 on HorizonXI's Issue Tracker](https://github.com/HorizonFFXI/HorizonXI-Issues/issues/739)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Adjusts the logic in attackround.cpp to include mob and pet objtypes in CAttackRound::IsH2H() 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Pets:
*!changejob BST 75
*!additem (any jug of a MNK type pet)
*!immortal on pet (Homunculus in my case)
*!immortal on a mob
*have pet attack mob, watched logs for an occasional second attack round

Mobs:
*!godmode and !immortal self
*agro any MNK type mob (tested on an Orcish Grappler)
*watched logs to check for an occasional second attack round
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
Requires server rebuild
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
