### PR TITLE
Fixes Treat Staff Latent Effect

### DIFF
--- a/scripts/globals/items/treat_staff.lua
+++ b/scripts/globals/items/treat_staff.lua
@@ -1,0 +1,38 @@
+-----------------------------------
+-- ID: 17566
+-- Treat Staff
+-- Players have a chance to be warped while attacking depeding on the following conditions:
+--  1) If the Harvest Festival active, while HP <= 75% and TP < 1000
+--  2) Under Full/New Moon, while HP <= 75% and TP < 1000
+-- Based on FFXIclopedia in 2005
+-- https://ffxiclopedia.fandom.com/wiki/Treat_Staff?direction=next&oldid=24549
+-- Proc Rate requires more testing (Currently Set to 20%)
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemDrop = function(player, item)
+end
+
+itemObject.onItemEquip = function(player, item)
+    player:addListener("ATTACK", "TRICK_STAFF_WARP", function(playerArg, mob)
+        if
+            xi.events.harvest.enabledCheck() or
+            IsMoonFull() or
+            IsMoonNew()
+        then
+            if
+                playerArg:getTP() < 1000 and
+                playerArg:getHPP() <= 75 and
+                math.random() <= .2
+            then
+                playerArg:warp()
+            end
+        end
+    end)
+end
+
+itemObject.onItemUnequip = function(player, item)
+    player:removeListener("TRICK_STAFF_WARP")
+end
+
+return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Treat Staff latent effect for warping will now trigger under the proper conditions.

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Fixes `Treat Staff` latent effect to warp under the following conditions:
1a- The Harvest Festival event is active
1b - Under Full or New Moon
2 - Player HPP <= 75%
3 - Player TP < 1000

These conditions are based on 2005 Era conditions as documented in Wiki
https://ffxiclopedia.fandom.com/wiki/Treat_Staff?direction=next&oldid=24549

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
Enable the HarvestFestival event:
`!additem 17566`
`!zone 5`
Beat on mobs with Treat Staff equipped under the specified conditions above
You should eventually be warped to your Home Point

Disable the HarvestFestival event and during Full or New Moon:
`!additem 17566`
`!zone 5`
Beat on mobs with Treat Staff equipped under the specified conditions above
You should eventually be warped to your Home Point

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
N/A