### PR TITLE
[core] Fixes spirit AI controller crashes

### DIFF
--- a/src/map/ai/controllers/spirit_controller.cpp
+++ b/src/map/ai/controllers/spirit_controller.cpp
@@ -694,7 +694,7 @@ PMemberTargets CSpiritController::GetBestQualifiedMembers()
                 }
 
                 // Check distance.
-                if (curDist < closestPerson && PSpirit->PAI->PathFind && PSpirit->PAI->PathFind->CanSeePoint(PMember->loc.p))
+                if (curDist < closestPerson && PSpirit->PAI->PathFind && PSpirit->CanSeeTarget(PMember, false))
                 {
                     closestPerson = curDist;
                     qualifiedTargets.PNearest = PMember;

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -600,11 +600,6 @@ bool CPathFind::InWater()
     return false;
 }
 
-bool CPathFind::CanSeePoint(const position_t& point, bool lookOffMesh)
-{
-    return m_POwner->loc.zone->lineOfSight->Raycast(m_POwner->loc.p, point).has_value();
-}
-
 const position_t& CPathFind::GetDestination() const
 {
     return m_points.back().position;

--- a/src/map/ai/helpers/pathfind.h
+++ b/src/map/ai/helpers/pathfind.h
@@ -115,10 +115,6 @@ public:
     // returns true if i'm in water
     bool InWater();
 
-    // checks if raycast was broken between current point and given
-    // returns true if raycast didn't hit any walls
-    bool CanSeePoint(const position_t& point, bool lookOffMesh = true);
-
     // returns the final destination of the current path
     const position_t& GetDestination() const;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixes a crash when Light Spirit casts a spell.
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Fixes: https://github.com/AirSkyBoat/AirSkyBoat/issues/3402
Fixes a crash when light spirit casts.

This was left in from LoS cherry-picks causing crashes when a light spirit casts a spell

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Summon Light Spirit in any zone
See it not crash when it casts a spell
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
