### PR TITLE
Fix mobskill readying distance and mob movement speed issues

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -101,6 +101,13 @@ xi.settings.map =
     -- Modifier to apply to agro'd monster speed. 0 is the retail accurate default. Negative numbers will reduce it.
     MOB_SPEED_MOD = -10,
 
+    -- Percent (out of 1) of the total mobskill distance in which mob will start readying the mobskill
+    -- Beyond this distance the mob will only finish an already started mobskill
+    -- And beyond the total distance the skill will be interrupted
+    MOB_ABILITY_READY_DISTANCE_PERCENT = 0.60,
+    -- Threshold mobskill distance for ignoring the above percent rule
+    MOB_ABILITY_READY_THRESHOLD = 6.8,
+
     -- Allows you to manipulate the constant multiplier in the skill-up rate formulas, having a potent effect on skill-up rates.
     SKILLUP_CHANCE_MULTIPLIER = 1.0,
     CRAFT_CHANCE_MULTIPLIER   = 1.0,

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -397,7 +397,7 @@ bool CMobController::MobSkill(int wsList)
         {
             float currentDistance = distance(PMob->loc.p, PActionTarget->loc.p);
 
-            if (currentDistance <= PMobSkill->getDistance())
+            if (currentDistance <= PMobSkill->getReadyDistance())
             {
                 return MobSkill(PActionTarget->targid, PMobSkill->getID());
             }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -259,8 +259,8 @@ uint8 CBattleEntity::GetSpeed()
     // Get the percentage of increase/decreate by mod
     auto modAmount = static_cast<float>(getMod(mod)) / 100.0f;
 
-    // Cap unmounted movement speed increase to 25%
-    if (mod == Mod::MOVE && modAmount > 0) // Only clamp position/negatvie if we're increasing speed
+    // Cap unmounted movement speed increase to 25% for PCs
+    if (mod == Mod::MOVE && modAmount > 0 && objtype == TYPE_PC) // Only clamp position/negatvie if we're increasing speed
     {
         if (StatusEffectContainer->GetStatusEffect(EFFECT_FLEE))
         {
@@ -1138,7 +1138,7 @@ uint8 CBattleEntity::GetDeathType()
 
 void CBattleEntity::addModifier(Mod type, int16 amount)
 {
-    if (type == Mod::MOVE)
+    if (type == Mod::MOVE && objtype == TYPE_PC)
     {
         m_MSNonItemValues.push_back(amount);
         m_modStat[type] = CalculateMSFromSources();
@@ -1160,7 +1160,7 @@ void CBattleEntity::addModifiers(std::vector<CModifier>* modList)
     TracyZoneScoped;
     for (auto modifier : *modList)
     {
-        if (modifier.getModID() == Mod::MOVE)
+        if (modifier.getModID() == Mod::MOVE && objtype == TYPE_PC)
         {
             addModifier(modifier.getModID(), modifier.getModAmount()); // Calculations in addModifier already, don't duplicate
         }
@@ -1232,7 +1232,7 @@ void CBattleEntity::addEquipModifiers(std::vector<CModifier>* modList, uint8 ite
             else
             {
                 // Add item with movement speed and prevent stacking
-                if (i.getModID() == Mod::MOVE)
+                if (i.getModID() == Mod::MOVE && objtype == TYPE_PC)
                 {
                     m_MSItemValues.push_back(i.getModAmount());
                     m_modStat[i.getModID()] = CalculateMSFromSources();
@@ -1335,7 +1335,7 @@ void CBattleEntity::setModifiers(std::vector<CModifier>* modList)
 
 void CBattleEntity::delModifier(Mod type, int16 amount)
 {
-    if (type == Mod::MOVE)
+    if (type == Mod::MOVE && objtype == TYPE_PC)
     {
         for (uint16 x = 0; x < m_MSNonItemValues.size(); x++)
         {
@@ -1375,7 +1375,7 @@ void CBattleEntity::delModifiers(std::vector<CModifier>* modList)
     TracyZoneScoped;
     for (auto& i : *modList)
     {
-        if (i.getModID() == Mod::MOVE)
+        if (i.getModID() == Mod::MOVE && objtype == TYPE_PC)
         {
             delModifier(i.getModID(), i.getModAmount()); // Calculations in delModifier already, don't duplicate
         }
@@ -1407,7 +1407,7 @@ void CBattleEntity::delEquipModifiers(std::vector<CModifier>* modList, uint8 ite
             else
             {
                 // Remove item with movement speed and prevent stacking
-                if (i.getModID() == Mod::MOVE)
+                if (i.getModID() == Mod::MOVE && objtype == TYPE_PC)
                 {
                     for (uint16 x = 0; x < m_MSItemValues.size(); x++)
                     {

--- a/src/map/lua/lua_mobskill.cpp
+++ b/src/map/lua/lua_mobskill.cpp
@@ -113,6 +113,11 @@ uint8 CLuaMobSkill::getMobHPP()
     return m_PLuaMobSkill->getHPP();
 }
 
+float CLuaMobSkill::getReadyDistance()
+{
+    return m_PLuaMobSkill->getReadyDistance();
+}
+
 //======================================================//
 
 void CLuaMobSkill::Register()
@@ -130,6 +135,7 @@ void CLuaMobSkill::Register()
     SOL_REGISTER("getTP", CLuaMobSkill::getTP);
     SOL_REGISTER("getMobHP", CLuaMobSkill::getMobHP);
     SOL_REGISTER("getMobHPP", CLuaMobSkill::getMobHPP);
+    SOL_REGISTER("getReadyDistance", CLuaMobSkill::getReadyDistance);
 }
 
 std::ostream& operator<<(std::ostream& os, const CLuaMobSkill& mobskill)

--- a/src/map/lua/lua_mobskill.h
+++ b/src/map/lua/lua_mobskill.h
@@ -53,6 +53,7 @@ public:
     void   setMsg(uint16 message);
     uint16 getMsg();
     uint16 getTotalTargets();
+    float  getReadyDistance();
 
     static void Register();
 };

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -218,6 +218,7 @@ namespace luautils
         lua.set_function("GetReadOnlyItem", &luautils::GetReadOnlyItem);
         lua.set_function("GetAbility", &luautils::GetAbility);
         lua.set_function("GetSpell", &luautils::GetSpell);
+        lua.set_function("GetMobSkill", &luautils::GetMobSkill);
         lua.set_function("SelectDailyItem", &luautils::SelectDailyItem);
         lua.set_function("GetContainerFilenamesList", &luautils::GetContainerFilenamesList);
         lua.set_function("GetCachedInstanceScript", &luautils::GetCachedInstanceScript);
@@ -5219,6 +5220,13 @@ namespace luautils
         TracyZoneScoped;
         CSpell* PSpell = spell::GetSpell(static_cast<SpellID>(id));
         return PSpell ? std::optional<CLuaSpell>(PSpell) : std::nullopt;
+    }
+
+    std::optional<CLuaMobSkill> GetMobSkill(uint16 id)
+    {
+        TracyZoneScoped;
+        CMobSkill* PMobSkill = battleutils::GetMobSkill(id);
+        return PMobSkill ? std::optional<CLuaMobSkill>(PMobSkill) : std::nullopt;
     }
 
     sol::table NearLocation(sol::table const& table, float radius, float theta)

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -46,6 +46,7 @@ extern sol::state lua;
 #define SOL_REGISTER(FuncName, Func) lua[className][FuncName] = &Func
 
 #include "items/item_equipment.h"
+#include "mobskill.h"
 #include "spell.h"
 
 #include "lua_ability.h"
@@ -152,6 +153,7 @@ namespace luautils
     auto GetReadOnlyItem(uint32 id) -> std::optional<CLuaItem>; // Returns a read only lookup item object of the specified ID
     auto GetAbility(uint16 id) -> std::optional<CLuaAbility>;
     auto GetSpell(uint16 id) -> std::optional<CLuaSpell>;
+    auto GetMobSkill(uint16 id) -> std::optional<CLuaMobSkill>;
 
     auto   SpawnMob(uint32 mobid, sol::object const& arg2, sol::object const& arg3) -> std::optional<CLuaBaseEntity>; // Spawn Mob By Mob Id - NMs, BCNM...
     void   DespawnMob(uint32 mobid, sol::object const& arg2);                                                         // Despawn (Fade Out) Mob By Id

--- a/src/map/mobskill.cpp
+++ b/src/map/mobskill.cpp
@@ -344,6 +344,20 @@ float CMobSkill::getDistance() const
     return m_Distance;
 }
 
+float CMobSkill::getReadyDistance() const
+{
+    // default the ready distance to the full distance
+    float mobSkillReadyDistance = m_Distance;
+
+    // calculate the ready distance based on fraction of full distance if
+    // greater than a threshold
+    if (m_Distance >= settings::get<float>("map.MOB_ABILITY_READY_THRESHOLD"))
+    {
+        mobSkillReadyDistance = m_Distance * settings::get<float>("map.MOB_ABILITY_READY_DISTANCE_PERCENT");
+    }
+    return mobSkillReadyDistance;
+}
+
 float CMobSkill::getRadius() const
 {
     if (m_Aoe == 2)

--- a/src/map/mobskill.h
+++ b/src/map/mobskill.h
@@ -58,6 +58,7 @@ public:
     uint16 getPetAnimationID() const;
     uint8  getAoe() const;
     float  getDistance() const;
+    float  getReadyDistance() const;
     uint8  getFlag() const;
     uint16 getAnimationTime() const;
     uint16 getActivationTime() const;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Monsters will now start readying mob abilities at more retail accurate distances from their targets. (Tracent)

## What does this pull request do? (Please be technical)
This PR lays the groundwork to have separate distances for 1) how far away a target can be and still have a mob start readying a mobskill and 2) how far away a target can be and still be hit by that mobskill (and not interrupted). Retail testing shows that these are different values. This change helps prevent players from stuttering mobs (i.e., locking the mob into many mobskills in a row that all get ranged by moving just slightly out of the max range each time) that have high regain.

The PR also fixes several Mod::MOVE checks to make sure they are only applying to players (as monsters have no 25% limit).

## Steps to test these changes
Fight many mobs with mobskill with different ranges

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
