### PR TITLE
Arts and Crafts fixes Hadahda dialogue and gives correct reward

### DIFF
--- a/scripts/quests/ahtUrhgan/Arts_and_Crafts.lua
+++ b/scripts/quests/ahtUrhgan/Arts_and_Crafts.lua
@@ -18,7 +18,7 @@ local quest = Quest:new(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.ARTS_A
 
 quest.reward =
 {
-    item = xi.items.IMPERIAL_SILVER_PIECE,
+    item = xi.items.IMPERIAL_BRONZE_PIECE,
 }
 
 quest.sections =
@@ -57,7 +57,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if quest:isVarBitsSet(player, 'Prog', 1, 2, 3, 4, 5, 6, 7) then
                         return quest:progressEvent(517)
-                    else
+                    elseif quest:getVar(player, 'Stage') == 0 then
                         return quest:event(509)
                     end
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Hadahda will no longer continue to ask for letters after you have obtained them all. The quest now rewards an Imperial Bronze Piece upon completion.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1726

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
1. !pos -112 -7 -66 50
2. speak to Hadahda
3. !pos 92 -7.5 -130 50
4. !pos -10 -1 -9 50
5. !pos 25 -7 126 50
6. !pos -13 1 103 50
7. !pos -90 -1 10 50
8. !pos -93 -7 129 50
9. !pos 54 -7 11 50
10. !pos -112 -7 -66 50
11. speak to Hadahda
12. trade Sutlac

I found another issue unrelated to this quest specifically. The messages to the player are all messed up and print 'Obtained  X gil.' instead of any items actually obtained.

![Capture](https://github.com/AirSkyBoat/AirSkyBoat/assets/27468039/638d1ac9-91d4-4592-a093-32fab63f7279)

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA
