### PR TITLE
Fix signal generation on tick drift and a double free bug

### DIFF
--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -256,10 +256,7 @@ int main(int argc, char** argv)
             }
             else
             {
-#ifndef SIGKILL
-#define SIGKILL 9
-#endif // SIGKILL
-                std::raise(SIGKILL);
+                std::raise(SIGTERM);
             }
         });
         // clang-format on

--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -150,12 +150,20 @@ static void sig_proc(int sn)
         case SIGINT:
         case SIGTERM:
             gRunFlag = false;
-            gConsoleService->stop();
+            if (gConsoleService)
+            {
+                gConsoleService->stop();
+            }
+            do_final(EXIT_SUCCESS);
+            exit(EXIT_SUCCESS);
             break;
         case SIGABRT:
         case SIGSEGV:
         case SIGFPE:
-            gConsoleService->stop();
+            if (gConsoleService)
+            {
+                gConsoleService->stop();
+            }
             dump_backtrace();
             do_abort();
 #ifdef _WIN32
@@ -273,7 +281,10 @@ int main(int argc, char** argv)
     // Re-enable Quick Edit Mode upon Exiting if it is still disabled
     SetConsoleMode(hInput, prev_mode);
 #endif // _WIN32
-    gConsoleService->stop();
+    if (gConsoleService)
+    {
+        gConsoleService->stop();
+    }
 
     do_final(EXIT_SUCCESS);
 }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -83,20 +83,20 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 void* operator new(std::size_t count)
 {
     auto ptr = malloc(count);
-TracyAlloc(ptr, count);
-return ptr;
+    TracyAlloc(ptr, count);
+    return ptr;
 }
 
 void operator delete(void* ptr) noexcept
 {
     TracyFree(ptr);
-free(ptr);
+    free(ptr);
 }
 
 void operator delete(void* ptr, std::size_t count)
 {
     TracyFree(ptr);
-free(ptr);
+    free(ptr);
 }
 #endif // TRACY_ENABLE
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -83,20 +83,20 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 void* operator new(std::size_t count)
 {
     auto ptr = malloc(count);
-    TracyAlloc(ptr, count);
-    return ptr;
+TracyAlloc(ptr, count);
+return ptr;
 }
 
 void operator delete(void* ptr) noexcept
 {
     TracyFree(ptr);
-    free(ptr);
+free(ptr);
 }
 
 void operator delete(void* ptr, std::size_t count)
 {
     TracyFree(ptr);
-    free(ptr);
+free(ptr);
 }
 #endif // TRACY_ENABLE
 
@@ -427,6 +427,11 @@ void do_final(int code)
 
     CTaskMgr::delInstance();
     CVanaTime::delInstance();
+    // TODO: Look into and clarify relation of lifetime of objects and logging/profiling of destructors
+    // sql needs to be released here, `TracyZoneScope` macro in SqlConnection destructor depends on logging functionality being available
+    // but the logging is shutdown later down in this function
+    // Before this change, it was released by atexit handlers
+    sql.release();
 
     timer_final();
     socket_final();

--- a/src/map/utils/itemutils.cpp
+++ b/src/map/utils/itemutils.cpp
@@ -632,12 +632,11 @@ namespace itemutils
         // Populate nullptrs in g_pDropList with an empty drop list
         // this support mobs that only drop loot through script logic
         // even if they do not have the default dropID of 0
-        auto emptyDropList = new DropList_t;
         for (int32 dropID = 0; dropID < MAX_DROPID; ++dropID)
         {
             if (g_pDropList[dropID] == nullptr)
             {
-                g_pDropList[dropID] = emptyDropList;
+                g_pDropList[dropID] = new DropList_t;
             }
         }
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

None

## What does this pull request do? (Please be technical)

- Windows does not have a way to use signals to guarantee a termination like `SIGKILL(9)` in POSIX, which leads to `_invalid_parameter_handler` call and an unrelated exception. Moreover, `SIGKILL` is way too crude and it's better to handle the termination on tick drift through `SIGTERM`
- There's a double free bug in `FreeItemList()` because of [multiple references to same empty list being added to `g_pDropList`](https://github.com/AirSkyBoat/AirSkyBoat/blob/5c23dc2f99f01a4cea17af550696d65d0d9013e5/src/map/utils/itemutils.cpp#L635). A straightforward solution is to assign unique empty drops list (memory overhead is not considerable, `MAXDROPID` is 8000)
- Another fix was added, `SqlConnection` destructor seems to have been profiled through `TracyZoneScoped`, but is not released until `atexit` handlers are called, even though logging functionality is shutdown, which `TracyZoneScoped` depends on. As such, releases `SqlConnection` instance early

## Steps to test these changes

- Signal changes can be checked by causing an unacceptable tick drift (perhaps changing the `timeout`?)
- The other change be checked any time by performing a termination of `xi_map` executable's process
- Look into returned error code on a graceful shutdown of `xi_map` process

## Special Deployment Considerations

None that I can think of
