### PR TITLE
WSNM Exploit Fix

### DIFF
--- a/scripts/quests/bastok/Inheritance.lua
+++ b/scripts/quests/bastok/Inheritance.lua
@@ -137,7 +137,9 @@ quest.sections =
             ['Maharaja'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/bastok/Shoot_First_Ask_Questions_Later.lua
+++ b/scripts/quests/bastok/Shoot_First_Ask_Questions_Later.lua
@@ -141,7 +141,9 @@ quest.sections =
             ['Beet_Leafhopper'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/bastok/The_Walls_of_Your_Mind.lua
+++ b/scripts/quests/bastok/The_Walls_of_Your_Mind.lua
@@ -138,7 +138,9 @@ quest.sections =
             ['Bodach'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/bastok/The_Weight_of_Your_Limits.lua
+++ b/scripts/quests/bastok/The_Weight_of_Your_Limits.lua
@@ -138,7 +138,9 @@ quest.sections =
             ['Greenman'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/jeuno/Axe_the_Competition.lua
+++ b/scripts/quests/jeuno/Axe_the_Competition.lua
@@ -137,7 +137,9 @@ quest.sections =
             ['Yallery_Brown'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/outlands/Bugi_Soden.lua
+++ b/scripts/quests/outlands/Bugi_Soden.lua
@@ -137,7 +137,9 @@ quest.sections =
             ['Megapod_Megalops'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/outlands/Cloak_and_Dagger.lua
+++ b/scripts/quests/outlands/Cloak_and_Dagger.lua
@@ -140,7 +140,9 @@ quest.sections =
             ['Baronial_Bat'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/outlands/The_Potential_Within.lua
+++ b/scripts/quests/outlands/The_Potential_Within.lua
@@ -137,7 +137,9 @@ quest.sections =
             ['Kettenkaefer'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/sandoria/Methods_Create_Madness.lua
+++ b/scripts/quests/sandoria/Methods_Create_Madness.lua
@@ -144,7 +144,9 @@ quest.sections =
             ['Water_Leaper'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/sandoria/Old_Wounds.lua
+++ b/scripts/quests/sandoria/Old_Wounds.lua
@@ -140,7 +140,9 @@ quest.sections =
             ['Girtablulu'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/sandoria/Souls_in_Shadow.lua
+++ b/scripts/quests/sandoria/Souls_in_Shadow.lua
@@ -140,7 +140,9 @@ quest.sections =
             ['Mokumokuren'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/windurst/Blood_and_Glory.lua
+++ b/scripts/quests/windurst/Blood_and_Glory.lua
@@ -140,7 +140,9 @@ quest.sections =
             ['Cailleach_Bheur'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/windurst/From_Saplings_Grow.lua
+++ b/scripts/quests/windurst/From_Saplings_Grow.lua
@@ -139,7 +139,9 @@ quest.sections =
             ['Stolas'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/windurst/Orastery_Woes.lua
+++ b/scripts/quests/windurst/Orastery_Woes.lua
@@ -139,7 +139,9 @@ quest.sections =
             ['Eldhrimnir'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    player:setLocalVar('killed_wsnm', 1)
+                    if player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
+                        player:setLocalVar('killed_wsnm', 1)
+                    end
                 end,
             },
         },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixes an exploit where players can bypass gaining WSNM quests. (Abdiah)

## What does this pull request do? (Please be technical)
Added a check to ensure player has the map to the annals and is qualified to continue the quest. Otherwise players were reportedly able to skip unlocking their weapon if a friend had spawned the NM for them.
