### PR TITLE
Saga of the Skyserpent add one game day wait

### DIFF
--- a/scripts/quests/ahtUrhgan/Saga_of_the_Skyserpent.lua
+++ b/scripts/quests/ahtUrhgan/Saga_of_the_Skyserpent.lua
@@ -44,7 +44,7 @@ quest.sections =
 
     {
         check = function(player, status, vars)
-            return status == QUEST_ACCEPTED and vars.Prog == 0
+            return status == QUEST_ACCEPTED
         end,
 
         [xi.zone.AL_ZAHBI] =
@@ -96,9 +96,7 @@ quest.sections =
             onZoneIn =
             {
                 function(player, prevZone)
-                    if quest:getVar(player, 'Prog') == 1 then
-                        return 12
-                    end
+                    return 12
                 end
             },
 
@@ -110,7 +108,7 @@ quest.sections =
 
                 [13] = function(player, csid, option, npc)
                     quest:setVar(player, 'Prog', 2)
-                    quest:setVar(player, 'Stage', VanadielUniqueDay())
+                    quest:setVar(player, 'Timer', VanadielUniqueDay() + 1)
                     player:delKeyItem(xi.keyItem.LILAC_RIBBON)
                     player:setPos(80, -6, -123, 65, xi.zone.AHT_URHGAN_WHITEGATE)
                 end,
@@ -127,19 +125,19 @@ quest.sections =
         {
             ['Biyaada'] = quest:event(279),
         },
+    },
+
+    {
+        check = function(player, status, vars)
+            return
+                status == QUEST_ACCEPTED and
+                vars.Prog == 2 and
+                vars.Timer <= VanadielUniqueDay()
+        end,
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =
         {
             ['Fari-Wari'] = quest:progressEvent(825, { text_table = 0 }),
-            {
-                onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Stage') < VanadielUniqueDay() then
-                        return quest:progressEvent(825, { text_table = 0 })
-                    else
-                        return quest:event(833)
-                    end
-                end,
-            },
 
             onEventFinish =
             {

--- a/scripts/zones/Aht_Urhgan_Whitegate/DefaultActions.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/DefaultActions.lua
@@ -4,6 +4,7 @@ return {
     ['Balakaf']            = { event = 515 },
     ['Cacaroon']           = { event = 248 },
     ['Hadahda']            = { event = 518 },
+    ['Fari-Wari']          = { event = 833 },
     ['Imperial_Whitegate'] = { messageSpecial = ID.text.GATE_IS_FIRMLY_CLOSED },
     ['Lathuya']            = { event = 770 },
     ['Mathlouq']           = { event = 543 },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Players will have to wait one game before speaking to Fari-Wari a third time to complete the quest.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
The dialog from Fari-Wari is set to quest:event(833) after speaking to him a second time if player did not wait one game day. The quest completes after waiting until the next game day before talking to him.

Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1722
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
1. !pos 80 -6 -137 50
2. speak to Fari-Wari
3. !pos -11 8 -185 62
4. click the ???
5. !pos 80 -6 -137 50
6. speak to Fari-Wari
7. !time < ? >
8. !goto < me >
9. speak to Fari-Wari

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
use addon enternity