### PR TITLE
Adds newmesh pathing back in until re-work is complete

### DIFF
--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -22,10 +22,12 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "pathfind.h"
 
 #include "ai/ai_container.h"
+#include "common/settings.h"
 #include "common/utils.h"
 #include "entities/baseentity.h"
 #include "entities/mobentity.h"
 #include "lua/luautils.h"
+#include "mob_modifier.h"
 #include "zone.h"
 
 namespace
@@ -152,7 +154,57 @@ bool CPathFind::PathInRange(const position_t& point, float range, uint8 pathFlag
 
     bool result = PathTo(point, pathFlags, false);
 
-    PrunePathWithin(range);
+        if (m_POwner->objtype == TYPE_MOB && !m_POwner->loc.zone->m_updatedNavmesh) // Target is too high.
+    {
+        auto PMob = static_cast<CMobEntity*>(m_POwner);
+
+        if (point.y - m_POwner->loc.p.y <= settings::get<int8>("map.VERTICAL_CHASE_RANGE") && !PMob->PAI->IsRoaming()) // Target is over 6 yalms above me, I should process disengage if needed.
+        {
+            auto disengageMod = PMob->getMobMod(MOBMOD_DISENGAGE_NO_PATH);
+
+            if (PMob->m_pathFindDisengage >= 1)
+            {
+                result = false;
+            }
+            else if ((PMob->m_pathFindDisengage >= (disengageMod > 0 ? disengageMod : 2)) ||
+                     (PMob->health.hp != PMob->health.maxhp && !PMob->PAI->IsRoaming())) // This is just to stop players from abusing the disengage. Adjustable via mobmod.
+            {
+                result = false; // Make me go up.
+            }
+            else if (PMob->PAI->IsEngaged())
+            {
+                PMob->m_pathFindDisengage += 1;
+                PMob->PAI->Disengage();
+            }
+            else
+            {
+                result = false;
+            }
+        }
+        else // I'm probably stuck on a rock or something dumb.
+        {
+            result = false; // Make me go down or up.
+        }
+    }
+
+    if (m_POwner->objtype == TYPE_MOB &&
+        m_POwner->loc.zone->m_updatedNavmesh)
+    {
+        auto PEntity = dynamic_cast<CBattleEntity*>(m_POwner)->GetBattleTarget();
+
+        if (PEntity && !m_POwner->m_ignoreWallhack)
+        {
+            result           = abs(m_POwner->loc.p.y - PEntity->loc.p.y) < m_POwner->loc.zone->m_navMesh->GetVerticalLimit() ? ValidPosition(PEntity->loc.p) : true;
+            m_carefulPathing = result ? true : false;
+        }
+    }
+
+    if (!result && !m_POwner->m_ignoreWallhack) // If I failed to path successfully, then I should wallhack to reach my destination.
+    {
+        pathFlags |= PATHFLAG_WALLHACK;
+        PathTo(point, pathFlags, false);
+    }
+
     return result;
 }
 
@@ -297,7 +349,7 @@ void CPathFind::FollowPath(time_point tick)
 
     if ((isNavMeshEnabled() && m_carefulPathing) || (isNavMeshEnabled() && m_POwner->loc.zone->m_zoneCarefulPathing))
     {
-        m_POwner->loc.zone->m_navMesh->snapToValidPosition(m_POwner->loc.p);
+        m_POwner->loc.zone->m_navMesh->snapToValidPosition(m_POwner->loc.p, targetPoint.position.y, false);
     }
 
     if (m_maxDistance && m_distanceMoved >= m_maxDistance)

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -488,11 +488,11 @@ bool CNavMesh::findFurthestValidPoint(const position_t& startPosition, const pos
     return true;
 }
 
-void CNavMesh::snapToValidPosition(position_t& position)
+void CNavMesh::snapToValidPosition(position_t& position, float targetY, bool force)
 {
     TracyZoneScoped;
 
-    if (!m_navMesh)
+    if (!m_navMesh || !targetY || (!force && abs(position.y - targetY) < 0.1f))
     {
         return;
     }
@@ -506,7 +506,7 @@ void CNavMesh::snapToValidPosition(position_t& position)
     filter.setIncludeFlags(0xffff);
     filter.setExcludeFlags(0);
 
-    dtPolyRef startRef = 0;
+    dtPolyRef startRef;
 
     dtStatus status = m_navMeshQuery.findNearestPoly(spos, polyPickExt, &filter, &startRef, snearest);
 

--- a/src/map/navmesh.h
+++ b/src/map/navmesh.h
@@ -92,7 +92,7 @@ public:
     bool findFurthestValidPoint(const position_t& startPosition, const position_t& endPosition, float* validPoint);
 
     // Like validPosition(), but will also set the given position to the valid position that it finds.
-    void snapToValidPosition(position_t& position);
+    void snapToValidPosition(position_t& position, float targetY, bool force = false);
 
     static inline void outputError(uint32 status)
     {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -6257,7 +6257,7 @@ namespace battleutils
         // Snap nearEntity to a guaranteed valid position
         if (PMob->loc.zone->m_navMesh)
         {
-            PMob->loc.zone->m_navMesh->snapToValidPosition(nearEntity);
+            PMob->loc.zone->m_navMesh->snapToValidPosition(nearEntity, pos.y, true);
         }
 
         // Move the target a little higher, just in case


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Nothing to say here
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
This pathing code needs to be added back in for the new meshes that were done for several zones. Once pathing re-work is done then this can come out.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
See pathing is normal in zones with careful pathing
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
nothing to say here
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
