### PR TITLE
Fix many issues including ZM16 Orbitals, WS, misc. ranged

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -16,6 +16,7 @@ require("scripts/globals/ability")
 require("scripts/globals/magic")
 require("scripts/globals/utils")
 require("scripts/globals/damage")
+require("scripts/globals/weaponskillids")
 -----------------------------------
 
 xi = xi or { }
@@ -136,7 +137,12 @@ local function fencerBonus(attacker)
     return bonus
 end
 
-local function shadowAbsorb(target)
+local function shadowAbsorb(target, wsIgnoreShadows)
+    -- allow bypassing all shadows for certain WSs like Catastrophe
+    if wsIgnoreShadows then
+        return false
+    end
+
     local targShadows = target:getMod(xi.mod.UTSUSEMI)
     local shadowType  = xi.mod.UTSUSEMI
 
@@ -330,14 +336,20 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, f
 
     local missChance = math.random()
 
-    missChance = xi.weaponskills.handleParry(attacker, target, missChance, calcParams.guaranteedHit)
+    -- ranged WS cannot be parried according to current understanding
+    if not isRanged then
+        missChance = xi.weaponskills.handleParry(attacker, target, missChance, calcParams.guaranteedHit)
+    end
+
+    -- Catastrophe ignores shadows (thus need special case here)
+    local wsIgnoreShadows = calcParams.wsID == xi.weaponskill.CATASTROPHE
 
     if
         (missChance <= calcParams.hitRate or
         calcParams.guaranteedHit) and
         not calcParams.mustMiss
     then
-        if not shadowAbsorb(target) then
+        if not shadowAbsorb(target, wsIgnoreShadows) then
             local critChance = math.random() -- See if we land a critical hit
             criticalHit = (wsParams.canCrit and critChance <= calcParams.critRate) or
                 calcParams.forcedFirstCrit or
@@ -579,8 +591,14 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
     calcParams.hitsLanded = 0
     calcParams.shadowsAbsorbed = 0
 
-    -- Calculate the damage from the first hit
-    if isRanged then
+    -- Calculate the damage from the first hit (only certain ranged WS have this bonus)
+    if
+        isRanged and
+        wsID ~= xi.weaponskill.CORONACH and
+        wsID ~= xi.weaponskill.DETONATOR and
+        wsID ~= xi.weaponskill.NAMAS_ARROW and
+        wsID ~= xi.weaponskill.EMPYREAL_ARROW
+    then
         hitdmg, calcParams = getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, false, isRanged, false)
     else
         hitdmg, calcParams = getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, true, isRanged, false)

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -99,7 +99,7 @@ entity.onMobFight = function(mob, target)
         if -- If mob uses its 2hr
             mob:getAnimationSub() == 2 and
             os.time() > twohourTime and
-            mob:getHP() <= 85
+            mob:getHPP() <= 85
         then
             mob:useMobAbility(695)
             twohourTime = os.time() + 300

--- a/sql/bcnm_battlefield.sql
+++ b/sql/bcnm_battlefield.sql
@@ -842,12 +842,18 @@ INSERT INTO `bcnm_battlefield` VALUES (293,3,17514544,3);
 INSERT INTO `bcnm_battlefield` VALUES (320,1,17518595,3); -- celestial_nexus
 INSERT INTO `bcnm_battlefield` VALUES (320,1,17518596,3);
 INSERT INTO `bcnm_battlefield` VALUES (320,1,17518597,2);
+INSERT INTO `bcnm_battlefield` VALUES (320,1,17518598,2);
+INSERT INTO `bcnm_battlefield` VALUES (320,1,17518599,2);
 INSERT INTO `bcnm_battlefield` VALUES (320,2,17518600,3);
 INSERT INTO `bcnm_battlefield` VALUES (320,2,17518601,3);
 INSERT INTO `bcnm_battlefield` VALUES (320,2,17518602,2);
+INSERT INTO `bcnm_battlefield` VALUES (320,2,17518603,2);
+INSERT INTO `bcnm_battlefield` VALUES (320,2,17518604,2);
 INSERT INTO `bcnm_battlefield` VALUES (320,3,17518605,3);
 INSERT INTO `bcnm_battlefield` VALUES (320,3,17518606,3);
 INSERT INTO `bcnm_battlefield` VALUES (320,3,17518607,2);
+INSERT INTO `bcnm_battlefield` VALUES (320,3,17518608,2);
+INSERT INTO `bcnm_battlefield` VALUES (320,3,17518609,2);
 INSERT INTO `bcnm_battlefield` VALUES (416,1,17600513,3); -- trial_by_wind
 INSERT INTO `bcnm_battlefield` VALUES (416,2,17600514,3);
 INSERT INTO `bcnm_battlefield` VALUES (416,3,17600515,3);

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1842,6 +1842,7 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
                 {
                     charutils::TrySkillUP(this, (SKILLTYPE)PAmmo->getSkillType(), PTarget->GetMLevel());
                 }
+                totalDamage += damage;
             }
         }
         else // miss
@@ -1878,7 +1879,6 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
                 hitCount = i;
             }
         }
-        totalDamage += damage;
     }
 
     // if a hit did occur (even without barrage)
@@ -1894,12 +1894,6 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
 
         actionTarget.param =
             battleutils::TakePhysicalDamage(this, PTarget, PHYSICAL_ATTACK_TYPE::RANGED, totalDamage, false, slot, realHits, nullptr, true, true);
-
-        // lower damage based on shadows taken
-        if (shadowsTaken)
-        {
-            actionTarget.param = (int32)(actionTarget.param * (1 - ((float)shadowsTaken / realHits)));
-        }
 
         // absorb message
         if (actionTarget.param < 0)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- The orbitals in the ZM16 BCNM can now be acted upon and function correctly. (Tracent)
- Monsters (mainly beastmen in dynamis) will no longer be able to parry player's ranged weapon skills. (Tracent)
- The ranged weapon skills Coronach, Detonator, Namas Arrow, and Empyreal Arrow now have an era accurate bonus of 100 ranged accuracy added. Note this accuracy is added after the ranged accuracy distance correction is applied.
- The weapon skill Catastrophe will now ignore Utsusemi and Blink shadows as in era. (Tracent)
- The ability Barrage now behaviors correctly against monsters with shadows. (Tracent)
- Jormungand now starts to use Bloodweapon at the correct HP level. (Tracent)

## What does this pull request do? (Please be technical)
This fixes several small issues with ZM16 and mainly WS issues. Also fixed an issue that caused wonky in certain cases where mob had shadows and player used barrage. This would sometimes result in the mob being reported as healed (though not actually healed), for example when barrage hit 4 shadows and the last 2 shots hit the mob. Also in cases of blink where only some shots are blocked the damage from the previous hit shot would still be added even if blink blocked the next (since damage variable was never cleared and always added).

## Steps to test these changes
Self-explanatory for most of the changes.

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/270
Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/1332
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1549
Part of https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1527
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
