### PR TITLE
[core] Removes dubious static_cast in petutils

### DIFF
--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1140,10 +1140,11 @@ namespace petutils
 
     void CalculateAvatarStats(CBattleEntity* PMaster, CPetEntity* PPet)
     {
-        uint32       petID    = PPet->m_PetID;
-        Pet_t*       PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [petID](Pet_t* t)
-                                              { return t->PetID == petID; });
-        CCharEntity* PChar    = static_cast<CCharEntity*>(PMaster);
+        uint32 petID    = PPet->m_PetID;
+        Pet_t* PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [petID](Pet_t* t)
+                                        { return t->PetID == petID; });
+
+        const auto PChar = dynamic_cast<CCharEntity*>(PMaster);
 
         uint8 mLvl = PMaster->GetMLevel();
 
@@ -1167,7 +1168,7 @@ namespace petutils
             PPet->SetMLevel(PMaster->GetSLevel());
             PPet->SetSLevel(PMaster->GetSLevel());
         }
-        else if ((charutils::HasItem(PChar, 14656) == true) && (petID == PETID_WATERSPIRIT)) // Check if Player has Poseidon Ring & PetID == Water Spirit
+        else if (PChar && (charutils::HasItem(PChar, 14656) == true) && (petID == PETID_WATERSPIRIT)) // Check if Player has Poseidon Ring & PetID == Water Spirit
         {
             PPet->SetMLevel(mLvl);
             PPet->SetSLevel(mLvl);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

No Description

## What does this pull request do? (Please be technical)

Removes dubious `static_cast<CCharEntity*>` from petutils.cpp in `CalculateAvatarStats`

`static_cast` will blow up if an entity is not castable to the requested type.  Not all Battle Entities are Characters.

Eventually, any reference to this should be removed entirely because checking item IDs in C++ is bad.

## Steps to test these changes

N/A

## Special Deployment Considerations

N/A
<!-- Example: Need to run one_time_sql_conversion.sql -->
