### PR TITLE
Removes KI Requirement to open Brass Door at top of Castle Oztroja

### DIFF
--- a/scripts/zones/Castle_Oztroja/npcs/_479.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_479.lua
@@ -15,7 +15,6 @@ entity.onTrade = function(player, npc, trade)
 
     if
         npcUtil.tradeHas(trade, 1142) and
-        player:hasKeyItem(xi.ki.BALGA_CHAMPION_CERTIFICATE) and
         zPos >= 80 and zPos < 86
     then
         npc:openDoor(2.5)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
- Players can now exit the Altar Room at the top of Castle Oztroja by trading a Judgement Key to the Brass Door.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
- It was not possible for players to leave the Altar Room that are not on the mission.
- Removed the Key Item requirement for the Brass Door at the top of Castle Oztroja to exit the Altar Room.
- The key item is not required to trigger the door.  The NPC Behind the door is used for the mission.  [Source: BG Wiki](https://www.bg-wiki.com/ffxi/Judgment_Key)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
- `!pos -99 -59 84 151`
- `!additem 1142`
- Trade the `Judgement Key` to the `Brass Door`
- Door should now open, regardless of mission status.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
