### PR TITLE
Fix several more errors

### DIFF
--- a/modules/era/scripts/globals/mobskills/onMobWeaponSkill.lua
+++ b/modules/era/scripts/globals/mobskills/onMobWeaponSkill.lua
@@ -807,7 +807,7 @@ m:addOverride("xi.globals.mobskills.astral_flow_pet.onMobWeaponSkill", function(
     skill:setMsg(xi.msg.basic.USES)
 
     -- no effect if pet is inactive
-    if petInactive(pet) then
+    if pet and petInactive(pet) then
         return xi.effect.ASTRAL_FLOW
     end
 

--- a/modules/era/sql/era_status_effects.sql
+++ b/modules/era/sql/era_status_effects.sql
@@ -1,0 +1,6 @@
+LOCK TABLE `status_effects` WRITE;
+
+-- add EFFECTFLAG_DETECTABLE so player using JAs and Spells on mobs removes mazurka
+UPDATE `status_effects` SET flags = 67893 WHERE `name` = "mazurka";
+
+UNLOCK TABLES;

--- a/scripts/commands/getfishhistory.lua
+++ b/scripts/commands/getfishhistory.lua
@@ -35,6 +35,6 @@ function onTrigger(player, target)
     player:PrintToPlayer(string.format("Showing Fishing Stats for: %s", targ:getName()), xi.msg.channel.SYSTEM_3)
     player:PrintToPlayer(string.format("Lines Cast: %s", fishStats["fishLinesCast"]), xi.msg.channel.SYSTEM_3)
     player:PrintToPlayer(string.format("Fish Caught: %s", fishStats["fishReeled"]), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Biggest Fish: %s ilms (%s)", fishStats["fishLongestLength"], xi.fish.getFishName(fishStats['fishLongestId'])), xi.msg.channel.SYSTEM_3)
-    player:PrintToPlayer(string.format("Heaviest Fish: %s ponzes (%s)", fishStats["fishHeaviestWeight"], xi.fish.getFishName(fishStats['fishHeaviestId'])), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Biggest Fish: %s ilms (%s)", fishStats["fishLongestLength"], xi.fishing.getFishName(fishStats['fishLongestId'])), xi.msg.channel.SYSTEM_3)
+    player:PrintToPlayer(string.format("Heaviest Fish: %s ponzes (%s)", fishStats["fishHeaviestWeight"], xi.fishing.getFishName(fishStats['fishHeaviestId'])), xi.msg.channel.SYSTEM_3)
 end

--- a/scripts/globals/items/chaosbringer.lua
+++ b/scripts/globals/items/chaosbringer.lua
@@ -14,6 +14,7 @@ itemObject.onItemEquip = function(player, item)
             mobAttkListener:addListener("ATTACKED", "VALID_KILL", function(mobAttkedListener, playerAttkedListener, action)
                 mobAttkedListener:setLocalVar("CBListenerApplied", 1)
                 if
+                    playerAttkedListener:isPC() and
                     playerAttkedListener:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DARKNESS) >= QUEST_ACCEPTED and
                     playerAttkedListener:getEquipID(xi.slot.MAIN) == xi.items.CHAOSBRINGER and
                     mobAttkedListener:getHP() == 0

--- a/scripts/mixins/families/uragnite.lua
+++ b/scripts/mixins/families/uragnite.lua
@@ -60,15 +60,22 @@ local function shellTimer(mob)
     local timeToShell = mob:getLocalVar("[uragnite]shellTimer")
 
     -- mob:isMobType check due to Shell We Dance ENM. Those uragnites do not enter their shell except through damage
-    if os.time() > timeToShell and mob:getAnimationSub() == 0 and not mob:isFollowingPath() and not mob:isMobType(xi.mobskills.mobType.BATTLEFIELD) then
+    if
+        os.time() > timeToShell and
+        mob:getAnimationSub() == 0 and
+        not mob:isFollowingPath() and
+        not mob:isMobType(xi.mobskills.mobType.BATTLEFIELD)
+    then
         enterShell(mob)
 
         local timeInShell = math.random(mob:getLocalVar("[uragnite]timeInShellMin"), mob:getLocalVar("[uragnite]timeInShellMax"))
-        local shellRandom = timeInShell + (os.time() + math.random(40,60))
+        local shellRandom = timeInShell + (os.time() + math.random(40, 60))
         mob:setLocalVar("[uragnite]shellTimer", shellRandom)
 
         mob:timer(timeInShell * 1000, function(uragnite)
-            exitShell(uragnite)
+            if uragnite:getAnimationSub() == 1 then
+                exitShell(uragnite)
+            end
         end)
     end
 end
@@ -93,6 +100,7 @@ xi.mix.uragnite.config = function(mob, params)
     if params.inShellRegen and type(params.inShellRegen) == "number" then
         mob:setLocalVar("[uragnite]inShellRegen", params.inShellRegen)
     end
+
     if params.shellChange and type(params.shellChange) == "number" then
         mob:setLocalVar("[uragnite]shellChange", params.shellChange)
     end
@@ -108,7 +116,7 @@ g_mixins.families.uragnite = function(uragniteMob)
         mob:setLocalVar("[uragnite]timeInShellMin", 30)
         mob:setLocalVar("[uragnite]timeInShellMax", 45)
         mob:setLocalVar("[uragnite]inShellRegen", 50)
-        mob:setLocalVar("[uragnite]shellChange", mob:getMaxHP() / math.random(7,10))
+        mob:setLocalVar("[uragnite]shellChange", mob:getMaxHP() / math.random(7, 10))
     end)
 
     uragniteMob:addListener("TAKE_DAMAGE", "URAGNITE_TAKE_DAMAGE", function(mob, amount, attacker, attackType, damageType)
@@ -118,19 +126,20 @@ g_mixins.families.uragnite = function(uragniteMob)
         if damageTaken > mob:getLocalVar("[uragnite]shellChange") then
             if mob:getAnimationSub() == 1 then
                 exitShell(mob)
-                mob:setLocalVar("[uragnite]shellChange", mob:getMaxHP() / math.random(5,10))
+                mob:setLocalVar("[uragnite]shellChange", mob:getMaxHP() / math.random(5, 10))
             else
                 enterShell(mob)
                 mob:useMobAbility(1572) -- Going into shell caused by damage always triggers venom shell
-                mob:setLocalVar("[uragnite]shellChange", mob:getMaxHP() / math.random(5,10))
+                mob:setLocalVar("[uragnite]shellChange", mob:getMaxHP() / math.random(5, 10))
 
                 local timeInShell = math.random(mob:getLocalVar("[uragnite]timeInShellMin"), mob:getLocalVar("[uragnite]timeInShellMax"))
                 mob:timer(timeInShell * 1000, function(uragnite)
-                    if mob:getAnimationSub() == 1 then
+                    if uragnite:getAnimationSub() == 1 then
                         exitShell(uragnite)
                     end
                 end)
             end
+
             mob:setLocalVar("damageTaken", 0)
         else
             mob:setLocalVar("damageTaken", damageTaken)

--- a/scripts/zones/Boneyard_Gully/mobs/Gwyn_Ap_Knudd.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Gwyn_Ap_Knudd.lua
@@ -15,7 +15,7 @@ end
 
 entity.onMobWeaponSkillPrepare = function(mob, target)
     for i = 1, 3 do
-        local undead = GetMobByID(mob:getID()+i)
+        local undead = GetMobByID(mob:getID() + i)
         local ability = math.random(478, 479)
 
         if undead:isAlive() then
@@ -29,7 +29,7 @@ end
 entity.onMobMagicPrepare = function(mob, target, spell)
     mob:timer(4000, function(mobArg)
         for i = 4, 9 do
-            local undead = GetMobByID(mobArg:getID()+i)
+            local undead = GetMobByID(mobArg:getID() + i)
 
             if undead:isAlive() then
                 if spell:getID() ~= 245 and spell:getID() ~= 247 then -- mimic aga spell but 1 tier lower
@@ -49,13 +49,13 @@ entity.onMobFight = function(mob, target)
         local control = false
 
         for i = 1, 9 do
-            if not GetMobByID(mob:getID()+i):isAlive() then
+            if not GetMobByID(mob:getID() + i):isAlive() then
                 control = true
             end
         end
 
         while control do
-            local undead = GetMobByID(mob:getID() + math.random(1,9))
+            local undead = GetMobByID(mob:getID() + math.random(1, 9))
             if not undead:isAlive() then
                 undead:setHP(undead:getMaxHP())
                 undead:resetAI()
@@ -69,15 +69,34 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    if optParams.isKiller then
+    -- player won the battle so cleanup by killing undead and allowing despawn
+    if mob:getLocalVar("cleanupUndead") == 0 then
         for i = 1, 9 do
-            local undead = GetMobByID(mob:getID()+i)
+            local undead = GetMobByID(mob:getID() + i)
             undead:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NONE))
 
             if undead:isAlive() then
                 undead:setHP(0)
             end
         end
+
+        mob:setLocalVar("cleanupUndead", 1)
+    end
+end
+
+entity.onMobDespawn = function(mob, player, optParams)
+    -- player lost without killing boss so despawn undead manually
+    if mob:getLocalVar("cleanupUndead") == 0 then
+        for i = 1, 9 do
+            local undead = GetMobByID(mob:getID() + i)
+
+            if undead:isSpawned() then
+                undead:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NONE))
+                DespawnMob(undead:getID())
+            end
+        end
+
+        mob:setLocalVar("cleanupUndead", 1)
     end
 end
 

--- a/scripts/zones/Empyreal_Paradox/Zone.lua
+++ b/scripts/zones/Empyreal_Paradox/Zone.lua
@@ -30,7 +30,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
-    if triggerArea:GetTriggerAreaID() == 1 then
+    if triggerArea:GetTriggerAreaID() == 1 and player:getZPos() ~= -500 then
         player:startEvent(100)
     end
 end

--- a/scripts/zones/Misareaux_Coast/mobs/Ziphius.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Ziphius.lua
@@ -19,7 +19,7 @@ entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 445)
 
     -- Set respawn timer for ???s
-    for i = 1, 6 do
+    for i = 0, 5 do
         GetNPCByID(ID.npc.ZIPHIUS_QM_BASE + i):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
     end
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Devil_Manta.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Devil_Manta.lua
@@ -20,7 +20,11 @@ entity.onMobDespawn = function(mob)
     local mantaOne = ID.mob.CHARYBDIS - 2
     local mantaTwo = ID.mob.CHARYBDIS - 4
 
-    if not xi.mob.phOnDespawn(mob, ID.mob.CHARYBDIS_PH, 10, 28800) then
+    if
+        (mob:getID() == mantaOne or
+        mob:getID() == mantaTwo) and
+        not xi.mob.phOnDespawn(mob, ID.mob.CHARYBDIS_PH, 10, 28800)
+    then
         -- Charbydis is not queued to spawn.
         -- Choose a Charbydis PH randomly to spawn next.
         local chooseManta = math.random(1, 2)

--- a/scripts/zones/The_Garden_of_RuHmet/Zone.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/Zone.lua
@@ -209,7 +209,7 @@ end
 
 zoneObject.onEventFinish = function(player, csid, option)
     if csid == 101 and option == 1 then
-        player:setPos(540, -1, -499.900, 62, 36)
+        player:setPos(540, -1, -500, 62, 36)
         player:setCharVar("Ru-Hmet-TP", 0)
         xi.teleport.clearEnmityList(player)
 

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Kfghrah_WHM.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Kfghrah_WHM.lua
@@ -43,7 +43,7 @@ entity.onMobFight = function(mob, target)
 
         mob:setAnimationSub(battleForm)
         mob:setLocalVar("changeTime", mob:getBattleTime())
-        if mob:setAnimationSub() == 0 then
+        if mob:getAnimationSub() == 0 then
             mob:setMagicCastingEnabled(true) -- will only cast magic in ball form
         else
             mob:setMagicCastingEnabled(false)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -15250,7 +15250,7 @@ bool CLuaBaseEntity::actionQueueEmpty()
  *  Notes   : Currently only used by a few select mobs
  ************************************************************************/
 
-void CLuaBaseEntity::castSpell(sol::object const& spell, sol::object entity)
+void CLuaBaseEntity::castSpell(sol::object const& spell, sol::object const& entity)
 {
     if (spell != sol::lua_nil)
     {

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -860,7 +860,7 @@ public:
 
     bool actionQueueEmpty(); // returns whether the action queue is empty or not
 
-    void  castSpell(sol::object const& spell, sol::object entity);                                                                                                                                           // forces a mob to cast a spell (parameter = spell ID, otherwise picks a spell from its list)
+    void  castSpell(sol::object const& spell, sol::object const& entity);                                                                                                                                    // forces a mob to cast a spell (parameter = spell ID, otherwise picks a spell from its list)
     void  useJobAbility(uint16 skillID, sol::object const& pet);                                                                                                                                             // forces a job ability use (players/pets only)
     void  useMobAbility(sol::variadic_args va);                                                                                                                                                              // forces a mob to use a mobability (parameter = skill ID)
     int32 triggerDrawIn(CLuaBaseEntity* PMobEntity, sol::object const& includePt, sol::object const& drawRange, sol::object const& maxReach, sol::object const& target, sol::object const& incDeadAndMount); // forces a mob to draw in target

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -629,6 +629,15 @@ void CZone::updateCharLevelRestriction(CCharEntity* PChar)
 
     if (m_levelRestriction != 0)
     {
+        // remove buffs in level cap zones as well (such as riverne sites)
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ERASABLE, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ATTACK, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ON_ZONE, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_SONG, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ROLL, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_SYNTH_SUPPORT, true);
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_BLOODPACT, true);
         PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_LEVEL_RESTRICTION, EFFECT_LEVEL_RESTRICTION, m_levelRestriction, 0, 0));
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Undead monsters from the Totentanz ENM should no longer appear in other ENM or mission fights in Boneyard Gully. (Tracent)
- Kf'ghrah (WHM) should now only cast spells in the correct form. (Tracent)
- Uragnites should no longer lose excessive HP per tick when exiting their shell under certain circumstances. (Tracent)
- Players should freeze less often when going down the teleporter to Empyreal Paradox. (Tracent)
- The status effect mazurka should now wear off when using using spells and job abilities on monsters (as in era). (Tracent)
- Buffs will now wear off when entering level capped zones (such as Riverne - Site B01) as in era. (Tracent)

## What does this pull request do? (Please be technical)
- Fixes an issue with Totentanz where the undead mobs were only allowed to despawn (by setting the behavior to xi.behavior.NONE from xi.behavior.NO_DESPAWN) when the boss was actually killed (onMobDeath). Thus added logic to despawn these undead also when the boss despawns (onMobDespawn) (for example for cases where the player warps away from the fight or times out).
- Fixes an issue with Devil Mantas in SSG that were not charby PHs yet were still impacting charby PH behavior. This is done by adding a check to the logic to make sure the manta is a charby PH.
- Fixes an issue with chaosbringer and potential interaction with pets. No player facing changes.
- Fixes an issue with castSpell function using wrong type and thus giving error if the second (optional) parameter is missing. This only impacts logs and not any player facing functionality.
- Fixes an issue with Kf'ghrah (WHM) casting spells even when not in ball form due to using setAnimationSub instead of getAnimationSub
- Fixes an issue with astral flow check when mob does not have an avatar. This only impacts logs and not any player facing functionality
- Fixes an issue with one of the Ziphius ??? not despawning on Ziphius death.
- Fixes issue with getfishhistory command bad function call. This only impacts GMs and not any player facing functionality
- Fixes issue with uragnite mixin where sometimes the uragnite could exit the shell twice in a row (thus causing negative regen).
- Fixes an issue with players freezing on the teleporter down to Empyreal Paradox due to event wonkiness (this is temp fix until it can be overhauled). The temp fix forces players to leave the telepad and then move back onto it to port back up.
- Added EFFECTFLAG_DETECTABLE bit on effect flag to mazurka so it wears off when players use job abilities or spells on monsters. This is the same flag used on eden and wings for mazurka.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
