### PR TITLE
Enable Third Eye to block ranged attacks

### DIFF
--- a/modules/era/scripts/globals/mobskills/onMobWeaponSkill.lua
+++ b/modules/era/scripts/globals/mobskills/onMobWeaponSkill.lua
@@ -11553,7 +11553,10 @@ m:addOverride("xi.globals.mobskills.ranged_attack.onMobWeaponSkill", function(ta
 
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.RANGED, xi.damageType.PIERCING, info.hitslanded)
 
-    if skill:getMsg() ~= xi.msg.basic.SHADOW_ABSORB then
+    if
+        skill:getMsg() ~= xi.msg.basic.SHADOW_ABSORB and
+        skill:getMsg() ~= xi.msg.basic.ANTICIPATE
+    then
         if dmg > 0 then
             skill:setMsg(xi.msg.basic.RANGED_ATTACK_HIT)
         else

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -777,7 +777,11 @@ function AbilityFinalAdjustments(dmg, mob, skill, target, skilltype, skillparam,
     end
 
     --handle Third Eye using shadowbehav as a guide
-    if skilltype == xi.attackType.PHYSICAL and mob:checkThirdEye(target) then
+    if
+        (skilltype == xi.attackType.PHYSICAL or
+        skilltype == xi.attackType.RANGED) and
+        mob:checkThirdEye(target)
+    then
         skill:setMsg(xi.msg.basic.ANTICIPATE)
         return 0
     end

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -626,12 +626,20 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
         target:delStatusEffect(xi.effect.THIRD_EYE)
     end
 
-    if attackType == xi.attackType.PHYSICAL and not skill:isSingle() then
+    if
+        (attackType == xi.attackType.PHYSICAL or
+        attackType == xi.attackType.RANGED) and
+        not skill:isSingle()
+    then
         target:delStatusEffect(xi.effect.THIRD_EYE)
     end
 
     --handle Third Eye using shadowbehav as a guide
-    if attackType == xi.attackType.PHYSICAL and mob:checkThirdEye(target) then
+    if
+        (attackType == xi.attackType.PHYSICAL or
+        attackType == xi.attackType.RANGED) and
+        mob:checkThirdEye(target)
+    then
         skill:setMsg(xi.msg.basic.ANTICIPATE)
         return 0
     end

--- a/scripts/globals/mobskills/ranged_attack.lua
+++ b/scripts/globals/mobskills/ranged_attack.lua
@@ -19,7 +19,10 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.RANGED, xi.damageType.PIERCING, info.hitslanded)
 
-    if skill:getMsg() ~= xi.msg.basic.SHADOW_ABSORB then
+    if
+        skill:getMsg() ~= xi.msg.basic.SHADOW_ABSORB and
+        skill:getMsg() ~= xi.msg.basic.ANTICIPATE
+    then
         if dmg > 0 then
             skill:setMsg(xi.msg.basic.RANGED_ATTACK_HIT)
         else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Enable Third Eye to block ranged attacks. (Tiberon)

## What does this pull request do? (Please be technical)

Add ranged attack type as checks for mobskill and abilitiy

## Steps to test these changes

Find a rng of some type and pick a fight as a sam or /sam
Use third eye and expect to see ranged attacks anticipated

use `!exec target:useMobAbility(737)` to trigger an EES

## Special Deployment Considerations

None

## Why Draft

I leveled sam to 37 on retail today and verified that at least on retail sam can anticipate ranged attacks and can seigan 3rd eye anticipate multiple ranged attacks until 3rd eye wears.

However I'm still looking for some era source.

Also, I'm looking to confirm that all ranged single target moves can be blocked by third eye - so things like pineconebomb, gigas catapult, etc.
