### PR TITLE
Allows DA TA QA to proc up to twice on a weaponskill where applicable

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -210,10 +210,12 @@ local function getMultiAttacks(attacker, target, wsParams)
     -- The logic here wasnt actually checking for the augment.
     -- Also, it was in a completely different scale, making triple attack trigger always.
 
-    -- QA/TA/DA can only proc on the first hit of each weapon or each fist
+    -- QA/TA/DA can only proc a maximum of twice per weaponskill
+    -- Can proc once per hit of WS, and once per hand if dual wielding/HtH - up to a maximum of 2 times
     if
         attacker:getOffhandDmg() > 0 or
-        attacker:getWeaponSkillType(xi.slot.MAIN) == xi.skill.HAND_TO_HAND
+        attacker:getWeaponSkillType(xi.slot.MAIN) == xi.skill.HAND_TO_HAND or
+        numHits >= 2
     then
         multiChances = 2
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Multi Hit single wield and 2 hand weaponskills can now proc a Double Attack or Triple Attack on each swing, up to twice. (Tiberon)

## What does this pull request do? (Please be technical)

Considers the number of hits in a weaponskill when determining the number of chances to proc a DA or TA

## Sources
BG Wiki
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/105882290/bd886437-d144-49c0-94b7-77feb43f0aaf)

Link from BG wiki with Raging Rush DA'ing twice multiple times.
https://www.bluegartr.com/threads/56273-DA-in-WS-amp-Gorget-Acc-Tests?p=1958293&viewfull=1#post1958293

FFXI Wiki is much looser - claiming any hit can double attack - implying things like a 6 hit Raging Rush, or an 8 hit vorpal blade.
Currently no proof exists of those TP returns.  ~~Capture request submitted since warriors can force 100% double attack now.~~  Testing on Retail complete - limit of 2 seems to hold for Raging Rush and Rampage.
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/105882290/b59da193-45b9-493b-bb11-8ed204f23437)


## Steps to test these changes

Give yourself 100% DA or TA rate and capped acc.
Use a 2 hit weaponskill when not dual wield or HtH.
Verify via TP return that two DAs or TAs proc'd and landed.

## Special Deployment Considerations
None.
