### PR TITLE
LSB cherrypick: add racc modifier for shigeto bow

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2220,6 +2220,15 @@ INSERT INTO `item_latents` VALUES (17212,26,20,37,5);
 INSERT INTO `item_latents` VALUES (17212,26,25,37,4);
 
 -- -------------------------------------------------------
+-- Shigeto Bow
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (18142,26,7,62,12);     -- RACC +7 for Samurai main job
+
+-- -------------------------------------------------------
+-- Shigeto Bow +1
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (18143,26,8,62,12);     -- RACC +8 for Samurai main job
+-- -------------------------------------------------------
 -- Musketeer Gun +1/+2
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES (17269,24,8,53,1);     -- RATT +8 in areas outside own nation's control

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -91,10 +91,11 @@ enum class LATENT : uint16
     VS_ECOSYSTEM               = 59, // Vs. Specific Ecosystem ID (e.g. Vs. Plantoid: Accuracy+3)
     VS_FAMILY                  = 60, // Vs. Specific Family ID (e.g. Vs. Korrigan: Accuracy+3)
     VS_SUPERFAMILY             = 61, // Vs. Specific SuperFamily ID (e.g. Vs. Mandragora: Accuracy+3)
+    MAINJOB                    = 62, // mainjob - PARAM: JOBTYPE
     CITIZEN_OF_NATION          = 70, // Player is a citizen of the provided nation
 };
 
-#define MAX_LATENTEFFECTID 61
+#define MAX_LATENTEFFECTID 63
 
 /************************************************************************
  *                                                                       *

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -1116,6 +1116,9 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
                 }
             }
             break;
+        case LATENT::MAINJOB:
+            expression = m_POwner->GetMJob() == latentEffect.GetConditionsValue();
+            break;
         case LATENT::EQUIPPED_IN_SLOT:
             expression = latentEffect.GetSlot() == latentEffect.GetConditionsValue();
             break;


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Added SAM ranged accuracy bonus for Shigeto Bow (Haplo)

## What does this pull request do? (Please be technical)

Adds a new latent effect for main job, plus the addition of racc for Shigeto Bow for SAM
https://github.com/LandSandBoat/server/pull/4646 from LSB

## Steps to test these changes

!additem 18142
!additem 18143

Change job to rng and then sam and /checkparam to see ranged accuracy changes
