### PR TITLE
Fix dyna pukis spawning and wyvern breath fire issue

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -1861,6 +1861,24 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
                 mob:addImmunity(xi.immunity.SLEEP)
             end },
 
+            ["onMobEngaged"] = { function(mob, mobTarget)
+            end },
+
+            ["onMobFight"] = { function(mob, mobTarget)
+            end },
+
+            ["onMobRoam"] = { function(mob)
+            end },
+
+            ["onMobMagicPrepare"] = { function(mob, mobTarget, spellId)
+            end },
+
+            ["onMobWeaponSkillPrepare"] = { function(mob)
+            end },
+
+            ["onMobWeaponSkill"] = { function(mob)
+            end },
+
             ["onMobDeath"] = { function(mob, player, optParams)
                 xi.dynamis.mobOnDeath(mob, player, optParams)
             end },

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -771,7 +771,7 @@ xi.job_utils.dragoon.pickAndUseDamageBreath = function(player, target)
         target:getMod(xi.mod.WATER_EEM),
     }
 
-    local highestEEM = resistances[1]
+    local highestEEM = 0
     local breath = breathList[math.random(#breathList)]
     local headEquip = player:getEquippedItem(xi.slot.HEAD)
     local headEquipID = 0

--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -83,9 +83,9 @@ end
 entity.onMobFight = function(mob, target)
     -- Wyrms automatically wake from sleep in the air
     if
-        (target:hasStatusEffect(xi.effect.SLEEP_I) or
-        target:hasStatusEffect(xi.effect.SLEEP_II) or
-        target:hasStatusEffect(xi.effect.LULLABY)) and
+        (mob:hasStatusEffect(xi.effect.SLEEP_I) or
+        mob:hasStatusEffect(xi.effect.SLEEP_II) or
+        mob:hasStatusEffect(xi.effect.LULLABY)) and
         mob:getAnimationSub() == 1
     then
         mob:wakeUp()

--- a/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
@@ -34,9 +34,9 @@ entity.onMobFight = function(mob, target)
     -- Wakeup from sleep immediately if flying
     if
         mob:getAnimationSub() == 1 and
-        (target:hasStatusEffect(xi.effect.SLEEP_I) or
-        target:hasStatusEffect(xi.effect.SLEEP_II) or
-        target:hasStatusEffect(xi.effect.LULLABY))
+        (mob:hasStatusEffect(xi.effect.SLEEP_I) or
+        mob:hasStatusEffect(xi.effect.SLEEP_II) or
+        mob:hasStatusEffect(xi.effect.LULLABY))
     then
         mob:wakeUp()
     end

--- a/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
@@ -65,9 +65,9 @@ entity.onMobFight = function(mob, target)
     -- Wakeup from sleep immediately if flying
     if
         mob:getAnimationSub() == 1 and
-        (target:hasStatusEffect(xi.effect.SLEEP_I) or
-        target:hasStatusEffect(xi.effect.SLEEP_II) or
-        target:hasStatusEffect(xi.effect.LULLABY))
+        (mob:hasStatusEffect(xi.effect.SLEEP_I) or
+        mob:hasStatusEffect(xi.effect.SLEEP_II) or
+        mob:hasStatusEffect(xi.effect.LULLABY))
     then
         mob:delStatusEffect(xi.effect.SLEEP_I)
         mob:delStatusEffect(xi.effect.SLEEP_II)

--- a/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
@@ -90,9 +90,9 @@ entity.onMobFight = function(mob, target)
     -- Wakeup from sleep immediately if flying
     if
         mob:getAnimationSub() == 1 and
-        (target:hasStatusEffect(xi.effect.SLEEP_I) or
-        target:hasStatusEffect(xi.effect.SLEEP_II) or
-        target:hasStatusEffect(xi.effect.LULLABY))
+        (mob:hasStatusEffect(xi.effect.SLEEP_I) or
+        mob:hasStatusEffect(xi.effect.SLEEP_II) or
+        mob:hasStatusEffect(xi.effect.LULLABY))
     then
         mob:delStatusEffect(xi.effect.SLEEP_I)
         mob:delStatusEffect(xi.effect.SLEEP_II)

--- a/scripts/zones/Riverne-Site_B01/mobs/Jormungand.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Jormungand.lua
@@ -117,9 +117,9 @@ entity.onMobFight = function(mob, target)
     -- Wyrms automatically wake from sleep in the air
     if
         mob:getAnimationSub() == 1 and
-        (target:hasStatusEffect(xi.effect.SLEEP_I) or
-        target:hasStatusEffect(xi.effect.SLEEP_II) or
-        target:hasStatusEffect(xi.effect.LULLABY))
+        (mob:hasStatusEffect(xi.effect.SLEEP_I) or
+        mob:hasStatusEffect(xi.effect.SLEEP_II) or
+        mob:hasStatusEffect(xi.effect.LULLABY))
     then
         mob:wakeUp()
     end

--- a/scripts/zones/Riverne-Site_B01/mobs/Ouryu.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Ouryu.lua
@@ -134,9 +134,9 @@ entity.onMobFight = function(mob, target)
     -- Wakeup from sleep immediately if flying
     if
         mob:getAnimationSub() == 1 and
-        (target:hasStatusEffect(xi.effect.SLEEP_I) or
-        target:hasStatusEffect(xi.effect.SLEEP_II) or
-        target:hasStatusEffect(xi.effect.LULLABY))
+        (mob:hasStatusEffect(xi.effect.SLEEP_I) or
+        mob:hasStatusEffect(xi.effect.SLEEP_II) or
+        mob:hasStatusEffect(xi.effect.LULLABY))
     then
         mob:delStatusEffect(xi.effect.SLEEP_I)
         mob:delStatusEffect(xi.effect.SLEEP_II)

--- a/scripts/zones/Riverne-Site_B01/mobs/Tiamat.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Tiamat.lua
@@ -133,9 +133,9 @@ entity.onMobFight = function(mob, target)
     -- Wyrms automatically wake from sleep in the air
     if
         mob:getAnimationSub() == 1 and
-        (target:hasStatusEffect(xi.effect.SLEEP_I) or
-        target:hasStatusEffect(xi.effect.SLEEP_II) or
-        target:hasStatusEffect(xi.effect.LULLABY))
+        (mob:hasStatusEffect(xi.effect.SLEEP_I) or
+        mob:hasStatusEffect(xi.effect.SLEEP_II) or
+        mob:hasStatusEffect(xi.effect.LULLABY))
     then
         mob:wakeUp()
     end

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -81,9 +81,9 @@ entity.onMobFight = function(mob, target)
     -- Wyrms automatically wake from sleep in the air
     if
         mob:getAnimationSub() == 1 and
-        (target:hasStatusEffect(xi.effect.SLEEP_I) or
-        target:hasStatusEffect(xi.effect.SLEEP_II) or
-        target:hasStatusEffect(xi.effect.LULLABY))
+        (mob:hasStatusEffect(xi.effect.SLEEP_I) or
+        mob:hasStatusEffect(xi.effect.SLEEP_II) or
+        mob:hasStatusEffect(xi.effect.LULLABY))
     then
         mob:wakeUp()
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Angra Mainyu from Dynamis-Beaucedine will now correctly spawn the Pukis. (Tracent)
- Wyrm mobs that fly will now wake up they begin to fly. (Tracent)

## What does this pull request do? (Please be technical)
- This fixes an issue whereby Angra Mainyu was not spawning Pukis due to missing onEngage functions in the dyna NM function list.
- This fixes a small issue with wyvern breath targeting weaknesses that was not fixed in a prior PR (https://github.com/AirSkyBoat/AirSkyBoat/pull/3422). With this fix it should now work correctly on all mobs. This has already been hotfixed on live.
- Also fixes an issue with wyrms (like Tiamat) not waking up when flying because target was used instead of mob in several functions from a recent LSB cherry pick.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
