### PR TITLE
Fix Faded Promises

### DIFF
--- a/scripts/quests/bastok/Faded_Promises.lua
+++ b/scripts/quests/bastok/Faded_Promises.lua
@@ -66,7 +66,6 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     local questProgress = quest:getVar(player, 'Prog')
-
                     if questProgress == 0 then
                         return quest:progressEvent(803)
                     elseif questProgress == 2 then
@@ -78,7 +77,7 @@ quest.sections =
             onEventFinish =
             {
                 [803] = function(player, csid, option, npc)
-                    if option == 1 then
+                    if option == 0 then
                         quest:setVar(player, 'Prog', 1)
                     end
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Faded Promises is now able to be completed.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Correctly sets quest variable Prog to 1 after speaking with Ayame for the first time.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
Run through the quest

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA
