### PR TITLE
Fixes Spell Recast In-Era Cap

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -6905,7 +6905,7 @@ namespace battleutils
             recast = static_cast<int32>(recast * 1.5f);
         }
 
-        recast = std::max<int32>(recast, static_cast<int32>(base * 0.2f));
+        recast = std::max<int32>(recast, static_cast<int32>(base * 0.5f)); // Haste Cap in Era - Was changes to 80% (0.2f) in 2011
 
         // Light/Dark arts recast bonus/penalties applies after other bonuses
         if (PSpell->getSpellGroup() == SPELLGROUP_BLACK)
@@ -6931,13 +6931,13 @@ namespace battleutils
                 recast = static_cast<int32>(recast * ((100.0f + PEntity->getMod(Mod::BLACK_MAGIC_RECAST)) / 100.0f));
             }
 
-            recast = std::max<int32>(recast, static_cast<int32>(base * 0.2f)); // recap to 80%
+            recast = std::max<int32>(recast, static_cast<int32>(base * 0.5f)); // Haste Cap in Era - Was changes to 80% (0.2f) in 2011
 
             // https://www.bg-wiki.com/ffxi/Alacrity
             if (PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_ALACRITY))
             {
                 recast = static_cast<int32>(recast * 0.60);                        // 40% reduction from Alacrity alone
-                recast = std::max<int32>(recast, static_cast<int32>(base * 0.2f)); // recap to 80%
+                recast = std::max<int32>(recast, static_cast<int32>(base * 0.5f)); // Haste Cap in Era - Was changes to 80% (0.2f) in 2011
 
                 // Only apply bonus mod if the spell element matches the weather, this is allowed to go over the 80% cap to a 90% cap.
                 if (battleutils::WeatherMatchesElement(battleutils::GetWeather(PEntity, false), static_cast<uint8>(PSpell->getElement())))
@@ -6945,7 +6945,7 @@ namespace battleutils
                     uint16 bonus = PEntity->getMod(Mod::ALACRITY_CELERITY_EFFECT);
 
                     recast = static_cast<int32>(recast * ((100 - bonus) / 100.0f));
-                    recast = std::max<int32>(recast, static_cast<int32>(base * 0.1f)); // cap to 90% reduction
+                    recast = std::max<int32>(recast, static_cast<int32>(base * 0.4f)); // cap to 60% reduction - Haste Cap in Era - Was changes to 80% (0.2f) in 2011
                 }
             }
         }
@@ -6973,13 +6973,13 @@ namespace battleutils
                 recast = static_cast<int32>(recast * ((100.0f + PEntity->getMod(Mod::WHITE_MAGIC_RECAST)) / 100.0f));
             }
 
-            recast = std::max<int32>(recast, static_cast<int32>(base * 0.2f)); // recap to 80%
+            recast = std::max<int32>(recast, static_cast<int32>(base * 0.5f)); // Haste Cap in Era - Was changes to 80% (0.2f) in 2011
 
             // https://www.bg-wiki.com/ffxi/Celerity
             if (PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_CELERITY))
             {
                 recast = static_cast<int32>(recast * 0.60);                        // 40% reduction from Celerity alone
-                recast = std::max<int32>(recast, static_cast<int32>(base * 0.2f)); // recap to 80%
+                recast = std::max<int32>(recast, static_cast<int32>(base * 0.5f)); // Haste Cap in Era - Was changes to 80% (0.2f) in 2011
 
                 // Only apply bonus mod if the spell element matches the weather, this is allowed to go over the 80% cap to a 90% cap.
                 if (battleutils::WeatherMatchesElement(battleutils::GetWeather(PEntity, false), static_cast<uint8>(PSpell->getElement())))
@@ -6987,7 +6987,7 @@ namespace battleutils
                     uint16 bonus = PEntity->getMod(Mod::ALACRITY_CELERITY_EFFECT);
 
                     recast = static_cast<int32>(recast * ((100 - bonus) / 100.0f));
-                    recast = std::max<int32>(recast, static_cast<int32>(base * 0.1f)); // cap to 90% reduction
+                    recast = std::max<int32>(recast, static_cast<int32>(base * 0.4f)); // Haste Cap in Era - Was changes to 80% (0.2f) in 2011
                 }
             }
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes the recast cap from the OOE amount of 80% to the in-era amount of 50%

## What does this pull request do? (Please be technical)


Fixes the recast cap from the OOE amount of 80% to the in-era amount of 50%:
SE changes the amount of recast reduction a spell could have from 50%->80% in 2011 as seen in - 

https://forum.square-enix.com/ffxi/threads/18132?_gl=1*wuyjkb*_gcl_au*MTQxNjQxMzkwNC4xNjk0NDYxNzMx&_ga=2.257253899.1408447630.1694461734-351604236.1667331329

https://www.bg-wiki.com/ffxi/The_History_of_Final_Fantasy_XI/2011#RecastCapChange

## Steps to test these changes

Log on and cast spells with max haste - see the cool downs now reflect era values.

## Special Deployment Considerations
None
