### PR TITLE
Removes item Enspell potency added in function doEnspell

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -429,7 +429,7 @@ xi.magic.calculateMagicDamage = function(caster, target, spell, params)
 end
 
 xi.magic.doEnspell = function(caster, target, spell, effect)
-    -- Calculate Bonus duration
+    -- Calculate bonus duration
     local baseDuration = 0
     if caster:getEquipID(xi.slot.MAIN) == xi.items.BUZZARD_TUCK then
         baseDuration = 210
@@ -439,52 +439,12 @@ xi.magic.doEnspell = function(caster, target, spell, effect)
 
     local duration = xi.magic.calculateDuration(baseDuration, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
-    --calculate potency
+    -- Calculate potency
     local magicskill = caster:getSkillLevel(xi.skill.ENHANCING_MAGIC)
 
-    -- Add effect bonuses from equipment
-    local potencybonus = 0
-    if caster:getEquipID(xi.slot.MAIN) == xi.items.BUZZARD_TUCK then
-        potencybonus = 2 + potencybonus
-    elseif
-        caster:getEquipID(xi.slot.EAR1) == xi.items.LYCOPODIUM_EARRING or
-        caster:getEquipID(xi.slot.EAR2) == xi.items.LYCOPODIUM_EARRING
-    then
-        potencybonus = 2 + potencybonus
-    elseif
-        caster:getEquipID(xi.slot.EAR1) == xi.items.HOLLOW_EARRING or
-        caster:getEquipID(xi.slot.EAR2) == xi.items.HOLLOW_EARRING
-    then
-        potencybonus = 3 + potencybonus
-    elseif
-        caster:getHPP() <= 75 and
-        caster:getTP() <= 100 and
-        (caster:getEquipID(xi.slot.RING1) == xi.items.FENCERS_RING or
-        caster:getEquipID(xi.slot.RING2) == xi.items.FENCERS_RING)
-    then
-        potencybonus = 5 + potencybonus
-    elseif caster:getEquipID(xi.slot.MAIN) == xi.items.ENHANCING_SWORD then
-        potencybonus = 5 + potencybonus
-    end
-
-    -- Potency with Effect Bonus
-    local potency = 0
-    if
-        caster:getWeaponSkillType(xi.slot.MAIN) == xi.skill.SWORD or
-        caster:getWeaponSkillType(xi.slot.SUB) == xi.skill.SWORD
-    then
-        if magicskill <= 200 then
-            potency = 3 + potencybonus + math.floor(6 * magicskill / 100)
-        elseif magicskill > 200 then
-            potency = 5 + potencybonus + math.floor(5 * magicskill / 100)
-        end
-    -- Potency without Effect Bonus
-    else
-        if magicskill <= 200 then
-            potency = 3 + math.floor(6 * magicskill / 100)
-        elseif magicskill > 200 then
-            potency = 5 + math.floor(5 * magicskill / 100)
-        end
+    local potency = 3 + math.floor(6 * magicskill / 100)
+    if magicskill > 200 then
+        potency = 5 + math.floor(5 * magicskill / 100)
     end
 
     if target:addStatusEffect(effect, potency, 0, duration) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Items with Enspell damage modifiers will not be added twice. This bug applied to only one of the equipped items. 

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Removes lines from doEnspell which added potency if the player had items giving the stat. This was already done through item mods in item_mods.sql, latents in item_latents.sql, and applied in battleutils.cpp

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
1. !additem 16011
2. !getmod 432

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA