### PR TITLE
Breaks up GM command !getstats

### DIFF
--- a/scripts/commands/getdefensive.lua
+++ b/scripts/commands/getdefensive.lua
@@ -1,0 +1,42 @@
+---------------------------------------------------------------------------------------------------
+-- func: getaccuracy
+-- desc: prints defensive stats of cursor target into chatlog, for debugging.
+---------------------------------------------------------------------------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+-- function onTrigger(player, extendedMode)
+function onTrigger(player)
+    local target = player:getCursorTarget()
+    if target == nil then
+        player:PrintToPlayer("Target something first.")
+        return
+    end
+
+    local targetType = target:getObjType()
+
+    if targetType == xi.objType.NPC then
+        player:PrintToPlayer("Target something other than an NPC..They don't have stats!")
+        return
+    end
+
+    player:PrintToPlayer(string.format("EVA Base: %i ", target:getMod(xi.mod.EVA)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("EVA Total: %i ", target:getStat(xi.mod.EVA)), xi.msg.channel.SYSTEM_3)
+
+    player:PrintToPlayer(string.format("Magic EVA Base: %i ", target:getMod(xi.mod.MEVA)), xi.msg.channel.SYSTEM_3)
+    -- player:PrintToPlayer(string.format("Total Magic EVA: %i ", target:getStat(xi.mod.MEVA)), xi.msg.channel.SYSTEM_3)
+    -- player:PrintToPlayer("Cannot easily and accurately get Magic Evasion with current methods.")
+
+    player:PrintToPlayer(string.format("Food Defense%% bonus: %i ", target:getMod(xi.mod.FOOD_DEFP)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Defense Base: %i ", target:getMod(xi.mod.DEF)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Total Defense: %i ", target:getStat(xi.mod.DEF)), xi.msg.channel.SYSTEM_3)
+
+    player:PrintToPlayer(string.format("Magic Defense bonus: %i ", target:getMod(xi.mod.MDEF)), xi.msg.channel.SYSTEM_3)
+    -- player:PrintToPlayer(string.format("Total Magic Defense: %i ", target:getStat(xi.mod.MDEF)), xi.msg.channel.SYSTEM_3)
+
+    -- player:PrintToPlayer(string.format("Total Subtle Blow: %i ", target:getMod(xi.mod.SUBTLE_BLOW)), xi.msg.channel.SYSTEM_3)
+end

--- a/scripts/commands/gethaste.lua
+++ b/scripts/commands/gethaste.lua
@@ -1,0 +1,30 @@
+---------------------------------------------------------------------------------------------------
+-- func: gethaste
+-- desc: prints haste of cursor target into chatlog, for debugging.
+---------------------------------------------------------------------------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+-- function onTrigger(player, extendedMode)
+function onTrigger(player)
+    local target = player:getCursorTarget()
+    if target == nil then
+        player:PrintToPlayer("Target something first.")
+        return
+    end
+
+    local targetType = target:getObjType()
+
+    if targetType == xi.objType.NPC then
+        player:PrintToPlayer("Target something other than an NPC..They don't have stats!")
+        return
+    end
+
+    player:PrintToPlayer(string.format("Haste Magic: %i ", target:getMod(xi.mod.HASTE_MAGIC)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Hate Ability: %i ", target:getMod(xi.mod.HASTE_ABILITY)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Haste Gear: %i ", target:getMod(xi.mod.HASTE_GEAR)), xi.msg.channel.SYSTEM_3)
+end

--- a/scripts/commands/getoffensive.lua
+++ b/scripts/commands/getoffensive.lua
@@ -1,0 +1,48 @@
+---------------------------------------------------------------------------------------------------
+-- func: getoffensive
+-- desc: prints offensive stats of cursor target into chatlog, for debugging.
+---------------------------------------------------------------------------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+-- function onTrigger(player, extendedMode)
+function onTrigger(player)
+    local target = player:getCursorTarget()
+    if target == nil then
+        player:PrintToPlayer("Target something first.")
+        return
+    end
+
+    local targetType = target:getObjType()
+
+    if targetType == xi.objType.NPC then
+        player:PrintToPlayer("Target something other than an NPC..They don't have stats!")
+        return
+    end
+
+    player:PrintToPlayer(string.format("Food Attack%% bonus: %i ", target:getMod(xi.mod.FOOD_ATTP)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Food Ranged Attack%% bonus: %i ", target:getMod(xi.mod.FOOD_RATTP)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Attack Base: %i ", target:getMod(xi.mod.ATT)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Total Attack: %i ", target:getStat(xi.mod.ATT)), xi.msg.channel.SYSTEM_3)
+
+    player:PrintToPlayer(string.format("Magic Attack bonus: %i ", target:getMod(xi.mod.MATT)), xi.msg.channel.SYSTEM_3)
+    -- player:PrintToPlayer(string.format("Total Magic Attack: %i ", target:getStat(xi.mod.MATT)), xi.msg.channel.SYSTEM_3)
+
+    player:PrintToPlayer(string.format("Food Accuracy%% bonus: %i ", target:getMod(xi.mod.FOOD_ACCP)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Accuracy Base: %i ", target:getMod(xi.mod.ACC)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Total Accuracy: %i ", target:getStat(xi.mod.ACC)), xi.msg.channel.SYSTEM_3)
+
+    player:PrintToPlayer(string.format("Food Ranged Accuracy%% bonus: %i ", target:getMod(xi.mod.FOOD_RACCP)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("RAccuracy Base: %i ", target:getMod(xi.mod.RACC)), xi.msg.channel.SYSTEM_3)
+    -- player:PrintToPlayer(string.format("Total RAccuracy: %i ", target:getStat(xi.mod.RACC)), xi.msg.channel.SYSTEM_3)
+
+    player:PrintToPlayer(string.format("Food Magic Accuracy%% bonus: %i ", target:getMod(xi.mod.FOOD_MACCP)), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Magic Accuracy bonus: %i ", target:getMod(xi.mod.MACC)), xi.msg.channel.SYSTEM_3)
+    -- player:PrintToPlayer(string.format("Total Magic Accuracy: %i ", target:getStat(xi.mod.MACC)), xi.msg.channel.SYSTEM_3)
+
+    -- player:PrintToPlayer(string.format("Total Store TP: %i ", target:getMod(xi.mod.STORETP)), xi.msg.channel.SYSTEM_3)
+end

--- a/scripts/commands/getresist.lua
+++ b/scripts/commands/getresist.lua
@@ -1,0 +1,32 @@
+---------------------------------------------------------------------------------------------------
+-- func: getresist
+-- desc: prints resistances of cursor target into chatlog, for debugging.
+---------------------------------------------------------------------------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+-- function onTrigger(player, extendedMode)
+function onTrigger(player)
+    local target = player:getCursorTarget()
+    if target == nil then
+        player:PrintToPlayer("Target something first.")
+        return
+    end
+
+    local targetType = target:getObjType()
+
+    if targetType == xi.objType.NPC then
+        player:PrintToPlayer("Target something other than an NPC..They don't have stats!")
+        return
+    end
+
+    --[[ future use: print resistances etc..
+    if extendedMode then
+        -- That'll be pretty spammy.. Maybe NOT print everything and make it a choice which "page" of stats to print.
+    end
+    ]]
+end

--- a/scripts/commands/getstats.lua
+++ b/scripts/commands/getstats.lua
@@ -37,43 +37,4 @@ function onTrigger(player)
     player:PrintToPlayer(string.format("Total MND: %i ", target:getStat(xi.mod.MND)), xi.msg.channel.SYSTEM_3)
     player:PrintToPlayer(string.format("Total INT: %i ", target:getStat(xi.mod.INT)), xi.msg.channel.SYSTEM_3)
     player:PrintToPlayer(string.format("Total CHR: %i ", target:getStat(xi.mod.CHR)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Food Accuracy%% bonus: %i ", target:getMod(xi.mod.FOOD_ACCP)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Accuracy Base: %i ", target:getMod(xi.mod.ACC)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Total Accuracy: %i ", target:getStat(xi.mod.ACC)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("RAccuracy Base: %i ", target:getMod(xi.mod.RACC)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Total RAccuracy: %i ", target:getStat(xi.mod.RACC)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("EVA Base: %i ", target:getMod(xi.mod.EVA)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("EVA Total: %i ", target:getStat(xi.mod.EVA)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Magic EVA Base: %i ", target:getMod(xi.mod.MEVA)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Attack Base: %i ", target:getMod(xi.mod.ATT)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Total Attack: %i ", target:getStat(xi.mod.ATT)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Defense Base: %i ", target:getMod(xi.mod.DEF)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Total Defense: %i ", target:getStat(xi.mod.DEF)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Magic Attack bonus: %i ", target:getMod(xi.mod.MATT)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Magic Defense bonus: %i ", target:getMod(xi.mod.MDEF)), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Magic Accuracy bonus: %i ", target:getMod(xi.mod.MACC)), xi.msg.channel.SYSTEM_3)
-    -- player:PrintToPlayer(string.format("Total Subtle Blow: %i ", target:getMod(xi.mod.SUBTLE_BLOW)), xi.msg.channel.SYSTEM_3)
-    -- player:PrintToPlayer(string.format("Total Store TP: %i ", target:getMod(xi.mod.STORETP)), xi.msg.channel.SYSTEM_3)
-    -- player:PrintToPlayer("Cannot easily and accurately get Magic Evasion with current methods.")
-
-    if targetType == xi.objType.PC then
-        player:PrintToPlayer(string.format("%s's base Treasure Hunter w/current equipment: %i",
-        target:getName(), target:getMod(xi.mod.TREASURE_HUNTER)), xi.msg.channel.SYSTEM_3)
-    elseif targetType == xi.objType.PET then
-        -- not needed yet, but we don't want to run MOB so just die in empty conditionals
-    elseif targetType == xi.objType.TRUST then
-        -- see above
-    elseif targetType == xi.objType.FELLOW then
-        -- see above
-    elseif targetType == xi.objType.MOB then
-        player:PrintToPlayer(string.format("Mob's current Treasure Hunter Tier: %i", target:getTHlevel()), xi.msg.channel.SYSTEM_3)
-        player:PrintToPlayer(string.format("Battletime: %i ", target:getBattleTime()), xi.msg.channel.SYSTEM_3)
-        -- Todo: check if raged and/or how long mobs ragetimer is.
-    end
-
-    --[[ future use: print resistances etc..
-    if extendedMode then
-        -- That'll be pretty spammy.. Maybe NOT print everything and make it a choice which "page" of stats to print.
-    end
-    ]]
 end

--- a/scripts/commands/getth.lua
+++ b/scripts/commands/getth.lua
@@ -1,0 +1,41 @@
+---------------------------------------------------------------------------------------------------
+-- func: getaccuracy
+-- desc: prints treasure hunter level of cursor target into chatlog, for debugging.
+---------------------------------------------------------------------------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+-- function onTrigger(player, extendedMode)
+function onTrigger(player)
+    local target = player:getCursorTarget()
+    if target == nil then
+        player:PrintToPlayer("Target something first.")
+        return
+    end
+
+    local targetType = target:getObjType()
+
+    if targetType == xi.objType.NPC then
+        player:PrintToPlayer("Target something other than an NPC..They don't have stats!")
+        return
+    end
+
+    if targetType == xi.objType.PC then
+        player:PrintToPlayer(string.format("%s's base Treasure Hunter w/current equipment: %i",
+        target:getName(), target:getMod(xi.mod.TREASURE_HUNTER)), xi.msg.channel.SYSTEM_3)
+    elseif targetType == xi.objType.PET then
+        -- not needed yet, but we don't want to run MOB so just die in empty conditionals
+    elseif targetType == xi.objType.TRUST then
+        -- see above
+    elseif targetType == xi.objType.FELLOW then
+        -- see above
+    elseif targetType == xi.objType.MOB then
+        player:PrintToPlayer(string.format("Mob's current Treasure Hunter Tier: %i", target:getTHlevel()), xi.msg.channel.SYSTEM_3)
+        player:PrintToPlayer(string.format("Battletime: %i ", target:getBattleTime()), xi.msg.channel.SYSTEM_3)
+        -- Todo: check if raged and/or how long mobs ragetimer is.
+    end
+end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
NA

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Breaks up GM command !getstats into more specific commands. Some lines are commented out because they are not implemented in getStat() found in lua_baseentity.cpp

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
!getstats
!gethaste
!getoffensive
!getdefensive
!getth
!getresist (not implemented)

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
