### PR TITLE
Haste Belt now grants enchantment haste

### DIFF
--- a/scripts/globals/items/haste_belt.lua
+++ b/scripts/globals/items/haste_belt.lua
@@ -3,12 +3,12 @@
 -- Item: Haste Belt
 -- Item Effect: 10% haste
 -----------------------------------
+
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local effect = target:getStatusEffect(xi.effect.HASTE)
-    if effect ~= nil and effect:getItemSourceID() == xi.items.HASTE_BELT then
-        target:delStatusEffect(xi.effect.HASTE)
+    if target:getStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HASTE_BELT) ~= nil then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.items.HASTE_BELT)
     end
 
     return 0
@@ -16,12 +16,16 @@ end
 
 itemObject.onItemUse = function(target)
     if target:hasEquipped(xi.items.HASTE_BELT) then
-        if not target:hasStatusEffect(xi.effect.HASTE) then
-            target:addStatusEffect(xi.effect.HASTE, 1000, 0, 180, 0, 0, 0, xi.items.HASTE_BELT)
-        else
-            target:messageBasic(xi.msg.basic.NO_EFFECT)
-        end
+        target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 180, 0, 0, 0, xi.items.HASTE_BELT)
     end
+end
+
+itemObject.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.HASTE_MAGIC, 1000)
+end
+
+itemObject.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.HASTE_MAGIC, 1000)
 end
 
 return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Haste Belt now gives enchantment haste instead spell haste. This effect will stack with the spell haste. Effect is removed when belt is unequipped.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Changes effect on Haste Belt from spell to enchantment.
Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1705

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
1. Cast haste on character
2. Use Haste Belt
3. Remove Haste Belt

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
