### PR TITLE
Cherry-Pick: Fix conquest tally update issues

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1573,8 +1573,19 @@ xi.conquest.sendConquestTallyStartMessage = function(player, messageBase)
     player:messageText(player, messageBase, 5)
 end
 
+-- City areas, though not technically conquest areas, should show the tally end message.
+xi.conquest.sendCityConquestTallyEndMessage = function(player, messageBase, ranking, isConquestAlliance)
+    -- Tallying conquest results...
+    player:messageText(player, messageBase + 1, 5)
+
+    -- Global balance of power message
+    xi.conquest.sendBalanceOfPowerMessage(player, messageBase, ranking, isConquestAlliance)
+end
+
+-- Used for non city conquest areas. shows tally end message + owner of the region.
 xi.conquest.sendConquestTallyEndMessage = function(player, messageBase, owner, ranking, isConquestAlliance)
-    player:messageText(player, messageBase + 1, 5) -- Tallying conquest results...
+    -- Tallying conquest results...
+    player:messageText(player, messageBase + 1, 5)
 
     if owner <= 3 then
         player:messageText(player, messageBase + 2 + owner, 5) -- This region is currently under <nation> control.
@@ -1582,8 +1593,13 @@ xi.conquest.sendConquestTallyEndMessage = function(player, messageBase, owner, r
         player:messageText(player, messageBase + 6, 5) -- This region is currently under beastman control.
     end
 
-    local offset = 0
+    -- Global balance of power message
+    xi.conquest.sendBalanceOfPowerMessage(player, messageBase, ranking, isConquestAlliance)
+end
 
+-- Helper method for sendConquestTallyUpdateMessage and sendConquestTallyEndMessage
+xi.conquest.sendBalanceOfPowerMessage = function(player, messageBase, ranking, isConquestAlliance)
+    local offset = 0
     if bit.band(ranking, 0x03) == 0x01 then
         offset = offset + 7 -- 7
         if bit.band(ranking, 0x30) == 0x10 then
@@ -1670,14 +1686,16 @@ xi.conquest.sendConquestTallyUpdateMessage = function(player, messageBase, owner
 end
 
 xi.conquest.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    -- onConquestUpdate is called for zones in city regions as well
+    -- in such cases, owner and influence is undetermined, so we call a city specific method.
+    local regionId = zone:getRegionID()
+    if regionId > xi.region.TAVNAZIANARCH and regionId < xi.region.DYNAMIS then
+        xi.conquest.onCityConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
+        return
+    end
+
     local messageBase        = zones[zone:getID()].text.CONQUEST_BASE
     local players            = zone:getPlayers()
-    -----------------------------------
-    -- Once per zone logic
-    -----------------------------------
-    if updatetype == conquestConstants.TALLY_END then
-        xi.conquest.toggleRegionalNPCs(zone)
-    end
 
     -----------------------------------
     -- WARNING: This is iterating every player in a zone, be careful not
@@ -1692,6 +1710,33 @@ xi.conquest.onConquestUpdate = function(zone, updatetype, influence, owner, rank
 
         elseif updatetype == conquestConstants.UPDATE then
             xi.conquest.sendConquestTallyUpdateMessage(player, messageBase, owner, ranking, influence, isConquestAlliance)
+        end
+    end
+end
+
+xi.conquest.onCityConquestUpdate = function(zone, updatetype, ranking, isconquestAlliance)
+    local messageBase        = zones[zone:getID()].text.CONQUEST_BASE
+    local players            = zone:getPlayers()
+
+    -----------------------------------
+    -- Once per zone logic
+    -----------------------------------
+
+    -- Triggers regional npc updates for city zones only
+    if updatetype == conquestConstants.TALLY_END then
+        xi.conquest.toggleRegionalNPCs(zone)
+    end
+
+    -----------------------------------
+    -- WARNING: This is iterating every player in a zone, be careful not
+    --        : to put expensive operations like db reads in here!
+    -----------------------------------
+    for _, player in pairs(players) do
+        if updatetype == conquestConstants.TALLY_START then
+            xi.conquest.sendConquestTallyStartMessage(player, messageBase)
+
+        elseif updatetype == conquestConstants.TALLY_END then
+            xi.conquest.sendCityConquestTallyEndMessage(player, messageBase, ranking, isconquestAlliance)
         end
     end
 end

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -215,7 +215,7 @@ namespace luautils
     int32 OnTriggerAreaLeave(CCharEntity* PChar, CTriggerArea* PTriggerArea); // when player leaves a trigger area in a zone
     int32 OnTransportEvent(CCharEntity* PChar, uint32 TransportID);
     void  OnTimeTrigger(CNpcEntity* PNpc, uint8 triggerID);
-    int32 OnConquestUpdate(CZone* PZone, ConquestUpdate type, uint8 influence, uint8 owner, uint8 ranking, bool isConquestAlliance); // hourly conquest update
+    int32 OnConquestUpdate(CZone* PZone, ConquestUpdate type, uint8 influence, uint8 owner, uint8 ranking, bool isConquestAlliance); // conquest update (hourly or tally)
 
     void OnServerStart();
     void OnJSTMidnight();

--- a/src/world/conquest_system.cpp
+++ b/src/world/conquest_system.cpp
@@ -95,8 +95,8 @@ void ConquestSystem::sendInfluencesMsg(bool shouldUpdateZones, uint64 ipp)
     auto influences = getRegionalInfluences();
 
     // Base length is the type + subtype + influence size
-    const std::size_t headerLength = 2 * sizeof(uint8);
-    const std::size_t dataLen      = headerLength + sizeof(bool) + sizeof(size_t) + sizeof(influence_t) * influences.size();
+    const std::size_t headerLength = 2 * sizeof(uint8) + sizeof(std::size_t) + sizeof(bool);
+    const std::size_t dataLen      = headerLength + sizeof(influence_t) * influences.size();
     const uint8*      data         = new uint8[dataLen];
 
     // Regional event type + conquest msg type
@@ -109,7 +109,7 @@ void ConquestSystem::sendInfluencesMsg(bool shouldUpdateZones, uint64 ipp)
     for (std::size_t i = 0; i < influences.size(); i++)
     {
         // Everything is offset by i*size of region control struct + headerLength
-        const std::size_t start              = headerLength + sizeof(bool) + sizeof(size_t) + i * sizeof(influence_t);
+        const std::size_t start              = headerLength + i * sizeof(influence_t);
         ref<uint16>((uint8*)data, start)     = influences[i].sandoria_influence;
         ref<uint16>((uint8*)data, start + 2) = influences[i].bastok_influence;
         ref<uint16>((uint8*)data, start + 4) = influences[i].windurst_influence;
@@ -140,8 +140,8 @@ void ConquestSystem::sendRegionControlsMsg(CONQUESTMSGTYPE msgType, uint64 ipp)
     //      - prev control (uint8)
     auto regionControls = getRegionControls();
 
-    // Base length is the type + subtype + region control size
-    const std::size_t headerLength = 2 * sizeof(uint8);
+    // Header length is the type + subtype + region control size + size of the size_t
+    const std::size_t headerLength = 2 * sizeof(uint8) + sizeof(std::size_t);
     const std::size_t dataLen      = headerLength + sizeof(region_control_t) * regionControls.size();
     const uint8*      data         = new uint8[dataLen];
 
@@ -153,8 +153,8 @@ void ConquestSystem::sendRegionControlsMsg(CONQUESTMSGTYPE msgType, uint64 ipp)
     ref<std::size_t>((uint8*)data, 2) = regionControls.size();
     for (std::size_t i = 0; i < regionControls.size(); i++)
     {
-        // Everything is offset by i*size of region control struct + headerLength + size of size_t
-        const std::size_t offset             = headerLength + sizeof(size_t) + sizeof(region_control_t) * i;
+        // Everything is offset by i*size of region control struct + headerLength
+        const std::size_t offset             = headerLength + sizeof(region_control_t) * i;
         ref<uint8>((uint8*)data, offset)     = regionControls[i].current;
         ref<uint8>((uint8*)data, offset + 1) = regionControls[i].prev;
     }


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

- Fixes client crash when hovering over certain areas after tally.
- Fixes corrupt conquest data after tally

## What does this pull request do? (Please be technical)

- Fixes conquest data issues that caused regional control to be incorrect after tally
- Fixes client crash after conquest tally
- Fixes certain areas incorrectly getting tally update messages

(cherry picked from commit 8c18f5ef6f4256fbde89421db35189edc7c31e54)

## Steps to test these changes

Run !updateconquest 0
Verify data is correct and can hover all map regions in /rmap.
