### PR TITLE
Remove unused charVar's in whitegate Zone lua

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -55,18 +55,6 @@ end
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
-        [1] = function()  -- Cutscene for Got It All quest.
-            if player:getCharVar("gotitallCS") == 5 then
-                player:startEvent(526)
-            end
-        end,
-
-        [2] = function() -- CS for Vanishing Act Quest
-            if player:getCharVar("vanishingactCS") == 3 then
-                player:startEvent(44)
-            end
-        end,
-
         [5] = function() -- AH mission
             if
                 player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.NAVIGATING_THE_UNFRIENDLY_SEAS) == QUEST_COMPLETED and
@@ -95,10 +83,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
-    if csid == 44 then
-        player:setCharVar("vanishingactCS", 4)
-        player:setPos(-80, -6, 122, 5)
-    elseif csid == 200 then
+    if csid == 200 then
         player:setPos(0, -2, 0, 0, 47)
     elseif csid == 201 then
         player:setPos(-11, 2, -142, 192)
@@ -107,9 +92,6 @@ zoneObject.onEventFinish = function(player, csid, option)
         player:setPos(0, -2, 0, 0, 58)
     elseif csid == 204 then
         player:setPos(11, 2, 142, 64)
-    elseif csid == 526 then
-        player:setCharVar("gotitallCS", 6)
-        player:setPos(60, 0, -71, 38)
     elseif csid == 797 then
         player:setCharVar("Quest[6][26]Prog", 1) -- Set For Corsair BCNM
         player:addQuest(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.AGAINST_ALL_ODDS) -- Start of af 3 not completed yet


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
NONE
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Removes unnecessary charVars that are no longer used due to  conversion of quest to Interaction Framework.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
https://github.com/AirSkyBoat/AirSkyBoat/blob/7fca920d873c41c77aea0cf0b208eb6db843e3db/scripts/quests/ahtUrhgan/Got_It_All.lua#L110
https://github.com/AirSkyBoat/AirSkyBoat/blob/7fca920d873c41c77aea0cf0b208eb6db843e3db/scripts/quests/ahtUrhgan/Vanishing_Act.lua#L113

## Steps to test these changes
None needed.
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
NONE
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
