### PR TITLE
[core] Fixes mob evasion using wrong skill value

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -998,17 +998,17 @@ uint16 CBattleEntity::EVA()
     else // If it is a player then evasion = SKILL_EVASION
     {
         evasion = GetSkill(SKILL_EVASION);
-    }
 
-    // Both mobs and players follow the same formula for over 200 evasion
-    if (evasion > 200)
-    {
-        evasion = 200 + (evasion - 200) * 0.9;
+        // Player only evasion calculation
+        if (evasion > 200)
+        {
+            evasion = 200 + (evasion - 200) * 0.9;
+        }
     }
 
     evasion += AGI() / 2;
 
-    return std::max(0, evasion + (this->objtype == TYPE_MOB || this->objtype == TYPE_PET ? 0 : m_modStat[Mod::EVA])); // The mod for a pet or mob is already calclated in the above so return 0
+    return std::max(1, evasion + (this->objtype == TYPE_MOB || this->objtype == TYPE_PET ? 0 : m_modStat[Mod::EVA])); // The mod for a pet or mob is already calclated in the above so return 0
 }
 
 /************************************************************************

--- a/src/map/utils/mobutils.h
+++ b/src/map/utils/mobutils.h
@@ -66,9 +66,8 @@ namespace mobutils
 
     uint16 GetWeaponDamage(CMobEntity* PMob, uint16 slot);
     uint16 GetMagicEvasion(CMobEntity* PMob);
-    uint16 GetDefense(CMobEntity* PMob, uint8 rank);
-    uint16 GetBase(CMobEntity* PMob, uint8 rank);
-
+    uint16 GetBaseDefEva(CMobEntity* PMob, uint8 rank);
+    uint16 GetBaseSkill(CMobEntity* PMob, uint8 rank);
     uint16 GetBaseToRank(uint8 rank, uint16 level);
     void   GetAvailableSpells(CMobEntity* PMob);
     void   InitializeMob(CMobEntity* PMob, CZone* PZone);

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -746,10 +746,10 @@ namespace petutils
 
         // It appears that Rabbit and Eft have lower stats (acc atk) than their counterparts
         // Require some more data points to see if we should special case those to rank 3 instead of rank 1
-        PMob->setModifier(Mod::DEF, mobutils::GetDefense(PMob, PMob->defRank));
-        PMob->setModifier(Mod::EVA, mobutils::GetBase(PMob, GetJugEvasionRank(PMob)));
-        PMob->setModifier(Mod::ATT, mobutils::GetBase(PMob, PMob->attRank));
-        PMob->setModifier(Mod::ACC, mobutils::GetBase(PMob, PMob->accRank));
+        PMob->setModifier(Mod::DEF, mobutils::GetBaseDefEva(PMob, PMob->defRank));
+        PMob->setModifier(Mod::EVA, mobutils::GetBaseSkill(PMob, GetJugEvasionRank(PMob)));
+        PMob->setModifier(Mod::ATT, mobutils::GetBaseSkill(PMob, PMob->attRank));
+        PMob->setModifier(Mod::ACC, mobutils::GetBaseSkill(PMob, PMob->accRank));
 
         ApplyJugStatCorrections(PMob);
     }
@@ -1207,21 +1207,21 @@ namespace petutils
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDamage(weaponDamage);
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (PPetData->cmbDelay / 60.0f))));
 
-        PPet->setModifier(Mod::DEF, mobutils::GetDefense(PPet, PPet->defRank));
-        PPet->setModifier(Mod::EVA, mobutils::GetBase(PPet, PPet->evaRank));
-        PPet->setModifier(Mod::ATT, mobutils::GetBase(PPet, PPet->attRank));
-        PPet->setModifier(Mod::ACC, mobutils::GetBase(PPet, PPet->accRank));
+        PPet->setModifier(Mod::DEF, mobutils::GetBaseDefEva(PPet, PPet->defRank));
+        PPet->setModifier(Mod::EVA, mobutils::GetBaseSkill(PPet, PPet->evaRank));
+        PPet->setModifier(Mod::ATT, mobutils::GetBaseSkill(PPet, PPet->attRank));
+        PPet->setModifier(Mod::ACC, mobutils::GetBaseSkill(PPet, PPet->accRank));
 
         // Fenrir has been proven to have an additional 30% ATK
         if (petID == PETID_FENRIR)
         {
-            PPet->addModifier(Mod::ATT, 0.3 * mobutils::GetBase(PPet, PPet->attRank));
+            PPet->addModifier(Mod::ATT, 0.3 * mobutils::GetBaseSkill(PPet, PPet->attRank));
         }
 
         // Diabolos has been proven to have an additional 30% DEF
         if (petID == PETID_DIABOLOS)
         {
-            PPet->addModifier(Mod::DEF, 0.3 * mobutils::GetDefense(PPet, PPet->defRank));
+            PPet->addModifier(Mod::DEF, 0.3 * mobutils::GetBaseDefEva(PPet, PPet->defRank));
         }
 
         // cap all magic skills so they play nice with spell scripts

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -694,13 +694,13 @@ namespace trustutils
             }
         }
 
-        PTrust->addModifier(Mod::DEF, mobutils::GetBase(PTrust, PTrust->defRank));
-        PTrust->addModifier(Mod::EVA, mobutils::GetBase(PTrust, PTrust->evaRank));
-        PTrust->addModifier(Mod::ATT, mobutils::GetBase(PTrust, PTrust->attRank));
-        PTrust->addModifier(Mod::ACC, mobutils::GetBase(PTrust, PTrust->accRank));
+        PTrust->addModifier(Mod::DEF, mobutils::GetBaseSkill(PTrust, PTrust->defRank));
+        PTrust->addModifier(Mod::EVA, mobutils::GetBaseSkill(PTrust, PTrust->evaRank));
+        PTrust->addModifier(Mod::ATT, mobutils::GetBaseSkill(PTrust, PTrust->attRank));
+        PTrust->addModifier(Mod::ACC, mobutils::GetBaseSkill(PTrust, PTrust->accRank));
 
-        PTrust->addModifier(Mod::RATT, mobutils::GetBase(PTrust, PTrust->attRank));
-        PTrust->addModifier(Mod::RACC, mobutils::GetBase(PTrust, PTrust->accRank));
+        PTrust->addModifier(Mod::RATT, mobutils::GetBaseSkill(PTrust, PTrust->attRank));
+        PTrust->addModifier(Mod::RACC, mobutils::GetBaseSkill(PTrust, PTrust->accRank));
 
         // Natural magic evasion
         PTrust->addModifier(Mod::MEVA, mobutils::GetMagicEvasion(PTrust));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Fixed an issue  where monster evasion was too low for anything level 61+ (Frank, Jimmayus)
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Cherry-pick: https://github.com/LandSandBoat/server/pull/4830

When implementing the mob stat re-work there a mix-up in how we calculate player evasion vs mob evasion.

See the explanation below by Jimmayus.

Player evasion: https://www.bg-wiki.com/ffxi/Evasion
Evasion = floor( AGI ÷ 2 ) + ( Evasion from Skill ) + ( Evasion from Traits/JAs/gear )

with a breakpoint at 200 skill resulting in a bifurcated formula:

Accuracy from Skill =
For Skill ≤ 200: Evasion = Skill
For Skill ≥ 201: Evasion = floor( (Evasion Skill-200) × 0.9 ) + 200

Mob Evasion: https://w.atwiki.jp/studiogobli/pages/25.html
敵防御 ＝ [f(Lv,種族の防御ランク) + 8 + [VIT/2] + ジョブ特性]×種族特性
敵回避 ＝ f(Lv,メインジョブの回避スキルランク) + [AGI/2] + ジョブ特性

Monster Defense: [f(Family Defense rank) + 8 + VIT/2] + job traits] * bonuses Monster Evasion f(main job skill rank) + AGI/2 + job traits + bonuses where "f" is defined by the following table:
Rank    Lv-1～50    Lv51～
Ａ    6+[(Lv-1)*3.0]    153+[(Lv-50)*5.0]?
Ｂ    5+[(Lv-1)*2.9]    147+[(Lv-50)*4.9]?
Ｃ    5+[(Lv-1)*2.8]    142+[(Lv-50)*4.8]
Ｄ    4+[(Lv-1)*2.7]    136+[(Lv-50)*4.7]?
Ｅ    4+[(Lv-1)*2.5]    126+[(Lv-50)*4.5]

the "?" is an ongoing problem because sometimes monsters express half ranks, but that's a can of worms and there's only so many researchers Anyway, in our current analysis the best way to explain why this is a big deal is to use Greater Colibri a level 82 Greater Colibri has 339 evasion and 67 agility using the player evasion skill analysis:

Colibri are RDM|RDM, RDMs have rank D evasion skill:
level 82 rank D skill is 240, 200 + (240-200)*.9 = 236 base vs
level 82 rank D skill monster is 136+[(Lv-50) * 4.7], 136 + (82 - 50) * 4.7, 136 + 150 (values are generally floored in XI) = 286
236 vs 286, or a base evasion drop of 50

1) 236 vs 286 evasion base, vs the known 339 evasion value
2) the only other 3 sources of evasion are job traits (none for rdm), agi & bonuses
3) 67 known agility is only 33 evasion additional, resulting in 269 and 319 evasion pre-bonuses

I'll spare use some additional math and link only to the excellent work already done on this subject: https://ffxiclopedia.fandom.com/wiki/Category_talk:Colibris

Before: 
![image](https://github.com/LandSandBoat/server/assets/105882754/62c985c3-dff9-4a23-8f2c-0f48de029c58)

After:
![image](https://github.com/LandSandBoat/server/assets/105882754/9f410554-07f3-4aa4-9b7b-69e3a1e06e72)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
I had to reproduce a level 82 Colibri so for this test with a known evasion value we had to do the following:
1) Change `Locus_Colibri` minLevel and maxLevel to be 82 to mimic the known values of these birds. `UPDATE mob_groups SET minLevel = 82, maxLevel = 82 WHERE name = 'Locus_Colibri'; `
2) !gotoid 16990444
3) !getstats

## Special Deployment Considerations
Nothing
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
