### PR TITLE
MTDR now does not apply for mobs or blue magic

### DIFF
--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -329,7 +329,11 @@ xi.spells.damage.calculateMTDR = function(caster, target, spell)
     local multipleTargetReduction = 1 -- The variable we want to calculate.
     local targets                 = spell:getTotalTargets()
 
-    if targets > 1 then
+    if
+        targets > 1 and
+        caster:isPC() and
+        spell:getSpellGroup() ~= xi.magic.spellGroup.BLUE
+    then
         if targets > 1 and targets < 10 then
             multipleTargetReduction = 0.9 - 0.05 * targets
         else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Multiple Target Damage Reduction now does not apply for mobs or player blue magic. (Tiberon)

## What does this pull request do? (Please be technical)

Adds a gate on MTDR to only apply to players and to exclude blu magic

## Steps to test these changes

This is tough without multiple players.
The math on reduction is as follows:

```
if targets > 1 and targets < 10 then
            multipleTargetReduction = 0.9 - 0.05 * targets
        else
            multipleTargetReduction = 0.4
        end
```

The best way to do this low man is:
Find a caster with a good chance to throw AoE spells
Make the mob cast fast `!setMobMod MAGIC_COOL 1`
Make sure they dont run out MP `!setmod refresh 500`

Pick a spell and try to reduce your resistance to it - bomb queen ring works well for fire.
Orchish hexspinner is a good mage
Have the mob get off a few of the same spells on a single target.
Track the damage and find the unresisted.  Naked 75 thf was taking ~777 for firaga3
Now, add in a player to PT to get hit by aoe too. - dmg on both would drop to 80%.
With this change, both players will take 777 ish dmg (variance expected due to equip, level, etc)

**This may trigger a round of other balance changes since dyna and such have been balanced and play tested with the previous behavior**

## Special Deployment Considerations

None