### PR TITLE
Fixes raises in battlegrounds with no experience loss

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2134,7 +2134,16 @@ void CCharEntity::OnRaise()
             // Player died within a battlefield, reward the battlefield level equivalent EXP
             if (StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
             {
-                expLost = m_LevelRestriction >= 1 && m_LevelRestriction <= 67 ? (charutils::GetExpNEXTLevel(m_LevelRestriction) * 8) / 100 : 2400;
+                if (PBattlefield != nullptr && (PBattlefield->GetRuleMask() & RULES_LOSE_EXP) != RULES_LOSE_EXP)
+                {
+                    expLost = 0;
+                }
+                else
+                {
+                    expLost = m_LevelRestriction >= 1 && m_LevelRestriction <= 67
+                                  ? (charutils::GetExpNEXTLevel(m_LevelRestriction) * 8) / 100
+                                  : 2400;
+                }
             }
 
             // Exp is enough to level you and (you're not under a level restriction, or the level restriction is higher than your current main level).


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Raises in battlegrounds with no experience loss no longer return experience.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
If player is in a battlefield where experience points are not lost the variable expLost is set to 0

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
I am going to keep the specifics for replicating this bug out.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA