### PR TITLE
Fix Nuclear Waste Chaining

### DIFF
--- a/scripts/zones/Sealions_Den/mobs/Ultima.lua
+++ b/scripts/zones/Sealions_Den/mobs/Ultima.lua
@@ -60,8 +60,11 @@ entity.onMobWeaponSkill = function(target, mob, skill)
         mob:getLocalVar("nuclearWaste") == 1
     then
         mob:timer(4000, function(mobArg)
-            local ability = math.random(1262, 1267)
-            mob:useMobAbility(ability)
+            if mobArg:getLocalVar("nuclearWaste") == 1 then
+                mobArg:setLocalVar("nuclearWaste", 0)
+                local ability = math.random(1262, 1267)
+                mobArg:useMobAbility(ability)
+            end
         end)
     end
 end

--- a/scripts/zones/Temenos/mobs/Proto-Ultima.lua
+++ b/scripts/zones/Temenos/mobs/Proto-Ultima.lua
@@ -60,8 +60,11 @@ entity.onMobWeaponSkill = function(target, mob, skill)
         mob:getLocalVar("nuclearWaste") == 1
     then
         mob:timer(4000, function(mobArg)
-            local ability = math.random(1262, 1267)
-            mob:useMobAbility(ability)
+            if mobArg:getLocalVar("nuclearWaste") == 1 then
+                mobArg:setLocalVar("nuclearWaste", 0)
+                local ability = math.random(1262, 1267)
+                mobArg:useMobAbility(ability)
+            end
         end)
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fix Nuclear Waste to no longer cause multiple elemental conals... again. (Tiberon)

## What does this pull request do? (Please be technical)

Moved the logical gate for this behavior to be as delayed as possible

## Steps to test these changes

Engage Proto-Ultima (or ultima) with 2 smns or 2 bst.
Immortal all the pets and players (and ultima)
If smn !setmod refresh 100

Target the ultima and use `!exec target:useMobAbility(1268)`
Ensure nuclear waste hits 4 targets.
Verify only one elemental conal is used following nuclear waste _and only one_

## Special Deployment Considerations

None - hotfixable.
