### PR TITLE
Adjust sell price of rune halberd to 12000 to match other rune weapons

### DIFF
--- a/sql/item_basic.sql
+++ b/sql/item_basic.sql
@@ -15383,7 +15383,7 @@ INSERT INTO `item_basic` VALUES (18080,0,'spark_fork','spark_fork',1,2084,8,0,75
 INSERT INTO `item_basic` VALUES (18081,0,'spark_fork_+1','spark_fork_+1',1,2080,8,0,9402);
 INSERT INTO `item_basic` VALUES (18082,0,'barchha','barchha',1,2084,8,0,6505);
 INSERT INTO `item_basic` VALUES (18083,0,'barchha_+1','barchha_+1',1,2080,8,0,8131);
-INSERT INTO `item_basic` VALUES (18084,0,'rune_halberd','rune_halberd',1,2052,8,0,1200);
+INSERT INTO `item_basic` VALUES (18084,0,'rune_halberd','rune_halberd',1,2052,8,0,12000);
 INSERT INTO `item_basic` VALUES (18085,0,'platoon_lance','platoon_lance',1,2052,8,0,1100);
 INSERT INTO `item_basic` VALUES (18086,0,'behourd_lance','behourd_lance',1,34820,8,0,2000);
 INSERT INTO `item_basic` VALUES (18087,0,'schwarz_lance','schwarz_lance',1,34820,8,0,5657);


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Adjusted the NPC sell price of Rune Halberd to the appropriate value (Haplo)

## What does this pull request do? (Please be technical)

Set NPC price of Rune Halberd to 12000 (standard for all rune weapons) instead of 1200 (likely either a typo or copy/pasted from rune arrow).

## Steps to test these changes

!giveitem <me> 18084
Sell to NPC

## Special Deployment Considerations
