### PR TITLE
[lua] Fix cure pot recieved to be a % mod instead of raw multiplier

### DIFF
--- a/scripts/globals/spells/healing_spell.lua
+++ b/scripts/globals/spells/healing_spell.lua
@@ -143,7 +143,7 @@ xi.spells.healing.doHealingSpell = function(caster, target, spell, isWhiteMagic)
 
     if xi.magic.isValidHealTarget(caster, target) then
         final = xi.spells.healing.applyCasterBonuses(caster, base, spell:getElement(), isWhiteMagic)
-        final = (final + (final * target:getMod(xi.mod.CURE_POTENCY_RCVD))) * xi.settings.main.CURE_POWER
+        final = (final * (1.0 + target:getMod(xi.mod.CURE_POTENCY_RCVD) / 100)) * xi.settings.main.CURE_POWER
         xi.spells.healing.handleAfflatusSolace(caster, target, final)
     else
         if target:isUndead() then
@@ -175,7 +175,7 @@ xi.spells.healing.doHealingSpell = function(caster, target, spell, isWhiteMagic)
         else
             if caster:isMob() and target:isMob() then
                 final = xi.spells.healing.applyCasterBonuses(caster, base, spell:getElement(), isWhiteMagic)
-                final = (final + (final * target:getMod(xi.mod.CURE_POTENCY_RCVD))) * xi.settings.main.CURE_POWER
+                final = (final * (1.0 + target:getMod(xi.mod.CURE_POTENCY_RCVD) / 100)) * xi.settings.main.CURE_POWER
             end
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fix cure potency received -- it is now a % mod instead of a raw multiplier. (Wintersolstice)
## What does this pull request do? (Please be technical)

Fix cure potency received to be a percent modifier instead of raw multiplier
i.e. 5 mod is now +5% instead of 5.0x

## Steps to test these changes

Use cure pot received items, see appropriate bonuses

## Special Deployment Considerations

N/A
