### PR TITLE
[lua] Add missing treat staff 1/2 and horror head 2 to Harvest

### DIFF
--- a/scripts/globals/events/harvest_festival.lua
+++ b/scripts/globals/events/harvest_festival.lua
@@ -168,9 +168,9 @@ local treatsTable2005 =
 local hqRewardList =
 {
     [1] = { required = xi.items.PUMPKIN_HEAD,   reward = xi.items.HORROR_HEAD, },
-    [2] = { required = xi.items.PUMPKIN_HEAD_2, reward = xi.items.HORROR_HEAD, },
-    [3] = { required = xi.items.TRICK_STAFF,    reward = xi.items.HORROR_HEAD, },
-    [4] = { required = xi.items.TRICK_STAFF_2,  reward = xi.items.HORROR_HEAD, },
+    [2] = { required = xi.items.PUMPKIN_HEAD_2, reward = xi.items.HORROR_HEAD_2, },
+    [3] = { required = xi.items.TRICK_STAFF,    reward = xi.items.TREAT_STAFF, },
+    [4] = { required = xi.items.TRICK_STAFF_2,  reward = xi.items.TREAT_STAFF_2, },
     [5] = { required = xi.items.PITCHFORK,      reward = xi.items.HORROR_HEAD, },
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Add missing treat staff 1/2 and horror head 2 to Harvest Festival (Wintersolstice)

## What does this pull request do? (Please be technical)

Add missing treat staff 1/2 and horror head 2 to Harvest

## Steps to test these changes

Equip Trick Staff, trade sweets and eventually get Treat Staff
Equip Trick Staff II, trade sweets and eventually get Treat Staff II
Equip Pumpkin Head II, trade sweets and eventually get Treat Staff II

![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/60417494/8fa107d5-af07-46ba-9ff1-88ca16f2ef0c)
![image-1](https://github.com/AirSkyBoat/AirSkyBoat/assets/60417494/5bda1d65-86d4-4ff3-b187-112d51ea6ff6)
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/60417494/4c835b7f-cdbd-462e-88a4-602dd8d206b2)

Note: Treat Staff's warp latent doesn't work yet.
## Special Deployment Considerations

N/A
