### PR TITLE
Fix Charybdis PH spawning issues

### DIFF
--- a/scripts/zones/Horlais_Peak/mobs/Archer_Pugil.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Archer_Pugil.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setMobSkillAttack(412)
+    mob:setMobSkillAttack(4049)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Horlais_Peak/mobs/Sniper_Pugil.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Sniper_Pugil.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setMobSkillAttack(412)
+    mob:setMobSkillAttack(4049)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Devil_Manta.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Devil_Manta.lua
@@ -17,22 +17,26 @@ entity.onMobDespawn = function(mob)
     -- 8 hour minimum, this is also set in the Charbydis script due to the multi-placeholders.
     -- See the Charbydis script for more.
 
+    local mantaOne = ID.mob.CHARYBDIS - 2
+    local mantaTwo = ID.mob.CHARYBDIS - 4
+
     if not xi.mob.phOnDespawn(mob, ID.mob.CHARYBDIS_PH, 10, 28800) then
         -- Charbydis is not queued to spawn.
         -- Choose a Charbydis PH randomly to spawn next.
         local chooseManta = math.random(1, 2)
-        local mantaOne = ID.mob.CHARYBDIS - 2
-        local mantaTwo = ID.mob.CHARYBDIS - 4
 
         if chooseManta == 2 then
-            GetMobByID(mantaTwo):setRespawnTime(GetMobRespawnTime(mantaTwo))
             DisallowRespawn(mantaOne, true)
             DisallowRespawn(mantaTwo, false)
+            GetMobByID(mantaTwo):setRespawnTime(GetMobRespawnTime(mantaTwo))
         elseif chooseManta == 1 then
-            GetMobByID(mantaOne):setRespawnTime(GetMobRespawnTime(mantaOne))
             DisallowRespawn(mantaOne, false)
             DisallowRespawn(mantaTwo, true)
+            GetMobByID(mantaOne):setRespawnTime(GetMobRespawnTime(mantaOne))
         end
+    else
+        DisallowRespawn(mantaOne, true)
+        DisallowRespawn(mantaTwo, true)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- The Charybdis placeholder should now spawn correctly. (Tracent, Siknoz)
- The monsters in the Shooting Fish BCNM now correctly attack players. (Tracent)

## What does this pull request do? (Please be technical)
This fixes two issues with Charybdis placeholder including that the placeholder (there are two but only one is up at any one time) would respawn even if Charybdis was alive, and the respawn time of would be incorrect due to ordering of setRespawnTime and DisallowRespawn.

This also fixes an issue with Shooting Fish BCNM where the fish were not attacking players because they use a special mobskill attack and the mobskill list id was changed without the mob code being changed as well.

## Steps to test these changes

Closes 
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
