### PR TITLE
Fix subeffects in apply ability resistance

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -788,6 +788,16 @@ xi.magic.applyAbilityResistance = function(player, target, params)
         end
     end
 
+    local subEffect = 0
+    if params.subEffect then
+        subEffect = params.subEffect
+    end
+
+    local subPower = 0
+    if params.subPower then
+        subPower = params.subPower
+    end
+
     if not params.element then
         params.element = xi.magic.ele.NONE
     end
@@ -827,13 +837,13 @@ xi.magic.applyAbilityResistance = function(player, target, params)
         params.chance * resist > math.random() * 150 and
         resist >= 0.5
     then
-        target:addStatusEffect(params.effect, params.power, params.tick, params.duration * resist)
+        target:addStatusEffect(params.effect, params.power, params.tick, params.duration * resist, subEffect, subPower)
     elseif
         params.effect and
         resist >= 0.5 and
         not params.chance
     then
-        target:addStatusEffect(params.effect, params.power, params.tick, params.duration * resist)
+        target:addStatusEffect(params.effect, params.power, params.tick, params.duration * resist, subEffect, subPower)
     end
 
     return resist


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
None (already addressed in prior PR)

## What does this pull request do? (Please be technical)
This PR fixes an issue with diabolos nightmare where the correct subeffect was not being applied in applyAbilityResistance.

## Steps to test these changes
Use Nightmare

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
