### PR TITLE
Fix mob job ability action type conditional typo

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -718,7 +718,7 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
     }
     // Non-damaging mob abilities to use proper humanoid animation IDs
     else if (PSkill->getID() == 1428 || PSkill->getID() == 1429 || (PSkill->getID() >= 1433 && PSkill->getID() <= 1436) || PSkill->getID() == 1438 ||
-             (PSkill->getID() >= 1992 && PSkill->getID() >= 1997))
+             (PSkill->getID() >= 1992 && PSkill->getID() <= 1997))
     {
         action.actiontype = ACTION_JOBABILITY_FINISH;
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Corrected a condition that caused all mob skills over 1997 to be sent with an actiontype of ACTION_JOBABILITY_FINISH. This would cause a client crash.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

There was a typo in the conditional that handled mob Puppet maneuver job abilities. It effectively included all mob skills with IDs greater than 1992, when the conditional should have been an inclusive between 1992 and 1997.

Closes #3425

## Steps to test these changes

!gotoid 17170493
engaged
!tp 3000

wait for mob to use a skill. client shouldn't crash

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
