### PR TITLE
Fix Maiden's Virelai check

### DIFF
--- a/scripts/globals/abilities/tame.lua
+++ b/scripts/globals/abilities/tame.lua
@@ -31,6 +31,7 @@ abilityObject.onUseAbility = function(player, target, ability)
         ability:setMsg(xi.msg.basic.JA_NO_EFFECT)
         return 0
     end
+
     local tameBonus   = 0
     local charmChance = xi.magic.getCharmChance(player, target, false)
 

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1933,7 +1933,11 @@ xi.magic.doAbsorbSpell = function(caster, target, spell, params)
     return spellTable[isAbsorbTp].returnVal
 end
 
-xi.magic.getCharmChance = function(charmer, target, includeCharmAffinityAndChanceMods)
+xi.magic.getCharmChance = function(charmer, target, includeCharmAffinityAndChanceMods, isMaidensVirelai)
+    if isMaidensVirelai == nil then
+        isMaidensVirelai = false
+    end
+
     -- Paranoid check
     if
         (not charmer or not target) or                            -- Invalid params
@@ -1950,28 +1954,25 @@ xi.magic.getCharmChance = function(charmer, target, includeCharmAffinityAndChanc
     local targetLevel     = target:getMainLvl()
     local charmres        = target:getMod(xi.mod.CHARMRES)
     local charmChance     = 50 - charmres
-    local charmerBSTLevel = 0
+    local charmerJobLevel = 0
 
     if charmer:isPC() then
-        charmerBSTLevel = charmer:getJobLevel(xi.job.BST)
-        local charmerBRDLevel = charmer:getJobLevel(xi.job.BRD)
-        -- Maiden's Virelai check
-        if charmer:getMainJob() == xi.job.BST and charmerBRDLevel > charmerBSTLevel then
-            charmerBSTLevel = charmerBRDLevel
+        if isMaidensVirelai then
+            charmerJobLevel = charmer:getJobLevel(xi.job.BRD)
+        else
+            charmerJobLevel = charmer:getJobLevel(xi.job.BST)
         end
-
-        charmerBSTLevel = math.min(charmerBSTLevel, charmerLevel)
     else
-        charmerBSTLevel = charmerLevel
+        charmerJobLevel = charmerLevel
     end
 
     -- dLvl varies for different level ranges
     if targetLevel >= 71 then
-        charmChance = charmChance - 10 * (targetLevel - charmerBSTLevel)
+        charmChance = charmChance - 10 * (targetLevel - charmerJobLevel)
     elseif targetLevel >= 51 then
-        charmChance = charmChance - 5 * (targetLevel - charmerBSTLevel)
+        charmChance = charmChance - 5 * (targetLevel - charmerJobLevel)
     else
-        charmChance = charmChance - 3 * (targetLevel - charmerBSTLevel)
+        charmChance = charmChance - 3 * (targetLevel - charmerJobLevel)
     end
 
     -- Multiplier determined by target's light EEM

--- a/scripts/globals/spells/songs/maidens_virelai.lua
+++ b/scripts/globals/spells/songs/maidens_virelai.lua
@@ -33,7 +33,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.effect = xi.effect.CHARM_I
     local resist = xi.magic.applyResistanceEffect(caster, target, spell, params)
 
-    if resist >= 0.25 and xi.magic.getCharmChance(caster, target, false) > 0 then
+    if
+        resist >= 0.25 and
+        xi.magic.getCharmChance(caster, target, false, true) > 0
+    then
         spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
 
         duration = duration * resist


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Check for Maiden's Virelai is now done correctly when calculating charm chance (Nixy)

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds a parameter to xi.magic.getCharmChance to check the spell/ability being used.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
Use print statements

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA