### PR TITLE
[Fix] SMN Flag and Root of Problem BLM AF2

### DIFF
--- a/scripts/zones/Windurst_Walls/npcs/Koru-Moru.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Koru-Moru.lua
@@ -10,11 +10,24 @@ require("scripts/globals/quests")
 require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
-
 entity.onTrade = function(player, npc, trade)
+    local count = trade:getItemCount()
+
+    if trade:hasItemQty(829, 1) and count == 1 and trade:getGil() == 0 then
+        if player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_ROOT_OF_THE_PROBLEM) == QUEST_ACCEPTED then
+            player:startEvent(349)
+            player:tradeComplete()
+            player:setCharVar("rootProblem", 2)
+        end
+    end
 end
 
 entity.onTrigger = function(player, npc)
+    local rootProblem = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_ROOT_OF_THE_PROBLEM)
+
+    if rootProblem == QUEST_ACCEPTED and player:getCharVar("rootProblem") == 1 then
+        player:startEvent(348, 0, 829)
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Windurst_Walls/npcs/_6n2.lua
+++ b/scripts/zones/Windurst_Walls/npcs/_6n2.lua
@@ -10,17 +10,32 @@ require("scripts/globals/missions")
 require("scripts/globals/quests")
 -----------------------------------
 local entity = {}
-
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
+    local iCanHearARainbow = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.I_CAN_HEAR_A_RAINBOW)
+
+    -- I CAN HEAR A RAINBOW
+    if
+        iCanHearARainbow == QUEST_AVAILABLE and
+        player:getMainLvl() >= 30 and
+        player:hasItem(1125)
+    then
+        player:startEvent(384, 1125, 1125, 1125, 1125, 1125, 1125, 1125, 1125)
+    elseif iCanHearARainbow == QUEST_ACCEPTED then
+        player:startEvent(385, 1125, 1125, 1125, 1125, 1125, 1125, 1125, 1125)
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
+        -- I CAN HEAR A RAINBOW
+    if csid == 384 then
+        player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.I_CAN_HEAR_A_RAINBOW)
+    end
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Addresses issue where players were unable to flag I Can Hear a Rainbow.
Addresses issue where players were unable to progress quest The Root of the Problem (BLM AF)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Replaces code that was erroneously removed during SMN AF conversion to IF.  
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
I Can Hear the Rainbow
!additem 1125 
!pos -26 -13 260 239
get Cutscene and quest is added 

The Root of the Problem
!addquest 2 68
!setplayervar <name> rootProblem 1
!additem square_of_silk_thread
talk to Koru - will mention silk thread
trade silk thread progress to rootProblem 2

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
