### PR TITLE
Add Bind effect to charm on not charmable mobs

### DIFF
--- a/scripts/globals/abilities/charm.lua
+++ b/scripts/globals/abilities/charm.lua
@@ -29,8 +29,22 @@ end
 
 abilityObject.onUseAbility = function(player, target, ability)
     if target:getMobMod(xi.mobMod.CHARMABLE) == 0 then
-        ability:setMsg(xi.msg.basic.JA_NO_EFFECT)
-        return
+        if not target:hasImmunity(xi.immunity.BIND) then
+            ability:setMsg(xi.msg.basic.JA_ENFEEB_IS)
+            local bindDuration = math.random(2, 8)
+
+            -- based on rumors on forums
+            -- needs capture for NM, Bind Immune, Bind Res Build, Ice Resist, etc
+            if target:isNM() then
+                bindDuration = bindDuration / 2
+            end
+
+            target:addStatusEffect(xi.effect.BIND, 1, 0, bindDuration, 0, 0)
+            return xi.effect.BIND
+        else
+            ability:setMsg(xi.msg.basic.JA_NO_EFFECT)
+            return
+        end
     end
 
     if target:isPC() then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Adds Bind effect to charms against uncharmable mobs. (Tiberon)

## What does this pull request do? (Please be technical)

If a target is not charmable, applies a bind.

## Steps to test these changes

Find a beastman, try to charm, get a bind instead
Try to charm a bind immune mob - no bind

## Special Deployment Considerations

None

## Source
https://www.youtube.com/watch?v=pTviDvRHGHI

## todo
how does the duration work vs:
- NMs
- Ice resisty mobs
- bind immune mobs
- mobs which have bind res build