### PR TITLE
Fix Sunbreeze goldfish scooping/regular fishing

### DIFF
--- a/sql/fishing_catch.sql
+++ b/sql/fishing_catch.sql
@@ -76,7 +76,7 @@ INSERT INTO `fishing_catch` VALUES (65,2,40);
 INSERT INTO `fishing_catch` VALUES (68,1,127);
 INSERT INTO `fishing_catch` VALUES (79,1,132);
 INSERT INTO `fishing_catch` VALUES (100,1,17);
-INSERT INTO `fishing_catch` VALUES (100,1,140); -- Goldfish (Sunbreeze Festival)
+INSERT INTO `fishing_catch` VALUES (100,1,140); -- Goldfish (Sunbreeze Festival) West_Ronfaure - Knightwell
 INSERT INTO `fishing_catch` VALUES (101,1,16);
 INSERT INTO `fishing_catch` VALUES (102,1,23);
 INSERT INTO `fishing_catch` VALUES (103,1,26);
@@ -90,7 +90,7 @@ INSERT INTO `fishing_catch` VALUES (105,2,27);
 INSERT INTO `fishing_catch` VALUES (106,1,43);
 INSERT INTO `fishing_catch` VALUES (106,2,44);
 INSERT INTO `fishing_catch` VALUES (107,1,46);
-INSERT INTO `fishing_catch` VALUES (107,1,140); -- Goldfish (Sunbreeze Festival)
+INSERT INTO `fishing_catch` VALUES (107,1,141); -- Goldfish (Sunbreeze Festival) South_Gustaberg - Hot Springs
 INSERT INTO `fishing_catch` VALUES (107,2,47);
 INSERT INTO `fishing_catch` VALUES (109,1,50);
 INSERT INTO `fishing_catch` VALUES (110,1,51);
@@ -105,13 +105,10 @@ INSERT INTO `fishing_catch` VALUES (115,1,59);
 INSERT INTO `fishing_catch` VALUES (115,2,60);
 INSERT INTO `fishing_catch` VALUES (116,1,2);
 INSERT INTO `fishing_catch` VALUES (116,2,3);
-INSERT INTO `fishing_catch` VALUES (116,2,140); -- Goldfish (Sunbreeze Festival)
 INSERT INTO `fishing_catch` VALUES (116,3,3);
-INSERT INTO `fishing_catch` VALUES (116,3,140); -- Goldfish (Sunbreeze Festival)
 INSERT INTO `fishing_catch` VALUES (116,4,3);
-INSERT INTO `fishing_catch` VALUES (116,4,140); -- Goldfish (Sunbreeze Festival)
+INSERT INTO `fishing_catch` VALUES (116,4,142); -- Goldfish (Sunbreeze Festival) East_Sarutabaruta - Other Waterside (rivers)
 INSERT INTO `fishing_catch` VALUES (116,5,1);
-INSERT INTO `fishing_catch` VALUES (116,5,140); -- Goldfish (Sunbreeze Festival)
 INSERT INTO `fishing_catch` VALUES (118,1,66);
 INSERT INTO `fishing_catch` VALUES (120,1,73);
 INSERT INTO `fishing_catch` VALUES (121,1,86);
@@ -190,26 +187,20 @@ INSERT INTO `fishing_catch` VALUES (221,1,136);
 INSERT INTO `fishing_catch` VALUES (227,1,137);
 INSERT INTO `fishing_catch` VALUES (228,1,137);
 INSERT INTO `fishing_catch` VALUES (231,1,9);
-INSERT INTO `fishing_catch` VALUES (231,1,140); -- Goldfish (Sunbreeze Festival)
 INSERT INTO `fishing_catch` VALUES (232,1,10);
 INSERT INTO `fishing_catch` VALUES (234,1,8);
-INSERT INTO `fishing_catch` VALUES (234,1,140); -- Goldfish (Sunbreeze Festival)
 INSERT INTO `fishing_catch` VALUES (235,1,5);
-INSERT INTO `fishing_catch` VALUES (235,1,140); -- Goldfish (Sunbreeze Festival)
 INSERT INTO `fishing_catch` VALUES (235,2,6);
 INSERT INTO `fishing_catch` VALUES (236,1,7);
 INSERT INTO `fishing_catch` VALUES (238,1,11);
-INSERT INTO `fishing_catch` VALUES (238,1,140); -- Goldfish (Sunbreeze Festival)
 INSERT INTO `fishing_catch` VALUES (239,1,11);
-INSERT INTO `fishing_catch` VALUES (239,1,140); -- Goldfish (Sunbreeze Festival)
 INSERT INTO `fishing_catch` VALUES (240,1,4);
 INSERT INTO `fishing_catch` VALUES (241,1,11);
-INSERT INTO `fishing_catch` VALUES (241,1,140); -- Goldfish (Sunbreeze Festival)
 INSERT INTO `fishing_catch` VALUES (242,1,12);
 INSERT INTO `fishing_catch` VALUES (245,1,13);
 INSERT INTO `fishing_catch` VALUES (246,1,14);
 INSERT INTO `fishing_catch` VALUES (247,1,89);
-INSERT INTO `fishing_catch` VALUES (247,1,140); -- Goldfish (Sunbreeze Festival)
+INSERT INTO `fishing_catch` VALUES (247,1,143); -- Goldfish (Sunbreeze Festival) Rabao - Whole Zone
 INSERT INTO `fishing_catch` VALUES (248,1,25);
 INSERT INTO `fishing_catch` VALUES (249,1,71);
 INSERT INTO `fishing_catch` VALUES (250,1,94);

--- a/sql/fishing_fish.sql
+++ b/sql/fishing_fish.sql
@@ -71,7 +71,7 @@ INSERT INTO `fishing_fish` VALUES (4360,'Bastore Sardine',9,21,11,6,1,1,10,0,0,2
 INSERT INTO `fishing_fish` VALUES (5473,'Bastore Sweeper',12,17,4,2,1,1,99,0,0,255,255,0,0,0,2,3,0,0,0,1,950,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5139,'Betta',68,16,3,12,1,1,10,0,0,255,255,0,0,7,4,9,0,0,0,1,600,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4479,'Bhefhel Marlin',61,20,10,11,60,140,23,1,0,255,255,0,0,7,1,8,0,0,0,1,700,0,'',0,0,1,0);
-INSERT INTO `fishing_fish` VALUES (4311,'Black Bubble-Eye',5,18,8,10,1,1,1,0,0,255,255,2,0,0,0,0,0,0,0,1,550,0,'',0,0,0,0);
+INSERT INTO `fishing_fish` VALUES (4311,'Black Bubble-Eye',5,18,8,10,1,1,1,0,0,255,255,0,2,0,0,0,0,0,0,1,550,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4318,'Bibiki Urchin',3,20,13,1,1,1,1,0,1,255,255,0,0,3,1,1,0,0,0,1,50,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4314,'Bibikibo',8,22,12,3,1,1,1,0,1,255,255,0,0,5,2,2,0,0,0,1,100,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4429,'Black Eel',47,24,5,8,1,1,15,0,0,255,255,0,0,4,4,3,0,0,0,1,800,0,'',0,0,0,0);
@@ -83,7 +83,7 @@ INSERT INTO `fishing_fish` VALUES (4399,'Bluetail',55,24,4,12,1,1,14,0,0,255,255
 INSERT INTO `fishing_fish` VALUES (5469,'Brass Loach',42,27,11,7,1,1,99,0,0,255,255,0,0,0,5,8,0,0,0,1,750,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5474,'Ca Cuong',78,17,12,6,1,1,99,0,0,255,255,0,0,0,0,0,0,0,0,1,500,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5465,'Caedarva Frog',30,17,6,13,1,1,5,0,0,255,255,0,0,4,2,0,0,0,0,1,1000,0,'',0,0,0,0);
-INSERT INTO `fishing_fish` VALUES (5715,'Calico Comet',5,12,10,15,1,1,1,0,0,255,255,2,0,0,0,0,0,0,0,1,250,0,'',0,0,0,0);
+INSERT INTO `fishing_fish` VALUES (5715,'Calico Comet',5,12,10,15,1,1,1,0,0,255,255,0,2,0,0,0,0,0,0,1,250,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4309,'Cave Cherax',130,36,7,4,115,235,32,1,0,255,255,0,0,3,1,0,1,0,0,1,500,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4379,'Cheval Salmon',21,21,7,7,1,1,17,0,0,255,255,0,0,3,1,0,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4443,'Cobalt Jellyfish',5,28,13,0,1,1,14,0,0,255,255,0,0,1,1,0,0,0,1,1,700,0,'',0,0,0,0);
@@ -135,7 +135,7 @@ INSERT INTO `fishing_fish` VALUES (5451,'Kilicbaligi',62,18,10,11,1,1,23,0,0,255
 INSERT INTO `fishing_fish` VALUES (5450,'Lakerda',41,16,6,13,55,100,22,1,0,255,255,0,0,1,4,0,0,0,0,1,900,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (2216,'Lamp Marimo',3,26,13,2,1,1,1,0,0,255,255,0,0,6,2,5,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5129,'Lik',134,48,2,14,185,465,33,1,0,255,255,0,0,3,1,6,1,8,0,1,850,1977,'',0,0,1,0);
-INSERT INTO `fishing_fish` VALUES (4312,'Lionhead',5,16,10,9,1,1,1,0,0,255,255,2,0,0,0,0,0,0,0,1,350,0,'',0,0,0,0);
+INSERT INTO `fishing_fish` VALUES (4312,'Lionhead',5,16,10,9,1,1,1,0,0,255,255,0,2,0,0,0,0,0,0,1,350,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4315,'Lungfish',32,16,4,8,1,1,10,0,0,255,255,0,0,1,1,8,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5468,'Matsya',134,31,5,12,163,331,99,1,0,255,255,0,0,0,1,0,1,0,0,1,500,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5467,'Megalodon',87,33,10,11,446,625,99,1,0,255,255,0,0,0,0,0,0,0,0,1,1000,0,'',0,0,0,0);
@@ -181,7 +181,7 @@ INSERT INTO `fishing_fish` VALUES (4463,'Takitaro',101,18,3,14,55,130,28,1,0,255
 INSERT INTO `fishing_fish` VALUES (5130,'Tavnazian Goby',75,30,7,8,1,1,10,0,0,255,255,0,0,3,4,2,0,0,0,1,850,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4478,'Three-Eyed Fish',79,22,10,10,50,120,25,1,0,255,255,0,0,3,4,8,0,0,0,1,500,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4483,'Tiger Cod',29,23,9,9,1,1,10,0,0,255,255,0,0,3,1,8,0,0,0,1,1000,0,'',0,0,0,0);
-INSERT INTO `fishing_fish` VALUES (4310,'Tiny Goldfish',5,20,10,8,1,1,1,0,0,255,255,2,0,0,0,0,0,0,0,1,1000,0,'',0,0,0,0);
+INSERT INTO `fishing_fish` VALUES (4310,'Tiny Goldfish',5,20,10,8,1,1,1,0,0,255,255,0,2,0,0,0,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5120,'Titanic Sawfish',125,39,6,13,75,210,29,1,1,255,255,0,0,0,1,9,1,0,0,1,400,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4476,'Titanictus',101,28,3,12,75,210,28,1,1,255,255,0,0,3,5,8,1,0,0,1,350,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4426,'Tricolored Carp',27,19,12,12,1,1,13,0,0,255,255,0,0,3,1,8,0,0,0,1,1000,0,'',0,0,0,0);

--- a/sql/fishing_group.sql
+++ b/sql/fishing_group.sql
@@ -1109,12 +1109,51 @@ INSERT INTO `fishing_group` VALUES (139,4469,900,190,6);
 INSERT INTO `fishing_group` VALUES (139,4472,1000,500,15);
 INSERT INTO `fishing_group` VALUES (139,5125,1000,500,15);
 INSERT INTO `fishing_group` VALUES (139,5126,1000,500,15);
--- Sunbreeze Festival (Goldfish)
+-- Sunbreeze Festival (Goldfish) West_Ronfaure - Knightwell
+INSERT INTO `fishing_group` VALUES (140,90,900,300,9);
+INSERT INTO `fishing_group` VALUES (140,688,500,200,6);
+INSERT INTO `fishing_group` VALUES (140,4401,1000,1000,36);
+INSERT INTO `fishing_group` VALUES (140,4402,750,260,5);
+INSERT INTO `fishing_group` VALUES (140,4469,900,190,6);
+INSERT INTO `fishing_group` VALUES (140,4472,1000,500,15);
+INSERT INTO `fishing_group` VALUES (140,14117,500,300,9);
 INSERT INTO `fishing_group` VALUES (140,4310,1000,9999,9999);
 INSERT INTO `fishing_group` VALUES (140,4311,450,9999,9999);
 INSERT INTO `fishing_group` VALUES (140,4312,350,9999,9999);
 INSERT INTO `fishing_group` VALUES (140,5714,300,9999,9999);
 INSERT INTO `fishing_group` VALUES (140,5715,250,9999,9999);
+-- Sunbreeze Festival (Goldfish) South_Gustaberg - Hot Springs
+INSERT INTO `fishing_group` VALUES (141,90,900,300,9);
+INSERT INTO `fishing_group` VALUES (141,12522,200,10,1);
+INSERT INTO `fishing_group` VALUES (141,13456,300,275,6);
+INSERT INTO `fishing_group` VALUES (141,14117,500,300,9);
+INSERT INTO `fishing_group` VALUES (141,14242,500,300,9);
+INSERT INTO `fishing_group` VALUES (141,4310,1000,9999,9999);
+INSERT INTO `fishing_group` VALUES (141,4311,450,9999,9999);
+INSERT INTO `fishing_group` VALUES (141,4312,350,9999,9999);
+INSERT INTO `fishing_group` VALUES (141,5714,300,9999,9999);
+INSERT INTO `fishing_group` VALUES (141,5715,250,9999,9999);
+-- Sunbreeze Festival (Goldfish) East_Sarutabaruta - Other Waterside (rivers)
+INSERT INTO `fishing_group` VALUES (142,4472,1000,500,15);
+INSERT INTO `fishing_group` VALUES (142,14242,500,300,9);
+INSERT INTO `fishing_group` VALUES (142,4310,1000,9999,9999);
+INSERT INTO `fishing_group` VALUES (142,4311,450,9999,9999);
+INSERT INTO `fishing_group` VALUES (142,4312,350,9999,9999);
+INSERT INTO `fishing_group` VALUES (142,5714,300,9999,9999);
+INSERT INTO `fishing_group` VALUES (142,5715,250,9999,9999);
+-- Sunbreeze Festival (Goldfish) Rabao - Whole Zone
+INSERT INTO `fishing_group` VALUES (143,90,900,300,9);
+INSERT INTO `fishing_group` VALUES (143,4291,1000,500,15);
+INSERT INTO `fishing_group` VALUES (143,4306,900,190,6);
+INSERT INTO `fishing_group` VALUES (143,4401,1000,1000,36);
+INSERT INTO `fishing_group` VALUES (143,4472,1000,500,15);
+INSERT INTO `fishing_group` VALUES (143,12522,200,10,1);
+INSERT INTO `fishing_group` VALUES (143,14117,500,300,9);
+INSERT INTO `fishing_group` VALUES (143,4310,1000,9999,9999);
+INSERT INTO `fishing_group` VALUES (143,4311,450,9999,9999);
+INSERT INTO `fishing_group` VALUES (143,4312,350,9999,9999);
+INSERT INTO `fishing_group` VALUES (143,5714,300,9999,9999);
+INSERT INTO `fishing_group` VALUES (143,5715,250,9999,9999);
 /*!40000 ALTER TABLE `fishing_group` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [x] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Goldfish scooping only functions in the correct zones and with bowl and scoops equipped, as intended. Disallows fishing without bait, preventing client freeze issue.

## What does this pull request do? (Please be technical)

fishing_fish: FISHFLAG_GOLDFISH value of 2 was incorrectly placed in the quest_status column.
fishing_group: created 3 additional groups, total of 4, or 1 for each event location. added regular fish for that zone into event group so both regular fishing and event fishing work.
fishing_catch: updated groupids with new groups from fishing_group

## Steps to test these changes

Normal fishing in a Sunbreeze location.
Normal fishing in a non-Sunbreeze location that was previously allowing goldfish.
Goldfish scooping in a Sunbreeze location.
Goldfish scooping in a non-Sunbreeze location.

## Special Deployment Considerations

dbtool update!
