### PR TITLE
Fix the Nightmare Worm to be targetable

### DIFF
--- a/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
@@ -52,7 +52,7 @@ end
 
 xi.dynamis.onMobEngagedNightmareWorm = function(mob, target)
     mob:setAnimationSub(0)
-    mob:setUntargetable(false)
+    mob:hideName(false)
     mob:setUntargetable(false)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [ ] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes an issue causing the nightmare worm in dyna tav to not be targetable.  (Tiberon)

## What does this pull request do? (Please be technical)

fixes a typo

## Steps to test these changes

Enter dyna tav
disable gm mode
walk around the second floor

## Special Deployment Considerations
none
