### PR TITLE
Increase Om'Phuabo phuabo organ drop rate

### DIFF
--- a/modules/era/sql/era_mob_droplist.sql
+++ b/modules/era/sql/era_mob_droplist.sql
@@ -14974,8 +14974,8 @@ INSERT INTO `mob_droplist` VALUES (1854,0,0,1000,1783,@RARE);     -- Sample Of L
 INSERT INTO `mob_droplist` VALUES (1854,4,0,1000,1783,0);         -- Sample Of Luminian Tissue (Despoil)
 
 -- ZoneID:  33 - Omphuabo
-INSERT INTO `mob_droplist` VALUES (1855,0,0,1000,1784,@UNCOMMON); -- Phuabo Organ (Uncommon, 10%)
-INSERT INTO `mob_droplist` VALUES (1855,0,0,1000,1784,@UNCOMMON); -- Phuabo Organ (Uncommon, 10%)
+INSERT INTO `mob_droplist` VALUES (1855,0,0,1000,1784,@COMMON); -- Phuabo Organ (Common, 15%)
+INSERT INTO `mob_droplist` VALUES (1855,0,0,1000,1784,@COMMON); -- Phuabo Organ (Common, 15%)
 INSERT INTO `mob_droplist` VALUES (1855,0,0,1000,1783,@RARE);     -- Sample Of Luminian Tissue (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (1855,0,0,1000,1852,@RARE);     -- High-Quality Phuabo Organ (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (1855,4,0,1000,1783,0);         -- Sample Of Luminian Tissue (Despoil)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Increase Om'Phuabo phuabo organ drop rate (Tiberon)

## What does this pull request do? (Please be technical)

Bumps Om'Phuabo phuabo organ drop rate from uncommon (10%) to common (15%)
Ideally based on ffxidb the TH0 drop rate on Om should be ~33% for one organ - which aligns closely with a 20% drop rate
1 - (.8*.8) would be 34%.
http://www.ffxidb.com/zones/33/omphuabo
However a 20% drop rate in the current code base doesnt recieve TH.
Therefore I have went with 15% vs 24% as 15% scales more closely with other reported numbers.

## Steps to test these changes

Kill 100 phuabo and see the drop rate has increased by 5% vs pre-fix.

## Special Deployment Considerations

era_mob_droplist.sql
