### PR TITLE
Fixes Blue Magic Nil Errors

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -289,10 +289,10 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     local finaldmg = math.floor(finalD * xi.spells.damage.calculateMTDR(caster, target, spell))
 
     -- Resistance
-    finaldmg = math.floor(finaldmg * applyResistance(caster, target, spell, params))
+    finaldmg = math.floor(finaldmg * xi.magic.applyResistance(caster, target, spell, params))
 
     -- MAB/MDB/weather/day/affinity/burst effect on damage
-    finaldmg = math.floor(addBonuses(caster, spell, target, finaldmg))
+    finaldmg = math.floor(xi.magic.addBonuses(caster, spell, target, finaldmg))
 
     return xi.spells.blue.applySpellDamage(caster, target, spell, finaldmg, params)
 end
@@ -305,9 +305,9 @@ xi.spells.blue.useDrainSpell = function(caster, target, spell, params, softCap, 
         dmg = utils.clamp(dmg, 0, softCap)
     end
 
-    dmg = dmg * applyResistance(caster, target, spell, params)
-    dmg = addBonuses(caster, spell, target, dmg)
-    dmg = adjustForTarget(target, dmg, spell:getElement())
+    dmg = dmg * xi.magic.applyResistance(caster, target, spell, params)
+    dmg = xi.magic.addBonuses(caster, spell, target, dmg)
+    dmg = xi.magic.adjustForTarget(target, dmg, spell:getElement())
 
     -- limit damage
     if target:isUndead() then
@@ -357,14 +357,14 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params, isConal)
     dmg = dmg * (1 + correlationMultiplier)
 
     -- Monster elemental adjustments
-    local mobEleAdjustments = getElementalDamageReduction(target, spell:getElement())
+    local mobEleAdjustments = xi.magic.getElementalDamageReduction(target, spell:getElement())
     dmg = dmg * mobEleAdjustments
 
     -- Modifiers
     dmg = dmg * (1 + (caster:getMod(xi.mod.BREATH_DMG_DEALT) / 100))
 
     -- Resistance
-    local resistance = applyResistance(caster, target, spell, params)
+    local resistance = xi.magic.applyResistance(caster, target, spell, params)
     dmg = math.floor(dmg * resistance)
 
     -- Final damage
@@ -433,7 +433,7 @@ xi.spells.blue.useEnfeeblingSpell = function(caster, target, spell, params, powe
     -- INT and Blue Magic skill are the default resistance modifiers
     params.diff = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
     params.skillType = xi.skill.BLUE_MAGIC
-    local resist = applyResistanceEffect(caster, target, spell, params)
+    local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     -- If unresisted
     if resist >= resistThreshold then
@@ -466,7 +466,7 @@ end
 
 -- Perform a curative Blue Magic spell
 xi.spells.blue.useCuringSpell = function(caster, target, spell, params)
-    local power = getCurePowerOld(caster)
+    local power = xi.magic.getCurePowerOld(caster)
     local divisor = params.divisor0
     local constant = params.constant0
 
@@ -478,7 +478,7 @@ xi.spells.blue.useCuringSpell = function(caster, target, spell, params)
         constant = params.constant1
     end
 
-    local final = getCureFinal(caster, spell, getBaseCureOld(power, divisor, constant), params.minCure, true)
+    local final = xi.magic.getCureFinal(caster, spell, getBaseCureOld(power, divisor, constant), params.minCure, true)
     final = final + (final * (target:getMod(xi.mod.CURE_POTENCY_RCVD) / 100))
     final = final * xi.settings.main.CURE_POWER
     final = utils.clamp(final, 0, target:getMaxHP() - target:getHP())
@@ -498,7 +498,7 @@ xi.spells.blue.usePhysicalSpellAddedEffect = function(caster, target, spell, par
         -- INT and Blue Magic skill are the default resistance modifiers
         params.diff = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
         params.skillType = xi.skill.BLUE_MAGIC
-        local resist = applyResistanceEffect(caster, target, spell, params)
+        local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
         if resist >= 0.5 then
             target:addStatusEffect(params.effect, power, tick, duration * resist)
         end
@@ -511,7 +511,7 @@ xi.spells.blue.useMagicalSpellAddedEffect = function(caster, target, spell, para
     params.diff = caster:getStat(params.attribute) - target:getStat(params.attribute)
     params.skillType = xi.skill.BLUE_MAGIC
     params.effect = params.addedEffect -- renamed to avoid magical spells' dmg resistance check being influenced by this
-    local resist = applyResistanceEffect(caster, target, spell, params)
+    local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
     if resist >= 0.5 then
         target:addStatusEffect(params.effect, power, tick, duration * resist)
     end


### PR DESCRIPTION
Fixes an issue where the functions that were made globals were not referenced correctly

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
n/a
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Fixes an issue where the functions that were made globals were not referenced correctly 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
use any blue magic spell and see no errors
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
