### PR TITLE
Fix Paralyzed Third Eye Recast.

### DIFF
--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -101,7 +101,7 @@ INSERT INTO `status_effects` VALUES (63,'souleater',4194344,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (64,'last_resort',41,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (65,'sneak_attack',4194340,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (66,'copy_image',33,0,0,0,0,36,3,0,50);
-INSERT INTO `status_effects` VALUES (67,'third_eye',41,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (67,'third_eye',41,0,0,3,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (68,'warcry',41,0,0,0,0,460,0,0,400);
 INSERT INTO `status_effects` VALUES (69,'invisible',3429,0,0,2,0,0,3,0,850);
 INSERT INTO `status_effects` VALUES (70,'deodorize',2341,0,0,2,0,0,3,0,1100);

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1404,6 +1404,11 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
             action.recast = PAbility->getRecastTime() - meritRecastReduction;
         }
 
+        if (PAbility->getID() == ABILITY_THIRD_EYE && this->StatusEffectContainer->HasStatusEffect(EFFECT_SEIGAN))
+        {
+            action.recast /= 2;
+        }
+
         if (PAbility->getID() == ABILITY_LIGHT_ARTS || PAbility->getID() == ABILITY_DARK_ARTS || PAbility->getRecastId() == 231) // stratagems
         {
             if (this->StatusEffectContainer->HasStatusEffect(EFFECT_TABULA_RASA))
@@ -1653,14 +1658,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
         }
         else
         {
-            if (this->StatusEffectContainer->HasStatusEffect(EFFECT_SEIGAN) && PAbility->getID() == 62)
-            {
-                PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), action.recast / 2);
-            }
-            else
-            {
-                PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), action.recast);
-            }
+            PRecastContainer->Add(RECAST_ABILITY, PAbility->getRecastId(), action.recast);
         }
 
         uint16 recastID = PAbility->getRecastId();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed an issue that was not applying the Seigan reduction to Third Eye when Third Eye was paralyzed.  (Tiberon)
Fixed an edge case where if a player used third eye as it wore off, third eye woud continue to wear off, leaving the player with no third eye for 29-30s (or 59-60s w/o seigan). (Tiberon)

## What does this pull request do? (Please be technical)

Removes the Seigan check for ability executing successfully.
Adds a Seigan check on the inital recast generation earlier in the fcn - which catches both normal use and paralyze.

Additionally, there is an issue where if a player uses third eye as it is about to wear off, the player loses the brand new third eye.
This happens rarely and generally happens when the sam or /sam has aggro, and is trying to get third eye up as its wearing, hitting third eye repeatedly.
This is caused by our third eye implementation.
Third Eye stores the number of anticipated hits in its power (this is wrong but we need captures to do better).
Third Eye was set to overwrite self if equal or greater power.
In the case where a sam is tanking, the power goes up on the existing buff and a new third eye cannot overwtire.
So I've change third eye to overwrite itself to cover the edge case.  When I get some third eye merits on retail or someone else can capture - I'll update if required.

~~I apologize, but I was not able to reproduce the issue locally without any changes, I believe this may be due to server lag.~~
Was an easy repro once I put my DB back to the old values :joy:

## Steps to test these changes

Be a Sam, ideally with third eye recast merits.
!givekeyitem limit_breaker
!setmerits 10

1. Test Case 1
Use Seigan
!addeffect paralysis 101 10001 <player name>
Use third eye - get para'd - have a 30s or less cooldown (less if merited)

2. Test Case 2
!reset to clear para and timers.
Use Seigan if not already on.
Use Third Eye
!reset to clear timers.
Use Third Eye - you now have a _new_ third eye.

3. Test Case 3
Go find a mob
Use Seigan
Use Third Eye
!reset for timers
Aggro Mob and Anticipate at least one hit and still have third eye
Use Third Eye - you now have a new third eye.

Turning on timers for status icons will help determine new vs old third eye.
If the timer doesnt reset to max on use its a failure
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
