### PR TITLE
Fix several small issues

### DIFF
--- a/modules/era/sql/era_mob_droplist.sql
+++ b/modules/era/sql/era_mob_droplist.sql
@@ -16250,9 +16250,9 @@ INSERT INTO `mob_droplist` VALUES (2027,0,0,1000,637,@UNCOMMON); -- Vial Of Slim
 INSERT INTO `mob_droplist` VALUES (2027,0,0,1000,1032,@RARE);    -- Shakhrami Chest Key (Rare, 5%)
 
 -- ZoneID:  22 - Provoker
-INSERT INTO `mob_droplist` VALUES (2028,0,0,1000,1723,500);       -- White Memosphere (50.0%)
-INSERT INTO `mob_droplist` VALUES (2028,0,0,1000,1761,300);       -- Recollection Of Anxiety (30.0%)
-INSERT INTO `mob_droplist` VALUES (2028,0,0,1000,1723,250);       -- White Memosphere (25.0%)
+INSERT INTO `mob_droplist` VALUES (2028,0,0,1000,1761,@VCOMMON);  -- Recollection Of Anxiety (Very Common, 24%)
+INSERT INTO `mob_droplist` VALUES (2028,0,0,1000,1723,@ALWAYS);   -- White Memosphere (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (2028,0,0,1000,1723,@COMMON);   -- White Memosphere (Common, 15%)
 INSERT INTO `mob_droplist` VALUES (2028,0,0,1000,1723,@UNCOMMON); -- White Memosphere (Uncommon, 10%)
 
 -- ZoneID:  74 - Psycheflayer
@@ -27013,4 +27013,3 @@ UNLOCK TABLES;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
-

--- a/scripts/quests/windurst/Heaven_Cent.lua
+++ b/scripts/quests/windurst/Heaven_Cent.lua
@@ -226,19 +226,19 @@ quest.sections =
 
                 -- Correct coin (Flag correct coin)
                 [46] = function(player, csid, option, npc)
-                    if option == 2 and npcUtil.giveItem(player, xi.items.SHELLING_PIECE) then
+                    if option == 1 and npcUtil.giveItem(player, xi.items.SHELLING_PIECE) then
                         quest:setVar(player, 'Coin', 1)
                     end
                 end,
 
                 [48] = function(player, csid, option, npc)
-                    if option == 2 and npcUtil.giveItem(player, xi.items.SHELLING_PIECE) then
+                    if option == 1 and npcUtil.giveItem(player, xi.items.SHELLING_PIECE) then
                         quest:setVar(player, 'Coin', 1)
                     end
                 end,
 
                 [50] = function(player, csid, option, npc)
-                    if option == 2 and npcUtil.giveItem(player, xi.items.SHELLING_PIECE) then
+                    if option == 1 and npcUtil.giveItem(player, xi.items.SHELLING_PIECE) then
                         quest:setVar(player, 'Coin', 1)
                     end
                 end,

--- a/scripts/zones/Monarch_Linn/bcnms/uninvited_guests.lua
+++ b/scripts/zones/Monarch_Linn/bcnms/uninvited_guests.lua
@@ -14,6 +14,7 @@ end
 battlefieldObject.onBattlefieldEnter = function(player, battlefield)
     player:messageSpecial(ID.text.KI_TORN, xi.ki.MONARCH_LINN_PATROL_PERMIT)
     player:delKeyItem(xi.ki.MONARCH_LINN_PATROL_PERMIT)
+    player:setCharVar("UninvitedGuestsStatus", 3) -- assume failure until proven that player won
 end
 
 battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
@@ -22,12 +23,6 @@ battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
         player:startEvent(32002)
-    elseif
-        leavecode == xi.battlefield.leaveCode.EXIT or
-        leavecode == xi.battlefield.leaveCode.WARPDC
-    then
-        -- However the player got out of the BCNM - they didnt win
-        player:setCharVar("UninvitedGuestsStatus", 3) -- update to failure state
     end
 end
 
@@ -35,9 +30,6 @@ battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 then
         -- Victory
         player:setCharVar("UninvitedGuestsStatus", 2) -- update to victory state
-    elseif csid == 32002 then
-        -- Failure
-        player:setCharVar("UninvitedGuestsStatus", 3) -- update to failure state
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Players that fail the ENM Uninvited Guests should now always be able to repeat the ENM the next week. (Tracent)
- Players should now be able to acquire the correct coin in the quest Heaven Cent. (Tracent)
- The drop rates for the NM Provoker are now era accurate. (Tracent)

## What does this pull request do? (Please be technical)
Fix several small issues. The ENM fix now assumes that players will fail upon entry and only sets progress to win once player beats ENM, this prevents condition where player does the ENM fight but their progress is stuck on 1 because neither the win or loss logic triggers for certain reasons. The drop rates of Provoker were audited and now use the standard TH base levels meaning they are also now impacted by treasure hunter.

## Steps to test these changes
Heaven Cent
!addquest 2 49
!setquestvar PlayerName 2 49 Prog 1
!gotoid 17588753
Click on chest and do not take coin if incorrect message, once correct message then try to take the coin

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/882
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1695
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
