### PR TITLE
[core] Audit Party/Alliance messaging

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -140,6 +140,7 @@ enum MSGSERVTYPE : uint8
     MSG_PT_INV_RES,
     MSG_PT_RELOAD,
     MSG_PT_DISBAND,
+    MSG_ALLIANCE_DISSOLVE,
     MSG_DIRECT,
     MSG_LINKSHELL_RANK_CHANGE,
     MSG_LINKSHELL_REMOVE,
@@ -181,6 +182,8 @@ constexpr auto msgTypeToStr = [](uint8 msgtype)
             return "MSG_PT_RELOAD";
         case MSG_PT_DISBAND:
             return "MSG_PT_DISBAND";
+        case MSG_ALLIANCE_DISSOLVE:
+            return "MSG_ALLIANCE_DISSOLVE";
         case MSG_DIRECT:
             return "MSG_DIRECT";
         case MSG_LINKSHELL_RANK_CHANGE:

--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -68,10 +68,9 @@ void CAlliance::dissolveAlliance(bool playerInitiated)
     {
         // sql->Query("UPDATE accounts_parties SET allianceid = 0, partyflag = partyflag & ~%d WHERE allianceid = %u;", ALLIANCE_LEADER | PARTY_SECOND
         // | PARTY_THIRD, m_AllianceID);
-        uint8 data[8]{};
+        uint8 data[4]{};
         ref<uint32>(data, 0) = m_AllianceID;
-        ref<uint32>(data, 4) = m_AllianceID;
-        message::send(MSG_PT_DISBAND, data, sizeof data, nullptr);
+        message::send(MSG_ALLIANCE_DISSOLVE, data, sizeof data, nullptr);
     }
     else
     {
@@ -164,17 +163,21 @@ void CAlliance::removeParty(CParty* party)
         }
     }
 
+    uint32 mainPartyID = getMainParty()->GetPartyID();
+
     delParty(party);
 
     sql->Query("UPDATE accounts_parties SET allianceid = 0, partyflag = partyflag & ~%d WHERE partyid = %u;",
                ALLIANCE_LEADER | PARTY_SECOND | PARTY_THIRD, party->GetPartyID());
+
+    // notify alliance
     uint8 data[4]{};
-    ref<uint32>(data, 0) = m_AllianceID;
+    ref<uint32>(data, 0) = mainPartyID;
     message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
 
-    uint8 data2[4]{};
-    ref<uint32>(data2, 0) = party->GetPartyID();
-    message::send(MSG_PT_RELOAD, data2, sizeof data2, nullptr);
+    // notify leaving party
+    ref<uint32>(data, 0) = party->GetPartyID();
+    message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
 }
 
 void CAlliance::delParty(CParty* party)
@@ -268,8 +271,9 @@ void CAlliance::addParty(CParty* party)
                party->GetPartyID());
     party->SetPartyNumber(newparty);
 
+    // MSG_PT_RELOAD also reloads all the alliances parties if available
     uint8 data[4]{};
-    ref<uint32>(data, 0) = m_AllianceID;
+    ref<uint32>(data, 0) = party->GetPartyID();
     message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
 }
 
@@ -293,9 +297,8 @@ void CAlliance::addParty(uint32 partyid) const
         }
     }
     sql->Query("UPDATE accounts_parties SET allianceid = %u, partyflag = partyflag | %d WHERE partyid = %u;", m_AllianceID, newparty, partyid);
-    uint8 data[8]{};
-    ref<uint32>(data, 0) = m_AllianceID;
-    ref<uint32>(data, 4) = partyid;
+    uint8 data[4]{};
+    ref<uint32>(data, 0) = partyid;
     message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
 }
 

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -337,44 +337,120 @@ namespace message
             }
             case MSG_PT_RELOAD:
             {
-                if (extra.size() == 8)
+                uint32  partyid = ref<uint32>((uint8*)extra.data(), 0);
+                CParty* PParty  = nullptr;
+
+                // TODO: when Party/Alliance gets a rewrite, make a zoneutils::ForEachParty or some other accessor to reduce the amount of iterations significantly.
+                // clang-format off
+                zoneutils::ForEachZone([partyid, &PParty](CZone* PZone)
                 {
-                    CCharEntity* PChar = zoneutils::GetCharToUpdate(ref<uint32>((uint8*)extra.data(), 4), ref<uint32>((uint8*)extra.data(), 0));
-                    if (PChar)
+                    PZone->ForEachChar([partyid, &PParty](CCharEntity* PChar)
                     {
-                        PChar->ReloadPartyInc();
-                        break;
+                        if (PChar->PParty && PChar->PParty->GetPartyID() == partyid)
+                        {
+                            PParty = PChar->PParty;
+                            return;
+                        }
+                    });
+
+                    if (PParty)
+                    {
+                        return;
+                    }
+                });
+                // clang-format on
+
+                if (PParty)
+                {
+                    if (PParty->m_PAlliance)
+                    {
+                        for (auto* entry : PParty->m_PAlliance->partyList)
+                        {
+                            for (auto* member : entry->members)
+                            {
+                                if (member->objtype == TYPE_PC)
+                                {
+                                    static_cast<CCharEntity*>(member)->ReloadPartyInc();
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        for (auto* member : PParty->members)
+                        {
+                            if (member->objtype == TYPE_PC)
+                            {
+                                static_cast<CCharEntity*>(member)->ReloadPartyInc();
+                            }
+                        }
                     }
                 }
-                else
-                {
-                    CCharEntity* PChar = zoneutils::GetChar(ref<uint32>((uint8*)extra.data(), 0));
-                    if (PChar)
-                    {
-                        PChar->ForAlliance([](CBattleEntity* PMember)
-                                           { ((CCharEntity*)PMember)->ReloadPartyInc(); });
-                    }
-                }
+
                 break;
             }
             case MSG_PT_DISBAND:
             {
-                CCharEntity* PChar = zoneutils::GetChar(ref<uint32>((uint8*)extra.data(), 0));
-                uint32       id    = ref<uint32>((uint8*)extra.data(), 4);
-                if (PChar)
+                uint32  partyid = ref<uint32>((uint8*)extra.data(), 0);
+                CParty* PParty  = nullptr;
+
+                // TODO: when Party/Alliance gets a rewrite, make a zoneutils::ForEachParty or some other accessor to reduce the amount of iterations significantly.
+                // clang-format off
+                zoneutils::ForEachZone([partyid, &PParty](CZone* PZone)
                 {
-                    if (PChar->PParty)
+                    PZone->ForEachChar([partyid, &PParty](CCharEntity* PChar)
                     {
-                        if (PChar->PParty->m_PAlliance && PChar->PParty->m_PAlliance->m_AllianceID == id)
+                        if (PChar->PParty && PChar->PParty->GetPartyID() == partyid)
                         {
-                            PChar->PParty->m_PAlliance->dissolveAlliance(false);
+                            PParty = PChar->PParty;
+                            return;
                         }
-                        else
-                        {
-                            PChar->PParty->DisbandParty(false);
-                        }
+                    });
+
+                    if (PParty)
+                    {
+                        return;
                     }
+                });
+                // clang-format on
+
+                if (PParty)
+                {
+                    PParty->DisbandParty(false);
                 }
+
+                break;
+            }
+            case MSG_ALLIANCE_DISSOLVE:
+            {
+                uint32     allianceid = ref<uint32>((uint8*)extra.data(), 0);
+                CAlliance* PAlliance  = nullptr;
+
+                // TODO: when Party/Alliance gets a rewrite, make a zoneutils::ForEachAlliance or some other accessor to reduce the amount of iterations significantly.
+                // clang-format off
+                zoneutils::ForEachZone([allianceid, &PAlliance](CZone* PZone)
+                {
+                    PZone->ForEachChar([allianceid, &PAlliance](CCharEntity* PChar)
+                    {
+                        if (PChar->PParty && PChar->PParty->m_PAlliance && PChar->PParty->m_PAlliance->m_AllianceID == allianceid)
+                        {
+                            PAlliance = PChar->PParty->m_PAlliance;
+                            return;
+                        }
+                    });
+
+                    if (PAlliance)
+                    {
+                        return;
+                    }
+                });
+                // clang-format on
+
+                if (PAlliance)
+                {
+                    PAlliance->dissolveAlliance(false);
+                }
+
                 break;
             }
             case MSG_DIRECT:

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4440,9 +4440,8 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                             sql->AffectedRows())
                         {
                             ShowDebug("%s has removed %s from party", PChar->GetName(), data[0x0C]);
-                            uint8 removeData[8]{};
+                            uint8 removeData[4]{};
                             ref<uint32>(removeData, 0) = PChar->PParty->GetPartyID();
-                            ref<uint32>(removeData, 4) = id;
                             message::send(MSG_PT_RELOAD, removeData, sizeof removeData, nullptr);
                         }
                     }
@@ -4529,9 +4528,8 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                                 sql->AffectedRows())
                             {
                                 ShowDebug("%s has removed %s party from alliance", PChar->GetName(), data[0x0C]);
-                                uint8 removeData[8]{};
+                                uint8 removeData[4]{};
                                 ref<uint32>(removeData, 0) = PChar->PParty->GetPartyID();
-                                ref<uint32>(removeData, 4) = id;
                                 message::send(MSG_PT_RELOAD, removeData, sizeof removeData, nullptr);
                             }
                         }
@@ -4738,8 +4736,10 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 ShowDebug("(Alliance)Changing leader to %s", data[0x04]);
                 PChar->PParty->m_PAlliance->assignAllianceLeader((const char*)data[0x04]);
+
+                // MSG_PT_RELOAD also reloads all the alliances parties if available
                 uint8 leaderData[4]{};
-                ref<uint32>(leaderData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
+                ref<uint32>(leaderData, 0) = PChar->PParty->GetPartyID();
                 message::send(MSG_PT_RELOAD, leaderData, sizeof leaderData, nullptr);
             }
         }

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -150,9 +150,8 @@ void CParty::DisbandParty(bool playerInitiated)
         // make sure chat server isn't notified of a disband if this came from the chat server already
         if (playerInitiated)
         {
-            uint8 data[8]{};
+            uint8 data[4]{};
             ref<uint32>(data, 0) = m_PartyID;
-            ref<uint32>(data, 4) = m_PartyID;
             message::send(MSG_PT_DISBAND, data, sizeof data, nullptr);
         }
     }
@@ -603,9 +602,8 @@ void CParty::AddMember(uint32 id)
         }
         sql->Query("INSERT INTO accounts_parties (charid, partyid, allianceid, partyflag) VALUES (%u, %u, %u, %u);", id, m_PartyID, allianceid,
                    Flags);
-        uint8 data[8]{};
+        uint8 data[4]{};
         ref<uint32>(data, 0) = m_PartyID;
-        ref<uint32>(data, 4) = id;
         message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
 
         /*if (PChar->nameflags.flags & FLAG_INVITE)

--- a/src/world/message_server.cpp
+++ b/src/world/message_server.cpp
@@ -111,6 +111,16 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
             ret                 = zmqSql->Query(query, partyid, partyid);
             break;
         }
+        case MSG_ALLIANCE_DISSOLVE:
+        {
+            const char* query = "SELECT server_addr, server_port, MIN(charid) FROM accounts_sessions JOIN accounts_parties USING (charid) "
+                                "WHERE allianceid = %d "
+                                "GROUP BY server_addr, server_port;";
+
+            uint32 allianceid = ref<uint32>((uint8*)extra->data(), 0);
+            ret               = sql->Query(query, allianceid);
+            break;
+        }
         case MSG_CHAT_LINKSHELL:
         {
             const char* query = "SELECT server_addr, server_port FROM accounts_sessions "


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Backend fixes to party updating and alliance updating (Wintersolstice)

## What does this pull request do? (Please be technical)

This should fix up little issues with invalid messages being sent that would never parse, such as your party/alliance never updating until you zone

## Steps to test these changes
Add party members to party, have them zone and see them zone out instead of stay in the same zone visually despite actually not being in the same zone. Same for alliance members.

Kick party/alliance members and have it work properly on the client.
Kick parties from the alliance and have it work properly on the client.
/acmd breakup and have it work properly on the client.

## Special Deployment Considerations

N/A
