### PR TITLE
Fix Messaging with Unlimited Shot and Barrage

### DIFF
--- a/scripts/globals/abilities/barrage.lua
+++ b/scripts/globals/abilities/barrage.lua
@@ -12,6 +12,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
+    player:delStatusEffect(xi.effect.UNLIMITED_SHOT)
     player:addStatusEffect(xi.effect.BARRAGE, 0, 0, 60)
 end
 

--- a/scripts/globals/abilities/unlimited_shot.lua
+++ b/scripts/globals/abilities/unlimited_shot.lua
@@ -12,6 +12,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
+    player:delStatusEffect(xi.effect.BARRAGE)
     player:addStatusEffect(xi.effect.UNLIMITED_SHOT, 1, 0, 60)
 end
 


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Player will now receive proper messaging when Barrage cancels Unlimited Shot and vice versa.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Closes #3612 , players will receive a message when `Barrage` cancels `Unlimited Shot` and vice versa.

## Steps to test these changes
* Use `Unlimited Shot`
* Use `Barrage`
* You should receive a message saying `Unlimited Shot` wore off
* `!reset` (if on test server) - otherwise wait for cooldowns to come back up
* Use `Barrage`
* Use `Unlimited Shot`
* You should receive a message saying `Barrage` wore off


## Special Deployment Considerations

`N/A`


## Visuals ##
| Before | After |
|-|-|
| ![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/43099213/bd20b80a-0542-4e74-aea4-e17f1d811a9c) | ![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/43099213/53709225-b39d-4333-b139-c08e79b23dcd) |
| ![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/43099213/418109d0-7015-47cf-98f4-4cbe80c6e1dd) | ![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/43099213/d6bfc31d-5250-4da4-933c-7d2faacf2212) |

## Disclosure ##
One `Heavy Shell` was harmed in the creation of this Pull Request 