### PR TITLE
[core] null raw pointers to special members in party on flag reload

### DIFF
--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -1264,6 +1264,11 @@ bool CParty::HasTrusts()
 
 void CParty::RefreshFlags(std::vector<partyInfo_t>& info)
 {
+    // Clear pointers in case they no longer exist on this instance
+    m_PLeader        = nullptr;
+    m_PQuarterMaster = nullptr;
+    m_PSyncTarget    = nullptr;
+
     for (auto&& memberinfo : info)
     {
         if (memberinfo.partyid == m_PartyID)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Attempt to fix crashes with bugged leaderless parties (Wintersolstice)

## What does this pull request do? (Please be technical)

Nulls raw pointers to special members on flag reload in case they are no longer in the zone

## Steps to test these changes

Set level sync, set QM, change leaders, see no change compared to previous behaviors.

## Special Deployment Considerations

N/A