### PR TITLE
Fixes a client lock up bug with Brygid The Sytlist Returns

### DIFF
--- a/scripts/zones/Bastok_Markets/npcs/Brygid.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Brygid.lua
@@ -121,7 +121,11 @@ entity.onEventFinish = function(player, csid, option)
         player:delQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BRYGID_THE_STYLIST_RETURNS)
         player:addQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BRYGID_THE_STYLIST_RETURNS)
 
-    elseif csid == 382 and option ~= 99 then
+    elseif
+        csid == 382 and
+        option <= 13 and
+        option > 0
+    then
         player:setCharVar("BrygidWantsSubligar", option)
 
     elseif csid == 383 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Cancelling a dialog during Brygid the Sytlist Returns will no longer lead to Brygid soft locking clients. (Tiberon)

## What does this pull request do? (Please be technical)

When a player hits Esc during a CS dialog prompt - the value returned to the server is a large large number.
Due to this, all interaction dialogs should be very careful when writing an `option` value directly to a data store without validation.

In this specfic scenario, hitting ESC on the subligar selection will result in the player having their player variable set to an obnociously large integer, instead of 1-13.
From that point forward, whenever the server attempts to send the subligar wanted to the player's client as part of CS, the parameter sent is not an item ID, but rather a value much higher than the client can handle.
The client then chokes and dies.

## Steps to test these changes

Run the quest up to selecting a subligar.
On the Subligar dialog hit esc.
Talk to the NPC again - and see if your client locks up.

## Special Deployment Considerations
None - hot fixable.