### PR TITLE
[Quest] One Good Dead sql and reference corrections.

### DIFF
--- a/scripts/quests/windurst/One_Good_Deed.lua
+++ b/scripts/quests/windurst/One_Good_Deed.lua
@@ -67,6 +67,7 @@ quest.sections =
                 [595] = function(player, csid, option, npc)
                     quest:setVar(player, 'Prog', 3)
                 end,
+
                 [597] = function(player, csid, option, npc)
                     quest:complete(player)
                 end,

--- a/scripts/quests/windurst/One_Good_Deed.lua
+++ b/scripts/quests/windurst/One_Good_Deed.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Orastery Woes
--- Kuroido-Moido !pos -112.5 -4.2 102.9 240
--- qm1 !pos 197 -8 -27.5 122
+-- Chipmy-Popmy !gotoid 17760309
+-- qm1 !gotoid 16793999
 -----------------------------------
 require('scripts/globals/interaction/quest')
 require('scripts/globals/npc_util')
@@ -17,6 +17,7 @@ quest.reward =
     gil = 3200,
     fame = 50,
     fameArea = xi.quest.fame_area.WINDURST,
+    title = xi.title.DEED_VERIFIER,
 }
 
 quest.sections =
@@ -24,7 +25,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == QUEST_AVAILABLE and
-            player:getFameLevel(xi.quest.fame_area.WINDURST) >= 6
+            player:getFameLevel(xi.quest.fame_area.WINDURST) >= 5
         end,
 
         [xi.zone.PORT_WINDURST] =
@@ -51,7 +52,10 @@ quest.sections =
             ['Chipmy-Popmy'] =
             {
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 2 and player:hasKeyItem(xi.ki.DEED_TO_PURGONORGO_ISLE) then
+                    if
+                        quest:getVar(player, 'Prog') == 2 and
+                        player:hasKeyItem(xi.ki.DEED_TO_PURGONORGO_ISLE)
+                    then
                         return quest:progressEvent(595, 0, xi.ki.DEED_TO_PURGONORGO_ISLE)
                     elseif quest:getVar(player, 'Prog') == 4 then
                         return quest:progressEvent(597) -- Complete Quest
@@ -74,7 +78,10 @@ quest.sections =
             ['qm_deed'] =
             {
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 0 and npcUtil.popFromQM(player, npc, bibikiID.mob.PEERIFOOLS, { claim = true, hide = 0 }) then
+                    if
+                        quest:getVar(player, 'Prog') == 0 and
+                        npcUtil.popFromQM(player, npc, bibikiID.mob.PEERIFOOLS, { claim = true, hide = 0 })
+                    then
                         return quest:message(bibikiID.text.YOU_ARE_NOT_ALONE)
                     elseif quest:getVar(player, 'Prog') == 1 then
                         return quest:progressEvent(34)
@@ -82,7 +89,7 @@ quest.sections =
                 end,
             },
 
-            ['Perifool'] =
+            ['Peerifool'] =
             {
                 onMobDeath = function(mob, player, optParams)
                     if quest:getVar(player, 'Prog') == 0 then

--- a/scripts/zones/Bibiki_Bay/DefaultActions.lua
+++ b/scripts/zones/Bibiki_Bay/DefaultActions.lua
@@ -2,5 +2,6 @@ local ID = require('scripts/zones/Bibiki_Bay/IDs')
 
 return {
     ['qm_dalham']  = { messageSpecial = ID.text.NOTHING_LEFT_INTEREST },
+    ['qm_deed']    = { messageSpecial = ID.text.NOTHING_LEFT_INTEREST },
     ['Warmachine'] = { text = ID.text.CLUNK_CLUNK_WHIRL_WHIZZ },
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Addresses issue(s) where players were unable to complete the quest One Good Dead. 
Adjusts fame requirement to match retail.
Adds appropriate title (Deed Verifier)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Fixes an SQL issue where it was renamed at some point in an LSB merge.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Accept quest and follow goto ID's
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
Will require dbtool to be run to update SQL. 
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
