### PR TITLE
Update Dyna Tav related skill behavior

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -817,9 +817,11 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
 
     -- special spawning of DL clones near victems
     if
-        mobIndex == 179 and
+        ((zoneID == xi.zone.DYNAMIS_TAVNAZIA and
+        mobIndex == 252) or
+        (mobIndex == 179 and
         oMobIndex == 179 and
-        zoneID == xi.zone.DYNAMIS_XARCABARD and
+        zoneID == xi.zone.DYNAMIS_XARCABARD)) and
         target
     then
         xPos = target:getXPos() + math.random() * 6 - 3

--- a/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
@@ -225,7 +225,7 @@ xi.dynamis.onMobFightDiabolosClub = function(mob, mobTarget)
     then
         mob:setLocalVar("ShardSummon1", 0)
         local zoneID = mob:getZoneID()
-        xi.dynamis.nmDynamicSpawn(252, 110, true, zoneID, mob, mob)
+        xi.dynamis.nmDynamicSpawn(252, 110, true, zoneID, mobTarget, mob)
     end
 
     if
@@ -235,7 +235,7 @@ xi.dynamis.onMobFightDiabolosClub = function(mob, mobTarget)
     then
         mob:setLocalVar("ShardSummon2", 0)
         local zoneID = mob:getZoneID()
-        xi.dynamis.nmDynamicSpawn(252, 110, true, zoneID, mob, mob)
+        xi.dynamis.nmDynamicSpawn(252, 110, true, zoneID, mobTarget, mob)
     end
 
     if mob:getLocalVar("RuinousOmenHPP") > 0 then

--- a/modules/era/scripts/globals/mobskills/onMobWeaponSkill.lua
+++ b/modules/era/scripts/globals/mobskills/onMobWeaponSkill.lua
@@ -2148,7 +2148,7 @@ end)
 m:addOverride("xi.globals.mobskills.cacodemonia.onMobWeaponSkill", function(target, mob, skill)
     local typeEffect = xi.effect.CURSE_I
     local power = 40
-    if skill:getID() == 1909 then -- Diabolos Dynamis Tavnazia - 48%
+    if mob:getZoneID() == xi.zone.DYNAMIS_TAVNAZIA then -- Diabolos Dynamis Tavnazia - 48%
         power = 48
     end
 
@@ -2238,7 +2238,7 @@ m:addOverride("xi.globals.mobskills.camisado.onMobWeaponSkill", function(target,
     local dmgmod = 1
 
     -- Diabolos Dynamis Tavnazia - covering skill IDs: single target 656 and AoE 1903
-    if mob:getZoneID() == 42 then
+    if mob:getZoneID() == xi.zone.DYNAMIS_TAVNAZIA then
         accmod = 4
         dmgmod = 4
     end
@@ -2246,7 +2246,10 @@ m:addOverride("xi.globals.mobskills.camisado.onMobWeaponSkill", function(target,
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
 
     local shadows = info.hitslanded
-    if skill:getID() == 1903 then
+    if
+        mob:getZoneID() == xi.zone.DYNAMIS_TAVNAZIA and
+        skill:getID() == 1903
+    then
         shadows = xi.mobskills.shadowBehavior.WIPE_SHADOWS
     end
 
@@ -4529,7 +4532,7 @@ m:addOverride("xi.globals.mobskills.dream_shroud.onMobWeaponSkill", function(tar
     local multiplier = 1
 
     -- Diabolos Dynamis Tavnazia
-    if skill:getID() == 1907 then
+    if mob:getZoneID() == xi.zone.DYNAMIS_TAVNAZIA then
         multiplier = 2
     end
 
@@ -9760,7 +9763,7 @@ end)
 m:addOverride("xi.globals.mobskills.nether_blast.onMobWeaponSkill", function(target, mob, skill)
     local multiplier = 5
     -- Diabolos Dynamis Tavnazia tosses nether blast for ~1k
-    if skill:getID() == 1910 then
+    if mob:getZoneID() == xi.zone.DYNAMIS_TAVNAZIA then
         multiplier = 10
     end
 
@@ -9808,7 +9811,7 @@ m:addOverride("xi.globals.mobskills.nightmare.onMobWeaponSkill", function(target
         subPower = 14       -- Unresisted, 10 ticks at 14 hp/tick = 140hp per target
     end
 
-    if skill:getID() == 1908 then -- Diabolos Dynamis Tavnazia - 35/tick, at least 60s
+    if mob:getZoneID() == xi.zone.DYNAMIS_TAVNAZIA then -- Diabolos Dynamis Tavnazia - 35/tick, at least 60s
         duration = 60
         subPower = 35
     end
@@ -9862,7 +9865,7 @@ end)
 m:addOverride("xi.globals.mobskills.noctoshield.onMobWeaponSkill", function(target, mob, skill)
     local power = 13
     -- Diabolos Dynamis Tavnazia
-    if skill:getID() == 1905 then
+    if mob:getZoneID() == xi.zone.DYNAMIS_TAVNAZIA then
         power = 35
     end
 
@@ -11977,7 +11980,7 @@ m:addOverride("xi.globals.mobskills.ruinous_omen.onMobWeaponSkill", function(tar
     local ratio = 4
 
     -- Diabolos Dynamis Tavnazia - Observed 60%-95%, with most being above 80%
-    if skill:getID() == 1911 then
+    if mob:getZoneID() == xi.zone.DYNAMIS_TAVNAZIA then
         hppTarget = 80
         hppMax = 95
         hppMin = 60
@@ -15697,7 +15700,7 @@ end)
 
 m:addOverride("xi.globals.mobskills.ultimate_terror.onMobWeaponSkill", function(target, mob, skill)
     -- Diabolos Dynamis Tavnazia -- adds TERROR
-    if skill:getID() == 1906 then
+    if mob:getZoneID() == xi.zone.DYNAMIS_TAVNAZIA then
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.TERROR, 1, 0, 30)
     end
 

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -96,7 +96,7 @@ INSERT INTO `mob_skill_lists` VALUES ('Avatar-Carbuncle',34,908);
 INSERT INTO `mob_skill_lists` VALUES ('Avatar-Carbuncle',34,909);
 INSERT INTO `mob_skill_lists` VALUES ('Avatar-Carbuncle',34,910);
 INSERT INTO `mob_skill_lists` VALUES ('Avatar-Carbuncle',34,911);
-INSERT INTO `mob_skill_lists` VALUES ('CoP-Diabolos',35,1903);
+INSERT INTO `mob_skill_lists` VALUES ('CoP-Diabolos',35,1554);
 INSERT INTO `mob_skill_lists` VALUES ('CoP-Diabolos',35,1905);
 INSERT INTO `mob_skill_lists` VALUES ('CoP-Diabolos',35,1906);
 INSERT INTO `mob_skill_lists` VALUES ('CoP-Diabolos',35,1908);
@@ -1738,7 +1738,7 @@ INSERT INTO `mob_skill_lists` VALUES ('Raptor',377,374);
 INSERT INTO `mob_skill_lists` VALUES ('Raptor',377,377);
 INSERT INTO `mob_skill_lists` VALUES ('Raptor',377,379);
 INSERT INTO `mob_skill_lists` VALUES ('Raptor',377,380);
-INSERT INTO `mob_skill_lists` VALUES ('Avatar-Diabolos',378,1903);
+INSERT INTO `mob_skill_lists` VALUES ('Avatar-Diabolos',378,1554);
 INSERT INTO `mob_skill_lists` VALUES ('Avatar-Diabolos',378,1904);
 INSERT INTO `mob_skill_lists` VALUES ('Avatar-Diabolos',378,1905);
 INSERT INTO `mob_skill_lists` VALUES ('Avatar-Diabolos',378,1906);
@@ -1754,7 +1754,7 @@ INSERT INTO `mob_skill_lists` VALUES ('Pet-Carbuncle',379,909);
 INSERT INTO `mob_skill_lists` VALUES ('Pet-Carbuncle',379,910);
 INSERT INTO `mob_skill_lists` VALUES ('Pet-Carbuncle',379,911);
 INSERT INTO `mob_skill_lists` VALUES ('Pet-Carbuncle',379,912);
-INSERT INTO `mob_skill_lists` VALUES ('Pet-Diabolos',380,1903);
+INSERT INTO `mob_skill_lists` VALUES ('Pet-Diabolos',380,1554);
 INSERT INTO `mob_skill_lists` VALUES ('Pet-Diabolos',380,1904);
 INSERT INTO `mob_skill_lists` VALUES ('Pet-Diabolos',380,1905);
 INSERT INTO `mob_skill_lists` VALUES ('Pet-Diabolos',380,1906);
@@ -4147,11 +4147,11 @@ INSERT INTO `mob_skill_lists` VALUES ('Diabolos_Diamond',4082,1908); -- Nightmar
 INSERT INTO `mob_skill_lists` VALUES ('Dark_Rider',4083,2126); -- Zantetsuken
 
 INSERT INTO `mob_skill_lists` VALUES ('Diabolos_Club',4084,1909); -- Cacodemonia
-INSERT INTO `mob_skill_lists` VALUES ('Diabolos_Club',4084,656); -- Camisado: Using old non-AoE Camisado
+INSERT INTO `mob_skill_lists` VALUES ('Diabolos_Club',4084,1554); -- Camisado: Using old non-AoE Camisado
 INSERT INTO `mob_skill_lists` VALUES ('Diabolos_Club',4084,1908); -- Nightmare
 INSERT INTO `mob_skill_lists` VALUES ('Diabolos_Club',4084,1905); -- Noctoshield
 
-INSERT INTO `mob_skill_lists` VALUES ('Diabolos_Spade',4085,656); -- Camisado: Using old non-AoE Camisado
+INSERT INTO `mob_skill_lists` VALUES ('Diabolos_Spade',4085,1554); -- Camisado: Using old non-AoE Camisado
 INSERT INTO `mob_skill_lists` VALUES ('Diabolos_Spade',4085,1910); -- Nether Blast
 INSERT INTO `mob_skill_lists` VALUES ('Diabolos_Spade',4085,1918); -- Nether Tempest
 INSERT INTO `mob_skill_lists` VALUES ('Diabolos_Spade',4085,1905); -- Noctoshield

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1510,7 +1510,7 @@ INSERT INTO `mob_skills` VALUES (1550,1144,'summon_wyrm',0,15.0,2000,0,1,0,0,0,0
 INSERT INTO `mob_skills` VALUES (1551,1136,'megaflare',4,15.0,6000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1552,1137,'gigaflare',1,20.0,6000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1553,1138,'teraflare',1,25.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1554,1298,'camisado',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1554,915,'camisado',0,10.0,2000,1500,4,0,0,2,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1555,1299,'blessed_radiance',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1556,1300,'regeneration',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1557,1146,'eagle_eye_shot',0,25.0,2000,0,4,2,0,0,0,0,0); -- ees breath
@@ -1859,7 +1859,7 @@ INSERT INTO `mob_skills` VALUES (1897,1244,'diamondhide',0,7.0,2000,1500,4,0,0,0
 -- INSERT INTO `mob_skills` VALUES (1900,1247,'healing_stomp',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1901,505,'activate',0,7.0,2000,0,1,4,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1902,1646,'.',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1903,915,'camisado',0,10.0,2000,1500,4,0,0,2,0,0,0);
+INSERT INTO `mob_skills` VALUES (1903,915,'camisado',1,10.0,2000,1500,4,0,0,2,0,0,0);
 INSERT INTO `mob_skills` VALUES (1904,1126,'somnolence',0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1905,916,'noctoshield',1,10.0,2000,1800,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1906,917,'ultimate_terror',1,30.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Diabolos in Waking Dreams and the CoP Mission will no longer have ehanced TP moves. (Tiberon)

## What does this pull request do? (Please be technical)

Changes the Dyna Tav Skill restrictions to be ID agnostic
Changes the Diabolos Shard impl to spawn on target .

## Steps to test these changes

1. Enter The Shrouded Maw BCNM 40 cap against diabolos.
Verify nightmare is 14/tick
Verify camisado is single target


1. Repeat for Waking Dreams
Verify nightmare is 21/tick


1. Enter Dyna Tav
Fight Diabolos Club (it uses nightmare, camisado, and summons shard.
Nightmare is 35 a tick
Camisado from club is single target
Push Club down around 50% - note that Shard summon is aoe camisado (!hp 15000 is 50%)

## Special Deployment Considerations

SQL deployment