### PR TITLE
Fix Barrage accidentally generating an extra hit of damage

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1846,6 +1846,7 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
         }
         else // miss
         {
+            damage                  = 0;
             actionTarget.reaction   = REACTION::EVADE;
             actionTarget.speceffect = SPECEFFECT::NONE;
             actionTarget.messageID  = 354;

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -350,6 +350,7 @@ void CTrustEntity::OnRangedAttack(CRangeState& state, action_t& action)
         }
         else // miss
         {
+            damage                  = 0;
             actionTarget.reaction   = REACTION::EVADE;
             actionTarget.speceffect = SPECEFFECT::NONE;
             actionTarget.messageID  = 354;


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Barrage will no longer apply a replicated hit of damage when one of the barrage shot misses. (Tiberon)

## What does this pull request do? (Please be technical)

Clears the damage variable on a miss - preventing it from being added back into total damage on a miss.

## Steps to test these changes

Find a mob with a lower than 95% hit rate.
I used Molech  ID 16797878.
Taru 75 RNG/WAR - nekkid with Valis Bow and Bone Arrows
Target the tauri
!setmobmod no_move 1
!immortal

Range 12 - with sharpshot - acc rate of about 80%
Take some shots for baseline damage.  I was seeing 74.
Macro:
!tp 0 <playername>
/wait 1
/ja barrage <me> <wait 1>
/ra <t>
/wait 1
!reset

For each barrage - track ammo count, TP return and damage.  Damage should be reasonably within the range of base * numHits - with some leinency for crits.

## Special Deployment Considerations

None
