### PR TITLE
Antican Magister fix

### DIFF
--- a/scripts/zones/Quicksand_Caves/IDs.lua
+++ b/scripts/zones/Quicksand_Caves/IDs.lua
@@ -60,7 +60,7 @@ zones[xi.zone.QUICKSAND_CAVES] =
         },
         ANTICAN_MAGISTER_PH     =
         {
-            [17629280] = 17629280, -- 856.187 1.120 -657.310
+            [17629411] = 17629412, -- -77 -0.5 -56
         },
         ANTICAN_PRAEFECTUS_PH   =
         {


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Antican Magister will now pop from its placeholder (Abdiah)

## What does this pull request do? (Please be technical)
ID used to spawn Antican Magister was Antican Princeps for both PH and result. Adjusted to be Signifier and Magister.
