### PR TITLE
Adjusts AI target pointer for mob spellcasting; add nullptr checks for targets

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -467,9 +467,9 @@ bool CMobController::TryCastSpell()
 {
     TracyZoneScoped;
 
-    if (PMob->GetBattleTarget() != nullptr)
+    if (PTarget != nullptr)
     {
-        if (PMob->GetBattleTarget()->StatusEffectContainer->HasStatusEffect(EFFECT_ALL_MISS) && PMob->GetBattleTarget()->StatusEffectContainer->GetStatusEffect(EFFECT_ALL_MISS)->GetPower() == 2) // Handles Super Jump
+        if (PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_ALL_MISS) && PTarget->StatusEffectContainer->GetStatusEffect(EFFECT_ALL_MISS)->GetPower() == 2) // Handles Super Jump
         {
             return false;
         }
@@ -481,13 +481,13 @@ bool CMobController::TryCastSpell()
     }
 
     // Having a distance check here (before the check in magic_state) prevents the mob from standing still during chainspell
-    if (distance(PMob->loc.p, PMob->GetBattleTarget()->loc.p) > 28.5f)
+    if (PTarget != nullptr && distance(PMob->loc.p, PTarget->loc.p) > 28.5f)
     {
         return false;
     }
 
     // Control for worms to only cast when target is out of melee range
-    if (PMob->m_roamFlags & ROAMFLAG_WORM && distance(PMob->loc.p, PMob->GetBattleTarget()->loc.p) <= 3)
+    if (PTarget != nullptr && PMob->m_roamFlags & ROAMFLAG_WORM && distance(PMob->loc.p, PTarget->loc.p) <= 3)
     {
         return false;
     }


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes random crashing when mobs try to cast a spell without a proper target

## What does this pull request do? (Please be technical)

- Switches the target selector in CMobController::TryCastSpell() to use the AI's `PTarget` instead of the mob's current m_battleTarget.
- Add nullptr checks to PTarget

## Steps to test these changes

Fight mobs that change targets and cast spells on things other than the current battle target.  The common crash was on Old Professor Mariselle in Sacrarium, when he would "disengage" after teleporting (thus not having a m_battleTarget) but still try to cast spells.

## Special Deployment Considerations

Additional nullptr checks are being added via LSB and will be pulled downstream when ready.  These checks hit ASB-level changes only.
