### PR TITLE
Remove restricted content era warnings in map

### DIFF
--- a/scripts/zones/Fort_Karugo-Narugo_[S]/Zone.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/Zone.lua
@@ -28,16 +28,18 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 end
 
 zoneObject.onZoneWeatherChange = function(weather)
-    local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS)
+    if xi.settings.main.ENABLE_WOTG == 1 then
+        local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS)
 
-    if npc ~= nil then
-        if
-            weather == xi.weather.DUST_STORM or
-            weather == xi.weather.SAND_STORM
-        then
-            npc:setStatus(xi.status.DISAPPEAR)
-        else
-            npc:setStatus(xi.status.NORMAL)
+        if npc ~= nil then
+            if
+                weather == xi.weather.DUST_STORM or
+                weather == xi.weather.SAND_STORM
+            then
+                npc:setStatus(xi.status.DISAPPEAR)
+            else
+                npc:setStatus(xi.status.NORMAL)
+            end
         end
     end
 end

--- a/scripts/zones/Grauberg_[S]/Zone.lua
+++ b/scripts/zones/Grauberg_[S]/Zone.lua
@@ -28,16 +28,18 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 end
 
 zoneObject.onZoneWeatherChange = function(weather)
-    local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS)
+    if xi.settings.main.ENABLE_WOTG == 1 then
+        local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS)
 
-    if npc ~= nil then
-        if
-            weather == xi.weather.WIND or
-            weather == xi.weather.GALES
-        then
-            npc:setStatus(xi.status.NORMAL)
-        else
-            npc:setStatus(xi.status.DISAPPEAR)
+        if npc ~= nil then
+            if
+                weather == xi.weather.WIND or
+                weather == xi.weather.GALES
+            then
+                npc:setStatus(xi.status.NORMAL)
+            else
+                npc:setStatus(xi.status.DISAPPEAR)
+            end
         end
     end
 end

--- a/scripts/zones/King_Ranperres_Tomb/Zone.lua
+++ b/scripts/zones/King_Ranperres_Tomb/Zone.lua
@@ -55,11 +55,13 @@ zoneObject.onEventFinish = function(player, csid, option)
 end
 
 zoneObject.onGameHour = function(zone)
-    -- Don't allow Ankou to spawn outside of night
-    if VanadielHour() >= 4 and VanadielHour() < 20 then
-        DisallowRespawn(ID.mob.ANKOU, true)
-    else
-        DisallowRespawn(ID.mob.ANKOU, false)
+    if xi.settings.main.ENABLE_WOTG == 1 then
+        -- Don't allow Ankou to spawn outside of night
+        if VanadielHour() >= 4 and VanadielHour() < 20 then
+            DisallowRespawn(ID.mob.ANKOU, true)
+        else
+            DisallowRespawn(ID.mob.ANKOU, false)
+        end
     end
 end
 

--- a/scripts/zones/Meriphataud_Mountains_[S]/Zone.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/Zone.lua
@@ -29,14 +29,16 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 end
 
 zoneObject.onGameHour = function(zone)
-    local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS)
-    local hour = VanadielHour()
+    if xi.settings.main.ENABLE_WOTG == 1 then
+        local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS)
+        local hour = VanadielHour()
 
-    if npc then
-        if hour == 17 then
-            npc:setStatus(xi.status.DISAPPEAR)
-        elseif hour == 7 then
-            npc:setStatus(xi.status.NORMAL)
+        if npc then
+            if hour == 17 then
+                npc:setStatus(xi.status.DISAPPEAR)
+            elseif hour == 7 then
+                npc:setStatus(xi.status.NORMAL)
+            end
         end
     end
 end

--- a/scripts/zones/Pashhow_Marshlands_[S]/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/Zone.lua
@@ -29,22 +29,24 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 end
 
 zoneObject.onZoneWeatherChange = function(weather)
-    local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS_OFFSET + 1) -- Indescript Markings (BOOTS)
+    if xi.settings.main.ENABLE_WOTG == 1 then
+        local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS_OFFSET + 1) -- Indescript Markings (BOOTS)
 
-    if npc then
-        if weather == xi.weather.RAIN or weather == xi.weather.THUNDER then
-            npc:setStatus(xi.status.DISAPPEAR)
-        else
-            npc:setStatus(xi.status.NORMAL)
+        if npc then
+            if weather == xi.weather.RAIN or weather == xi.weather.THUNDER then
+                npc:setStatus(xi.status.DISAPPEAR)
+            else
+                npc:setStatus(xi.status.NORMAL)
+            end
         end
-    end
 
-    npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS_OFFSET + 2) -- Indescript Markings (BODY)
-    if npc then
-        if weather == xi.weather.RAIN then
-            npc:setStatus(xi.status.DISAPPEAR)
-        else
-            npc:setStatus(xi.status.NORMAL)
+        npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS_OFFSET + 2) -- Indescript Markings (BODY)
+        if npc then
+            if weather == xi.weather.RAIN then
+                npc:setStatus(xi.status.DISAPPEAR)
+            else
+                npc:setStatus(xi.status.NORMAL)
+            end
         end
     end
 end

--- a/scripts/zones/Vunkerl_Inlet_[S]/Zone.lua
+++ b/scripts/zones/Vunkerl_Inlet_[S]/Zone.lua
@@ -23,27 +23,31 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onZoneWeatherChange = function(weather)
-    local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS) -- Indescript Markings
+    if xi.settings.main.ENABLE_WOTG == 1 then
+        local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS) -- Indescript Markings
 
-    if npc ~= nil then
-        if weather == xi.weather.FOG or weather == xi.weather.THUNDER then
-            npc:setStatus(xi.status.DISAPPEAR)
-        elseif VanadielHour() >= 16 or VanadielHour() <= 6 then
-            npc:setStatus(xi.status.NORMAL)
+        if npc ~= nil then
+            if weather == xi.weather.FOG or weather == xi.weather.THUNDER then
+                npc:setStatus(xi.status.DISAPPEAR)
+            elseif VanadielHour() >= 16 or VanadielHour() <= 6 then
+                npc:setStatus(xi.status.NORMAL)
+            end
         end
     end
 end
 
 zoneObject.onGameHour = function(zone)
-    local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS) -- Indescript Markings
+    if xi.settings.main.ENABLE_WOTG == 1 then
+        local npc = GetNPCByID(ID.npc.INDESCRIPT_MARKINGS) -- Indescript Markings
 
-    if npc ~= nil then
-        if VanadielHour() == 16 then
-            npc:setStatus(xi.status.DISAPPEAR)
-        end
+        if npc ~= nil then
+            if VanadielHour() == 16 then
+                npc:setStatus(xi.status.DISAPPEAR)
+            end
 
-        if VanadielHour() == 6 then
-            npc:setStatus(xi.status.NORMAL)
+            if VanadielHour() == 6 then
+                npc:setStatus(xi.status.NORMAL)
+            end
         end
     end
 end


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
No player facing changes

## What does this pull request do? (Please be technical)
This PR prevents errors from throwing invalid NPCs / mobs when servers have RESTRICT_CONTENT on. Disabling NPCs and or Mobs that have content tags set beyond their selected era. This is simply achieved by checking if the appropriate era is enabled in settings.
