### PR TITLE
Add's status message to spike effects for armor.

### DIFF
--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -75,6 +75,7 @@ enum MSGBASIC_ID : uint16
     MSGBASIC_SPIKES_EFFECT_DMG      = 44,  /* <target>'s spikes deal <number> damage to <attacker> */
     MSGBASIC_SPIKES_EFFECT_HEAL     = 383, /* <target>'s spikes restore <number> HP to <attacker> */
     MSGBASIC_SPIKES_EFFECT_HP_DRAIN = 132, /* <target>'s spikes drain <number> HP from the <attacker>. */
+    MSGBASIC_SPIKES_ARMOR_SUBEFFECT = 374, /* Striking <target>'s armor causes <attacker> to become <status>. */
     /* Distance */
     MSGBASIC_TARG_OUT_OF_RANGE  = 4,  /* <target> is out of range. */
     MSGBASIC_UNABLE_TO_SEE_TARG = 5,  /* Unable to see <target>. */

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1062,7 +1062,7 @@ namespace battleutils
             // spikes landed
             if (spikesType == SUBEFFECT_CURSE_SPIKES)
             {
-                Action->spikesMessage = 0; // log says nothing? // TODO: find "Additional Effect: Curse" message
+                Action->spikesMessage = MSGBASIC_SPIKES_ARMOR_SUBEFFECT;
                 Action->spikesParam   = EFFECT_CURSE;
             }
             else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Armor with spike status effects (like curse) will now display proc messages. (sarca571ca)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Sends the proper message packet for spike status effect's from armor to the client. Now players will know when the status procs.
- Closes #3545  
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Equip Iqgira Weskit and pull a bunch of mobs. Wait for the spike effect to proc and see the message appear in the chatlog.
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
Since this is a core change you'll need to rebuild xi_map.
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
