### PR TITLE
Prevent mobs which are not technically alive or spawned from linking

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -212,7 +212,7 @@ void CMobController::TryLink()
                     continue;
                 }
 
-                if (PPartyMember->PAI->IsRoaming() && PPartyMember->CanLink(&PMob->loc.p, PMob->getMobMod(MOBMOD_SUPERLINK)))
+                if (PPartyMember->isAlive() && PPartyMember->PAI->IsRoaming() && PPartyMember->CanLink(&PMob->loc.p, PMob->getMobMod(MOBMOD_SUPERLINK)))
                 {
                     PPartyMember->PEnmityContainer->AddBaseEnmity(PTarget);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

No player facing announcement required I dont think

## What does this pull request do? (Please be technical)
Some BCNMs and Event fights have mobs which are inserted into the events but they are not spawned until required.
Some BCNMs like UnivitedGuests and Vzhal ENM have mobs which may never be spawned.
These unspawned mobs are still given superlink mods and made available to "link" with the mobs that are spawned.
Some more digging can be done to perhaps dynamically add the required mobs - but for now I've placed a check in `TryLink` before `PEnmityContainer->AddBaseEnmity` which will ensure mobs that dont exists, wont link with those that do.

## Steps to test these changes

Using two chracters spam enter and exit of bcnms, running in to aggro mobs and alternating run away with !zone to bcnm entrance.  Doing so I had a consistent 30-40% rate of getting the bcnm to lock prematurely eventually.

After deep diving and determining this cut off - for UG testing specifically I went 0/30.

## Special Deployment Considerations

none
