### PR TITLE
Fixes Cover using the coverr for PDIF calcs

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -471,24 +471,24 @@ void CAttack::ProcessDamage(bool isCritical, bool isGuarded, bool isKick)
         {
             // mobdamage = (floor((level + 2 + fstr) * .9) / 2) * pdif
             int8 mobH2HDamage = m_attacker->GetMLevel() + 2;
-            m_damage          = (uint32)((std::floor((mobH2HDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * 0.9f) / 2) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 1, slot, 0, isGuarded));
+            m_damage          = (uint32)((std::floor((mobH2HDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * 0.9f) / 2) * battleutils::GetDamageRatio(m_attacker, m_victim, isCritical, 1, slot, 0, isGuarded));
         }
         else
         {
-            m_damage = (uint32)(((m_baseDamage + m_naturalH2hDamage + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 1, slot, 0, isGuarded)));
+            m_damage = (uint32)(((m_baseDamage + m_naturalH2hDamage + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_victim, isCritical, 1, slot, 0, isGuarded)));
         }
     }
     else if (slot == SLOT_MAIN)
     {
-        m_damage = (uint32)(((m_attacker->GetMainWeaponDmg() + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 1, slot, 0, isGuarded)));
+        m_damage = (uint32)(((m_attacker->GetMainWeaponDmg() + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_victim, isCritical, 1, slot, 0, isGuarded)));
     }
     else if (slot == SLOT_SUB)
     {
-        m_damage = (uint32)(((m_attacker->GetSubWeaponDmg() + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 1, slot, 0, isGuarded)));
+        m_damage = (uint32)(((m_attacker->GetSubWeaponDmg() + m_trickAttackDamage + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetDamageRatio(m_attacker, m_victim, isCritical, 1, slot, 0, isGuarded)));
     }
     else if (slot == SLOT_AMMO || slot == SLOT_RANGED)
     {
-        m_damage = (uint32)((m_attacker->GetRangedWeaponDmg() + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetRangedDamageRatio(m_attacker, m_attacker->GetBattleTarget(), isCritical, 0));
+        m_damage = (uint32)((m_attacker->GetRangedWeaponDmg() + battleutils::GetFSTR(m_attacker, m_victim, slot)) * battleutils::GetRangedDamageRatio(m_attacker, m_victim, isCritical, 0));
     }
 
     // Apply Scarlet Delirium damage bonus
@@ -529,9 +529,9 @@ void CAttack::ProcessDamage(bool isCritical, bool isGuarded, bool isKick)
         SetAttackType(PHYSICAL_ATTACK_TYPE::SAMBA);
     }
 
-    if (m_attacker->objtype == TYPE_PET && m_attacker->GetBattleTarget() != nullptr && m_attacker->GetBattleTarget()->getMod(Mod::PET_DMG_TAKEN_PHYSICAL) != 0)
+    if (m_attacker->objtype == TYPE_PET && m_victim != nullptr && m_victim->getMod(Mod::PET_DMG_TAKEN_PHYSICAL) != 0)
     {
-        m_damage *= m_attacker->GetBattleTarget()->getMod(Mod::PET_DMG_TAKEN_PHYSICAL) / 100;
+        m_damage *= m_victim->getMod(Mod::PET_DMG_TAKEN_PHYSICAL) / 100.0f;
     }
 
     // Get damage multipliers.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed an issue causing Cover to use the player being covered for PDIF calculations, instead of the Cover user. (Tiberon)

## What does this pull request do? (Please be technical)

attacker->getBattleTarget() was being used in PDIF for processDamage, not m_victim.
So the override being done by cover to change m_victom was not being used.
Changed it and other cases to m_victim.

## Steps to test these changes

Create the following scenario:
Mob > <Pld_1 < Pld_2
Mob should be at least level 50
Pld_1 should be 75, augement with gear or a !setmod DEF
Pld_2 should be level 15 ish.
!setmod acc 1000 on the level 50 mob, we want it to hit.

Have Pld_1 banish the mob or voke for initial hate
Record damage done (was 10-30 for me)
Have Pld_2 banish the mob (prob wont take hate)
Have Pld_2 invincible
Click off the invincible effect (why is this even possible?!)
Pld_2 will take 200ish a hit
Have Pld_1 cover Pld2
Pld_1 will take 10-30 a hit - not 200 a hit

I also tested the `PET_DMG_TAKEN_PHYSICAL` mod since I changed that code - using a pet vs a mob and giving the mob the mod at 95%.
But that OOE as far as I know.
To run the test - get a pet (smn works well)
Let it auto a mob for a while, then !setmod PET_DMG_TAKEN_PHYSICAL 50

**Fun fact** - this mod never worked before - was always reducing dmg to 0 due to integer division

## Special Deployment Considerations

None
