### PR TITLE
[Lost for Words] Allow Refusing Nanaa Mihgo's Offer

### DIFF
--- a/scripts/commands/checkmissionstatus.lua
+++ b/scripts/commands/checkmissionstatus.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- func: checkmissionstatus <Log ID> <Player>
+-- func: checkmissionstatus (player) (log ID) (index)
 -- desc: Prints current missionStatus for the given LogID and target Player to the in game chatlog
 -----------------------------------
 require("scripts/globals/missions")

--- a/scripts/missions/windurst/2_1_Lost_for_Words.lua
+++ b/scripts/missions/windurst/2_1_Lost_for_Words.lua
@@ -163,7 +163,7 @@ mission.sections =
         },
     },
 
-    -- Speak to Nanaa Mihgo in Windurst Woods (neat Home Point #1).
+    -- Speak to Nanaa Mihgo in Windurst Woods (near Home Point #1).
     {
         check = function(player, currentMission, missionStatus)
             return currentMission == mission.missionId and missionStatus == 2
@@ -176,6 +176,11 @@ mission.sections =
             onEventFinish =
             {
                 [165] = function(player, csid, option, npc)
+                    -- "Refuse"
+                    if option == 2 then
+                        return
+                    end
+
                     npcUtil.giveKeyItem(player, xi.ki.LAPIS_MONOCLE)
                     mission:setVar(player, "Rock", mazeID.npc.FOSSIL_ROCKS[math.random(#mazeID.npc.FOSSIL_ROCKS)])
                     player:setMissionStatus(mission.areaId, 3)


### PR DESCRIPTION
Fix the option where the player refuses the offer. The player can talk to Nanaa Mihgo again to accept.

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Allow refusing Nanaa Mihgo's offer in Lost for Words (Public)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)

Early return if you select Refuse.

## Steps to test these changes

```
!addmission 2 3
!pos 62 -4 240 241
!setmissionstatus 2 2
```
Talk to Nanaa Mihgo
Refuse

Fixes https://github.com/AirSkyBoat/AirSkyBoat/issues/3384