### PR TITLE
Fixes Reap What You Sow

### DIFF
--- a/scripts/quests/windurst/Reap_What_You_Sow.lua
+++ b/scripts/quests/windurst/Reap_What_You_Sow.lua
@@ -26,9 +26,7 @@ quest.sections =
         -- Players can only start the quest if they are below rank 4 fame
         -- else they must complete let sleeping dogs lie
         check = function(player, status, vars)
-            return status == QUEST_AVAILABLE and
-            (player:getFameLevel(xi.quest.fame_area.WINDURST) < 4 or
-            player:hasCompletedQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LET_SLEEPING_DOGS_LIE))
+            return status == QUEST_AVAILABLE
         end,
 
         [xi.zone.WINDURST_WATERS] =
@@ -36,8 +34,11 @@ quest.sections =
             ['Mashuu-Ajuu'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getFameLevel(xi.quest.fame_area.WINDURST) >= 4 then
-                        return quest:progressEvent(483)
+                    if
+                        player:getFameLevel(xi.quest.fame_area.WINDURST) >= 4 and
+                        not player:hasCompletedQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LET_SLEEPING_DOGS_LIE)
+                    then
+                        return quest:event(483)
                     else
                         return quest:progressEvent(463, 0, xi.items.SOBBING_FUNGUS, xi.items.BAG_OF_HERB_SEEDS)
                     end
@@ -47,7 +48,7 @@ quest.sections =
             onEventFinish =
             {
                 [463] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, xi.items.BAG_OF_HERB_SEEDS) and option == 3 then
+                    if option == 3 and npcUtil.giveItem(player, xi.items.BAG_OF_HERB_SEEDS) then
                         quest:begin(player)
                     end
                 end,

--- a/scripts/zones/Windurst_Waters/npcs/Mashuu-Ajuu.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Mashuu-Ajuu.lua
@@ -15,7 +15,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(429)
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Players at or above rank 4 Windhurst reputation will be able to accept the quest after completing Let Sleeping Dogs Lie. Fixed the issue where Mashuu-Ajuu would give the bag of herb seeds even when the player did not accept the quest.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Removes a check (somewhat redundant) which prevented players from accepting the quest when they met the conditions for doing so. Added another check to keep event(483) when player has Windhurst fame >= 4 and has not completed Let Sleeping Dogs Lie.
Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1757

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
1. !pos 130 -5 167 238
2. !setfamelevel 2 9
3. !completequest 2 46
4. speak to Mashuu-Ajuu

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA
