### PR TITLE
Fix spice gals quest and other small issues

### DIFF
--- a/scripts/quests/sandoria/Spice_Gals.lua
+++ b/scripts/quests/sandoria/Spice_Gals.lua
@@ -118,9 +118,10 @@ quest.sections =
             onEventFinish =
             {
                 [725] = function(player, csid, option, npc)
-                    player:delKeyItem(xi.ki.RIVERNEWORT)
-                    npcUtil.giveItem(player, xi.items.MIRATETES_MEMOIRS)
-                    quest:setVar(player, 'Option', getConquestTally())
+                    if npcUtil.giveItem(player, xi.items.MIRATETES_MEMOIRS) then
+                        player:delKeyItem(xi.ki.RIVERNEWORT)
+                        quest:setVar(player, 'Option', getConquestTally())
+                    end
                 end,
             },
         },

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -557,7 +557,7 @@ INSERT INTO `mob_skills` VALUES (596,882,'pl_hellstorm',1,15.0,2000,1500,4,0,0,0
 INSERT INTO `mob_skills` VALUES (598,1598,'berserk',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (599,885,'arctic_impact',1,15.0,2000,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (600,886,'cold_wave',1,15,2000,2000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (601,887,'hiemal_storm',1,15.0,2000,2000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (601,887,'hiemal_storm',4,15.0,2000,2000,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (602,346,'hypothermal_combustion',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (603,432,'lateral_slash_2hr',0,7.0,2000,0,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (604,433,'throat_stab_2hr',0,7.0,2000,0,1,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- The quest Spice Gals will now behavior correctly even if a player has a full inventory. (Tracent)
- The mob skill Hiemal Storm is now conal. (Tracent)

## What does this pull request do? (Please be technical)
See the above two issues

## Steps to test these changes
!completequest 0 110
!addkeyitem RIVERNEWORT
!gotoid 17719492
With full inventory talk to Rouva and try to complete the quest, see that it does not allow completion unless you talk without full inventory

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1358
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
