### PR TITLE
Reap What You Sow: Fix Duplicate Gil Message

### DIFF
--- a/scripts/quests/windurst/Reap_What_You_Sow.lua
+++ b/scripts/quests/windurst/Reap_What_You_Sow.lua
@@ -88,7 +88,9 @@ quest.sections =
             {
                 [475] = function(player, csid, option, npc)
                     player:confirmTrade()
-                    npcUtil.giveCurrency(player, 'gil', 500)
+                    -- player:addGil over npcUtil:giveCurrency to avoid duplicate
+                    -- 'Obtained X gil' messages.
+                    player:addGil(500)
                 end,
 
                 [477] = function(player, csid, option, npc)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)

Fixes a duplicate message.

## Steps to test these changes

Do the quest.
Before:
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/140564555/bf208f09-8436-4d4e-8e14-d44314fded96)
After:
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/140564555/7ff6bc63-4409-4092-93c9-99120a268ab0)

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
