### PR TITLE
Even more blu updates

### DIFF
--- a/scripts/globals/spells/blue/1000_needles.lua
+++ b/scripts/globals/spells/blue/1000_needles.lua
@@ -47,7 +47,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc = 1.0
 
     local damage = 1000
-    local resist = applyResistance(caster, target, spell, params)
+    local resist = xi.magic.applyResistance(caster, target, spell, params)
     if resist == 1 then
         local targets = spell:getTotalTargets()
         damage = damage / targets

--- a/scripts/globals/spells/blue/blank_gaze.lua
+++ b/scripts/globals/spells/blue/blank_gaze.lua
@@ -32,7 +32,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local resistThreshold = 0.25
     local effect = xi.effect.NONE
 
-    local resist = applyResistance(caster, target, spell, params)
+    local resist = xi.magic.applyResistance(caster, target, spell, params)
     if resist >= resistThreshold then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
 

--- a/scripts/globals/spells/blue/cold_wave.lua
+++ b/scripts/globals/spells/blue/cold_wave.lua
@@ -32,7 +32,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local tick = 3
     local duration = 60
     local resistThreshold = 0.5
-    local resist = applyResistance(caster, target, spell, params)
+    local resist = xi.magic.applyResistance(caster, target, spell, params)
 
     -- Cannot apply if target has Burn
     if target:getStatusEffect(xi.effect.BURN) ~= nil then

--- a/scripts/globals/spells/blue/corrosive_ooze.lua
+++ b/scripts/globals/spells/blue/corrosive_ooze.lua
@@ -50,7 +50,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     params.attribute = xi.mod.INT
     params.skillType = xi.skill.BLUE_MAGIC
-    local resist = applyResistanceEffect(caster, target, spell, params)
+    local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then
         target:addStatusEffect(typeEffectOne, power, tick, duration * resist)

--- a/scripts/globals/spells/blue/enervation.lua
+++ b/scripts/globals/spells/blue/enervation.lua
@@ -35,7 +35,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local resistThreshold = 0.5
     local returnEffect = typeEffectOne
 
-    local resist = applyResistance(caster, target, spell, params)
+    local resist = xi.magic.applyResistance(caster, target, spell, params)
     if resist >= resistThreshold then
 
         local actionOne = target:addStatusEffect(typeEffectOne, 10, 0, duration * resist)

--- a/scripts/globals/spells/blue/feather_tickle.lua
+++ b/scripts/globals/spells/blue/feather_tickle.lua
@@ -31,7 +31,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local power = 1500
     local resistThreshold = 0.5
 
-    local resist = applyResistance(caster, target, spell, params)
+    local resist = xi.magic.applyResistance(caster, target, spell, params)
     if resist >= resistThreshold then
         if target:getTP() == 0 then
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/blue/geist_wall.lua
+++ b/scripts/globals/spells/blue/geist_wall.lua
@@ -32,7 +32,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local resistThreshold = 0.25
     local effect = xi.effect.NONE
 
-    local resist = applyResistance(caster, target, spell, params)
+    local resist = xi.magic.applyResistance(caster, target, spell, params)
     if resist >= resistThreshold then
         effect = target:dispelStatusEffect()
         spell:setMsg(xi.msg.basic.MAGIC_ERASE)

--- a/scripts/globals/spells/blue/light_of_penance.lua
+++ b/scripts/globals/spells/blue/light_of_penance.lua
@@ -35,7 +35,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local resistThreshold = 0.5
     local returnEffect = typeEffectOne
 
-    local resist = applyResistance(caster, target, spell, params)
+    local resist = xi.magic.applyResistance(caster, target, spell, params)
     if resist >= resistThreshold then
 
         spell:setMsg(xi.msg.basic.MAGIC_TP_REDUCE) -- this doesn't seem to do much

--- a/scripts/globals/spells/blue/voracious_trunk.lua
+++ b/scripts/globals/spells/blue/voracious_trunk.lua
@@ -28,7 +28,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillType = xi.skill.BLUE_MAGIC
     local stolen = 0
 
-    local resist = applyResistanceEffect(caster, target, spell, params)
+    local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
     if resist >= 0.5 then
         stolen = caster:stealStatusEffect(target)
         if stolen ~= 0 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Added xi.magic. to blu spells to be in line with bluemagic.lua
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
