### PR TITLE
Fixes Dynamis having an extra 15 minutes

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis.lua
@@ -47,7 +47,6 @@ local dynamisMinLvl = 65
 local dynamisReservationCancel = 180
 local dynamisReentryDays = 3
 local dynamisReentryHours = 71
-local dynamisStagingTime = 15 -- Extra time added at registration of dynamis in minutes.
 
 local gmFlags =
 {
@@ -1141,7 +1140,7 @@ xi.dynamis.registerDynamis = function(player)
     -- luacheck: ignore 113
     local instanceID = RegisterDynamisInstance(zoneID, player:getID())
 
-    local expirationTime = os.time() + (60 * (60 + dynamisStagingTime)) -- Amount of time to extend timepoint by. 60 minutes by default for fresh zones.
+    local expirationTime = os.time() + 3600 -- Amount of time to extend timepoint by. 60 minutes by default for fresh zones.
 
     if zoneID == xi.zone.TAVNAZIAN_SAFEHOLD then
         expirationTime = os.time() + 60 * 15 -- Initial time for Dyna Tav should only be 15 minutes


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Removed the extra 15 minutes when entering Dynamis (Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Fixes Dynamis having an extra 15 minutes
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Enter dynamis see it has 60 minutes
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
