### PR TITLE
Ensure Diabolos doesnt become passive due to timer issues

### DIFF
--- a/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diabolos.lua
@@ -34,6 +34,8 @@ end
 entity.onMobSpawn = function(mob)
     local dBase = ID.mob.DIABOLOS_OFFSET
     local dPrimeBase = dBase + 27
+    mob:setAutoAttackEnabled(true)
+    mob:setMobAbilityEnabled(true)
 
     -- Only add these for the CoP Diabolos NOT Prime
     if mob:getID() >= dBase and mob:getID() <= dBase + 14 then  -- three possible instances of Diabolos
@@ -126,6 +128,7 @@ end
 -- After Nightmare or Ultimate Terror then always use Camisado
 entity.onMobWeaponSkill = function(target, mob, skill)
     local skillID = skill:getID()
+    -- ToDo this is prob incorrect since this will be triggered for each target hit by a skill
     if skillID == 659 or skillID == 1908 then
         useCamisado(mob)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Diabolos in Darkness Named and Waking Dreams will no longer occasionally stand around doing nothing. (Tiberon)

## What does this pull request do? (Please be technical)

The diabolos lua uses some timers force diabolos to use camisado after nightmare or ultimate terror.
In doing so - the code forces diabolos to disable autoattacks and mob skill usages.
These functions change a member variable on the mob.
These member variables are not reset between spawn/despawn.
So for diabolos, if it is killed post nightmare/ultimate terror, but before the timer value completes - it is left in a disabled state.

To fix this for now, I have enforced renabling on spawn.
Long term this code should be refactored as its not safe, we likely dont need to disable autos and mob skills (it is tiggered by a tp move, it has no tp left).
Additionally, the tirgger mechanism is onMobSkill for a AoE skills.  It will likely trigger 2x timers per target hit by nightmare or ultimate terror - so it should be adjusted to not do so.

## Steps to test these changes

wait for diabolos in the bcnm to do nightmare or ultimate terror
!hp 0 right after.
re-enter bcnm - ensure you have the same diabolos - there are 3 and battlefields rotate iirc for this bcnm to screw with the floor.  Just check the ID.
Note that diabolos will melee and use mob skills.

## Special Deployment Considerations

none
