### PR TITLE
add day/weather macc modifiers

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -985,6 +985,35 @@ xi.magic.getMagicHitRate = function(caster, target, skillType, element, effect, 
         local elementBonus = caster:getMod(spellAcc[element])
         xi.msg.debugValue(caster, "Elemental Bonus", elementBonus)
         bonusAcc = bonusAcc + affinityBonus + elementBonus
+        if
+            math.random(1, 100) <= 33 or
+            caster:getMod(xi.magic.elementalObi[element]) >= 1
+        then
+            local dayElement = VanadielDayElement()
+            -- Strong day.
+            if dayElement == element then
+                bonusAcc = bonusAcc + 5
+
+            -- Weak day.
+            elseif dayElement == xi.magic.elementDescendant[element] then
+                bonusAcc = bonusAcc - 5
+            end
+
+            local weather = caster:getWeather()
+            -- Strong weathers.
+            if weather == xi.magic.singleWeatherStrong[element] then
+                bonusAcc = bonusAcc + caster:getMod(xi.mod.IRIDESCENCE) * 5 + 5
+            elseif weather == xi.magic.doubleWeatherStrong[element] then
+                bonusAcc = bonusAcc + caster:getMod(xi.mod.IRIDESCENCE) * 5 + 10
+
+            -- Weak weathers.
+            elseif weather == xi.magic.singleWeatherWeak[element] then
+                bonusAcc = bonusAcc - caster:getMod(xi.mod.IRIDESCENCE) * 5 - 5
+            elseif weather == xi.magic.doubleWeatherWeak[element] then
+                bonusAcc = bonusAcc - caster:getMod(xi.mod.IRIDESCENCE) * 5 - 10
+            end
+        end
+
         xi.msg.debugValue(caster, "Bonus Magic Accuracy", bonusAcc)
     end
 

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -484,6 +484,35 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
         local elementBonus  = caster:getMod(spellAcc[spellElement])
         xi.msg.debugValue(caster, "Elemental Bonus", elementBonus)
         magicAcc = magicAcc + affinityBonus + elementBonus
+        if
+            math.random(1, 100) <= 33 or
+            caster:getMod(elementalObi[spellElement]) >= 1
+        then
+            local dayElement = VanadielDayElement()
+            -- Strong day.
+            if dayElement == spellElement then
+                magicAcc = magicAcc + 5
+
+            -- Weak day.
+            elseif dayElement == xi.magic.elementDescendant[spellElement] then
+                magicAcc = magicAcc - 5
+            end
+
+            local weather = caster:getWeather()
+            -- Strong weathers.
+            if weather == xi.magic.singleWeatherStrong[spellElement] then
+                magicAcc = magicAcc + caster:getMod(xi.mod.IRIDESCENCE) * 5 + 5
+            elseif weather == xi.magic.doubleWeatherStrong[spellElement] then
+                magicAcc = magicAcc + caster:getMod(xi.mod.IRIDESCENCE) * 5 + 10
+
+            -- Weak weathers.
+            elseif weather == xi.magic.singleWeatherWeak[spellElement] then
+                magicAcc = magicAcc - caster:getMod(xi.mod.IRIDESCENCE) * 5 - 5
+            elseif weather == xi.magic.doubleWeatherWeak[spellElement] then
+                magicAcc = magicAcc - caster:getMod(xi.mod.IRIDESCENCE) * 5 - 10
+            end
+        end
+
         xi.msg.debugValue(caster, "Adjusted Magic Accuracy", magicAcc)
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Day and weather now has an effect on accuracy of spells (Nixy)

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds logic to calculate day/weather modifiers for spell accuracy in function getMagicHitRate
Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1774

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
!additem 28419

In xi.spells.damage.calculateResist, comment out math.random(1, 100) <= 33 on line 488 then put a print for the variable magicAcc. Test with and without an obi equipped.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA