### PR TITLE
Summoning magic cast time merit

### DIFF
--- a/modules/era/sql/merits.sql
+++ b/modules/era/sql/merits.sql
@@ -135,7 +135,7 @@ REPLACE INTO `merits` (`meritid`, `name`, `upgrade`, `value`, `jobs`, `upgradeid
     (2886, 'strafe_effect', 5, 5, 8192, 7, 44),
 
     -- SMN Group 1: Elemental MP Perpetuation Cost
-    (1288, 'summoning_magic_cast_time', 5, 1, 16384, 6, 19), -- Elemental MP Cost, in era
+    -- (1288, 'summoning_magic_cast_time', 5, 1, 16384, 6, 19), -- Elemental MP Cost, in era
     -- SMN Group 2
     (2944, 'meteor_strike', 5, 400, 16384, 7, 45),
     (2946, 'heavenly_strike', 5, 400, 16384, 7, 45),

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -6719,6 +6719,12 @@ namespace battleutils
         else if (PSpell->getSpellGroup() == SPELLGROUP_SUMMONING)
         {
             cast -= 1000 * PEntity->getMod(Mod::SUMMONING_MAGIC_CAST);
+
+            if (PEntity->objtype == TYPE_PC)
+            {
+                auto* PChar = static_cast<CCharEntity*>(PEntity);
+                cast -= base * 0.01 * PChar->PMeritPoints->GetMeritValue(MERIT_SUMMONING_MAGIC_CAST_TIME, PChar);
+            }
         }
         else if (PSpell->getSpellGroup() == SPELLGROUP_SONG)
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Summoner group 1 merit summoning magic cast time applies the effect now (Nixy)

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
I commented out a line in the module merits.sql because I am assuming it was for the perpetuation merit that was never implemented.
Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1782

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
Summon avatars with and without the merit

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
NA