### PR TITLE
Add JP midnight wait to Easterly Winds

### DIFF
--- a/scripts/missions/toau/05_Confessions_of_Royalty.lua
+++ b/scripts/missions/toau/05_Confessions_of_Royalty.lua
@@ -40,6 +40,7 @@ mission.sections =
             {
                 [564] = function(player, csid, option, npc)
                     if option == 1 then
+                        player:setCharVar('Mission[4][5]Stage', getMidnight())
                         player:delKeyItem(xi.ki.RAILLEFALS_LETTER)
                         mission:complete(player)
                     end

--- a/scripts/missions/toau/06_Easterly_Winds.lua
+++ b/scripts/missions/toau/06_Easterly_Winds.lua
@@ -15,7 +15,7 @@ local mission = Mission:new(xi.mission.log_id.TOAU, xi.mission.id.toau.EASTERLY_
 
 mission.reward =
 {
-    nextMission = { xi.mission.log_id.TOAU, xi.mission.id.toau.WESTERLY_WINDS },
+    nextMission = { xi.mission.log_id.TOAU, xi.mission.id.toau.WESTERLY_WINDS }
 }
 
 mission.sections =
@@ -34,6 +34,13 @@ mission.sections =
                 end,
             },
         },
+    },
+
+    {
+        check = function(player, currentMission, missionStatus, vars)
+            return currentMission == mission.missionId and
+                os.time() >= vars.Stage
+        end,
 
         [xi.zone.RULUDE_GARDENS] =
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Easterly Winds now has a JP midnight wait before player can get the cutscene in Ru'Lude Gardens.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
```player:setCharVar('ConfessionsOfRoyalty_date', getMidnight())``` upon completing Confessions of Royalty 
```os.time() >= player:getCharVar('ConfessionsOfRoyalty_date')``` before getting the cutscene in Easterly Winds

Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1728

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
1. !addmission 4 4
2. !addkeyitem 785
3. !pos 2 0.1 0.1 233
4. speak to Halver
5. !zone 243
6. run to the palace after JP midnight

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA
