### PR TITLE
Apply Magic Null to Magical mob skills

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -661,6 +661,13 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
     end
 
     if attackType == xi.attackType.MAGICAL then
+        if
+            target:getMod(xi.mod.MAGIC_NULL) > 0 and
+            math.random(1, 100) <= target:getMod(xi.mod.MAGIC_NULL)
+        then
+            return 0
+        end
+
         dmg = utils.oneforall(target, dmg)
         dmg = utils.rampart(target, dmg)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Items which offer magic nullification (e.g. Shadow Ring) will now apply to magical mob skills. (Tiberon)

## What does this pull request do? (Please be technical)

Adds a check in `mobFinalAdjustments` for the magic_null mod.
The mob skill damage chain misses other applications of this mod due to the usage of takeDamage.
This will apply to 301 mobskills in the game which call mobFinalAdjustments as magical.

## Steps to test these changes

find a mob with a magical tp moves (a skeleman is a good target, 2/4 magical moves)
aggro the mob
!setmod regain 3000
sit back and watch the tp moves
With a shadow ring on, pray to RNGesus and see around a 13% nullification rate.

## Special Deployment Considerations

none
