### PR TITLE
Fix dyna issues

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -92,7 +92,7 @@ xi.dynamis.spawnWave = function(zone, zoneID, waveNumber)
         end
     end
 
-    if waveNumber == 5 and zoneID == xi.zone.DYNAMIS_XARCABARD then
+    if waveNumber == 4 and zoneID == xi.zone.DYNAMIS_XARCABARD then
         local playersInZone = zone:getPlayers()
         for _, player in pairs(playersInZone) do
             player:messageSpecial(zones[xi.zone.DYNAMIS_XARCABARD].text.PRISON_OF_SOULS_HAS_SET_FREE)
@@ -116,10 +116,7 @@ xi.dynamis.parentOnEngaged = function(mob, target)
 
         if xi.dynamis.mobList[zoneID][oMobIndex].nmchildren ~= nil then
             for index, MobIndex in pairs(xi.dynamis.mobList[zoneID][oMobIndex].nmchildren) do
-                if
-                    MobIndex or
-                    not MobIndex
-                then
+                if type(MobIndex) == "boolean" then
                     index = index + 1
                 else
                     local forceLink = xi.dynamis.mobList[zoneID][oMobIndex].nmchildren[1]


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
None (fixes issues not yet on Horizon but already on ASB and Beta)

## What does this pull request do? (Please be technical)
This fixes two small issues introduced in recent ASB/Horizon PRs that have not yet been made live. The boolean type check fix is because the mobIndex fix can be a boolean or a number thus needs such a check. While the wave change was due to the reordering of waves in dyna xarc.

## Steps to test these changes
Try to spawn the NMs in dyna xarc from the sets of three eyes.
After killing all the NMs the free souls message should be displayed to players.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
