### PR TITLE
Fix Aquaveil out of era behavior

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1804,21 +1804,6 @@ namespace battleutils
 
         if (chance < check)
         {
-            // Prevent interrupt if Aquaveil is active, if it were to interrupt.
-            if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_AQUAVEIL))
-            {
-                auto aquaCount = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_AQUAVEIL)->GetPower();
-                if (aquaCount - 1 == 0) // removes the status, but still prevents the interrupt
-                {
-                    PDefender->StatusEffectContainer->DelStatusEffect(EFFECT_AQUAVEIL);
-                }
-                else
-                {
-                    PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_AQUAVEIL)->SetPower(aquaCount - 1);
-                }
-                return false;
-            }
-            // Otherwise interrupt the spell cast.
             return true;
         }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Aquaveil should no longer wear off after a certain number of spell interruption preventions. (Tracent)

## What does this pull request do? (Please be technical)
This removes some out of era Aquaveil code brought in through a recent LSB cherry pick (https://github.com/AirSkyBoat/AirSkyBoat/pull/3400), the behavior of preventing a fixed number of interruptions was from a 2010 update (https://www.bg-wiki.com/ffxi/Version_Update_(06/21/2010)). Also the current behavior is an incorrect mix of pre-2010 (preventing a percentage of all interruptions) and post-2010 as the SPELLINTERRUPT percentage mod of Aquavei is still in the code even after the LSB PR.

## Steps to test these changes


## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
