### PR TITLE
Fix wyvern breath and weaknesses

### DIFF
--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -763,31 +763,35 @@ xi.job_utils.dragoon.pickAndUseDamageBreath = function(player, target)
 
     local resistances =
     {
-        target:getMod(xi.mod.FIRE_MEVA),
-        target:getMod(xi.mod.ICE_MEVA),
-        target:getMod(xi.mod.WIND_MEVA),
-        target:getMod(xi.mod.EARTH_MEVA),
-        target:getMod(xi.mod.THUNDER_MEVA),
-        target:getMod(xi.mod.WATER_MEVA),
+        target:getMod(xi.mod.FIRE_EEM),
+        target:getMod(xi.mod.ICE_EEM),
+        target:getMod(xi.mod.WIND_EEM),
+        target:getMod(xi.mod.EARTH_EEM),
+        target:getMod(xi.mod.THUNDER_EEM),
+        target:getMod(xi.mod.WATER_EEM),
     }
 
-    local lowest = resistances[1]
+    local highestEEM = resistances[1]
     local breath = breathList[math.random(#breathList)]
-    local head = player:getEquippedItem(xi.slot.HEAD)
+    local headEquip = player:getEquippedItem(xi.slot.HEAD)
+    local headEquipID = 0
+    if headEquip then
+        headEquipID = headEquip:getID()
+    end
 
     -- https://ffxiclopedia.fandom.com/wiki/Drachen_Armet?oldid=965925
     -- https://ffxiclopedia.fandom.com/wiki/Elemental_Breath?oldid=738854
-    -- The wyvern picks breath based on the lowest resistance if the player has Drachen Armet equipped.
+    -- The wyvern picks breath based on the highest eem (lowest resistance) if the player has Drachen Armet equipped.
     -- If all resistances are equal, a random breath is used.
     -- However there innately exists a chance where wyvern use breath based on weakness.
     if
-        head == xi.items.DRACHEN_ARMET or
-        head == xi.items.DRACHEN_ARMET_P1 or
+        headEquipID == xi.items.DRACHEN_ARMET or
+        headEquipID == xi.items.DRACHEN_ARMET_P1 or
         math.random() < 0.5
     then
         for i, v in ipairs(breathList) do
-            if resistances[i] < lowest then
-                lowest = resistances[i]
+            if resistances[i] > highestEEM then
+                highestEEM = resistances[i]
                 breath = v
             end
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
A player's wyvern should now correctly use the elemental breath that corresponds to the enemy's weakness about 50% of the time. This rises to 100% while player is wearing Drachen Armet or Drachen Armet+1. (Tracent)

## What does this pull request do? (Please be technical)
This changes the wyvern breath selection code to use EEM instead of MEVA mods which are now zero for most normal mobs on ASB and also fixes an issue where a getID() function call was missing.

## Steps to test these changes
Fight mobs such as Torama in Labyrinth of Onzozo and see your wyvern should use earth based breath 50% of the time without Drachen Armet and 100% of the time with Drachen Armet (as Torama is weak to earth).

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1249
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
