### PR TITLE
Fixes Dynamis Bubu Entrance Issue

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -1762,7 +1762,7 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
 
             ["mixins"] = {   },
         },
-        ["Buburimu Dwagon"] =
+        ["Buburimu Dragon"] =
         {
             ["onMobSpawn"] = { function(mob)
                 xi.dynamis.onSpawnNoAuto(mob)
@@ -1772,11 +1772,11 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
             end },
 
             ["onMobFight"] = { function(mob, mobTarget)
-                xi.dynamis.onFightDwagon(mob, mobTarget)
+                xi.dynamis.onFightDragon(mob, mobTarget)
             end },
 
             ["onMobRoam"] = { function(mob)
-                xi.dynamis.onRoamDwagon(mob)
+                xi.dynamis.onRoamDragon(mob)
             end },
 
             ["onMobMagicPrepare"] = { function(mob, mobTarget, spellId)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixes an issue where you were not able to enter Dynamis Bubu (Frank)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Spelling was wrong causing nil values when calling the entrance spawn function
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Enter Dyna Bubu successfully 
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
n/a
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
