### PR TITLE
Add JP midnight wait to A Mercenary LIfe

### DIFF
--- a/scripts/missions/toau/07_Westerly_Winds.lua
+++ b/scripts/missions/toau/07_Westerly_Winds.lua
@@ -60,6 +60,7 @@ mission.sections =
 
                 [3028] = function(player, csid, option, npc)
                     if mission:complete(player) then
+                        player:setCharVar('Mission[4][7]Stage', getMidnight())
                         player:delKeyItem(xi.ki.RAILLEFALS_NOTE)
                         player:setLocalVar('Mission[4][7]mustZone', 1)
                     end

--- a/scripts/missions/toau/08_A_Mercenary_Life.lua
+++ b/scripts/missions/toau/08_A_Mercenary_Life.lua
@@ -32,8 +32,10 @@ mission.sections =
 
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and
-                not mission:getMustZone(player)
+            return
+                currentMission == mission.missionId
+                and os.time() >= vars.Stage
+                and not mission:getMustZone(player)
         end,
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
A Mercenary LIfe now has a JP midnight wait before player can complete mission.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
```player:setCharVar('WesterlyWinds_date', getMidnight())``` upon completing Westerly Winds
```os.time() >= player:getCharVar('WesterlyWinds_date')``` before completing the mission
Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1730

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
1. !addmission 4 6
2. visit the Shararat Teahouse (K-12)
4. speak with Naja
5. return to Salaheem's Sentinels after JP midnight

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA