### PR TITLE
Revised March formulas to match era

### DIFF
--- a/scripts/globals/spells/enhancing_song.lua
+++ b/scripts/globals/spells/enhancing_song.lua
@@ -59,9 +59,9 @@ local pTable =
     [xi.magic.spell.SHEEPFOE_MAMBO    ] = { 1, xi.effect.MAMBO,     xi.mod.AUGMENT_SONG_STAT, xi.mod.MAMBO_EFFECT,    0,                        0,                    5,  85,  15, 2.5, 18, true  },
     [xi.magic.spell.DRAGONFOE_MAMBO   ] = { 2, xi.effect.MAMBO,     xi.mod.AUGMENT_SONG_STAT, xi.mod.MAMBO_EFFECT,    0,                        0,                    9, 130,  30, 2.5, 18, true  },
     -- March
-    [xi.magic.spell.ADVANCING_MARCH   ] = { 1, xi.effect.MARCH,     xi.mod.AUGMENT_SONG_STAT, xi.mod.MARCH_EFFECT,    0,                        0,                   35, 200,  70,  10,  7, true  },
-    [xi.magic.spell.VICTORY_MARCH     ] = { 2, xi.effect.MARCH,     xi.mod.AUGMENT_SONG_STAT, xi.mod.MARCH_EFFECT,    0,                        0,                   43, 300, 128,  10,  7, true  },
-    [xi.magic.spell.HONOR_MARCH       ] = { 3, xi.effect.MARCH,     xi.mod.AUGMENT_SONG_STAT, xi.mod.MARCH_EFFECT,    0,                        0,                   24, 400, 126,  10,  7, true  }, -- Not an error. It is weaker.
+    [xi.magic.spell.ADVANCING_MARCH   ] = { 1, xi.effect.MARCH,     xi.mod.AUGMENT_SONG_STAT, xi.mod.MARCH_EFFECT,    0,                        0,                   35, 200,  64,  16,  7, true  },
+    [xi.magic.spell.VICTORY_MARCH     ] = { 2, xi.effect.MARCH,     xi.mod.AUGMENT_SONG_STAT, xi.mod.MARCH_EFFECT,    0,                        0,                   53, 300, 128,  16,  7, true  },
+    [xi.magic.spell.HONOR_MARCH       ] = { 3, xi.effect.MARCH,     xi.mod.AUGMENT_SONG_STAT, xi.mod.MARCH_EFFECT,    0,                        0,                   24, 400, 126,  10,  7, true  },-- Not an error. It is weaker.
     -- Minne: Skill Caps unknown?
     [xi.magic.spell.KNIGHTS_MINNE     ] = { 1, xi.effect.MINNE,     xi.mod.AUGMENT_SONG_STAT, xi.mod.MINNE_EFFECT,    xi.merit.MINNE_EFFECT,    xi.jp.MINNE_EFFECT,   5,   0,  14, 2.5, 15, true  },
     [xi.magic.spell.KNIGHTS_MINNE_II  ] = { 2, xi.effect.MINNE,     xi.mod.AUGMENT_SONG_STAT, xi.mod.MINNE_EFFECT,    xi.merit.MINNE_EFFECT,    xi.jp.MINNE_EFFECT,  6,   0,  28, 2.5, 15, true  },
@@ -157,7 +157,7 @@ xi.spells.enhancing.calculateSongPower = function(caster, target, spell, spellId
         end
     -- Level 75 Victory March tiers
     elseif songEffect == xi.effect.MARCH and tier == 2 and singingLvl >= 445 then
-        power = 85
+        power = 73
         local increase = 23
         for _, v in pairs(marchTiers) do
             if singingLvl >= v then
@@ -292,11 +292,9 @@ xi.spells.enhancing.useEnhancingSong = function(caster, target, spell)
 
     -- EXCEPTION: March Songs effect conversion.
     if songEffect == xi.effect.MARCH then
-        if power >= 85 then
-            power = math.floor((power / 1000) * 10000)
-        else
-            power = math.floor((power / 1024) * 10000)
-        end
+        -- March haste is a value of x/1024 BGWiki has tiers for Advancing March: https://www.bg-wiki.com/index.php?title=Victory_March&oldid=97072
+        -- Testing that was used as a source for BGWiki: https://www.bluegartr.com/threads/52417-Yey!-Another-Haste-Topic!
+        power = math.floor((power / 1024) * 10000)
     end
 
     -- Handle Status Effects.


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Revised Advancing and Victory March formulas to match era. (Cybin)

## What does this pull request do? (Please be technical)

Advancing March cap was changed to 64/1024 without instrument bonus and the instrument bonus was increased from 10/1024 to 16/1024 per increment.
Victory March base power was increased to 53/1024, instrument bonus was increased from 10/1024 to 16/1024 per increment, and the above 445 skill formula was consolidated to utilize increments of 1/1024 instead of 1/1000. Due to the increment change 445 base power was also modified from 85 to 73.
Changes end up in a slight buff to Advancing March and pre 445 skill Victory March while having a slight nerf on post 445 Victory March.

All changes were based on: https://www.bg-wiki.com/index.php?title=Victory_March&oldid=97072 and the source it used https://www.bluegartr.com/threads/52417-Yey!-Another-Haste-Topic!

## Steps to test these changes

Cast Advancing/Victory March at various skill levels and use !geteffects on yourself to determine the power. Compare it to the Google sheet: https://docs.google.com/spreadsheets/d/1-0VQdfpI0AAkU_gxGFoJ-Qrkilz1UgfddLGEXYSnAjU/edit?usp=share_link

## Special Deployment Considerations

N/A
