### PR TITLE
Fix issue with byakko and crafting renouncement

### DIFF
--- a/modules/era/sql/era_mob_droplist.sql
+++ b/modules/era/sql/era_mob_droplist.sql
@@ -15096,7 +15096,7 @@ INSERT INTO `mob_droplist` VALUES (1871,2,0,1000,751,0);   -- Platinum Beastcoin
 INSERT INTO `mob_droplist` VALUES (1872,0,0,1000,12342,@RARE); -- Lantern Shield (Rare, 5%)
 
 -- ZoneID: 105 - Orcish Beastrider
--- INSERT INTO `mob_droplist` VALUES (1873,0,0,1000,1706,@RARE);   -- Nyumomo Doll (Rare, 5%) WOTG item
+INSERT INTO `mob_droplist` VALUES (1873,0,0,1000,1706,@RARE);   -- Nyumomo Doll (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (1873,2,0,1000,750,0);        -- Silver Beastcoin (Steal)
 
 -- ZoneID: 149 - Orcish Beastrider
@@ -15143,7 +15143,7 @@ INSERT INTO `mob_droplist` VALUES (1878,2,0,1000,748,0); -- Gold Beastcoin (Stea
 
 -- ZoneID: 105 - Orcish Brawler
 -- ZoneID: 105 - Orcish Impaler
--- INSERT INTO `mob_droplist` VALUES (1879,0,0,1000,1706,@RARE);   -- Nyumomo Doll (Rare, 5%) WOTG item
+INSERT INTO `mob_droplist` VALUES (1879,0,0,1000,1706,@RARE);   -- Nyumomo Doll (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (1879,2,0,1000,750,0);        -- Silver Beastcoin (Steal)
 INSERT INTO `mob_droplist` VALUES (1879,4,0,1000,4376,0);       -- Strip Of Meat Jerky (Despoil)
 
@@ -15530,7 +15530,7 @@ INSERT INTO `mob_droplist` VALUES (1929,0,0,1000,12944,@VRARE); -- Scale Greaves
 INSERT INTO `mob_droplist` VALUES (1929,2,0,1000,656,0);        -- Beastcoin (Steal)
 
 -- ZoneID: 105 - Orcish Nightraider
--- INSERT INTO `mob_droplist` VALUES (1930,0,0,1000,1706,@RARE);   -- Nyumomo Doll (Rare, 5%) WOTG item
+INSERT INTO `mob_droplist` VALUES (1930,0,0,1000,1706,@RARE);   -- Nyumomo Doll (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (1930,2,0,1000,750,0);        -- Silver Beastcoin (Steal)
 
 -- ZoneID: 149 - Orcish Nightraider

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -407,7 +407,7 @@ xi.crafting.unionRepresentativeTriggerRenounceCheck = function(player, eventId, 
 
         for craftID = xi.skill.WOODWORKING, xi.skill.COOKING do
             local rank = player:getSkillRank(craftID)
-            if rank < 7 then
+            if rank < 6 then
                 bitmask = bit.bor(bitmask, bit.lshift(1, craftID - 48))
             else
                 count = count + 1

--- a/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
@@ -8,17 +8,15 @@ require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
-entity.onMobInitialize = function(mob)
+entity.onMobSpawn = function(mob, target)
     mob:setMod(xi.mod.SILENCERES, 90)
     mob:setMod(xi.mod.ATT, 391)
     mob:setMod(xi.mod.DEF, 345)
     mob:addMod(xi.mod.VIT, 43)
     mob:addMod(xi.mod.DOUBLE_ATTACK, 10)
+    mob:setMod(xi.mod.EVA, 397)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 35)
-end
-
-entity.onMobSpawn = function(mob, target)
     GetNPCByID(ID.npc.PORTAL_TO_BYAKKO):setAnimation(xi.anim.CLOSE_DOOR)
     mob:setMagicCastingEnabled(false)
 end

--- a/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
@@ -8,9 +8,9 @@ require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
-entity.onMobInitialize = function(mob)
+entity.onMobSpawn = function(mob, target)
     mob:setMod(xi.mod.SILENCERES, 90)
-    mob:addMod(xi.mod.EVA, 39)
+    mob:setMod(xi.mod.EVA, 316)
     mob:addMod(xi.mod.DEF, 210)
     mob:addMod(xi.mod.VIT, 78)
     mob:addMod(xi.mod.DOUBLE_ATTACK, 10)
@@ -18,9 +18,6 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 35)
     mob:setLocalVar('defaultATT', mob:getMod(xi.mod.ATT))
-end
-
-entity.onMobSpawn = function(mob, target)
     GetNPCByID(ID.npc.PORTAL_TO_GENBU):setAnimation(xi.anim.CLOSE_DOOR)
     mob:setMagicCastingEnabled(false)
 end

--- a/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
@@ -8,18 +8,15 @@ require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
-entity.onMobInitialize = function(mob)
+entity.onMobSpawn = function(mob, target)
     mob:setMod(xi.mod.SILENCERES, 90)
     mob:addMod(xi.mod.ATT, 50)
-    mob:addMod(xi.mod.EVA, 80)
+    mob:setMod(xi.mod.EVA, 367)
     mob:addMod(xi.mod.DOUBLE_ATTACK, 10)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 35)
     -- TP move about every 9 seconds without TP feed
     mob:setMod(xi.mod.REGAIN, 750)
-end
-
-entity.onMobSpawn = function(mob, target)
     GetNPCByID(ID.npc.PORTAL_TO_SEIRYU):setAnimation(xi.anim.CLOSE_DOOR)
     mob:setMagicCastingEnabled(false)
 end

--- a/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
@@ -8,17 +8,14 @@ require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
-entity.onMobInitialize = function(mob)
+entity.onMobSpawn = function(mob, target)
     mob:setMod(xi.mod.SILENCERES, 90)
     mob:addMod(xi.mod.ATT, 155)
     mob:addMod(xi.mod.DEF, 94)
-    mob:addMod(xi.mod.EVA, 104)
+    mob:setMod(xi.mod.EVA, 377)
     mob:addMod(xi.mod.VIT, 77)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 35)
-end
-
-entity.onMobSpawn = function(mob, target)
     GetNPCByID(ID.npc.PORTAL_TO_SUZAKU):setAnimation(xi.anim.CLOSE_DOOR)
     mob:setMagicCastingEnabled(false)
 end

--- a/scripts/zones/Sealions_Den/bcnms/one_to_be_feared_helper.lua
+++ b/scripts/zones/Sealions_Den/bcnms/one_to_be_feared_helper.lua
@@ -36,6 +36,12 @@ local function returnToAirship(player)
     elseif instance == 3 then
         player:setPos(499.969, 56.652, -806.132, 193)
     end
+
+    -- allow resending raise/reraise prompt since we moved player
+    -- which removes the prompt from player screen
+    if player:isDead() then
+        player:allowSendRaisePrompt()
+    end
 end
 
 -----------------------------------

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
@@ -9,15 +9,12 @@ require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
-entity.onMobInitialize = function(mob)
+entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:addMod(xi.mod.DEF, 120)
-    mob:addMod(xi.mod.EVA, 100)
+    mob:setMod(xi.mod.EVA, 424)
     mob:setMod(xi.mod.REGAIN, 1000)
-end
-
-entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.WIND_MEVA, -64) -- Todo: Move to mob_resists.sql
     mob:setMod(xi.mod.SILENCERES, 35)
     mob:setMod(xi.mod.STUNRES, 35)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10379,6 +10379,28 @@ void CLuaBaseEntity::sendTractor(float xPos, float yPos, float zPos, uint8 rotat
 }
 
 /************************************************************************
+ *  Function: allowSendRaisePrompt()
+ *  Purpose : Allows the raise prompt to be sent again to client
+ *            if for example player was moved while dead (thus removing the prompt)
+ *  Example : player:allowSendRaisePrompt()
+ ************************************************************************/
+
+void CLuaBaseEntity::allowSendRaisePrompt()
+{
+    if (m_PBaseEntity == nullptr || m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowError("m_PBaseEntity is null or not a Player.");
+        return;
+    }
+
+    if (m_PBaseEntity->PAI->IsCurrentState<CDeathState>())
+    {
+        auto deathState = static_cast<CDeathState*>(m_PBaseEntity->PAI->GetCurrentState());
+        deathState->allowSendRaise();
+    }
+}
+
+/************************************************************************
  *  Function: countdown()
  *  Purpose : Starts or clears a visible countdown bar for player
  *  Example : player:countdown(60)
@@ -17226,6 +17248,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("sendRaise", CLuaBaseEntity::sendRaise);
     SOL_REGISTER("sendReraise", CLuaBaseEntity::sendReraise);
     SOL_REGISTER("sendTractor", CLuaBaseEntity::sendTractor);
+    SOL_REGISTER("allowSendRaisePrompt", CLuaBaseEntity::allowSendRaisePrompt);
 
     SOL_REGISTER("countdown", CLuaBaseEntity::countdown);
     SOL_REGISTER("enableEntities", CLuaBaseEntity::enableEntities);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -562,6 +562,7 @@ public:
     void sendRaise(uint8 raiseLevel);
     void sendReraise(uint8 raiseLevel);
     void sendTractor(float xPos, float yPos, float zPos, uint8 rotation);
+    void allowSendRaisePrompt();
 
     void countdown(sol::object const& secondsObj,
                    sol::object const& bar1NameObj, sol::object const& bar1ValObj,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Byakko's attack and defense are now more retail accurate. (Tracent)
- Players can now renounce their rank starting at craftsman rank as in era. (Tracent)
- The appropriate mobs will now drop the quest item Nyumomo Doll. (Tracent)
- Raise and reraise will now persist (and not longer cause bugs) when moving from the fighting area to the waiting area in the CoP 6-4 One to be Feared battlefield.


## What does this pull request do? (Please be technical)

- This fixes an issue with the attack and defense of Byakko which were incorrect because they were set in onMobInitialize rather than onMobSpawn. In order to override the default calculated stats the values need to be set in onMobSpawn, if set in onMobInitialize then the default calculated values are added to the set values (thus almost doubling). For consistency the stat adjustments for all gods were moved to onMobSpawn and the EVA values were changed to setMod so they are not impacted by incoming mob EVA formula change.
- Also the level required for crafting renouncement was changed to craftsman+ as in era, the artisan+ requirement is OoE.
- Also adds quest item that was incorrectly marked as out of era (see [here](https://ffxi.allakhazam.com/db/item.html?fitem=5709))
- Fixes raise issue in CoP 6-4 whereby players would lose the raise prompt (due to being moved from fighting area to waiting area) but the server still assumed the player had the prompt. Thus bugging the player out so they could not be raised at all. This is fixed by allowing lua access to the deathstate function that clears the variable tracking if the prompt was sent or not. This function is then called when players are moved.

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1817
Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1712

## Steps to test these changes
Spawn Byakko use !getstats

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
