### PR TITLE
ToAU NM Audit Pt. 4

### DIFF
--- a/modules/era/sql/era_mob_groups.sql
+++ b/modules/era/sql/era_mob_groups.sql
@@ -467,6 +467,18 @@ UPDATE mob_groups SET content_tag='ABYSSEA' WHERE name='Orichalcumshell' AND gro
 UPDATE mob_groups SET content_tag='ABYSSEA' WHERE name='Scoriaceous_Eruca' AND groupid='35' AND zoneid='61';
 
 -- ------------------------------------------------------------
+-- Mamook (Zone 65)
+-- ------------------------------------------------------------
+
+UPDATE mob_groups SET HP='20000' WHERE name='Devout_Radol_Ja' AND groupid='19' AND zoneid='65';
+UPDATE mob_groups SET HP='17500' WHERE name='Dragonscaled_Bugaal_Ja' AND groupid='26' AND zoneid='65';
+UPDATE mob_groups SET HP='5000' WHERE name='Tyrannobugard' AND groupid='27' AND zoneid='65';
+UPDATE mob_groups SET HP='18000', minlevel='82', maxlevel='85' WHERE name='Hundredfaced_Hapool_Ja' AND groupid='29' AND zoneid='65';
+UPDATE mob_groups SET HP='10000', minlevel='82', maxlevel='85' WHERE name='Hundredfaced_clone' AND groupid='72' AND zoneid='65';
+UPDATE mob_groups SET HP='21000' WHERE name='Darting_Kachaal_Ja' AND groupid='41' AND zoneid='65';
+UPDATE mob_groups SET HP='7000' WHERE name='Mamool_Ja_Treasurer' AND groupid='49' AND zoneid='65';
+
+-- ------------------------------------------------------------
 -- Mamool_Ja_Training_Grounds (Zone 66)
 -- ------------------------------------------------------------
 

--- a/scripts/zones/Mamook/IDs.lua
+++ b/scripts/zones/Mamook/IDs.lua
@@ -44,6 +44,10 @@ zones[xi.zone.MAMOOK] =
             [17043773]           = 17043779, -- -201.522 17.209 -363.865
             [17043774]           = 17043779, -- -206.458 17.525 -373.798
         },
+        DEVOUT_RADOL_JA          = 17043532,
+        DRAGONSCALED_BUGAAL_JA   = 17043626,
+        HUNDREDFACED_HAPOOL_JA   = 17043665,
+        DARTING_KACHAAL_JA       = 17043736,
         GULOOL_JA_JA             = 17043875,
         CHAMROSH                 = 17043887,
         IRIRI_SAMARIRI           = 17043888,

--- a/scripts/zones/Mamook/Zone.lua
+++ b/scripts/zones/Mamook/Zone.lua
@@ -8,6 +8,14 @@ local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
     xi.helm.initZone(zone, xi.helm.type.LOGGING)
+
+    if xi.settings.main.ENABLE_TOAU then
+        xi.mob.nmTODPersistCache(zone, ID.mob.HUNDREDFACED_HAPOOL_JA)
+        xi.mob.nmTODPersistCache(zone, ID.mob.DRAGONSCALED_BUGAAL_JA)
+        xi.mob.nmTODPersistCache(zone, ID.mob.DARTING_KACHAAL_JA)
+        xi.mob.nmTODPersistCache(zone, ID.mob.DEVOUT_RADOL_JA)
+        xi.mob.nmTODPersistCache(zone, ID.mob.GULOOL_JA_JA)
+    end
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Mamook/mobs/Archaic_Mirror.lua
+++ b/scripts/zones/Mamook/mobs/Archaic_Mirror.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Mamook
+--  Mob: Archaic Mirror
+-----------------------------------
+local entity = {}
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    -- TODO: Reduces Archaic Mirror count by 1
+end
+
+return entity

--- a/scripts/zones/Mamook/mobs/Darting_Kachaal_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Darting_Kachaal_Ja.lua
@@ -1,10 +1,104 @@
 -----------------------------------
 -- Area: Mamook
 --  Mob: Darting Kachaal Ja
+-- Note: Does not auto attack. Will run away when current target
+--  draws near. Casts either bindga, stun, or sleepga II before running.
+--  appears to run in a track rather than to random distance away from player.
+--  Does not approach his target in order to cast. Will continuously run around track.
+--
+--  Appears to have two types of engagement: A fleeing mode, and an aggressive mode.
+--  Under some time of being untouched, Kachaal Ja will become aggressive and no longer
+--  flee from its target and begin to spam aeroga iii. It also regains the ability to
+--  auto-attack. However, it begins fleeing again after taking damage.
 -----------------------------------
 local entity = {}
 
+local pathNodes =
+{
+    { x = -8, y = 18,   z = -413 },
+    { x = 5,  y = 19,   z = -425 },
+    { x = 18, y = 19,   z = -438 },
+    { x = 40, y = 17.5, z = -440 },
+    { x = 45, y = 18,   z = -412 },
+    { x = 1,  y = 17.5, z = -400 },
+    { x = 21, y = 19,   z = -397 },
+}
+
+entity.onMobSpawn = function(mob)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP) -- Needs verification
+
+    mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.STANDBACK))
+    mob:setMobMod(xi.mobMod.MAGIC_COOL, 30)
+    mob:setMobAbilityEnabled(false) -- Not witnessed to use any mob abilities
+    mob:setLocalVar("nextPoint", 1)
+end
+
+entity.onMobEngage = function(mob)
+    -- Find nearest point in path
+    for i = 2, #pathNodes do
+        local nearest = pathNodes[mob:getLocalVar("nextPoint")]
+        local next = pathNodes[i]
+
+        if mob:checkDistance(next.x, next.y, next.z) < mob:checkDistance(nearest.x, nearest.y, nearest.z) then
+            mob:setLocalVar("nextPoint", i)
+        end
+    end
+end
+
+entity.onMobFight = function(mob, target)
+    local pos = pathNodes[mob:getLocalVar("nextPoint")]
+
+    -- Doesn't run out of MP
+    mob:setMP(mob:getMaxMP())
+
+    -- Update to next destination for flee path. If out of range of
+    -- table, reset to 1
+    if mob:checkDistance(pos.x, pos.y, pos.z) < 3 then
+        mob:setLocalVar("nextPoint", mob:getLocalVar("nextPoint") + 1)
+
+        if mob:getLocalVar("nextPoint") > #pathNodes then
+            mob:setLocalVar("nextPoint", 1)
+        end
+
+        pos = pathNodes[mob:getLocalVar("nextPoint")]
+    end
+
+    if mob:checkDistance(target) <= 10 then
+        mob:setLocalVar("fleeMode", 1)
+
+        -- Only stops running after certain amount of time
+    elseif mob:getLocalVar("fleeTimer") < os.time() then
+        mob:setLocalVar("fleeTimer", os.time() + math.random(15, 30))
+        mob:setLocalVar("fleeMode", 0)
+    end
+
+    -- Spam aeroga 3
+    if mob:getLocalVar("fleeMode") == 0 then
+        mob:setSpellList(5078)
+        mob:setAutoAttackEnabled(true)
+
+    -- Path around and cast mob control spells
+    else
+        mob:setSpellList(5077)
+        mob:setAutoAttackEnabled(false)
+        -- Leave room to cast spells
+        if mob:getLocalVar("fleeTimer") < os.time() then
+            mob:setLocalVar("fleeTimer", os.time() + 2)
+            mob:pathTo(pos.x, pos.y, pos.z)
+        end
+    end
+end
+
 entity.onMobDeath = function(mob, player, optParams)
+    -- TODO: Reduces Mamool Ja Savages' military force by 1
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.nmTODPersist(mob, math.random(100800, 259200)) -- 28 to 72 hours **Needs verification**
 end
 
 return entity

--- a/scripts/zones/Mamook/mobs/Devout_Radol_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Devout_Radol_Ja.lua
@@ -1,15 +1,36 @@
 -----------------------------------
 -- Area: Mamook
 --   NM: Devout Radol Ja
+-- Note: Appears to have a unique HP display, where the first % HP drops down
+--  extremely quickly and the rest dropping much more slowly.
+--  However, Radol Ja appears to have approx 20k HP.
+--  Fight with cures + benediction Radol Ja went through 80k HP in total
+-----------------------------------
+mixins = { require("scripts/mixins/job_special") }
 -----------------------------------
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP) -- Needs verification
+
+    xi.mix.jobSpecial.config(mob, {
+        specials =
+        {
+            { id = xi.jsa.BENEDICTION, hpp = 3 },
+        },
+    })
+end
+
 entity.onMobDeath = function(mob, player, optParams)
+    -- TODO: Reduces Mamool Ja Savages' military force by 1
 end
 
 entity.onMobDespawn = function(mob)
-    UpdateNMSpawnPoint(mob:getID())
-    mob:setRespawnTime(math.random(259200, 432000)) -- 3 to 5 days
+    xi.mob.nmTODPersist(mob, math.random(259200, 432000)) -- 3 to 5 days **Spawn behaviour needs verification**
 end
 
 return entity

--- a/scripts/zones/Mamook/mobs/Dragonscaled_Bugaal_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Dragonscaled_Bugaal_Ja.lua
@@ -1,15 +1,90 @@
 -----------------------------------
 -- Area: Mamook
 --   NM: Dragonscaled Bugaal Ja
+-- Note: True behavior of bugard respawn unfconfirmed, and assumed to be
+--  similar to that of wikipedia entries
+-----------------------------------
+mixins = { require("scripts/mixins/job_special") }
 -----------------------------------
 local entity = {}
 
+local function respawnBugards(mob)
+    if mob:getLocalVar("respawnTime") < os.time() then
+        mob:setLocalVar("respawnTime", os.time() + 120)
+        local pos = mob:getPos()
+
+        for i = 1, 3 do
+            local bugard = GetMobByID(mob:getID() + i)
+
+            if not bugard:isAlive() then
+                mob:entityAnimationPacket("casm")
+                mob:setMobMod(xi.mobMod.NO_MOVE, 1)
+                mob:setAutoAttackEnabled(false)
+                mob:setMagicCastingEnabled(false)
+                mob:setMobAbilityEnabled(false)
+
+                mob:timer(1500, function(mobArg)
+                    mobArg:entityAnimationPacket("shsm")
+                    bugard:setSpawn(pos.x + math.random(-5, 5), pos.y, pos.z + math.random(-5, 5))
+                    bugard:spawn()
+                    xi.follow.follow(bugard, mob)
+
+                    if mobArg:getTarget() ~= nil then
+                        bugard:updateEnmity(mob:getTarget())
+                    end
+
+                    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+                    mobArg:setAutoAttackEnabled(true)
+                    mobArg:setMagicCastingEnabled(true)
+                    mobArg:setMobAbilityEnabled(true)
+                end)
+
+                return
+            end
+        end
+    end
+end
+
+entity.onMobSpawn = function(mob)
+    mob:addImmunity(xi.immunity.STUN)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP) -- Needs verification
+
+    xi.mix.jobSpecial.config(mob, {
+        specials =
+        {
+            { id = xi.jsa.FAMILIAR, hpp = 85 },
+        },
+    })
+end
+
+entity.onMobRoam = function(mob)
+    respawnBugards(mob)
+end
+
+entity.onMobFight = function(mob, target)
+    respawnBugards(mob)
+
+    for i = 1, 3 do
+        local bugard = GetMobByID(mob:getID() + i)
+
+        if
+            bugard:isAlive() and
+            bugard:getCurrentAction() == xi.action.ROAMING
+        then
+            bugard:updateEnmity(target)
+        end
+    end
+end
+
 entity.onMobDeath = function(mob, player, optParams)
+    -- TODO: Reduces Mamool Ja Savages' military force by 1
 end
 
 entity.onMobDespawn = function(mob)
-    UpdateNMSpawnPoint(mob:getID())
-    mob:setRespawnTime(math.random(100800, 259200)) -- 28 to 72 hours
+    xi.mob.nmTODPersist(mob, math.random(100800, 259200)) -- 28 to 72 hours
 end
 
 return entity

--- a/scripts/zones/Mamook/mobs/Tyrannobugard.lua
+++ b/scripts/zones/Mamook/mobs/Tyrannobugard.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- Area: Mamook
+--  Mob: Tyrannobugard (Pet of Dragonscaled Bugaal Ja)
+-----------------------------------
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    mob:addImmunity(xi.immunity.SLEEP)
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+return entity

--- a/scripts/zones/Mamook/mobs/Watch_Wyvern.lua
+++ b/scripts/zones/Mamook/mobs/Watch_Wyvern.lua
@@ -12,7 +12,9 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.FIREDANCE_MAGMAAL_JA_PH, 5, 3600) -- 1 hour
+    if xi.settings.main.ENABLE_WOTG == 1 then
+        xi.mob.phOnDespawn(mob, ID.mob.FIREDANCE_MAGMAAL_JA_PH, 5, 3600) -- 1 hour
+    end
 end
 
 return entity

--- a/sql/mob_spell_lists.sql
+++ b/sql/mob_spell_lists.sql
@@ -5745,6 +5745,14 @@ INSERT INTO `mob_spell_lists` VALUES ('Bukki',5076,252,45,255); -- stun (45~255)
 INSERT INTO `mob_spell_lists` VALUES ('Bukki',5076,254,4,255);  -- blind (4~255)
 INSERT INTO `mob_spell_lists` VALUES ('Bukki',5076,258,7,255);  -- bind (7~255)
 
+-- Darting Kachaal Ja (Flee Mode)
+INSERT INTO `mob_spell_lists` VALUES ('Darting_Kachaal_Ja_Flee',5077,252,1,255);  -- stun (1~255)
+INSERT INTO `mob_spell_lists` VALUES ('Darting_Kachaal_Ja_Flee',5077,274,1,255);  -- sleepga_ii (1~255)
+INSERT INTO `mob_spell_lists` VALUES ('Darting_Kachaal_Ja_Flee',5077,362,1,255);  -- bindga (1~255)
+
+-- Darting Kachaal Ja (Aggressive Mode)
+INSERT INTO `mob_spell_lists` VALUES ('Darting_Kachaal_Ja_Aggressive',5078,186,1,255);  -- aeroga_iii (1~255)
+
 /*!40000 ALTER TABLE `mob_spell_lists` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
No player facing changes

## What does this pull request do? (Please be technical)
Implements all ToAU era beastmen NMs in Mamook
All evidence based from capture: https://www.youtube.com/watch?v=1N6W7IdCtxw
All NMs given persistence
Added immunities to all NMs based from capture (With the assumption of light based sleeps)

# Darting Kachaal Ja
- Runs away from players for 15-30 seconds before coming back to attack player
- When turned back into an aggressive state, exclusively spams aeroga 3 Otherwise casts mob control spells on its target

# Devout Radol Ja
- Uses Benediction around 5% HP
- TODO: Appears to have a custom HP scaling system where his HP% drops more and more slowly the lower it gets.

# Dragonscaled Bugaal Ja
- Accompanied by 3 bugards
- Uses familiar @80%
