### PR TITLE
Fixes The Antique Collector

### DIFF
--- a/scripts/quests/jeuno/The_Antique_Collector.lua
+++ b/scripts/quests/jeuno/The_Antique_Collector.lua
@@ -70,6 +70,10 @@ quest.sections =
                 [15] = function(player, csid, option, npc)
                     if quest:complete(player) then
                         player:confirmTrade()
+                        if not player:hasKeyItem(xi.ki.MAP_OF_DELKFUTTS_TOWER) then
+                            player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MAP_OF_DELKFUTTS_TOWER)
+                            player:addKeyItem(xi.ki.MAP_OF_DELKFUTTS_TOWER)
+                        end
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
The Antique Collector now gives key item Map of Delkfutt's Tower upon completion.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Add key item Map of Delkfutt's Tower to quest reward.
Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1709

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
1. !additem 16631
2. !pos -165 11 94 246
3. Speak to Imasuke
4. Trade Kaiser Sword
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA
