### PR TITLE
Change Goblin Dice Reset to target players, not the gobbo

### DIFF
--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1065,7 +1065,7 @@ INSERT INTO `mob_skills` VALUES (1105,756,'dice_sleep',1,10.0,3000,1500,4,0,0,0,
 INSERT INTO `mob_skills` VALUES (1106,757,'dice_slow',1,10.0,3000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1107,758,'dice_tp_loss',1,10.0,3000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1108,759,'dice_dispel',1,10.0,3000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1109,760,'dice_reset',1,10.0,3000,1500,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1109,760,'dice_reset',1,10.0,3000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1110,761,'seismostomp',1,15.0,3000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1111,762,'numbing_glare',6,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1112,763,'seismostomp',1,15.0,3000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

The Dynamis Goblin NM Dice move which resets ability timers will now target players, not mobs. (Tiberon)

## What does this pull request do? (Please be technical)

flips the valid targets from self to foes

## Steps to test these changes

fight goblin NMs in dyna - see them use goblin dice.
When it happens, it should reset the players, not the mobs.

This shouldnt happen :joy:
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/105882290/3a1361c3-a43c-4c0a-8f14-9d50701618e4)


## Special Deployment Considerations

mobskills sql