### PR TITLE
Fixes Oscar Scarf

### DIFF
--- a/scripts/globals/items/oscar_scarf.lua
+++ b/scripts/globals/items/oscar_scarf.lua
@@ -1,0 +1,49 @@
+-----------------------------------------
+-- ID: 13182
+-- Item: Oscar Scarf
+-- Item Effect: Enchantment Slighly Bad Breath (inflicts Bind, Paralyze, and Silence on an enemy)
+-----------------------------------------
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, player)
+    local result = 0
+    if target:checkDistance(player) > 10 then
+        result = xi.msg.basic.TOO_FAR_AWAY
+    end
+
+    return result
+end
+
+itemObject.onItemUse = function(target, player)
+    local chance = 70
+    local effects =
+    {
+        {
+            immunity = xi.immunity.BIND,
+            effect = xi.effect.BIND
+        },
+        {
+            immunity = xi.immunity.PARALYZE,
+            effect = xi.effect.PARALYSIS
+        },
+        {
+            immunity = xi.immunity.SILENCE,
+            effect = xi.effect.SILENCE
+        }
+    }
+
+    for _, data in ipairs(effects) do
+        if target:hasImmunity(data.immunity) or math.random(0, 100) >= chance then
+            target:messageBasic(xi.msg.basic.NO_EFFECT)
+        else
+            target:delStatusEffect(data.effect)
+            if not target:hasStatusEffect(data.effect) then
+                target:addStatusEffect(data.effect, 10, 0, 30)
+            end
+        end
+    end
+
+    target:updateClaim(player)
+end
+
+return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Adds functionality to Oscar Scarf

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
There is not **specific** information on the 'Enchantment: Slightly Bad Breath'. This was based off the information found here https://ffxiclopedia.fandom.com/wiki/Oscar_Scarf and the Blind Ring implementation in ASB. I don't know if all three effects should be grouped into one roll with a chance of landing or always be applied if the target is not immune to any of the effects. As it is right now all three effects are rolled separately with a 70% chance and each is checked for immunity. Will require a capture to make retail accurate.
Closes: #3455

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
1. Equip Oscar Scarf
2. Use item on enemy

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA
