### PR TITLE
Update Dynamis Lord to always drop a 100 currency.

### DIFF
--- a/modules/era/sql_dynamis/era_dyna_sql.sql
+++ b/modules/era/sql_dynamis/era_dyna_sql.sql
@@ -707,9 +707,9 @@ REPLACE INTO `mob_droplist` VALUES (3220,2,0,1000,1452,0); -- Bronzepiece (Steal
 DELETE FROM `mob_droplist` WHERE dropid = "730"; -- Dynamis Lord
 REPLACE INTO `mob_droplist` VALUES (730,0,0,1000,13658,@COMMON); -- Shadow Mantle
 REPLACE INTO `mob_droplist` VALUES (730,0,0,1000,14646,@UNCOMMON); -- Shadow Ring
-REPLACE INTO `mob_droplist` VALUES (730,1,1,@VRARE,1456,333); -- Hundred Byne
-REPLACE INTO `mob_droplist` VALUES (730,1,1,@VRARE,1450,333); -- Jadeshell
-REPLACE INTO `mob_droplist` VALUES (730,1,1,@VRARE,1453,334); -- Montiont Silverpiece
+REPLACE INTO `mob_droplist` VALUES (730,1,1,@ALWAYS,1456,333); -- Hundred Byne
+REPLACE INTO `mob_droplist` VALUES (730,1,1,@ALWAYS,1450,333); -- Jadeshell
+REPLACE INTO `mob_droplist` VALUES (730,1,1,@ALWAYS,1453,334); -- Montiont Silverpiece
 REPLACE INTO `mob_droplist` VALUES (730,0,0,1000,4249,@VCOMMON); -- Schultz's Strategems
 --              NMs              --
 DELETE FROM `mob_droplist` WHERE dropid = "521"; -- Count Zaebos


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Update Dynamis Lord to always drop aleast a 100 currency piece.

## What does this pull request do? (Please be technical)
Changes the group which contains a relatively even split across 100s to be @ALWAYS instead of @VRARE.

closes #3361 
## Steps to test these changes

Go Kill DL - do it over and over - get 100s.

## Special Deployment Considerations

None
