### PR TITLE
Fix several small issues

### DIFF
--- a/modules/era/sql/synth_recipes_era.sql
+++ b/modules/era/sql/synth_recipes_era.sql
@@ -1392,6 +1392,7 @@ UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Griffon Leathe
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Griffon Leather' AND ID = 44541;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Griffon Leather' AND ID = 44545;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ID = 53007;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Poisona Ring' AND ID = 21518;
 
 -- ------------------------------------------------------------
 -- ToAU Synths
@@ -1463,7 +1464,6 @@ UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Piercing Dagg
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Brass Grip' AND ID = 20517;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Keen Zaghnal' AND ID = 20523;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Tigereye Ring' AND ID = 21517;
-UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Poisona Ring' AND ID = 21518;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Mythril Grip' AND ID = 21531;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Mythril Mesh Sheet' AND ID = 22004;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Electrum Ingot' AND ID = 22008;

--- a/scripts/quests/bastok/Wish_Upon_a_Star.lua
+++ b/scripts/quests/bastok/Wish_Upon_a_Star.lua
@@ -88,8 +88,11 @@ quest.sections =
                     if npcUtil.tradeHasExactly(trade, xi.items.FALLEN_STAR) then
                         local isNight = VanadielTOTD() == xi.time.NIGHT or VanadielTOTD() == xi.time.MIDNIGHT
 
+                        -- Accept also SUNSHINE weather for now as currently bastok markets does not have any NONE weather patterns
+                        -- However retail captures indicate it should have NONE roughly half of the time so can revisit
                         if
-                            player:getWeather() == xi.weather.NONE and
+                            (player:getWeather() == xi.weather.NONE or
+                            player:getWeather() == xi.weather.SUNSHINE) and
                             isNight
                         then
                             return quest:progressEvent(334)

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
@@ -11,6 +11,8 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar("xolotlDead", 0)
+    mob:setMod(xi.mod.SLEEPRES, 20)
+    mob:setMod(xi.mod.LULLABYRES, 20)
 end
 
 entity.onMobFight = function(mob, target)
@@ -46,12 +48,16 @@ entity.onMobFight = function(mob, target)
     end
 
     -- Sets max sleep resist if a sleep lands on Xolotl
+    -- this is special res building just for Xolotl
     if
-        target:hasStatusEffect(xi.effect.SLEEP_I) or
-        target:hasStatusEffect(xi.effect.SLEEP_II) or
-        target:hasStatusEffect(xi.effect.LULLABY)
+        (mob:hasStatusEffect(xi.effect.SLEEP_I) or
+        mob:hasStatusEffect(xi.effect.SLEEP_II) or
+        mob:hasStatusEffect(xi.effect.LULLABY)) and
+        (mob:getMod(xi.mod.SLEEPRES) ~= 100 or
+        mob:getMod(xi.mod.LULLABYRES) ~= 100)
     then
-        target:setMod(xi.mod.SLEEPRES, 100)
+        mob:setMod(xi.mod.SLEEPRES, 100)
+        mob:setMod(xi.mod.LULLABYRES, 100)
     end
 end
 
@@ -64,22 +70,10 @@ end
 
 entity.onMobWeaponSkill = function(target, mob, skill)
     -- Can be slept with Lullaby once after each Charm, after which he builds resistance.
+    -- this is special res building just for Xolotl
     if skill:getID() == 533 or skill:getID() == 1329 then
         mob:setMod(xi.mod.SLEEPRES, 20)
-    end
-end
-
-entity.onMagicHit = function(caster, target, spell)
-    -- Sets max sleep resist if a light based sleep lands on Xolotl
-    if
-        spell:tookEffect() and
-        caster:isPC() and
-        (spell:getID() == 376 or
-        spell:getID() == 463 or
-        spell:getID() == 576 or
-        spell:getID() == 584)
-    then
-        target:setMod(xi.mod.SLEEPRES, 100)
+        mob:setMod(xi.mod.LULLABYRES, 20)
     end
 end
 

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Hound_Warrior.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Hound_Warrior.lua
@@ -5,6 +5,10 @@
 -----------------------------------
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.LULLABYRESBUILD, 50)
+end
+
 entity.onMobRoam = function(mob)
     local hour = VanadielHour()
 

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Sacrifice.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotls_Sacrifice.lua
@@ -5,6 +5,10 @@
 -----------------------------------
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.LULLABYRESBUILD, 50)
+end
+
 entity.onMobRoam = function(mob)
     local hour = VanadielHour()
 

--- a/scripts/zones/Balgas_Dais/mobs/Macan_Gadangan.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Macan_Gadangan.lua
@@ -23,7 +23,7 @@ entity.onMobMagicPrepare = function(mob, target, spell)
     -- Increase magic rank after every 3 casts
     if mob:getLocalVar("casts") % 3 == 0 and mob:getLocalVar("magicRank") < 4 then
         mob:setLocalVar("magicRank", mob:getLocalVar("magicRank") + 1)
-        mob:addMod(xi.mod.MATT, 100)
+        mob:addMod(xi.mod.MATT, 50)
     end
 
     local rank = mob:getLocalVar("magicRank")
@@ -48,7 +48,7 @@ entity.onMobFight = function(mob)
 
     if mob:hasStatusEffect(xi.effect.SILENCE) then
         mob:setLocalVar("magicRank", 5)
-        mob:setMod(xi.mod.MATT, 400)
+        mob:setMod(xi.mod.MATT, 200)
     end
 
     if

--- a/scripts/zones/Misareaux_Coast/mobs/Gration.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Gration.lua
@@ -29,13 +29,9 @@ end
 entity.onMobFight = function(mob, target)
     local enmityList = mob:getEnmityList()
     for _, v in ipairs(enmityList) do
-        local shouldintimidate = math.random(1, 20)
-        if shouldintimidate >= 19 then
-            if v.entity:hasStatusEffect(xi.effect.INTIMIDATE) then
-                v.entity:delStatusEffectSilent(xi.effect.INTIMIDATE)
-            end
-
-            v.entity:addStatusEffectEx(xi.effect.INTIMIDATE, 0, 1, 0, 1)
+        -- repeatedly apply short duration intimidate (5 sec) with 50% power to all entities on enmity list
+        if not v["entity"]:hasStatusEffect(xi.effect.INTIMIDATE) then
+            v["entity"]:addStatusEffectEx(xi.effect.INTIMIDATE, 0, 50, 3, 5)
         end
     end
 end

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -468,6 +468,12 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
     m_charList.erase(PChar->targid);
     charTargIds.erase(PChar->targid);
 
+    // Need to interupt fishing on zone out otherwise fished up mobs get stuck in hooked state
+    if (PChar->hookedFish && PChar->hookedFish->hooked == true)
+    {
+        fishingutils::InterruptFishing(PChar);
+    }
+
     ShowDebug("CZone:: %s DecreaseZoneCounter <%u> %s", m_zone->GetName(), m_charList.size(), PChar->GetName());
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Poisona Ring can now be crafted. (Tracent)
- The required weather conditions for completing the quest Wish Upon a Star have been adjusted. (Tracent)
- The magic attack building of Macan Gadangan from the BCNM Wild Wild Whiskers has been lowered to be more retail accurate. (Tracent)
- Gration now intimidates players at an era accurate rate. (Tracent)
- Xolotl and his pets now build resistance to light based sleep. Note that Xolotl (but not his pets) has a special resistance building mechanism that is different from other mobs that build resistance. (Tracent, Siknoz)
- Monsters (including NMs) that can be fished up should no longer go missing from fishing pools due to certain conditions. (Tracent)

## What does this pull request do? (Please be technical)
This fixes several small issues. The weather conditions for Wish Upon a Star needed to be changed because Bastok Markets does not have NONE weather, thus adding SUNSHINE as an option until weather system is overhauled to reflect actual retail capture results from Zach. The change in magic attack for Macan Gadangan brings the damage of Charged Whiskers more in line with actual era and retail values. The Xolotl change fixes some issues with his unique sleep building mechanism (based on era info) and adds basic sleep building to his pets (based on retail capture from siknoz). The fishing change is related to fish being removed from the catchable monster pool if the fish is being caught when the player zones (such as boat docking).

## Steps to test these changes
Mainly self-explanatory, though for the quest Wish Upon a Star the conditions to check are at night with !setweather 1 , whereas Charged Whiskers should do about 300-600 damage (after silencing NM to add max magic attack to NM). Xolotl should be able to be slept (with lullaby) only 1 time until it uses charm tp move and then should be able to be slept (with lullaby) again only 1 time, and so on. The pets should be able to be slept (with lullaby) but the duration of lullaby should decrease 5 seconds with each successful cast. Gration should now intimidate players roughly 50% of the time.

Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/2953
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1470
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1075
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1501
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
