### PR TITLE
cherry-pick from LSB to deal with bugged player position

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -310,26 +310,26 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
         char session_key[20 * 2 + 1];
         bin2hex(session_key, (uint8*)PSession->blowfish.key, 20);
 
-        uint16 destination = MAX_ZONEID + 1; // Forces the function to fail closed
-
-        if (PChar != nullptr)
+        if (!PChar)
         {
-            destination = PChar->loc.destination; // Only sets destination if PChar isn't nullptr
-        }
-
-        if (destination >= MAX_ZONEID) // Fails to putting player back to it's previous zone
-        {
-            ShowWarning("packet_system::SmallPacket0x00A GetZone Bad Args for IncreaseZoneCounter, MITIGATING: Sending %s to loc.prevzone.", PChar->GetName());
-            destination = PChar->loc.prevzone;
-        }
-
-        auto zone = zoneutils::GetZone(destination);
-        if (zone == nullptr)
-        {
+            ShowWarning("packet_system::SmallPacket0x00A tried to zone a player that doesn't exist!");
             return;
         }
 
-        zone->IncreaseZoneCounter(PChar);
+        uint16 destination = PChar->loc.destination;
+
+        if (destination >= MAX_ZONEID)
+        {
+            // TODO: work out how to drop player in moghouse that exits them to the zone they were in before this happened, like we used to.
+            ShowWarning("packet_system::SmallPacket0x00A player tried to enter zone out of range: %d", destination);
+            ShowWarning("packet_system::SmallPacket0x00A dumping player `%s` to homepoint!", PChar->GetName());
+            charutils::HomePoint(PChar);
+        }
+
+        if (auto zone = zoneutils::GetZone(destination))
+        {
+            zone->IncreaseZoneCounter(PChar);
+        }
 
         PChar->m_ZonesList[PChar->getZone() >> 3] |= (1 << (PChar->getZone() % 8));
 
@@ -380,20 +380,15 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             PChar->m_charHistory.mhEntrances++;
             gardenutils::UpdateGardening(PChar, false);
-        }
-    }
 
-    // Only release client from "Downloading Data" if the packet sequence came in without a drop on 0x00D
-    // It is also possible that the client also never received our packets to release themselves from the loading screen.
-    // TODO: Need further research into the relationship between 0x00D and 0x00A, if any.
-    if (PChar->loc.zone != nullptr)
-    {
-        // Push Downloading Data before inventory count packets...
-        // This is how it happens on retail.
-        PChar->pushPacket(new CDownloadingDataPacket());
+            // Only release client from "Downloading Data" if the packet sequence came in without a drop on 0x00D
+            // It is also possible that the client also never received our packets to release themselves from the loading screen.
+            // TODO: Need further research into the relationship between 0x00D and 0x00A, if any.
 
-        if (PChar->m_moghouseID != 0)
-        {
+            // Push Downloading Data before inventory count packets...
+            // This is how it happens on retail.
+            PChar->pushPacket(new CDownloadingDataPacket());
+
             // Update any mannequins that might be placed on zonein
             // Build Mannequin model id list
             auto getModelIdFromStorageSlot = [](CCharEntity* PChar, uint8 slot) -> uint16


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Player is warped to homepoint instead of getting placed outside of map (Nixy, TeoTwawki)

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
cherry-pick https://github.com/LandSandBoat/server/pull/2150

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
I could use some help testing this. I cannot seem to trigger an invalid key message. Normal zoning still works.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA
