### PR TITLE
Raise EES dmgmod to LSB levels

### DIFF
--- a/modules/era/scripts/globals/mobskills/onMobWeaponSkill.lua
+++ b/modules/era/scripts/globals/mobskills/onMobWeaponSkill.lua
@@ -4720,7 +4720,7 @@ end)
 m:addOverride("xi.globals.mobskills.eagle_eye_shot.onMobWeaponSkill", function(target, mob, skill)
     local numhits = 1
     local accmod = 2
-    local dmgmod = 1 + math.random()
+    local dmgmod = 9 + math.random()
 
     local info = xi.mobskills.mobRangedMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
 

--- a/scripts/globals/mobskills/eagle_eye_shot.lua
+++ b/scripts/globals/mobskills/eagle_eye_shot.lua
@@ -12,7 +12,7 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local numhits = 1
     local accmod = 2
-    local dmgmod = 1 + math.random()
+    local dmgmod = 9 + math.random()
 
     local info = xi.mobskills.mobRangedMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

The mob 2 hour Eagle Eye Shot has been signficantly enhanced. (Tiberon)

## What does this pull request do? (Please be technical)

LSB has a much higher dmg mod than ASB.
Pulling in LSB's value
https://github.com/LandSandBoat/server/blob/84398a8c4679318f0c27e8946b16d084c2f4ee96/scripts/actions/mobskills/eagle_eye_shot.lua#L13

## Steps to test these changes

Engage a ranger mob that can 2 hour.
See that it does significant dmg

## Special Deployment Considerations
none, hotfixable
