### PR TITLE
[core] Fix nation zone/login issues.

### DIFF
--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -656,9 +656,14 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
     auto expression  = false;
     auto latentFound = true;
 
+    if (m_POwner == nullptr)
+    {
+        return false;
+    }
+
     // this gets the current zone ID or destination zone ID if zoning
     uint16 playerZoneID = m_POwner->getZone();
-    if (m_POwner == nullptr || playerZoneID == 0)
+    if (playerZoneID == 0)
     {
         return false;
     }
@@ -1022,19 +1027,12 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
             break;
         case LATENT::NATION_CONTROL:
         {
-           // player is logging in/zoning
-            // checking the state of the user's current zone and
-            // the destination zone in tandem seems to work.
-            if (m_POwner->loc.zone == nullptr && static_cast<uint16_t>(m_POwner->loc.destination) == 0)
-            {
-                return false;
-            }
-            // Grab the user's destination if they're zoning.
-            // Otherwise, grab their current zone.
-            auto region      = m_POwner->loc.zone == nullptr ? zoneutils::GetCurrentRegion(m_POwner->loc.destination) : zoneutils::GetCurrentRegion(playerZoneID);
-            auto hasSignet   = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET);
-            auto hasSanction = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION);
-            auto hasSigil    = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SIGIL);
+            // playerZoneId represents the player's destination if they're zoning.
+            // Otherwise, it represents their current zone.
+            auto region                   = zoneutils::GetCurrentRegion(playerZoneID);
+            auto hasSignet                = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET);
+            auto hasSanction              = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION);
+            auto hasSigil                 = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SIGIL);
             auto regionAlwaysOutOfControl = zoneutils::IsAlwaysOutOfNationControl(region);
             switch (latentEffect.GetConditionsValue())
             {
@@ -1053,17 +1051,8 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
         }
         case LATENT::ZONE_HOME_NATION:
         {
-
-            // player is logging in/zoning
-            // checking the state of the user's current zone and
-            // the destination zone in tandem seems to work.
-            if (m_POwner->loc.zone == nullptr && static_cast<uint16_t>(m_POwner->loc.destination) == 0)
-            {
-                return false;
-            }
-
             auto  nationRegion = static_cast<REGION_TYPE>(latentEffect.GetConditionsValue());
-            auto  region = m_POwner->loc.zone == nullptr ? zoneutils::GetCurrentRegion(m_POwner->loc.destination) : zoneutils::GetCurrentRegion(playerZoneID);
+            auto  region       = zoneutils::GetCurrentRegion(playerZoneID);
 
             switch (nationRegion)
             {


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Cherry-pick: https://github.com/LandSandBoat/server/pull/4624

* Checks for destination region when zoning, to avoid issues with latent effects not triggering
* Fixes log spam for players in these non conquest but still latent applying regions
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Zone into a sea with items such as master caster bracelets. Check that latent applies and there are no errors logged about "Invalid conquest region passed to function"
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
