### PR TITLE
Fix several small issues

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -1280,6 +1280,10 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         },
         ["Goublefaupe"] =
         {
+            ["onMobInitialize"] = { function(mob)
+                mob:setMobMod(xi.mobMod.MP_BASE, 100)
+            end },
+
             ["onMobSpawn"] = { function(mob)
                 xi.dynamis.onSpawnGouble(mob)
             end },
@@ -1340,6 +1344,10 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         },
         ["Quiebitiel"] =
         {
+            ["onMobInitialize"] = { function(mob)
+                mob:setMobMod(xi.mobMod.MP_BASE, 100)
+            end },
+
             ["onMobSpawn"] = { function(mob)
                 xi.dynamis.onSpawnQuieb(mob)
             end },
@@ -1370,6 +1378,10 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         },
         ["Velosareon"] =
         {
+            ["onMobInitialize"] = { function(mob)
+                mob:setMobMod(xi.mobMod.MP_BASE, 100)
+            end },
+
             ["onMobSpawn"] = { function(mob)
                 xi.dynamis.onSpawnVelosar(mob)
             end },
@@ -2085,6 +2097,15 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
         rotation = rPos,
         groupId = xi.dynamis.nmInfoLookup[mobName][2],
         groupZoneId = xi.dynamis.nmInfoLookup[mobName][3],
+        -- certain NMs need onMobInitialize functions to set mob mods (as dynamic mobs do not get pool mob mods)
+        onMobInitialize = function(mob)
+            local specFuncTable = xi.dynamis.nmFunctions[xi.dynamis.nmInfoLookup[mobName][7]]["onMobInitialize"]
+            if specFuncTable ~= nil then
+                local specFunc = specFuncTable[1]
+                specFunc(mob)
+            end
+        end,
+
         onMobSpawn = function(mob)
             local specFunc = xi.dynamis.nmFunctions[xi.dynamis.nmInfoLookup[mobName][7]]["onMobSpawn"][1]
             specFunc(mob)

--- a/modules/era/lua_dynamis/mobs/era_beaucedine_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_beaucedine_mobs.lua
@@ -130,7 +130,7 @@ xi.dynamis.onSpawnDagour = function(mob)
         between = 60,
         specials =
         {
-            { id = xi.jsa.ASTRAL_FLOW, hpp = 95 },
+            { id = xi.jsa.ASTRAL_FLOW, hpp = 95, cooldown = 90 },
         },
     })
 end
@@ -156,9 +156,9 @@ xi.dynamis.onSpawnGouble = function(mob)
         between = 60,
         specials =
         {
-            { id = xi.jsa.MIGHTY_STRIKES, hpp = 95 },
-            { id = xi.jsa.INVINCIBLE, hpp = 95 },
-            { id = xi.jsa.CHAINSPELL, hpp = 95 },
+            { id = xi.jsa.MIGHTY_STRIKES, hpp = 95, cooldown = 181 },
+            { id = xi.jsa.INVINCIBLE, hpp = 95, cooldown = 181 },
+            { id = xi.jsa.CHAINSPELL, hpp = 95, cooldown = 181 },
         },
     })
 end
@@ -167,12 +167,12 @@ xi.dynamis.onSpawnMildaun = function(mob)
     xi.dynamis.setNMStats(mob)
     xi.mix.jobSpecial.config(mob,
     {
-        between = 60,
+        between = 45,
         specials =
         {
-            { id = xi.jsa.HUNDRED_FISTS, hpp = 95 },
-            { id = xi.jsa.PERFECT_DODGE, hpp = 95 },
-            { id = xi.jsa.MIJIN_GAKURE, hpp = 95 },
+            { id = xi.jsa.HUNDRED_FISTS, hpp = 95, cooldown = 136 },
+            { id = xi.jsa.PERFECT_DODGE, hpp = 95, cooldown = 136 },
+            { id = xi.jsa.MIJIN_GAKURE, hpp = 30, cooldown = 136 },
         },
     })
 end
@@ -184,9 +184,9 @@ xi.dynamis.onSpawnQuieb = function(mob)
         between = 60,
         specials =
         {
-            { id = xi.jsa.BENEDICTION, hpp = 95 },
-            { id = xi.jsa.MANAFONT, hpp = 95 },
-            { id = xi.jsa.SOUL_VOICE, hpp = 95 },
+            { id = xi.jsa.BENEDICTION, hpp = 95, cooldown = 181 },
+            { id = xi.jsa.MANAFONT, hpp = 95, cooldown = 181 },
+            { id = xi.jsa.SOUL_VOICE, hpp = 95, cooldown = 181 },
         },
     })
 end
@@ -195,12 +195,12 @@ xi.dynamis.onSpawnVelosar = function(mob)
     xi.dynamis.setNMStats(mob)
     xi.mix.jobSpecial.config(mob,
     {
-        between = 60,
+        between = 30,
         specials =
         {
-            { id = xi.jsa.BLOOD_WEAPON, hpp = 95 },
-            { id = xi.jsa.MEIKYO_SHISUI, hpp = 95 },
-            { id = xi.jsa.EES_SHADE, hpp = 95 },
+            { id = xi.jsa.BLOOD_WEAPON, hpp = 95, cooldown = 91 },
+            { id = xi.jsa.MEIKYO_SHISUI, hpp = 95, cooldown = 91 },
+            { id = xi.jsa.EES_SHADE, hpp = 95, cooldown = 91 },
         },
     })
 end

--- a/modules/era/sql_dynamis/era_dyna_sql.sql
+++ b/modules/era/sql_dynamis/era_dyna_sql.sql
@@ -2513,15 +2513,15 @@ REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `
 --                            Fix Mob MP                            --
 -- --------------------------------------------------------------------
 DELETE FROM mob_groups WHERE name = "Goublefaupe";
-REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `spawntype`, `dropid`, `HP`, `MP`, `minLevel`, `maxLevel`, `allegiance`) VALUES (6,1774,134,'Goublefaupe',0,128,2574,5000,0,81,83,0);
+REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `spawntype`, `dropid`, `HP`, `MP`, `minLevel`, `maxLevel`, `allegiance`) VALUES (6,1774,134,'Goublefaupe',0,128,2574,17000,17000,81,83,0);
 DELETE FROM mob_groups WHERE name = "Quiebitiel";
-REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `spawntype`, `dropid`, `HP`, `MP`, `minLevel`, `maxLevel`, `allegiance`) VALUES (7,3289,134,'Quiebitiel',0,128,2066,5000,0,81,83,0);
+REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `spawntype`, `dropid`, `HP`, `MP`, `minLevel`, `maxLevel`, `allegiance`) VALUES (7,3289,134,'Quiebitiel',0,128,2066,17000,17000,81,83,0);
 DELETE FROM mob_groups WHERE name = "Mildaunegeux";
-REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `spawntype`, `dropid`, `HP`, `MP`, `minLevel`, `maxLevel`, `allegiance`) VALUES (8,2660,134,'Mildaunegeux',0,128,2574,5000,0,81,83,0);
+REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `spawntype`, `dropid`, `HP`, `MP`, `minLevel`, `maxLevel`, `allegiance`) VALUES (8,2660,134,'Mildaunegeux',0,128,2574,17000,0,81,83,0);
 DELETE FROM mob_groups WHERE name = "Velosareon";
-REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `spawntype`, `dropid`, `HP`, `MP`, `minLevel`, `maxLevel`, `allegiance`) VALUES (9,4219,134,'Velosareon',0,128,2574,5000,0,81,83,0);
+REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `spawntype`, `dropid`, `HP`, `MP`, `minLevel`, `maxLevel`, `allegiance`) VALUES (9,4219,134,'Velosareon',0,128,2574,17000,17000,81,83,0);
 DELETE FROM mob_groups WHERE name = "Dagourmarche";
-REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `spawntype`, `dropid`, `HP`, `MP`, `minLevel`, `maxLevel`, `allegiance`) VALUES (10,892,134,'Dagourmarche',0,128,2066,5000,0,81,83,0);
+REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `spawntype`, `dropid`, `HP`, `MP`, `minLevel`, `maxLevel`, `allegiance`) VALUES (10,892,134,'Dagourmarche',0,128,2066,17000,0,81,83,0);
 DELETE FROM mob_groups WHERE name = "Apocalyptic_Beast";
 REPLACE INTO mob_groups (`groupid`, `poolid`, `zoneid`, `name`, `respawntime`, `spawntype`, `dropid`, `HP`, `MP`, `minLevel`, `maxLevel`, `allegiance`) VALUES (1,198,40,'Apocalyptic_Beast',0,128,146,27000,27000,85,85,0);
 -- --------------------------------------------------------------------

--- a/scripts/globals/spells/enhancing_teleport.lua
+++ b/scripts/globals/spells/enhancing_teleport.lua
@@ -46,7 +46,8 @@ xi.spells.enhancing.useTeleportSpell = function(caster, target, spell)
     if
         target:getObjType() == xi.objType.PC and
         (keyItem == 0 or (keyItem > 0 and target:hasKeyItem(keyItem))) and
-        (not campaign or (campaign and target:getCampaignAllegiance() > 0))
+        (not campaign or (campaign and target:getCampaignAllegiance() > 0)) and
+        not target:isInMogHouse()
     then
         target:addStatusEffectEx(xi.effect.TELEPORT, 0, teleportId, 0, paramFive)
         spell:setMsg(xi.msg.basic.MAGIC_TELEPORT)

--- a/scripts/missions/sandoria/8_1_Coming_of_Age.lua
+++ b/scripts/missions/sandoria/8_1_Coming_of_Age.lua
@@ -186,7 +186,10 @@ mission.sections =
             onZoneIn =
             {
                 function(player, prevZone)
-                    if mission:getVar(player, 'Progress') < os.time() then
+                    if
+                        mission:getVar(player, 'Progress') < os.time() and
+                        not player:isInMogHouse()
+                    then
                         return 16
                     end
                 end

--- a/scripts/zones/Full_Moon_Fountain/mobs/Fenrir_Prime.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Fenrir_Prime.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Full Moon Fountain
+-- Mob: Fenrir Prime
+-- Quest: Moonlit Path
+-----------------------------------
+mixins = { require("scripts/mixins/job_special") }
+-----------------------------------
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.mix.jobSpecial.config(mob, {
+        specials =
+        {
+            { id = 839, hpp = math.random(45, 55) }, -- uses Howling Moon once while near 50% HPP.
+        },
+    })
+end
+
+entity.onMobFight = function(mob, target)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+return entity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -9213,11 +9213,11 @@ INSERT INTO `mob_groups` VALUES (2,1344,134,'Fire_Pukis',0,128,0,10000,0,82,82,0
 INSERT INTO `mob_groups` VALUES (3,3167,134,'Poison_Pukis',0,128,0,10000,0,82,82,0);
 INSERT INTO `mob_groups` VALUES (4,4351,134,'Wind_Pukis',0,128,0,10000,0,82,82,0);
 INSERT INTO `mob_groups` VALUES (5,3122,134,'Petro_Pukis',0,128,0,10000,0,82,82,0);
-INSERT INTO `mob_groups` VALUES (6,1774,134,'Goublefaupe',0,128,1211,5000,0,81,83,0);
-INSERT INTO `mob_groups` VALUES (7,3289,134,'Quiebitiel',0,128,2066,5000,0,81,83,0);
-INSERT INTO `mob_groups` VALUES (8,2660,134,'Mildaunegeux',0,128,1672,5000,0,81,83,0);
-INSERT INTO `mob_groups` VALUES (9,4219,134,'Velosareon',0,128,2574,5000,0,81,83,0);
-INSERT INTO `mob_groups` VALUES (10,892,134,'Dagourmarche',0,128,559,5000,0,81,83,0);
+INSERT INTO `mob_groups` VALUES (6,1774,134,'Goublefaupe',0,128,1211,17000,17000,81,83,0);
+INSERT INTO `mob_groups` VALUES (7,3289,134,'Quiebitiel',0,128,2066,17000,17000,81,83,0);
+INSERT INTO `mob_groups` VALUES (8,2660,134,'Mildaunegeux',0,128,1672,17000,0,81,83,0);
+INSERT INTO `mob_groups` VALUES (9,4219,134,'Velosareon',0,128,2574,17000,17000,81,83,0);
+INSERT INTO `mob_groups` VALUES (10,892,134,'Dagourmarche',0,128,559,17000,0,81,83,0);
 INSERT INTO `mob_groups` VALUES (11,893,134,'Dagourmarches_Wyvern',0,128,0,0,0,77,79,0);
 INSERT INTO `mob_groups` VALUES (12,1179,134,'Dagourmarches_Avatar',0,128,0,0,0,77,79,0);
 INSERT INTO `mob_groups` VALUES (13,6094,134,'Taquede',0,128,3221,8000,8000,95,95,0);
@@ -10590,7 +10590,7 @@ INSERT INTO `mob_groups` VALUES (10,2272,153,'Knight_Crawler',960,0,1456,0,0,62,
 INSERT INTO `mob_groups` VALUES (11,2962,153,'Old_Goobbue',960,0,399,0,0,65,68,0);
 INSERT INTO `mob_groups` VALUES (12,3375,153,'Robber_Crab',960,0,2109,0,0,62,66,0);
 INSERT INTO `mob_groups` VALUES (13,4309,153,'Water_Elemental',960,4,2629,0,0,69,72,0);
-INSERT INTO `mob_groups` VALUES (14,206,153,'Aquarius',0,32,149,0,0,69,71,0);
+INSERT INTO `mob_groups` VALUES (14,206,153,'Aquarius',0,32,149,5800,0,69,71,0);
 INSERT INTO `mob_groups` VALUES (15,3912,153,'Thunder_Elemental',960,4,2410,0,0,69,72,0);
 INSERT INTO `mob_groups` VALUES (16,4103,153,'Unut',0,32,2524,6300,0,72,72,0);
 INSERT INTO `mob_groups` VALUES (17,2745,153,'Morbol_Menace',960,0,1738,0,0,67,70,0);
@@ -11280,8 +11280,8 @@ INSERT INTO `mob_groups` VALUES (127,5146,164,'Laidly_Laurence',0,128,0,0,9999,9
 
 INSERT INTO `mob_groups` VALUES (1,3579,165,'Shadow_Lord_1',0,128,0,10000,10000,60,60,0);
 INSERT INTO `mob_groups` VALUES (2,4593,165,'Shadow_Lord_2',0,128,0,4000,4000,60,60,0);
-INSERT INTO `mob_groups` VALUES (3,4498,165,'Zeid',0,128,0,0,0,75,76,0);
-INSERT INTO `mob_groups` VALUES (4,4498,165,'Zeid',0,128,0,0,0,75,78,0);
+INSERT INTO `mob_groups` VALUES (3,4498,165,'Zeid',0,128,0,7750,3000,75,76,0);
+INSERT INTO `mob_groups` VALUES (4,4498,165,'Zeid',0,128,0,7750,3000,75,78,0);
 INSERT INTO `mob_groups` VALUES (5,3580,165,'Shadow_of_Rage',0,128,0,500,0,75,75,0);
 INSERT INTO `mob_groups` VALUES (6,1788,165,'Grand_Marquis_Chomiel',0,128,0,0,0,63,65,0);
 INSERT INTO `mob_groups` VALUES (7,1130,165,'Duke_Amduscias',0,128,0,0,0,63,65,0);
@@ -11470,7 +11470,7 @@ INSERT INTO `mob_groups` VALUES (42,2664,169,'Mimic',0,128,1684,0,0,65,67,0);
 -- Full_Moon_Fountain (Zone 170)
 -- ------------------------------------------------------------
 
-INSERT INTO `mob_groups` VALUES (1,1322,170,'Fenrir_Prime',0,128,0,0,0,80,82,0);
+INSERT INTO `mob_groups` VALUES (1,1322,170,'Fenrir_Prime',0,128,0,14600,0,80,82,0);
 INSERT INTO `mob_groups` VALUES (2,32,170,'Ace_of_Cups',0,128,12,0,0,73,75,0);
 INSERT INTO `mob_groups` VALUES (3,30,170,'Ace_of_Batons',0,128,10,0,0,73,75,0);
 INSERT INTO `mob_groups` VALUES (4,33,170,'Ace_of_Swords',0,128,13,0,0,73,75,0);

--- a/sql/nm_spawn_points.sql
+++ b/sql/nm_spawn_points.sql
@@ -4410,7 +4410,7 @@ INSERT INTO `nm_spawn_points` VALUES (17403939,2,190.750,8.500,-152.000);
 INSERT INTO `nm_spawn_points` VALUES (17403939,3,200.000,9.000,-167.000);
 INSERT INTO `nm_spawn_points` VALUES (17404000,0,165.93,9.344,-56.348); -- Aquarius
 INSERT INTO `nm_spawn_points` VALUES (17404029,0,104.340,8.423,81.217); -- Unut
-INSERT INTO `nm_spawn_points` VALUES (17404290,0,237,9.767,-281.7); -- Ancient Goobbue
+INSERT INTO `nm_spawn_points` VALUES (17404290,0,-237,9.767,-281.7); -- Ancient Goobbue
 INSERT INTO `nm_spawn_points` VALUES (17404300,0,-220.5,13.621,73.357); -- Leshonki
 INSERT INTO `nm_spawn_points` VALUES (17404331,0,-215.158,5.671,184.629); -- Voluptuous Vivian
 INSERT INTO `nm_spawn_points` VALUES (17404331,1,-215.792,5.718,187.152);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Players will not longer be teleported from their moghouses when their party teleports near the moghouse. (Tracent)
- Zeid from Bastok Mission 9-2 fight now has retail accurate HP. (Tracent)
- Ancient Goobbue will now spawn in the correct era-accurate location. (Tracent)
- Players will no longer become stuck in a cutscene in their moghouse in Sandoria mission 8-1. (Tracent)
- Aquarius now has retail accurate HP. (Tracent)
- The attestation monsters in Dynamis-Beaucedine can now use their 2 hour abilities multiple times, can cast spells, and have retail accurate HP. (Tracent)
- Fenrir Prime now can now use its 2 hour ability and has retail accurate HP. (Tracent)

## What does this pull request do? (Please be technical)
See above, they are self-explanatory

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1719
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/3409
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1325
Part of https://github.com/HorizonFFXI/HorizonXI-Issues/issues/258 (do not close)
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
