### PR TITLE
Fixes an issue with weaponskill acc capping in some scenarios

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -267,6 +267,13 @@ xi.weaponskills.getRangedHitRate = function(attacker, target, capHitRate, bonus,
         bonus = 0
     end
 
+    if
+        calcParams ~= nil and
+        calcParams.bonusAcc ~= nil
+    then
+        bonus = bonus + calcParams.bonusAcc
+    end
+
     local acc100 = (wsParams and wsParams.acc100) or 0
     local acc200 = (wsParams and wsParams.acc200) or 0
     local acc300 = (wsParams and wsParams.acc300) or 0
@@ -321,7 +328,7 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams, f
         end
     end
 
-    calcParams.hitRate = utils.clamp(calcParams.hitRate + calcParams.bonusAcc, 0.2, 0.95)
+    calcParams.hitRate = utils.clamp(calcParams.hitRate, 0.2, 0.95)
 
     if firstHitAccBonus ~= nil and firstHitAccBonus then
         calcParams.hitRate = calcParams.hitRate + 0.5 -- First hit gets a +100 ACC bonus which translates to +50 hit
@@ -773,7 +780,7 @@ xi.weaponskills.doPhysicalWeaponskill = function(attacker, target, wsID, wsParam
     calcParams.bonusfTP = gorgetBeltFTP or 0
     calcParams.bonusAcc = (gorgetBeltAcc or 0) + attacker:getMod(xi.mod.WSACC)
     calcParams.bonusWSmods = wsParams.bonusWSmods or 0
-    calcParams.hitRate = xi.weaponskills.getHitRate(attacker, target, false, calcParams.bonusAcc, false, wsParams, calcParams)
+    calcParams.hitRate = xi.weaponskills.getHitRate(attacker, target, false, 0, false, wsParams, calcParams)
     calcParams.skillType = attack.weaponType
 
     if
@@ -1100,6 +1107,13 @@ xi.weaponskills.getHitRate = function(attacker, target, capHitRate, bonus, isSub
         bonus = 0
     end
 
+    if
+        calcParams ~= nil and
+        calcParams.bonusAcc ~= nil
+    then
+        bonus = bonus + calcParams.bonusAcc
+    end
+
     local hitrate = 0
     local flourisheffect = attacker:getStatusEffect(xi.effect.BUILDING_FLOURISH)
     local accVarryTP = 0
@@ -1147,22 +1161,9 @@ xi.weaponskills.fTP = function(tp, ftp1, ftp2, ftp3)
         print("fTP error: TP value is not between 1000-3000!")
     end
 
-    return 1 -- no ftp mod
+    -- no ftp mod
+    return 1
 end
-
--- local function fTPMob(tp, ftp1, ftp2, ftp3)
---     if (tp < 1000) then
---         tp = 1000
---     end
-
---     if (tp >= 1000 and tp < 1500) then
---         return ftp1 + ( ((ftp2 - ftp1 ) / 500) * (tp - 1000) )
---     elseif (tp >= 1500 and tp <= 3000) then
---         -- generate a straight line between ftp2 and ftp3 and find point @ tp
---         return ftp2 + ( ((ftp3 - ftp2) / 1500) * (tp - 1500) )
---     end
---     return 1 -- no ftp mod
--- end
 
 xi.weaponskills.calculatedIgnoredDef = function(tp, def, ignore1, ignore2, ignore3)
     if tp >= 1000 and tp < 2000 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed some scenarios where weaponskill accuracy would be capped when it should not be.  (Tiberon)

## What does this pull request do? (Please be technical)

Moves the bonusAcc calcs to getHitRate instead of additively applying to a float.

## Steps to test these changes
Enter a scenario where you would not expect capped WS acc (say vs Kirin).
WS with different gear (acc neck, ws gorget, etc)
Note that acc is not 95%

## Special Deployment Considerations

none
