### PR TITLE
Fix several issues

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -421,6 +421,15 @@ xi.dynamis.normalDynamicSpawn = function(oMob, oMobIndex, target)
                 groupZoneId = nameObj[job][3],
                 onMobSpawn = function(mobArg)
                     xi.dynamis.setMobStats(mobArg)
+
+                    -- Hydra mobs in Dynamis Beaucedine are immune to sleep
+                    if
+                        mobArg:getFamily() == 359 and
+                        mobArg:getZoneID() == xi.zone.DYNAMIS_BEAUCEDINE
+                    then
+                        mobArg:addImmunity(xi.immunity.SLEEP)
+                    end
+
                     -- set all dyna mobs to same sublink so for example statues link when seeing normal mobs
                     mobArg:setMobMod(xi.mobMod.SUBLINK, xi.dynamis.SUBLINK_ID)
                 end,
@@ -2724,7 +2733,7 @@ xi.dynamis.setMobStats = function(mob)
 
         mob:setTrueDetection(true)
 
-        if     mob:getFamily() == 359 then -- If Hydra
+        if mob:getFamily() == 359 then -- If Hydra
             mob:setMobLevel(math.random(80, 82))
         elseif mob:getFamily() == 358 then -- If Kindred
             mob:setMobLevel(math.random(77, 80))
@@ -2732,7 +2741,7 @@ xi.dynamis.setMobStats = function(mob)
             mob:setMobLevel(math.random(77, 78))
         end
 
-        if     job == xi.job.WAR then
+        if job == xi.job.WAR then
             local params = {  }
             params.specials = {  }
             params.specials.skill = {  }

--- a/modules/era/sql/era_bcnm_info.sql
+++ b/modules/era/sql/era_bcnm_info.sql
@@ -10,6 +10,10 @@ LOCK TABLES `bcnm_info` WRITE,
 -- Update the header info for the BCNMs
 UPDATE `bcnm_info` SET `levelCap`=40 WHERE `bcnmId`=737; -- Changed to level 40 cap
 
+-- Update so players do not lose exp from death in ENMs 
+UPDATE `bcnm_info` SET `rules`=13 WHERE `zoneId` IN (6, 8, 10, 13, 17, 19, 21, 23, 31) AND `rules`=15;
+UPDATE `bcnm_info` SET `rules`=12 WHERE `zoneId` IN (6, 8, 10, 13, 17, 19, 21, 23, 31) AND `rules`=14;
+
 -- Update BCNM Mob data
 DELETE FROM `bcnm_battlefield` WHERE `bcnmid`=737;
 INSERT INTO `bcnm_battlefield` VALUES

--- a/modules/era/sql/era_mod_family_mods.sql
+++ b/modules/era/sql/era_mod_family_mods.sql
@@ -1,0 +1,11 @@
+LOCK TABLES `mob_family_mods` WRITE;
+
+-- Fomor (remove SLEEPRES and LULLABYRES)
+DELETE FROM `mob_family_mods` WHERE familyid = 115 and modid = 240;
+DELETE FROM `mob_family_mods` WHERE familyid = 115 and modid = 254;
+
+-- Fomor (remove SLEEPRES and LULLABYRES)
+DELETE FROM `mob_family_mods` WHERE familyid = 359 and modid = 240;
+DELETE FROM `mob_family_mods` WHERE familyid = 359 and modid = 254;
+
+UNLOCK TABLES;

--- a/scripts/battlefields/Apollyon/se_apollyon.lua
+++ b/scripts/battlefields/Apollyon/se_apollyon.lua
@@ -269,6 +269,7 @@ content.groups =
         mods =
         {
             [xi.mod.UDMGPHYS] = -8000,
+            [xi.mod.UDMGRANGE] = -8000,
             [xi.mod.MAGIC_NULL] = 100,
         },
 
@@ -296,6 +297,7 @@ content.groups =
         death = function(battlefield, mob, count)
             local boss = mob:getZone():queryEntitiesByName("Evil_Armory")[1]
             boss:setMod(xi.mod.UDMGPHYS, (8 - count) * -1000)
+            boss:setMod(xi.mod.UDMGRANGE, (8 - count) * -1000)
             if count == 1 then
                 -- Make the boss become targetable after the first kill
                 boss:setBattleID(0)

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -366,9 +366,12 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
     -- Calculate Blood Pact Damage before stoneskin
     dmg = dmg + dmg * mob:getMod(xi.mod.BP_DAMAGE) / 100
 
-    -- if magic then apply magic mods here
+    -- if magic or breath then apply magic mods here
     -- (physical mods are applied in physicalSDT)
-    if skilltype == xi.attackType.MAGICAL then
+    if
+        skilltype == xi.attackType.MAGICAL or
+        skilltype == xi.attackType.BREATH
+    then
         dmg = xi.damage.applyDamageTaken(target, dmg, skilltype, damagetype)
     end
 

--- a/scripts/zones/Attohwa_Chasm/mobs/Citipati.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Citipati.lua
@@ -21,12 +21,12 @@ entity.onMobDisengage = function(mob)
         DespawnMob(mob:getID())
     end
 
-    DisallowRespawn(ID.mob.CITIPATI, true)
+    DisallowRespawn(mob:getID(), true)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 278)
-    DisallowRespawn(ID.mob.CITIPATI, true)
+    DisallowRespawn(mob:getID(), true)
 end
 
 entity.onMobDespawn = function(mob, player)

--- a/scripts/zones/Boneyard_Gully/mobs/Race_Runner.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Race_Runner.lua
@@ -68,15 +68,9 @@ entity.onMobSpawn = function(mob)
             mob:setMobAbilityEnabled(false)
         end
     end)
-
-    entity.onMobRoam(mob)
-    mob:pathThrough(pathNodes, bit.bor(xi.path.flag.PATROL, xi.path.flag.REVERSE))
 end
 
 entity.onMobRoam = function(mob)
-    local bfNum = mob:getBattlefield():getArea()
-    local point = math.random(1, 8)
-    mob:pathTo(pathNodes[bfNum][point][1], pathNodes[bfNum][point][2], pathNodes[bfNum][point][3], xi.path.flag.SCRIPT)
 end
 
 entity.onMobWeaponSkillPrepare = function(mob, target)

--- a/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_TSTBF.lua
+++ b/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_TSTBF.lua
@@ -7,8 +7,16 @@ mixins = { require("scripts/mixins/job_special") }
 -----------------------------------
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setWallhackAllowed(false)
+end
+
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =
@@ -16,6 +24,11 @@ entity.onMobSpawn = function(mob)
             { id = 848, hpp = math.random(30, 55) }, -- uses Inferno once while near 50% HPP.
         },
     })
+end
+
+entity.onMobEngaged = function(mob, target)
+    -- they should always use a tp move when first engaged
+    mob:setTP(3000)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_Trial.lua
+++ b/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_Trial.lua
@@ -9,6 +9,10 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.FIRE_ABSORB, 100)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =

--- a/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_WTB.lua
@@ -13,7 +13,7 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar("HPThreshold", math.random(10, 90))
-    mob:setMod(xi.mod.FIRE_ABSORB, 1000)
+    mob:setMod(xi.mod.FIRE_ABSORB, 100)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_TSTBI.lua
+++ b/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_TSTBI.lua
@@ -7,8 +7,16 @@ mixins = { require("scripts/mixins/job_special") }
 -----------------------------------
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setWallhackAllowed(false)
+end
+
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =
@@ -16,6 +24,11 @@ entity.onMobSpawn = function(mob)
             { id = 884, hpp = math.random(30, 55) }, -- uses Diamond Dust once while near 50% HPP.
         },
     })
+end
+
+entity.onMobEngaged = function(mob, target)
+    -- they should always use a tp move when first engaged
+    mob:setTP(3000)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_Trial.lua
+++ b/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_Trial.lua
@@ -9,6 +9,10 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.ICE_ABSORB, 100)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =

--- a/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_WTB.lua
@@ -13,7 +13,7 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar("HPThreshold", math.random(10, 90))
-    mob:setMod(xi.mod.ICE_ABSORB, 1000)
+    mob:setMod(xi.mod.ICE_ABSORB, 100)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_TSTBW.lua
+++ b/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_TSTBW.lua
@@ -7,8 +7,16 @@ mixins = { require("scripts/mixins/job_special") }
 -----------------------------------
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setWallhackAllowed(false)
+end
+
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =
@@ -16,6 +24,11 @@ entity.onMobSpawn = function(mob)
             { id = 875, hpp = math.random(30, 55) }, -- uses Aerial Blast once while near 50% HPP.
         },
     })
+end
+
+entity.onMobEngaged = function(mob, target)
+    -- they should always use a tp move when first engaged
+    mob:setTP(3000)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_Trial.lua
+++ b/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_Trial.lua
@@ -9,6 +9,10 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.WIND_ABSORB, 100)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =

--- a/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_WTB.lua
@@ -13,7 +13,7 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar("HPThreshold", math.random(10, 90))
-    mob:setMod(xi.mod.WIND_ABSORB, 1000)
+    mob:setMod(xi.mod.WIND_ABSORB, 100)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TSTBL.lua
+++ b/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TSTBL.lua
@@ -7,8 +7,16 @@ mixins = { require("scripts/mixins/job_special") }
 -----------------------------------
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setWallhackAllowed(false)
+end
+
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =
@@ -16,6 +24,11 @@ entity.onMobSpawn = function(mob)
             { id = 893, hpp = math.random(30, 55) }, -- uses Judgment Bolt once while near 50% HPP.
         },
     })
+end
+
+entity.onMobEngaged = function(mob, target)
+    -- they should always use a tp move when first engaged
+    mob:setTP(3000)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_Trial.lua
+++ b/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_Trial.lua
@@ -9,6 +9,10 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.LTNG_ABSORB, 100)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =

--- a/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_WTB.lua
@@ -13,7 +13,7 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar("HPThreshold", math.random(10, 90))
-    mob:setMod(xi.mod.LTNG_ABSORB, 1000)
+    mob:setMod(xi.mod.LTNG_ABSORB, 100)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TSTBW.lua
+++ b/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TSTBW.lua
@@ -7,8 +7,16 @@ mixins = { require("scripts/mixins/job_special") }
 -----------------------------------
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setWallhackAllowed(false)
+end
+
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =
@@ -16,6 +24,11 @@ entity.onMobSpawn = function(mob)
             { id = 866, hpp = math.random(30, 55) }, -- uses Tidal Wave once while near 50% HPP.
         },
     })
+end
+
+entity.onMobEngaged = function(mob, target)
+    -- they should always use a tp move when first engaged
+    mob:setTP(3000)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_Trial.lua
+++ b/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_Trial.lua
@@ -9,6 +9,10 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.WATER_ABSORB, 100)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =

--- a/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_WTB.lua
@@ -13,7 +13,7 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar("HPThreshold", math.random(10, 90))
-    mob:setMod(xi.mod.WATER_ABSORB, 1000)
+    mob:setMod(xi.mod.WATER_ABSORB, 100)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_TSTBE.lua
+++ b/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_TSTBE.lua
@@ -7,8 +7,16 @@ mixins = { require("scripts/mixins/job_special") }
 -----------------------------------
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setWallhackAllowed(false)
+end
+
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =
@@ -16,6 +24,11 @@ entity.onMobSpawn = function(mob)
             { id = 857, hpp = math.random(30, 55) }, -- uses Earthen Fury once while near 50% HPP.
         },
     })
+end
+
+entity.onMobEngaged = function(mob, target)
+    -- they should always use a tp move when first engaged
+    mob:setTP(3000)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_Trial.lua
+++ b/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_Trial.lua
@@ -9,6 +9,10 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGAIN, 50)
+    mob:setMod(xi.mod.EARTH_ABSORB, 100)
+    mob:setMod(xi.mod.UDMGPHYS, -6000)
+    mob:setMod(xi.mod.UDMGRANGE, -6000)
+    mob:setMobMod(xi.mobMod.MAGIC_RANGE, 40)
 
     xi.mix.jobSpecial.config(mob, {
         specials =

--- a/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_WTB.lua
+++ b/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_WTB.lua
@@ -13,7 +13,7 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar("HPThreshold", math.random(10, 90))
-    mob:setMod(xi.mod.EARTH_ABSORB, 1000)
+    mob:setMod(xi.mod.EARTH_ABSORB, 100)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
@@ -8,7 +8,7 @@ local ID = require("scripts/zones/Empyreal_Paradox/IDs")
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:addMod(xi.mod.REGAIN, 30)
+    mob:addMod(xi.mod.REGAIN, 50)
     mob:setMobMod(xi.mobMod.NO_REST, 1)
     mob:addListener('RAISE_RECEIVED', 'PRISHE_RAISE_RECEIVED', function(target, raiseLevel)
         target:setLocalVar("Raise", 1)

--- a/scripts/zones/Horlais_Peak/mobs/Huntfly.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Huntfly.lua
@@ -10,26 +10,9 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobEngaged = function(mob)
-    mob:setLocalVar("agroTimer", os.time() + math.random(1, 5))
-    mob:setLocalVar("fly", 1)
 end
 
 entity.onMobFight = function(mob, target)
-    local fly = mob:getLocalVar("fly")
-
-    if mob:getLocalVar("agroTimer") < os.time() then
-        mob:setLocalVar("agroTimer", os.time() + math.random(1, 5))
-
-        if fly:isAlive() then
-            fly:updateEnmity(target)
-        end
-
-        if fly == 8 then
-            mob:setLocalVar("fly", 1)
-        else
-            mob:setLocalVar("fly", fly + 1)
-        end
-    end
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/The_Celestial_Nexus/mobs/Ealdnarche_2.lua
+++ b/scripts/zones/The_Celestial_Nexus/mobs/Ealdnarche_2.lua
@@ -12,6 +12,7 @@ entity.onMobInitialize = function(mob)
     -- 60% fast cast, -75% physical damage taken, 10tp/tick regain, no standback
     mob:addMod(xi.mod.UFASTCAST, 60)
     mob:addMod(xi.mod.UDMGPHYS, -7500)
+    mob:addMod(xi.mod.UDMGRANGE, -7500)
     mob:addMod(xi.mod.REGAIN, 100)
     mob:setMobMod(xi.mobMod.HP_STANDBACK, -1)
 end

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -13226,7 +13226,7 @@ INSERT INTO `mob_groups` VALUES (75,4006,206,'Trion',0,128,0,0,0,75,75,1); -- al
 -- Cloister_of_Flames (Zone 207)
 -- ------------------------------------------------------------
 
-INSERT INTO `mob_groups` VALUES (1,4645,207,'Ifrit_Prime_TBF',0,128,0,7650,0,60,60,0);
+INSERT INTO `mob_groups` VALUES (1,2050,207,'Ifrit_Prime_TBF',0,128,0,7650,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (2,7052,207,'Ifrit_Prime_TSTBF',0,128,0,700,0,20,20,0);
 INSERT INTO `mob_groups` VALUES (3,4645,207,'Ifrit_Prime_WTB',0,128,0,27000,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (4,1341,207,'Fire_Elemental',0,128,0,3000,0,75,75,0);
@@ -13310,7 +13310,7 @@ INSERT INTO `mob_groups` VALUES (5,20001,210,'Garrison_75',0,129,0,0,0,70,75,1);
 -- Cloister_of_Tides (Zone 211)
 -- ------------------------------------------------------------
 
-INSERT INTO `mob_groups` VALUES (1,4646,211,'Leviathan_Prime_TBW',0,128,0,9500,0,60,60,0);
+INSERT INTO `mob_groups` VALUES (1,2402,211,'Leviathan_Prime_TBW',0,128,0,9500,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (2,7054,211,'Leviathan_Prime_TSTBW',0,128,0,700,0,20,20,0);
 INSERT INTO `mob_groups` VALUES (3,4646,211,'Leviathan_Prime_WTB',0,128,0,27000,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (4,4309,211,'Water_Elemental',0,128,0,3000,0,75,75,0);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1234,7 +1234,7 @@ INSERT INTO `mob_skills` VALUES (1274,919,'impalement',0,10.0,2000,1500,4,0,0,0,
 INSERT INTO `mob_skills` VALUES (1275,920,'empty_thrash',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1276,921,'promyvion_brume',1,10.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1277,1021,'inferno_blast',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1278,652,'inferno_blast_alt',0,7.0,500,0,4,4,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1278,652,'inferno_blast_alt',0,20.0,500,0,4,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1279,653,'tebbad_wing',1,30.0,2000,1500,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1280,654,'spike_flail',1,23.0,2000,2000,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1281,655,'fiery_breath',6,18.0,2000,1500,4,8,0,0,0,0,0);
@@ -1244,7 +1244,7 @@ INSERT INTO `mob_skills` VALUES (1284,658,'tebbad_wing_air',1,30.0,2000,1500,4,8
 INSERT INTO `mob_skills` VALUES (1285,659,'absolute_terror',0,18.0,2000,1500,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1286,660,'horrid_roar_3',0,18.0,2000,1500,4,8,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1287,964,'sleet_blast',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1288,963,'sleet_blast_alt',0,7.0,500,0,4,4,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1288,963,'sleet_blast_alt',0,20.0,500,0,4,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1289,653,'gregale_wing',1,30.0,2000,1500,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1290,654,'spike_flail',1,23.0,2000,2000,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1291,962,'glacial_breath',4,18.0,2000,1500,4,8,0,0,0,0,0);
@@ -1254,7 +1254,7 @@ INSERT INTO `mob_skills` VALUES (1294,658,'gregale_wing_air',1,30.0,2000,1500,4,
 INSERT INTO `mob_skills` VALUES (1295,659,'absolute_terror',0,18.0,4000,1500,4,8,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1296,660,'horrid_roar_3',0,18.0,4000,1500,4,8,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1297,1041,'ocher_blast',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1298,966,'ochre_blast_alt',0,7.0,500,0,4,4,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1298,966,'ochre_blast_alt',0,20.0,500,0,4,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1299,653,'typhoon_wing',1,30.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1300,654,'spike_flail',1,23.0,2000,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1301,965,'geotic_breath',6,18.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Air auto-attacks of Tiamat, Ouryu, and Jormungand now have more retail accurate range of 20 yalms. (Tracent)
- Evil Armory in SE Apollyon now also has ranged damage down. (Tracent)
- Eald'narche in Zilart mission 16 BCNM fight now also has ranged damage down. (Tracent)
- Prishe in Dawn BCNM now has slightly higher regain as on retail. (Tracent)
- Breath damage modifiers will now correctly impact the blood pact Nether Blast. (Tracent)
- Fomor mobs (in areas other than Dynamis-Beaucedine) are no longer immune to dark based sleep (as in era). (Tracent)
- Hydra mobs in Dynamis-Beaucedine are now immune to both light and dark based sleep (as in era). (Tracent)
- Players will no longer lose experience points when dying in ENM battlefields (as in era). (Tracent)
- Trial-by avatars (level 60) and trial-size-by avatars (level 20) now have 60% physical and ranged damage reduction (as in era). (Tracent)
- Trial-by avatars (level 60) Ifrit and Leviathan will no longer use their two hour abilities multiple times per battle. (Tracent)
- Trial-size-by avatars (level 20) will now always use a mob skill immediately upon engaging (as in era). (Tracent)
- Trial-by avatars (level 60) will now absorb magical damage that matches their element (as in era). (Tracent)
- Trial-by avatars (level 60) and trial-size-by avatars (level 20) now have magic aggro range of 40 yalms (as in era). (Tracent)
- Trial-size-by avatars (level 20) now always follow the full path in the battlefield. (Tracent)

## What does this pull request do? (Please be technical)

- See [capture](https://youtu.be/fzgacJ2rgYY?t=6204) for proof of air auto-attacks of Tiamat having range of at least 17 yalms, thus rounding up to 20 is reasonable. The range might be larger (KS99 wyrm is currently set to 30) but hard to get proof from these NMs because of draw-in range.
- The breath damage reduction of Nether Blast can be seen for example in [era videos](https://youtu.be/b-qhWrI8TRI?t=2) of Tiamat.
- The change for Huntfly removes broken code related to linking all flies in the BCNM. The broken code might be trying to do some kind of partial enmity sharing that wiki says should exist but there are no captures or testing to understand how this should work and the existing code does not do anything but add errors to the error log. Thus better to remove for now and try to get capture.
- The Race Runner code also just adds errors to the error log but does not see to do anything as Race Runner should not move quickly and randomly between points while roaming in any case (as seen in capture [here](https://youtu.be/l4dF94Wnr2E?t=103)). Also the `mob:pathThrough(pathNodes, bit.bor(xi.path.flag.PATROL, xi.path.flag.REVERSE))` does not make sense as there is already random point pathing enabled in the `onMobFight` method.
- The Citipati change just fixes an error that appears in the logs.
- The Avatar fight changes are either bug fixes or from retail testing. The only exception is the light meva of trial-size-by avatars which is estimated from resist rates of SL from era videos (only 3/27 half resist), this is potentially impacted by bias in terms of what videos are uploaded but is the best we have at the moment.

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1802
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1809
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1042
## Steps to test these changes

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
