### PR TITLE
Fix Jailer of Faith QM Spawn #3244

### DIFF
--- a/scripts/zones/The_Garden_of_RuHmet/Zone.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/Zone.lua
@@ -86,12 +86,11 @@ zoneObject.afterZoneIn = function(player)
 end
 
 zoneObject.onGameHour = function(zone)
-    local vanadielHour = VanadielHour()
     local qmDrk = GetNPCByID(ID.npc.QM_IXAERN_DRK) -- Ix'aern drk
     local qmFaith = GetNPCByID(ID.npc.QM_JAILER_OF_FAITH)
 
     -- Jailer of Faith spawn randomiser
-    if  
+    if
         qmFaith:getStatus() ~= xi.status.DISAPPEAR and
         qmFaith:getLocalVar("nextMove") < os.time()
     then -- Change ??? position every 30 mins

--- a/scripts/zones/The_Garden_of_RuHmet/Zone.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/Zone.lua
@@ -63,6 +63,7 @@ zoneObject.onInitialize = function(zone)
     -- Give the Faith ??? a random spawn
     local qmFaith = GetNPCByID(ID.npc.QM_JAILER_OF_FAITH)
     qmFaith:setPos(unpack(ID.npc.QM_JAILER_OF_FAITH_POS[math.random(1, 5)]))
+    qmFaith:setLocalVar("nextMove", os.time() + 1800) -- 30 minutes from now
 
     -- Give Ix'DRG a random placeholder by picking one of the four groups at random, then adding a random number of 0-2 for the specific mob.
     local groups = ID.mob.AWAERN_DRG_GROUPS
@@ -87,13 +88,16 @@ end
 zoneObject.onGameHour = function(zone)
     local vanadielHour = VanadielHour()
     local qmDrk = GetNPCByID(ID.npc.QM_IXAERN_DRK) -- Ix'aern drk
-    local s = math.random(6, 12) -- wait time till change to next spawn pos, random 15~30 mins.
+    local qmFaith = GetNPCByID(ID.npc.QM_JAILER_OF_FAITH)
 
     -- Jailer of Faith spawn randomiser
-    if vanadielHour % s == 0 then
-        local qmFaith = GetNPCByID(ID.npc.QM_JAILER_OF_FAITH) -- Jailer of Faith
-        qmFaith:hideNPC(60) -- Hide it for 60 seconds
-        qmFaith:setPos(unpack(ID.npc.QM_JAILER_OF_FAITH_POS[math.random(1, 5)])) -- Set the new position
+    if  
+        qmFaith:getStatus() ~= xi.status.DISAPPEAR and
+        qmFaith:getLocalVar("nextMove") < os.time()
+    then -- Change ??? position every 30 mins
+        qmFaith:hideNPC(60)
+        qmFaith:setLocalVar("nextMove", os.time() + 1800) -- 30 minutes later
+        qmFaith:setPos(unpack(ID.npc.QM_JAILER_OF_FAITH_POS[math.random(1, 5)]))
     end
 
     -- Ix'DRK spawn randomiser

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Faith.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Faith.lua
@@ -53,7 +53,6 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-
     -- Observed to use manafont at 80/50/25% HP
     xi.mix.jobSpecial.config(mob, {
         specials =
@@ -95,7 +94,10 @@ entity.onMobFight = function(mob)
         local sum = mobArg:getLocalVar("PhysicalDamage") + mobArg:getLocalVar("MagicalDamage") + mobArg:getLocalVar("RangedDamage") + mobArg:getLocalVar("BreathDamage")
         if mobArg:getAnimationSub() == 2 and sum > 1500 then -- Faith will close flower upon taking 1500 damage combined.
             closeFlower(mobArg)
-        elseif mobArg:getAnimationSub() <= 1 and mobArg:getBattleTime() > mobArg:getLocalVar("[faith]changeTime") then
+        elseif
+            mobArg:getAnimationSub() <= 1 and
+            mobArg:getBattleTime() > mobArg:getLocalVar("[faith]changeTime")
+        then
             openFlower(mobArg)
         else
             -- if no dmg taken - dont trigger a change

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Faith.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Faith.lua
@@ -117,6 +117,8 @@ entity.onMobDeath = function(mob)
 end
 
 entity.onMobDespawn = function(mob)
+    local qmFaith = GetNPCByID(ID.npc.QM_JAILER_OF_FAITH)
+    qmFaith:setLocalVar("nextMove", os.time() + 1800 + xi.settings.main.FORCE_SPAWN_QM_RESET_TIME) -- 30 minutes from the time the QM respawns
     -- Move QM to random location
     GetNPCByID(ID.npc.QM_JAILER_OF_FAITH):setPos(unpack(ID.npc.QM_JAILER_OF_FAITH_POS[math.random(1, 5)]))
 end


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Jailer of Faith Quest Marker will now only move once every 30 minutes.

## What does this pull request do? (Please be technical)

Replaces the Jailer of Faith Spawn Randomiser code to pattern match Ix'Drk, and only move the `???` around once every 30 minutes.

## Steps to test these changes

- Watch the Jailer of Faith `???` to see it move
- Confirm that it doesn't move again within 30 minutes
- (Bonus) Kill Jailer of Faith and confirm that the `???` respawns 15 minutes after the time of death, and that it doesn't move for at least 30 minutes after spawning

## Special Deployment Considerations

N/A

## Related Issue
https://github.com/AirSkyBoat/AirSkyBoat/issues/3244