### PR TITLE
Fixes pets pulling in Dynamis

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -426,6 +426,11 @@ xi.dynamis.normalDynamicSpawn = function(oMob, oMobIndex, target)
                 end,
 
                 onMobEngaged = function(mobArg, mobTarget)
+                    if mobTarget:isPet() then
+                        local petOwner = mobTarget:getMaster()
+                        mobArg:updateEnmity(petOwner)
+                    end
+
                     xi.dynamis.mobOnEngaged(mobArg, mobTarget)
                 end,
 
@@ -742,7 +747,16 @@ xi.dynamis.nonStandardDynamicSpawn = function(mobIndex, oMob, forceLink, zoneID,
             mob:setMobMod(xi.mobMod.SUBLINK, xi.dynamis.SUBLINK_ID)
         end,
 
-        onMobEngaged = mobFunctions[mobMobType]["onMobEngaged"][1],
+        onMobEngaged = function(mob, mobTarget)
+            local specFunc = mobFunctions[mobMobType]["onMobEngaged"][1]
+            specFunc(mob)
+
+            if mobTarget:isPet() then
+                local petOwner = mobTarget:getMaster()
+                mob:updateEnmity(petOwner)
+            end
+        end,
+
         onMobFight = mobFunctions[mobMobType]["onMobFight"][1],
         onMobRoam =  mobFunctions[mobMobType]["onMobRoam"][1],
         onMobDeath = function(mob, player, optParams)
@@ -2128,7 +2142,16 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
             mob:setMobMod(xi.mobMod.SUBLINK, xi.dynamis.SUBLINK_ID)
         end,
 
-        onMobEngaged = xi.dynamis.nmFunctions[xi.dynamis.nmInfoLookup[mobName][7]]["onMobEngaged"][1],
+        onMobEngaged = function(mob, mobTarget)
+            local specFunc = xi.dynamis.nmFunctions[xi.dynamis.nmInfoLookup[mobName][7]]["onMobEngaged"][1]
+            specFunc(mob)
+
+            if mobTarget:isPet() then
+                local petOwner = mobTarget:getMaster()
+                mob:updateEnmity(petOwner)
+            end
+        end,
+
         onMobFight = xi.dynamis.nmFunctions[xi.dynamis.nmInfoLookup[mobName][7]]["onMobFight"][1],
         onMobRoam = xi.dynamis.nmFunctions[xi.dynamis.nmInfoLookup[mobName][7]]["onMobRoam"][1],
         onMobMagicPrepare = xi.dynamis.nmFunctions[xi.dynamis.nmInfoLookup[mobName][7]]["onMobMagicPrepare"][1],


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixes an issue where you could pull dynamis statues with a pet and bypass all aggro mechanics.
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Adds base enmity to the pets master when pulling any dynamis mob with a pet
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go into dynamis
Summoner Carbuncle
Assault a statue
Wait for carbuncle to die
Watch the mobs kill you
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
