### PR TITLE
RSE Satchet droprate fix

### DIFF
--- a/scripts/zones/Gusgen_Mines/npcs/qm1.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/qm1.lua
@@ -28,7 +28,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_FLY):addListener("ITEM_DROPS", "ITEM_DROPS_RSE", function(mob, loot)
-            loot:addItemFixed(item, xi.drop_rate.UNCOMMON)
+            loot:addItem(item, xi.drop_rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???

--- a/scripts/zones/Maze_of_Shakhrami/npcs/qm1.lua
+++ b/scripts/zones/Maze_of_Shakhrami/npcs/qm1.lua
@@ -28,7 +28,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_CRAWLER):addListener("ITEM_DROPS", "ITEM_DROPS_RSE", function(mob, loot)
-            loot:addItemFixed(item, xi.drop_rate.UNCOMMON)
+            loot:addItem(item, xi.drop_rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???

--- a/scripts/zones/Ordelles_Caves/npcs/qm1.lua
+++ b/scripts/zones/Ordelles_Caves/npcs/qm1.lua
@@ -28,7 +28,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_LEECH):addListener("ITEM_DROPS", "ITEM_DROPS_RSE", function(mob, loot)
-            loot:addItemFixed(item, xi.drop_rate.UNCOMMON)
+            loot:addItem(item, xi.drop_rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed droprates of RSE satchets to be 10% from 0.5% (Abdiah)

## What does this pull request do? (Please be technical)
Using loot:addItemFixed takes the raw droprate. Where xi.drop_rate.UNCOMMON was returning an int of 5. (Which was used to access an index) loot:addItem uses said index properly to access the proper 10% droprate

## Steps to test these changes
kill RSE NMs and test drop rates
