### PR TITLE
Add gates to inactive state to only ignore charm for players

### DIFF
--- a/src/map/ai/states/inactive_state.cpp
+++ b/src/map/ai/states/inactive_state.cpp
@@ -46,7 +46,15 @@ bool CInactiveState::Update(time_point tick)
             return true;
         }
 
-        if (!PBattleEntity->StatusEffectContainer->HasPreventActionEffect(true))
+        bool ignoreCharm = false;
+        if (PBattleEntity->objtype == ENTITYTYPE::TYPE_PC)
+        {
+            // Player AI should ignore charm when considering if they can leave the idle state
+            // This enabled players who are slept before/during charm to re-engage after sleep wears
+            ignoreCharm = true;
+        }
+
+        if (!PBattleEntity->StatusEffectContainer->HasPreventActionEffect(ignoreCharm))
         {
             return true;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Its very likely that charmed pets will stop beating their owners to death. (Tiberon)

## What does this pull request do? (Please be technical)

Adds logical gates to the change made in PR https://github.com/AirSkyBoat/AirSkyBoat/pull/3638

## Steps to test these changes

See PR https://github.com/AirSkyBoat/AirSkyBoat/pull/3638

## Special Deployment Considerations

Core change - full rebuild and server bounce
