### PR TITLE
[sql] Fixes removing mounts flags & zone-wide loot

### DIFF
--- a/modules/era/sql/era_zone_settings.sql
+++ b/modules/era/sql/era_zone_settings.sql
@@ -25,19 +25,11 @@ UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `z
 UPDATE `zone_settings` SET `updatedmesh` = 1, `forcecarefulpathing` = 1 WHERE `zoneid` = 128;
 
 -- Remove mount flag from zones that cannot have Chocobos prior to mounts being added
-UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 5;   -- Uleguerand Range
-UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 7;   -- Attohwa Chasm
-UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 24;  -- Lufaise Meadows
-UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 25;  -- Misareaux Coast
-UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 111; -- Beaucedine Glacier
-UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 112; -- Xarcabard
-UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 113; -- Cape Teriggan
-UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 122; -- Ro'Maeve
-UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 126; -- Qufim Island
-UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 127; -- Behemoth's Dominion
-UPDATE `zone_settings` SET `misc` = 2200 WHERE `zoneid` = 128; -- Valley of Sorrows
+-- This will subtract the bitwise 4 from the misc column only if the bitwise exists
+UPDATE `zone_settings` SET `misc` = `misc` & ~4 WHERE `zoneid` IN (5, 7, 24, 25, 111, 112, 113, 122, 126, 127, 128) AND (`misc` & 4) <> 0;
 
--- Add fellows in proper areas if not already there
-UPDATE zone_settings SET misc = misc + 2 WHERE misc & ~2 and zoneid IN (2, 4, 5, 7, 11, 12, 24, 25, 51, 52, 68, 79, 81, 82, 83, 84, 88, 89, 90, 91, 95, 96, 97, 98, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 141, 142, 143, 145, 147, 149, 151, 153, 157, 158, 159, 160, 161, 162, 164, 166, 167, 171, 172, 173, 174, 175, 176, 184, 190, 191, 192, 193, 194, 195, 196, 197, 198, 200, 204, 205, 208, 212, 213);
+-- Dynamis Zones
+UPDATE `zone_settings` SET `misc` = `misc` | 256 WHERE `name` LIKE "Dynamis%" AND `name` NOT LIKE "Dynamis_%_[D]" AND ((`misc` & 256) = 0); -- Adds zonewide loot pool if it does not have it
+UPDATE `zone_settings` SET `misc` = `misc` & ~8 WHERE (name = "Dynamis-San_dOria" OR name = "Dynamis-Windurst" OR name = "Dynamis-Bastok" OR name = "Dynamis-Jeuno" OR name = "Dynamis-Tavnazia") AND (`misc` & 8) = 8;
 
 UNLOCK TABLES;

--- a/modules/era/sql_dynamis/era_dyna_sql.sql
+++ b/modules/era/sql_dynamis/era_dyna_sql.sql
@@ -2527,7 +2527,5 @@ REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `
 -- --------------------------------------------------------------------
 --                     Zone Misc Modifications                      --
 -- --------------------------------------------------------------------
-UPDATE zone_settings SET misc = 408 WHERE name LIKE "Dynamis%" AND name NOT LIKE "Dyanamis_%_[D]";
-UPDATE zone_settings SET misc = misc & ~8 WHERE name = "Dynamis-San_dOria" OR name = "Dynamis-Windurst" OR name = "Dynamis-Bastok" OR name = "Dynamis-Jeuno" OR name = "Dynamis-Tavnazia";
-
+-- THESE HAVE BEEN MOVED TO era/sql/zone_settings.sql
 UNLOCK TABLES;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Nothing to say 
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
- Corrects the zone settings for removing chocobo from several zones
- Removes fellows addition from module as it was applied upstream
- Corrects dynamis zone miscs and moves to era/sql/era_zone_settings.sql
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
- Kill mobs in dynamis with two different characters and see zone-wide loot still works

- Check that you cannot use a chocobo in the following zones:
Uleguerand Range
Attohwa Chasm
Lufaise Meadows
Misareaux Coast
Beaucedine Glacier
Xarcabard
Cape Teriggan
Ro'Maeve
Qufim Island
Behemoth's Dominion
Valley of Sorrows

From a dev perspective you can run these and see the dyna zones that have mazurka and all global zones.
SELECT * FROM zone_settings WHERE misc & 0x0008 = 0x0008 and `name` LIKE "Dynamis%"; -- Mazurka
SELECT * FROM zone_settings WHERE misc & 0x0100 = 0x0100 and `name` LIKE "Dynamis%"; -- Global Zone pools
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
nothing here
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
