### PR TITLE
Fix several dyna and res building issues

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -602,7 +602,7 @@ xi.dynamis.nonStandardDynamicSpawn = function(mobIndex, oMob, forceLink, zoneID,
             ["onMobSpawn"] = { function(mob) xi.dynamis.setNightmareStats(mob) end },
             ["onMobEngaged"] = { function(mob, target) end },
             ["onMobFight"] = { function(mob) end },
-            ["onMobRoam"] = { function(mob) xi.dynamis.mobOnRoam(mob) end },
+            ["onMobRoam"] = { function(mob) end },
             ["mixins"] = {  }
         },
         ["Beastmen"] =

--- a/modules/era/sql/era_mob_droplist.sql
+++ b/modules/era/sql/era_mob_droplist.sql
@@ -18759,7 +18759,6 @@ INSERT INTO `mob_droplist` VALUES (2393,0,0,1000,995,@UNCOMMON); -- Ten Of Sword
 -- ZoneID:  28 - Teratotaur
 INSERT INTO `mob_droplist` VALUES (2394,0,0,1000,1620,@UNCOMMON); -- Taurus Horn (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (2394,0,0,1000,1877,@UNCOMMON); -- Fomor Codex (Uncommon, 10%)
-INSERT INTO `mob_droplist` VALUES (2394,2,0,1000,886,0);          -- Demon Skull (Steal)
 INSERT INTO `mob_droplist` VALUES (2394,4,0,1000,902,0);          -- Demon Horn (Despoil)
 
 -- ZoneID: 215 - Terminus Eft

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1830,27 +1830,38 @@ xi.magic.calculateDuration = function(duration, magicSkill, spellGroup, caster, 
     return math.floor(duration)
 end
 
-xi.magic.calculateBuildDuration = function(target, duration, effect, caster)
+xi.magic.incrementBuildDuration = function(target, effect, caster)
     if target:isMob() and target:isNM() then
-        local buildRes = xi.magic.getEffectResistance(target, effect, true, caster)
+        local resType = xi.magic.getEffectResistance(target, effect, true, caster)
 
-        local buildResMod = target:getMod(buildRes)
+        local buildResMod = target:getMod(resType)
 
         if buildResMod ~= nil then
-            local durationDecrease = target:getLocalVar(string.format("[RESBUILD]Base_%s", buildRes))
-            local spellCount = target:getLocalVar(string.format("[RESBUILD]Base_%s_Count", buildRes))
-
-            duration = utils.clamp(duration - durationDecrease, 0, 65535) -- Used to add more fidelity to the build. Adding a mod of 30 will be -3 seconds per cast.
+            local durationDecrease = target:getLocalVar(string.format("[RESBUILD]Base_%s", resType))
+            local spellCount = target:getLocalVar(string.format("[RESBUILD]Base_%s_Count", resType))
 
             -- find next duration decrease with min of 1 second (MOD <= 10) and max of 100 seconds (MOD >= 1000)
             local nextDecrease = utils.clamp(math.floor(buildResMod / 10), 1, 100)
 
-            target:setLocalVar(string.format("[RESBUILD]Base_%s", buildRes), durationDecrease + nextDecrease)
-            target:setLocalVar(string.format("[RESBUILD]Base_%s_Count", buildRes), spellCount + 1)
+            target:setLocalVar(string.format("[RESBUILD]Base_%s", resType), durationDecrease + nextDecrease)
+            target:setLocalVar(string.format("[RESBUILD]Base_%s_Count", resType), spellCount + 1)
             -- set local var to denote that these res should be reset when mob roams at 100% HP
             if target:getLocalVar("HasStatusResBuild") == 0 then
                 target:setLocalVar("HasStatusResBuild", 1)
             end
+        end
+    end
+end
+
+xi.magic.calculateBuildDuration = function(target, duration, effect, caster)
+    if target:isMob() and target:isNM() then
+        local resType = xi.magic.getEffectResistance(target, effect, true, caster)
+
+        local buildResMod = target:getMod(resType)
+
+        if buildResMod ~= nil then
+            local durationDecrease = target:getLocalVar(string.format("[RESBUILD]Base_%s", resType))
+            duration = utils.clamp(duration - durationDecrease, 0, 65535) -- Used to add more fidelity to the build. Adding a mod of 30 will be -3 seconds per cast.
         end
     end
 

--- a/scripts/globals/mobskills/attractant.lua
+++ b/scripts/globals/mobskills/attractant.lua
@@ -25,7 +25,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         return typeEffect
     end
 
-    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 30)
     if msg == xi.msg.basic.SKILL_ENFEEB_IS then
         mob:charm(target)
         mob:resetEnmity(target)

--- a/scripts/globals/mobskills/soporific.lua
+++ b/scripts/globals/mobskills/soporific.lua
@@ -16,21 +16,14 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         local resist = xi.mobskills.applyPlayerResistance(mob, nil, target, mob:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), 1, xi.magic.ele.DARK)
         local duration = math.ceil(60 + math.floor(31 * math.random()) * resist) -- wiki: duration variable from 30 to 90. can be thought of random 60-90 with possible half resist making it range 30-90
         if resist >= 0.5 then
-            target:delStatusEffectSilent(effect)
-            target:delStatusEffectSilent(xi.effect.LULLABY)
-            target:delStatusEffectSilent(xi.effect.SLEEP_I)
-            target:delStatusEffectSilent(xi.effect.POISON)
-            local dotdmg = 50
             if
                 not (target:hasImmunity(xi.immunity.SLEEP) or
                 target:hasStatusEffect(xi.effect.SLEEP_I) or
                 target:hasStatusEffect(xi.effect.SLEEP_II) or
-                target:hasStatusEffect(xi.effect.LULLABY))
-                and target:addStatusEffect(effect, 1, 0, duration, 25, 25, 1)
-            then -- subid/subpower for poison detection on wakup function
-
-
-                    target:addStatusEffect(xi.effect.POISON, dotdmg, 3, duration, 3, 15, 2)
+                target:hasStatusEffect(xi.effect.LULLABY)) and
+                -- use nightmare tick with 50 hp every 3 seconds
+                target:addStatusEffect(effect, 20, 3, duration, 135, 50)
+            then
                 skill:setMsg(xi.msg.basic.SKILL_ENFEEB_IS)
             else
                 skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
@@ -38,6 +31,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         else
             skill:setMsg(xi.msg.basic.SKILL_MISS)
         end
+
         return effect
     else
         local typeEffect = xi.effect.SLEEP_I

--- a/scripts/globals/spells/black/bind.lua
+++ b/scripts/globals/spells/black/bind.lua
@@ -37,6 +37,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, target:getSpeed(), 0 , resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/bindga.lua
+++ b/scripts/globals/spells/black/bindga.lua
@@ -33,6 +33,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(xi.effect.BIND, target:getSpeed(), 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/blind.lua
+++ b/scripts/globals/spells/black/blind.lua
@@ -50,6 +50,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/blind_ii.lua
+++ b/scripts/globals/spells/black/blind_ii.lua
@@ -51,6 +51,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/blindga.lua
+++ b/scripts/globals/spells/black/blindga.lua
@@ -49,6 +49,8 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.NONE)
         elseif target:addStatusEffect(params.effect, power, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/break.lua
+++ b/scripts/globals/spells/black/break.lua
@@ -31,6 +31,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/breakga.lua
+++ b/scripts/globals/spells/black/breakga.lua
@@ -29,8 +29,10 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
 
-        if target:addStatusEffect(params.effect, 1, 0, duration * resist) then
+        if target:addStatusEffect(params.effect, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/curse.lua
+++ b/scripts/globals/spells/black/curse.lua
@@ -33,6 +33,8 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.NONE)
         elseif target:addStatusEffect(xi.effect.CURSE_I, power, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/graviga.lua
+++ b/scripts/globals/spells/black/graviga.lua
@@ -32,6 +32,8 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.NONE)
         elseif target:addStatusEffect(xi.effect.WEIGHT, power, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/gravity.lua
+++ b/scripts/globals/spells/black/gravity.lua
@@ -47,6 +47,8 @@ spellObject.onSpellCast = function(caster, target, spell)
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
         if target:addStatusEffect(params.effect, power, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/gravity_ii.lua
+++ b/scripts/globals/spells/black/gravity_ii.lua
@@ -45,6 +45,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison.lua
+++ b/scripts/globals/spells/black/poison.lua
@@ -41,6 +41,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison_ii.lua
+++ b/scripts/globals/spells/black/poison_ii.lua
@@ -41,6 +41,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poison_iii.lua
+++ b/scripts/globals/spells/black/poison_iii.lua
@@ -39,6 +39,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poisonga.lua
+++ b/scripts/globals/spells/black/poisonga.lua
@@ -41,6 +41,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poisonga_ii.lua
+++ b/scripts/globals/spells/black/poisonga_ii.lua
@@ -41,6 +41,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/poisonga_iii.lua
+++ b/scripts/globals/spells/black/poisonga_iii.lua
@@ -53,6 +53,8 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.NONE)
         elseif target:addStatusEffect(effect, power, 3, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/sleep.lua
+++ b/scripts/globals/spells/black/sleep.lua
@@ -37,6 +37,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/sleep_ii.lua
+++ b/scripts/globals/spells/black/sleep_ii.lua
@@ -42,6 +42,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, 2, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/sleepga.lua
+++ b/scripts/globals/spells/black/sleepga.lua
@@ -49,6 +49,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect

--- a/scripts/globals/spells/black/sleepga_ii.lua
+++ b/scripts/globals/spells/black/sleepga_ii.lua
@@ -37,6 +37,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, 2, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/stun.lua
+++ b/scripts/globals/spells/black/stun.lua
@@ -35,6 +35,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/black/virus.lua
+++ b/scripts/globals/spells/black/virus.lua
@@ -31,6 +31,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(effect, 5, 3, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/songs/battlefield_elegy.lua
+++ b/scripts/globals/spells/songs/battlefield_elegy.lua
@@ -58,6 +58,8 @@ spellObject.onSpellCast = function(caster, target, spell)
         -- Try to overwrite weaker elegy
         elseif target:addStatusEffect(xi.effect.ELEGY, power, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
         end

--- a/scripts/globals/spells/songs/carnage_elegy.lua
+++ b/scripts/globals/spells/songs/carnage_elegy.lua
@@ -63,6 +63,8 @@ spellObject.onSpellCast = function(caster, target, spell)
         -- Try to overwrite weaker elegy
         elseif target:addStatusEffect(xi.effect.ELEGY, power, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
         end

--- a/scripts/globals/spells/songs/foe_lullaby.lua
+++ b/scripts/globals/spells/songs/foe_lullaby.lua
@@ -51,6 +51,8 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.NONE)
         elseif target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         end

--- a/scripts/globals/spells/songs/foe_lullaby_ii.lua
+++ b/scripts/globals/spells/songs/foe_lullaby_ii.lua
@@ -51,6 +51,8 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.NONE)
         elseif target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         end

--- a/scripts/globals/spells/songs/horde_lullaby.lua
+++ b/scripts/globals/spells/songs/horde_lullaby.lua
@@ -51,6 +51,8 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.NONE)
         elseif target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         end

--- a/scripts/globals/spells/songs/horde_lullaby_ii.lua
+++ b/scripts/globals/spells/songs/horde_lullaby_ii.lua
@@ -51,6 +51,8 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.NONE)
         elseif target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         end

--- a/scripts/globals/spells/songs/maidens_virelai.lua
+++ b/scripts/globals/spells/songs/maidens_virelai.lua
@@ -45,6 +45,8 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.NONE)
         elseif caster:isMob() then
             target:addStatusEffect(xi.effect.CHARM_I, 0, 0, duration)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             caster:charm(target)
         else
             caster:charmDuration(target, duration)

--- a/scripts/globals/spells/songs/massacre_elegy.lua
+++ b/scripts/globals/spells/songs/massacre_elegy.lua
@@ -59,6 +59,8 @@ spellObject.onSpellCast = function(caster, target, spell)
         -- Try to overwrite weaker elegy
         elseif target:addStatusEffect(xi.effect.ELEGY, power, 0, duration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
         end

--- a/scripts/globals/spells/white/paralyga.lua
+++ b/scripts/globals/spells/white/paralyga.lua
@@ -45,6 +45,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
             if target:addStatusEffect(xi.effect.PARALYSIS, potency, 0, resduration) then
                 spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+                -- only increment the resbuild if successful (not on a no effect)
+                xi.magic.incrementBuildDuration(target, params.effect, caster)
                 xi.magic.handleBurstMsg(caster, target, spell)
             else
                 -- no effect

--- a/scripts/globals/spells/white/paralyze.lua
+++ b/scripts/globals/spells/white/paralyze.lua
@@ -48,6 +48,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, potency, 0, duration * resist, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             -- no effect

--- a/scripts/globals/spells/white/paralyze_ii.lua
+++ b/scripts/globals/spells/white/paralyze_ii.lua
@@ -48,6 +48,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, potency, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/silence.lua
+++ b/scripts/globals/spells/white/silence.lua
@@ -34,6 +34,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect , 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/white/silencega.lua
+++ b/scripts/globals/spells/white/silencega.lua
@@ -40,6 +40,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(effectType, 1, 0, resduration) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/white/slow.lua
+++ b/scripts/globals/spells/white/slow.lua
@@ -54,6 +54,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/slow_ii.lua
+++ b/scripts/globals/spells/white/slow_ii.lua
@@ -43,6 +43,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         if target:addStatusEffect(params.effect, power, 0, resduration, 0, params.tier) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/globals/spells/white/slowga.lua
+++ b/scripts/globals/spells/white/slowga.lua
@@ -34,6 +34,8 @@ spellObject.onSpellCast = function(caster, target, spell)
         resduration = xi.magic.calculateBuildDuration(target, resduration, params.effect, caster)
         if target:addStatusEffect(params.effect, power, 0, resduration, 0, 1) then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+            -- only increment the resbuild if successful (not on a no effect)
+            xi.magic.incrementBuildDuration(target, params.effect, caster)
             xi.magic.handleBurstMsg(caster, target, spell)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Teratotaurs no longer allow out-of-era stealing of demon skulls. (Tracent)
- The durations of status effects on certain NMs that build resistance no longer decrease due to enfeebling spells that have no effect (such as when enfeebling a mob that already has the status effect). This is retail accurate behavior. (Tracent, Kanryu)
- Soporific of Dragontraps no longer overwrites itself and now correctly drains 50 HP per tick. (Tracent, Kanryu)
- Attractant (charm) of Nant'ina now has a retail accurate maximum duration of 30 seconds rather than 60 seconds. (Tracent, Kanryu)

## What does this pull request do? (Please be technical)
See the above description. The main change is the splitting of calculateBuildDuration into calculateBuildDuration and incrementBuildDuration. Now calculateBuildDuration just calculates the duration of the effect given current resbuild while incrementBuildDuration actually adjusts the resbuild so the next cast has lower duration. This is required because only successful spells should adjust the resbuild and no effects should not (yet the duration calculation is required by the function that determines success.

This replaces an earlier PR that had some issues (see https://github.com/AirSkyBoat/AirSkyBoat/pull/3407).

## Steps to test these changes

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/3360
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
