### PR TITLE
Fix SJ Restriction

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis.lua
@@ -869,7 +869,7 @@ xi.dynamis.handleDynamis = function(zone)
                         end
                     end
 
-                    player:addStatusEffect(xi.effect.SJ_RESTRICTION, 0, 0, 0, 18000) -- Inflict SJ Restriction
+                    player:addStatusEffect(xi.effect.SJ_RESTRICTION, 0, 0, 18000) -- Inflict SJ Restriction
                 end
             end
 

--- a/scripts/zones/Jade_Sepulcher/bcnms/beast_within.lua
+++ b/scripts/zones/Jade_Sepulcher/bcnms/beast_within.lua
@@ -16,7 +16,7 @@ battlefieldObject.onBattlefieldRegister = function(player, battlefield)
 end
 
 battlefieldObject.onBattlefieldEnter = function(player, battlefield)
-    player:addStatusEffect(xi.effect.SJ_RESTRICTION, 0, 0, 0, 600) -- Inflict SJ Restriction
+    player:addStatusEffect(xi.effect.SJ_RESTRICTION, 0, 0, 600) -- Inflict SJ Restriction
 end
 
 battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)

--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -191,7 +191,7 @@ INSERT INTO `status_effects` VALUES (153,'damage_spikes',41,34,0,0,0,0,0,0,800);
 INSERT INTO `status_effects` VALUES (154,'shining_ruby',41,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (155,'medicine',0,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (156,'flash',8405026,0,0,1,0,0,7,0,0);
-INSERT INTO `status_effects` VALUES (157,'sj_restriction',8388864,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (157,'sj_restriction',142606592,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (158,'provoke',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (159,'penalty',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (160,'preparations',32,0,0,0,0,0,0,0,0);

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -1196,6 +1196,8 @@ void CZone::CharZoneOut(CCharEntity* PChar)
         PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_LEVEL_RESTRICTION);
     }
 
+    PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ON_ZONE);
+
     if (PChar->PLinkshell1 != nullptr)
     {
         PChar->PLinkshell1->DelMember(PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

SubJob Restriction (e.g. in CoP Dynamis) should now properly apply and be removed. (Tiberon)
Players will now lose HP/MP/Stats/Spells/Abilites which are derived only from their SubJob.

## What does this pull request do? (Please be technical)

Fixes params being used to add the status effect which was causing a status effect of `item/Mighty_Knife` to be applied (which doesnt exist) instead of the actualy SJ Restriction Status.

Also adds the "dont show time remaining" flag to the SJ Restriction status effect.

Also adds a wipe of status effects with the flag "lose on zone" when a player zones out.
This is required because without it - the game will store state of the player between zones as not having a SJ, and then will force the player to have no SJ after the zone even though the SJ Restriction status effect has been removed.

## Steps to test these changes

1.  Enter Dyna CoP, fulfill Dyna SJ requirements - verify SJ (hp/mp and abilities and stats) all go away on apply and come back after.
1. Try leaving and re-entering dyna
1. Try logging out and logging in during dyna - with SJ restriction in place
1. Try logging out with SJ restirction on, then loggin in after the dyna SJ restiction is lifted.

Once application in dyna is verified as correct - you can also use !addeffect 157 and !deleffect 157 to add/remove the SJ Restriction to test more fun things.   Easy to zone, log, level sync, etc at that point.

Note:  One known gap I do not have time to resolve today is:
Having a Pet out when the SJ is applied (which is hard to do) does not desummon the pet.

## Special Deployment Considerations
None