### PR TITLE
[world] Refactor regionalMsgHandlers handling (cherry-pick)

### DIFF
--- a/src/map/ai/states/magic_state.h
+++ b/src/map/ai/states/magic_state.h
@@ -60,7 +60,7 @@ public:
     void   ApplyEnmity(CBattleEntity* PTarget, int ce, int ve);
     void   ApplyMagicCoverEnmity(CBattleEntity* PCoverAbilityTarget, CBattleEntity* PCoverAbilityUser, CMobEntity* PMob);
 
-    void SetInstantCast(const bool bInstantCast)
+    void SetInstantCast(bool const bInstantCast)
     {
         m_instantCast = bInstantCast;
     }

--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -238,7 +238,7 @@ private:
     uint8                  m_LevelCap;
     // Entity id of the Armoury Crate that appears upon victory
     uint32     m_armouryCrate = 0;
-    const bool m_isInteraction;
+    bool const m_isInteraction;
 
     time_point m_cleanupTime;
     bool       m_cleanedPlayers = false;

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -89,7 +89,7 @@ struct SearchCommInfo
     uint16 port;
 };
 
-void TaskManagerThread(const bool& requestExit);
+void TaskManagerThread(bool const& requestExit);
 
 int32 ah_cleanup(time_point tick, CTaskMgr::CTask* PTask);
 
@@ -936,7 +936,7 @@ search_req _HandleSearchRequest(CTCPRequestPacket& PTCPRequest)
  *                                                                       *
  ************************************************************************/
 
-void TaskManagerThread(const bool& requestExit)
+void TaskManagerThread(bool const& requestExit)
 {
     duration next;
     while (!requestExit)

--- a/src/world/besieged_system.cpp
+++ b/src/world/besieged_system.cpp
@@ -32,14 +32,12 @@ BesiegedSystem::BesiegedSystem()
 {
 }
 
-bool BesiegedSystem::handleMessage(std::vector<uint8>&& payload,
-                                   in_addr              from_addr,
-                                   uint16               from_port)
+bool BesiegedSystem::handleMessage(HandleableMessage&& message)
 {
     // TODO: Handle incoming map messages
     DebugBesieged(fmt::format("Message: unknown conquest type received from {}:{}",
-                              from_addr.s_addr,
-                              from_port));
+                              message.from_addr.s_addr,
+                              message.from_port));
 
     return false;
 }

--- a/src/world/besieged_system.h
+++ b/src/world/besieged_system.h
@@ -34,12 +34,8 @@ public:
 
     /**
      * IMessageHandler implementation. Used to handle messages from message_server.
-     * NOTE: The copy of payload here is intentional, since these systems will eventually
-     *     : be moved to their own threads.
      */
-    bool handleMessage(std::vector<uint8>&& payload,
-                       in_addr              from_addr,
-                       uint16               from_port) override;
+    bool handleMessage(HandleableMessage&& message) override;
 
     /**
      * Called every vana hour (every 2.4 min). Used to send updated stronghold data

--- a/src/world/campaign_system.h
+++ b/src/world/campaign_system.h
@@ -21,9 +21,16 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #pragma once
 
-class CampaignSystem
+#include "message_handler.h"
+
+class CampaignSystem : public IMessageHandler
 {
 public:
     CampaignSystem()  = default;
     ~CampaignSystem() = default;
+
+    bool handleMessage(HandleableMessage&& message) override
+    {
+        return false;
+    }
 };

--- a/src/world/colonization_system.h
+++ b/src/world/colonization_system.h
@@ -21,9 +21,16 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #pragma once
 
-class ColonizationSystem
+#include "message_handler.h"
+
+class ColonizationSystem : public IMessageHandler
 {
 public:
     ColonizationSystem()  = default;
     ~ColonizationSystem() = default;
+
+    bool handleMessage(HandleableMessage&& message) override
+    {
+        return false;
+    }
 };

--- a/src/world/conquest_system.h
+++ b/src/world/conquest_system.h
@@ -38,12 +38,8 @@ public:
 
     /**
      * IMessageHandler implementation. Used to handle messages from message_server.
-     * NOTE: The copy of payload here is intentional, since these systems will eventually
-     *     : be moved to their own threads.
      */
-    bool handleMessage(std::vector<uint8>&& payload,
-                       in_addr              from_addr,
-                       uint16               from_port) override;
+    bool handleMessage(HandleableMessage&& message) override;
 
     /**
      * Called weekly, updates conquest data and sends regional control information

--- a/src/world/message_handler.h
+++ b/src/world/message_handler.h
@@ -22,6 +22,14 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #pragma once
 
 #include "common/mmo.h"
+#include "common/socket.h"
+
+struct HandleableMessage
+{
+    std::vector<uint8> payload;
+    in_addr            from_addr;
+    uint16             from_port;
+};
 
 #ifdef WIN32
 #include <winsock2.h>
@@ -36,11 +44,9 @@ public:
     {
     }
 
-    /*
-     * NOTE: The copy of payload here is intentional, since these systems will eventually
-     *     : be moved to their own threads.
+    /**
+     * Handles an incoming message from a map server.
+     * Return true if the message was handled, false otherwise.
      */
-    virtual bool handleMessage(std::vector<uint8>&& payload,
-                               in_addr              from_addr,
-                               uint16               from_port) = 0;
+    virtual bool handleMessage(HandleableMessage&& message) = 0;
 };

--- a/src/world/message_server.cpp
+++ b/src/world/message_server.cpp
@@ -49,13 +49,13 @@ namespace
     zmq::context_t                 zContext;
     std::unique_ptr<zmq::socket_t> zSocket;
 
-    moodycamel::ConcurrentQueue<chat_message_t> outgoing_queue;
+    moodycamel::ConcurrentQueue<chat_message_t>    outgoing_queue;
+    moodycamel::ConcurrentQueue<HandleableMessage> external_processing_queue;
 
-    std::unique_ptr<SqlConnection>                                        sql;
-    std::unordered_map<REGIONALMSGTYPE, std::shared_ptr<IMessageHandler>> regionalMsgHandlers;
-    std::unordered_map<uint16, zone_settings_t>                           zoneSettingsMap;
-    std::vector<uint64>                                                   mapEndpoints;
-    std::vector<uint64>                                                   yellMapEndpoints;
+    std::unique_ptr<SqlConnection>              sql;
+    std::unordered_map<uint16, zone_settings_t> zoneSettingsMap;
+    std::vector<uint64>                         mapEndpoints;
+    std::vector<uint64>                         yellMapEndpoints;
 } // namespace
 
 void queue_data(uint64 ipp, MSGSERVTYPE type, const uint8* data, std::size_t size)
@@ -93,6 +93,12 @@ void queue_message_broadcast(MSGSERVTYPE type, zmq::message_t* extra, zmq::messa
     {
         queue_message(ipp, type, extra, packet);
     }
+}
+
+auto pop_external_processing_message() -> std::optional<HandleableMessage>
+{
+    HandleableMessage out;
+    return external_processing_queue.try_dequeue(out) ? std::optional<HandleableMessage>(out) : std::nullopt;
 }
 
 void message_server_send(uint64 ipp, MSGSERVTYPE type, zmq::message_t* extra, zmq::message_t* packet)
@@ -249,20 +255,12 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
         }
         case MSG_MAP2WORLD_REGIONAL_EVENT:
         {
-            uint8*      data    = (uint8*)extra->data();
-            const uint8 subType = ref<uint8>(data, 0);
+            uint8* data = (uint8*)extra->data();
 
+            // Create a copy
             std::vector<uint8> bytes(data, data + extra->size());
-            try
-            {
-                auto& handler = regionalMsgHandlers.at((REGIONALMSGTYPE)subType);
-                handler->handleMessage(std::move(bytes), from_ip, from_port);
-            }
-            catch (const std::out_of_range& e)
-            {
-                ShowError(fmt::format("Handler not found: {}", e.what()));
-            }
 
+            external_processing_queue.enqueue(HandleableMessage{ bytes, from_ip, from_port });
             break;
         }
         default:
@@ -293,7 +291,7 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
     }
 }
 
-void message_server_listen(const bool& requestExit)
+void message_server_listen(bool const& requestExit)
 {
     while (!requestExit)
     {
@@ -374,16 +372,12 @@ void cache_zone_settings()
     std::copy(yellMapEndpointSet.begin(), yellMapEndpointSet.end(), std::back_inserter(yellMapEndpoints));
 }
 
-void message_server_init(const bool& requestExit)
+void message_server_init(bool const& requestExit)
 {
     TracySetThreadName("Message Server (ZMQ)");
 
     // Setup SQL
     sql = std::make_unique<SqlConnection>();
-
-    // Handler map registrations
-    regionalMsgHandlers[REGIONALMSGTYPE::REGIONAL_EVT_MSG_CONQUEST] = std::make_shared<ConquestSystem>();
-    regionalMsgHandlers[REGIONALMSGTYPE::REGIONAL_EVT_MSG_BESIEGED] = std::make_shared<BesiegedSystem>();
 
     // Populate zoneSettingsCache with sql data
     cache_zone_settings();

--- a/src/world/message_server.h
+++ b/src/world/message_server.h
@@ -36,12 +36,14 @@ void queue_data_broadcast(MSGSERVTYPE type, const uint8* data, std::size_t size)
 void queue_message(uint64 ipp, MSGSERVTYPE type, zmq::message_t* extra, zmq::message_t* packet = nullptr);
 void queue_message_broadcast(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_t* packet = nullptr);
 
-void message_server_init(const bool& requestExit);
+auto pop_external_processing_message() -> std::optional<HandleableMessage>;
+
+void message_server_init(bool const& requestExit);
 void message_server_close();
 
 struct message_server_wrapper_t
 {
-    message_server_wrapper_t(const std::atomic_bool& requestExit)
+    message_server_wrapper_t(std::atomic_bool const& requestExit)
     : m_thread(std::make_unique<nonstd::jthread>(std::bind(message_server_init, std::ref(requestExit))))
     {
     }


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

- Fixed condition that caused conquest map to sometimes not show the correct regional influence (Kore, Zach2Good)

## What does this pull request do? (Please be technical)

- World server message handling and time server methods are now executed in the same thread. This solves potential out-of-sync issues
