### PR TITLE
Limit relic dmg procs to the first swing of an attack round. Apply re…

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -536,7 +536,7 @@ void CAttack::ProcessDamage(bool isCritical, bool isGuarded, bool isKick)
 
     // Get damage multipliers.
     m_damage =
-        attackutils::CheckForDamageMultiplier((CCharEntity*)m_attacker, dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[slot]), m_damage, m_attackType, slot);
+        attackutils::CheckForDamageMultiplier((CCharEntity*)m_attacker, dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[slot]), m_damage, m_attackType, slot, m_isFirstSwing);
 
     // Apply Sneak Attack Augment Mod
     if (m_attacker->getMod(Mod::AUGMENTS_SA) > 0 && m_trickAttackDamage > 0 && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK))

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1824,15 +1824,6 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
 
                 if (slot == SLOT_RANGED)
                 {
-                    if (state.IsRapidShot())
-                    {
-                        damage = attackutils::CheckForDamageMultiplier(this, PItem, damage, PHYSICAL_ATTACK_TYPE::RAPID_SHOT, SLOT_RANGED);
-                    }
-                    else
-                    {
-                        damage = attackutils::CheckForDamageMultiplier(this, PItem, damage, PHYSICAL_ATTACK_TYPE::RANGED, SLOT_RANGED);
-                    }
-
                     if (PItem != nullptr)
                     {
                         charutils::TrySkillUP(this, (SKILLTYPE)PItem->getSkillType(), PTarget->GetMLevel());
@@ -1890,6 +1881,18 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
             actionTarget.messageID  = 352;
             actionTarget.reaction   = REACTION::HIT;
             actionTarget.speceffect = SPECEFFECT::CRITICAL_HIT;
+        }
+
+        if (slot == SLOT_RANGED)
+        {
+            if (state.IsRapidShot())
+            {
+                totalDamage = attackutils::CheckForDamageMultiplier(this, PItem, totalDamage, PHYSICAL_ATTACK_TYPE::RAPID_SHOT, SLOT_RANGED, true);
+            }
+            else
+            {
+                totalDamage = attackutils::CheckForDamageMultiplier(this, PItem, totalDamage, PHYSICAL_ATTACK_TYPE::RANGED, SLOT_RANGED, true);
+            }
         }
 
         actionTarget.param =

--- a/src/map/utils/attackutils.cpp
+++ b/src/map/utils/attackutils.cpp
@@ -389,8 +389,9 @@ namespace attackutils
      *                                                                       *
      *  Handles damage multiplier, relic weapons etc.                        *
      *                                                                       *
+     *  Param: allowRelicProc used to gate relic dmg procs.                  *
      ************************************************************************/
-    uint32 CheckForDamageMultiplier(CCharEntity* PChar, CItemWeapon* PWeapon, uint32 damage, PHYSICAL_ATTACK_TYPE attackType, uint8 weaponSlot)
+    uint32 CheckForDamageMultiplier(CCharEntity* PChar, CItemWeapon* PWeapon, uint32 damage, PHYSICAL_ATTACK_TYPE attackType, uint8 weaponSlot, bool allowRelicProc)
     {
         if (PWeapon == nullptr)
         {
@@ -422,25 +423,28 @@ namespace attackutils
         float occ_extra_dmg        = battleutils::GetScaledItemModifier(PChar, PWeapon, Mod::OCC_DO_EXTRA_DMG) / 100.f;
         int16 occ_extra_dmg_chance = battleutils::GetScaledItemModifier(PChar, PWeapon, Mod::EXTRA_DMG_CHANCE) / 10;
 
-        if (occ_extra_dmg > 3.f && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
+        if (allowRelicProc)
         {
-            return (uint32)(damage * occ_extra_dmg);
-        }
-        else if (occ_do_triple_dmg > 0 && xirand::GetRandomNumber(100) <= occ_do_triple_dmg)
-        {
-            return (uint32)(damage * 3.f);
-        }
-        else if (occ_extra_dmg > 2.f && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
-        {
-            return (uint32)(damage * occ_extra_dmg);
-        }
-        else if (occ_do_double_dmg > 0 && xirand::GetRandomNumber(100) <= occ_do_double_dmg)
-        {
-            return (uint32)(damage * 2.f);
-        }
-        else if (occ_extra_dmg > 0 && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
-        {
-            return (uint32)(damage * occ_extra_dmg);
+            if (occ_extra_dmg > 3.f && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
+            {
+                return (uint32)(damage * occ_extra_dmg);
+            }
+            else if (occ_do_triple_dmg > 0 && xirand::GetRandomNumber(100) <= occ_do_triple_dmg)
+            {
+                return (uint32)(damage * 3.f);
+            }
+            else if (occ_extra_dmg > 2.f && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
+            {
+                return (uint32)(damage * occ_extra_dmg);
+            }
+            else if (occ_do_double_dmg > 0 && xirand::GetRandomNumber(100) <= occ_do_double_dmg)
+            {
+                return (uint32)(damage * 2.f);
+            }
+            else if (occ_extra_dmg > 0 && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
+            {
+                return (uint32)(damage * occ_extra_dmg);
+            }
         }
 
         switch (attackType)

--- a/src/map/utils/attackutils.h
+++ b/src/map/utils/attackutils.h
@@ -33,7 +33,7 @@ enum class PHYSICAL_ATTACK_TYPE;
 namespace attackutils
 {
     uint8  getHitCount(uint8 hits); // The multihit calculator.
-    uint32 CheckForDamageMultiplier(CCharEntity* PChar, CItemWeapon* PWeapon, uint32 damage, PHYSICAL_ATTACK_TYPE attackType, uint8 weapnSlot);
+    uint32 CheckForDamageMultiplier(CCharEntity* PChar, CItemWeapon* PWeapon, uint32 damage, PHYSICAL_ATTACK_TYPE attackType, uint8 weapnSlot, bool allowRelicProc = false);
     uint8  TryAnticipate(CBattleEntity* PDefender, CBattleEntity* PAttacker, PHYSICAL_ATTACK_TYPE attackType);
 
     bool IsParried(CBattleEntity* PAttacker, CBattleEntity* PDefender); // Is the attack parried.


### PR DESCRIPTION
…lic proc once to barrage.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Relic Weapon dmg procs are now limited to the first swing of an attack round. (Tiberon)
Relic Weapon dmg procs are now applied at the end of a barrage instead of to each barrage shot. (Tiberon)

## What does this pull request do? (Please be technical)

Adds an optional param to `CheckForDamageMultiplier` which determines if relic weapon dmg should be allowed to proc.
This optional param defaults to false.
On an attack round, `m_isFirstSwing` is passed as the param, limiting procs to only the first swing of combat.
This effectively fixes the issue with Spharai procing on off hand hits and kicks.
Additionally this param is set to true for ranged attacks including barrage.
This param is set to false for retaliation and jumps (even though the jump function is obsolete).
`CheckForDamageMultiplier` is not called for counters.

Also, in this PR is moving the relic dmg check to the end of a barrage instead of checking each individual shot.

## Steps to test these changes
Make a mob immortal and give a high regen
Engage the mob.
!setmobmod no_move 1
!exec target:setBehaviour(xi.behavior.NO_TURN, 1)

**Spharai** ID: 18264
Note that spharai will only proc on the first swing of a round.
Note that it does not proc on counters or kicks

**Gugnir** ID: 18300
make a macro with jump, wait, !reset
Spam the macro - note there are no procs on jumps

**Yoichinoyumi** ID: 18348
**Annihilator** ID: 18336
helpful to set recycle to over 100%
create a macro.  barrage, wait 1, ra <t>, !reset
Spam macro - not the dmg range and them when the relic procs, its a full proc
3x for Yoich and Anni

Spam ranged attacks - note that ~5% of the time, relic dmg procs
Give self 100% snapshot
Note that relic dmg still procs about 5% of the time.

**Bravura** ID: 18294
Give 100% double attack
note that relic proc only happens on first swing

Unlikely to be testable w/o modifying the Database: 
give your self retaliation
Note that relic procs dont happen during retaliation

**Mandau** ID: 18270
Give 100% triple, note proc only happens on first swing
make a macro - /ja sneak attack <me>, /wait 1, !reset
Stand behind the mob that has no move and no turn
hit macro.
Note that ~5% of the time - SA is spiked by relic proc

Change to /nin
Offhand mandau
Note that it never procs, because its never the first swing

**Any relic:**
Give yourself regain 3k
Spam weaponskills
Note that there is no relic dmg proc on weaponskills.

## Special Deployment Considerations

none