### PR TITLE
Fixes Automaton Assault race requirement

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -547,9 +547,21 @@ local function checkReqs(player, npc, bfid, registrant)
         return zones[player:getZoneID()].npc.ENTRANCE_OFFSET + offset
     end
 
+    local function getRace(entity)
+        local race = entity:getRace()
+        if race < 7 then
+            if race % 2 == 0 then
+                race = race - 1
+            end
+        end
+
+        return race
+    end
+
     local function getPartyRace()
+        local playerRace = getRace(player)
         for _, v in pairs(player:getParty()) do
-            if v:getRace() ~= player:getRace() then
+            if getRace(v) ~= playerRace then
                 return false
             end
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Different genders of the same race can now enter Automaton Assault.
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Fixes check for same race in the Shaft Entrance onTrigger() function.
Closes #3459 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. !addkeyitem 707
2. Interact with the Shaft Entrance with characters of the same race and different genders.

I have only tested with two Tarutaru characters. The logic was taken from the ArmoryCrate.lua file so it should work for other races, assuming that implementation is correct.

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA
