### PR TITLE
Fix (reduce) delay for mobs under hundred fists

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -310,6 +310,12 @@ int16 CBattleEntity::GetWeaponDelay(bool tp)
     TracyZoneScoped;
     if (StatusEffectContainer->HasStatusEffect(EFFECT_HUNDRED_FISTS) && !tp)
     {
+        if (this->objtype == ENTITYTYPE::TYPE_MOB)
+        {
+            // Captures show mobs swing around 700 delay under hundered fists
+            return 700;
+        }
+
         return 1700;
     }
     uint16 WeaponDelay = 9999;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Based on capture data - mob hundred fists delay has been lowered. (Tiberon)

## What does this pull request do? (Please be technical)

When checking delay for hundred fists - if its a mob, return 700, not 1700.
This can be seen clearly in seiryu captures and frenzy pollen captures.

## Steps to test these changes

!spawnmob 17309981
!gotoid 17309981
engage sieryu
!hp 10000 seiryu
This will push seiryu to 2 hour threshold.
Once the first swing happens - watch the fun.
Being a pld with a shield and setting def (!setmod def 600) is helpful if you do not have armor to guage the impact this will have

## Special Deployment Considerations
None