### PR TITLE
Sanction obtainable only after completion of "Immortal Sentries" mission

### DIFF
--- a/scripts/globals/besieged.lua
+++ b/scripts/globals/besieged.lua
@@ -164,7 +164,10 @@ end
 
 xi.besieged.onEventFinish = function(player, csid, option)
     local ID = zones[player:getZoneID()]
-    if option == 0 or option == 16 or option == 32 or option == 48 then
+    if
+        (option == 0 or option == 16 or option == 32 or option == 48) and
+        player:hasCompletedMission(xi.mission.log_id.TOAU, 1)
+    then
         -- Sanction
         if option ~= 0 then
             player:delCurrency("imperial_standing", 100)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Sanction obtainable from imperial gate guards only after completion of "Immortal Sentries" mission.

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds condition to xi.besieged.onEventFinish that checks for mission completion.
Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1720
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
Talk to an imperial gate guard.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA
