### PR TITLE
Add server-side chat filtering

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2998,3 +2998,25 @@ void CCharEntity::clearCharVarsWithPrefix(std::string const& prefix)
 
     sql->Query("DELETE FROM char_vars WHERE charid = %u AND varname LIKE '%s%%';", this->id, prefix.c_str());
 }
+
+/*************************************************************************
+ *                                                                       *
+ *  Does the user have all yell mesages filtered?                        *
+ *                                                                       *
+ ************************************************************************/
+
+bool CCharEntity::isYellFiltered() const
+{
+    return (chatFilterFlags & CHATFILTER_YELL) != 0;
+}
+
+/*************************************************************************
+ *                                                                       *
+ *  Does the user have "all yell/shout messages deemed spam" filtered?   *
+ *                                                                       *
+ ************************************************************************/
+
+bool CCharEntity::isYellSpamFiltered() const
+{
+    return (chatFilterFlags & CHATFILTER_YELL_SPAM) != 0;
+}

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -675,6 +675,9 @@ public:
     bool   m_Locked;       // Is the player locked in a cutscene
     uint32 m_prevTargetId; // ID of the last target for the player.
 
+    bool isYellFiltered() const;     // Does the user have all yell mesages filtered?
+    bool isYellSpamFiltered() const; // Does the user have "all yell/shout messages deemed spam" filtered?
+
     CCharEntity();
     ~CCharEntity();
 

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -243,8 +243,13 @@ namespace message
                     {
                         PZone->ForEachChar([&packet, &extra](CCharEntity* PChar)
                         {
-                            // don't push to sender
-                            if (PChar->id != ref<uint32>((uint8*)extra.data(), 0))
+                            auto serverId = ref<uint32>((uint8*)extra.data(), 0);
+
+                            // boolean, is this message considered spam, for the "all yell/shout messages deemed spam" filter
+                            auto isMarkedSpam = (ref<uint32>((uint8*)extra.data(), 4) != 0) && PChar->isYellSpamFiltered();
+
+                            // don't push to the sender or anyone with yell filtered
+                            if (PChar->id != serverId && !PChar->isYellFiltered() && !isMarkedSpam)
                             {
                                 CBasicPacket* newPacket = new CBasicPacket();
                                 memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5796,8 +5796,9 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                         if (gettick() >= PChar->m_LastYell)
                         {
                             PChar->m_LastYell = gettick() + settings::get<uint16>("map.YELL_COOLDOWN") * 1000;
-                            int8 packetData[4]{};
+                            int8 packetData[8]{};
                             ref<uint32>(packetData, 0) = PChar->id;
+                            ref<uint32>(packetData, 4) = 0; // boolean, is this message considered spam, for the "all yell/shout messages deemed spam" filter
 
                             message::send(MSG_CHAT_YELL, packetData, sizeof packetData, new CChatMessagePacket(PChar, MESSAGE_YELL, (const char*)data[6]));
                         }

--- a/src/map/packets/treasure_lot_item.cpp
+++ b/src/map/packets/treasure_lot_item.cpp
@@ -52,7 +52,7 @@ CTreasureLotItemPacket::CTreasureLotItemPacket(CBaseEntity* PWinner, uint8 slotI
     memcpy(data + (0x16), PWinner->GetName().c_str(), PWinner->GetName().size());
 }
 
-CTreasureLotItemPacket::CTreasureLotItemPacket(CBaseEntity* PHighestLotter, uint16 HighestLot, CBaseEntity* PLotter, uint8 SlotID, uint16 Lot)
+CTreasureLotItemPacket::CTreasureLotItemPacket(CBaseEntity* PHighestLotter, uint16 HighestLot, CBaseEntity* PLotter, uint8 SlotID, uint16 Lot, bool isFiltered)
 {
     this->setType(0xD3);
     this->setSize(0x3C);
@@ -72,4 +72,11 @@ CTreasureLotItemPacket::CTreasureLotItemPacket(CBaseEntity* PHighestLotter, uint
     ref<uint8>(0x14) = SlotID;
 
     memcpy(data + 0x26, PLotter->GetName().c_str(), PLotter->GetName().size());
+
+    if (isFiltered)
+    {
+        // A NUL here and the client won't show the chat message
+        // (this is really what retail does)
+        ref<uint8>(0x26) = '\0';
+    }
 }

--- a/src/map/packets/treasure_lot_item.h
+++ b/src/map/packets/treasure_lot_item.h
@@ -38,7 +38,7 @@ class CBaseEntity;
 class CTreasureLotItemPacket : public CBasicPacket
 {
 public:
-    CTreasureLotItemPacket(CBaseEntity* PHighestLotter, uint16 HighestLot, CBaseEntity* PLotter, uint8 SlotID, uint16 Lot);
+    CTreasureLotItemPacket(CBaseEntity* PHighestLotter, uint16 HighestLot, CBaseEntity* PLotter, uint8 SlotID, uint16 Lot, bool isFiltered);
     CTreasureLotItemPacket(uint8 slotID, ITEMLOTTYPE MessageType);
     CTreasureLotItemPacket(CBaseEntity* PWinner, uint8 SlotID, uint16 Lot, ITEMLOTTYPE MessageType);
 };

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -30,6 +30,7 @@
 #include "recast_container.h"
 #include "treasure_pool.h"
 #include "utils/charutils.h"
+#include "utils/chatfilter.h"
 #include "utils/itemutils.h"
 
 static constexpr duration treasure_checktime = 3s;
@@ -316,9 +317,12 @@ void CTreasurePool::LotItem(CCharEntity* PChar, uint8 SlotID, uint16 Lot)
     }
 
     // Player lots Item for XXX message
+    CChatFilter chatFilter(PChar, CHATFILTER_LOT_RESULTS);
+
     for (auto& member : members)
     {
-        member->pushPacket(new CTreasureLotItemPacket(highestLotter, highestLot, PChar, SlotID, Lot));
+        bool isFiltered = chatFilter.isFiltered(member);
+        member->pushPacket(new CTreasureLotItemPacket(highestLotter, highestLot, PChar, SlotID, Lot, isFiltered));
     }
 
     // if all lotters have lotted, evaluate immediately.
@@ -375,10 +379,14 @@ void CTreasurePool::PassItem(CCharEntity* PChar, uint8 SlotID)
     }
 
     uint16 PassedLot = 65535; // passed mask is FF FF
+
     // Player lots Item for XXX message
+    CChatFilter chatFilter(PChar, CHATFILTER_LOT_RESULTS);
+
     for (auto& member : members)
     {
-        member->pushPacket(new CTreasureLotItemPacket(highestLotter, highestLot, PChar, SlotID, PassedLot));
+        bool isFiltered = chatFilter.isFiltered(member);
+        member->pushPacket(new CTreasureLotItemPacket(highestLotter, highestLot, PChar, SlotID, PassedLot, isFiltered));
     }
 
     // if all lotters have lotted, evaluate immediately.

--- a/src/map/utils/CMakeLists.txt
+++ b/src/map/utils/CMakeLists.txt
@@ -9,6 +9,8 @@ set(UTIL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/blueutils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/charutils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/charutils.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/chatfilter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/chatfilter.h
     ${CMAKE_CURRENT_SOURCE_DIR}/fellowutils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fellowutils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/fishingcontest.cpp

--- a/src/map/utils/chatfilter.cpp
+++ b/src/map/utils/chatfilter.cpp
@@ -1,0 +1,129 @@
+/*
+===========================================================================
+
+Copyright (c) 2023 LandSandBoat Dev Teams
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <string.h>
+
+#include "../../common/mmo.h"
+#include "chatfilter.h"
+
+#include "../entities/charentity.h"
+#include "../packets/caught_fish.h"
+#include "../packets/chat_message.h"
+
+// Which messages should NOT bypass the filters for senders?
+// e.g. Users can filter out their own jobemotes, but
+// should still be able to see their own fishing results.
+static constexpr uint64 SenderFilterMask = ~(CHATFILTER_SYNTHESIS | CHATFILTER_LOT_RESULTS);
+
+// Which messages should NOT bypass the filters for GMs?
+static constexpr uint64 GMFilterMask = 0;
+
+static constexpr uint64 DefaultFilterMask = ~0;
+
+CChatFilter::CChatFilter(const CBaseEntity* const _sender, CBasicPacket* packet)
+: sender(_sender)
+, filterMask(0)
+{
+    if (packet == nullptr)
+    {
+        return;
+    }
+
+    auto packetId = packet->getType();
+
+    // CChatMessagePacket
+    bool isChatMessagePacket = (packetId == 0x17);
+    bool isSay               = (isChatMessagePacket && packet->ref<uint8>(0x04) == MESSAGE_SAY);
+    bool isShout             = (isChatMessagePacket && packet->ref<uint8>(0x04) == MESSAGE_SHOUT);
+    bool isEmote             = (isChatMessagePacket && packet->ref<uint8>(0x04) == MESSAGE_EMOTION);
+
+    // bool isYell = isChatMessagePacket && packet->ref<uint8>(0x04) == MESSAGE_YELL;
+    // bool isTellSpam = false;
+    // bool isYellSpam = false;
+    //
+    // // todo - yells don't use CChatFilter (yet?); sender info isn't available after the broadcast.
+    // // spam tests should happen in SmallPacket0x0B5, before any fan-out.
+    // if (isShout || isYell)
+    // {
+    // }
+
+    // CCharEmotionPacket
+    bool isEmotePacket = (packetId == 0x5A);
+    bool isJobEmote    = (isEmotePacket && (packet->ref<uint8>(0x10) >= 74));
+
+    // CSynthResultMessagePacket
+    bool isSynth = (packetId == 0x70);
+
+    // CMessageNamePacket
+    bool isMessageNamePacket = (packetId == 0x27);
+
+    // CCaughtFishPacket (does not inherit from CMessageNamePacket but shares same id)
+    bool isFish = (isMessageNamePacket && typeid(*packet) == typeid(CCaughtFishPacket));
+
+    if (isSay)
+    {
+        filterMask |= CHATFILTER_SAY;
+    }
+
+    if (isShout)
+    {
+        filterMask |= CHATFILTER_SHOUT;
+    }
+
+    if (isEmote)
+    {
+        filterMask |= CHATFILTER_EMOTES;
+    }
+
+    // if (isYell)
+    // {
+    //     filterMask |= CHATFILTER_YELL;
+    // }
+    //
+    // if (isTellSpam)
+    // {
+    //     filterMask |= CHATFILTER_TELL_SPAM;
+    // }
+    //
+    // if (isYellSpam)
+    // {
+    //     filterMask |= CHATFILTER_YELL_SPAM;
+    // }
+
+    if (isJobEmote)
+    {
+        filterMask |= CHATFILTER_JOBEMOTE;
+    }
+
+    if (isSynth || isFish)
+    {
+        filterMask |= CHATFILTER_SYNTHESIS;
+    }
+}
+
+bool CChatFilter::isFiltered(const CCharEntity* const entity) const
+{
+    const CCharEntity* const cSender    = ((sender != nullptr) && (sender->objtype == TYPE_PC)) ? dynamic_cast<const CCharEntity*>(sender) : nullptr;
+    uint64                   senderMask = ((cSender != nullptr) && (cSender->id == entity->id)) ? SenderFilterMask : DefaultFilterMask;
+    uint64                   gmMask     = ((cSender != nullptr) && (cSender->nameflags.flags & FLAG_GM)) ? GMFilterMask : DefaultFilterMask;
+
+    return (filterMask & senderMask & gmMask & entity->chatFilterFlags) != 0;
+}

--- a/src/map/utils/chatfilter.h
+++ b/src/map/utils/chatfilter.h
@@ -1,0 +1,49 @@
+/*
+===========================================================================
+
+Copyright (c) 2023 LandSandBoat Dev Teams
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#ifndef _CHATFILTER_H
+#define _CHATFILTER_H
+
+#include "../../common/cbasetypes.h"
+
+class CBasicPacket;
+
+class CBaseEntity;
+class CCharEntity;
+
+class CChatFilter
+{
+public:
+    CChatFilter(const CBaseEntity* const _sender, CBasicPacket* packet);
+    CChatFilter(const CBaseEntity* const _sender, uint64 _filterMask)
+    : sender(_sender)
+    , filterMask(_filterMask)
+    {
+    }
+
+    bool isFiltered(const CCharEntity* const entity) const;
+
+private:
+    const CBaseEntity* sender;
+    uint64             filterMask;
+};
+
+#endif

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -52,6 +52,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "battlefield.h"
 #include "utils/battleutils.h"
 #include "utils/charutils.h"
+#include "utils/chatfilter.h"
 #include "utils/moduleutils.h"
 #include "utils/petutils.h"
 #include "utils/synthutils.h"
@@ -1274,6 +1275,9 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
         }
     }
 
+    // Get the possible ways this message can be filtered by the user.
+    CChatFilter chatFilter((CCharEntity*)PEntity, packet);
+
     if (!m_charList.empty())
     {
         // clang-format off
@@ -1282,7 +1286,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
             case CHAR_INRANGE_SELF:
             {
                 TracyZoneCString("CHAR_INRANGE_SELF");
-                if (PEntity->objtype == TYPE_PC)
+                if (PEntity->objtype == TYPE_PC && !chatFilter.isFiltered((CCharEntity*)PEntity))
                 {
                     ((CCharEntity*)PEntity)->pushPacket(new CBasicPacket(*packet));
                 }
@@ -1298,7 +1302,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                 for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
                 {
                     CCharEntity* PCurrentChar = (CCharEntity*)it->second;
-                    if (PEntity != PCurrentChar)
+                    if (PEntity != PCurrentChar && !chatFilter.isFiltered(PCurrentChar))
                     {
                         if (distanceSquared(PEntity->loc.p, PCurrentChar->loc.p) < checkDistanceSq &&
                             ((PEntity->objtype != TYPE_PC) || (((CCharEntity*)PEntity)->m_moghouseID == PCurrentChar->m_moghouseID)))
@@ -1363,7 +1367,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                 for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
                 {
                     CCharEntity* PCurrentChar = (CCharEntity*)it->second;
-                    if (PEntity != PCurrentChar)
+                    if (PEntity != PCurrentChar && !chatFilter.isFiltered(PCurrentChar))
                     {
                         if (distance(PEntity->loc.p, PCurrentChar->loc.p) < 180 &&
                             ((PEntity->objtype != TYPE_PC) || (((CCharEntity*)PEntity)->m_moghouseID == PCurrentChar->m_moghouseID)))
@@ -1383,7 +1387,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
 
                     if (PCurrentChar->m_moghouseID == 0)
                     {
-                        if (PEntity != PCurrentChar)
+                        if (PEntity != PCurrentChar && !chatFilter.isFiltered(PCurrentChar))
                         {
                             PCurrentChar->pushPacket(new CBasicPacket(*packet));
                         }


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Add server-side chat filtering for: say, emote, shout, yell, synthesis and fishing results, lot results, and job emotes.

## What does this pull request do? (Please be technical)

This is a direct port of my "Add additional server-side chat filtering" change from Wings, sans the yell spam bit.

## Steps to test these changes

1. Get two accounts together
2. Enable a chat filter on one character and back out of menu
3. Perform action on other character
4. Verify that the action was filtered
5. Disable the filter
6. Perform and verify that action was not filtered

tested:
- say
- emote
- shout
- yell
- others' synthesis and fishing results
- lot results
- job emote

not implemented:
- assist j
- assist e
- campaign-related data
- tell messages deemed spam
- shout/yell messages deemed spam
- messages from alter egos

not tested:
- all battle-related, filtering is on client side
- system lv.x, filtering is on client side

## Special Deployment Considerations

n/a
