### PR TITLE
Fix starlight celebration and kirin evasion

### DIFF
--- a/scripts/globals/events/starlight_celebrations.lua
+++ b/scripts/globals/events/starlight_celebrations.lua
@@ -310,7 +310,9 @@ function xi.events.starlightCelebration.tokenMoogleOnFinish(player, id, csid, op
                 count = 0
                 npcUtil.giveItem(player, reward)
             else
-                if picked > 178 and picked < 10382 then -- checks if reward is a food item
+                local pickedItem = GetReadOnlyItem(picked)
+                local isNotRare = bit.band(pickedItem:getFlag(), xi.itemFlag.RARE) == 0
+                if isNotRare then -- checks if reward is rare and thus should not attempt to give
                     reward = picked
                     count = 0
                     npcUtil.giveItem(player, reward)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
@@ -13,7 +13,7 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:addMod(xi.mod.DEF, 120)
-    mob:setMod(xi.mod.EVA, 424)
+    mob:setMod(xi.mod.EVA, 373)
     mob:setMod(xi.mod.REGAIN, 1000)
     mob:setMod(xi.mod.WIND_MEVA, -64) -- Todo: Move to mob_resists.sql
     mob:setMod(xi.mod.SILENCERES, 35)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
- Moogles should no longer attempt to give players rare items they already have during starlight celebration event. (Tracent)
- Kirin's evasion is now more retail accurate. (Tracent)

## What does this pull request do? (Please be technical)
The starlight fix is needed due to the previous unreliable check that just used item id ranges to check for items assumed to be food (and thus non-rare), a better method is to check for rare items and not attempt to give those items if the player already has

The kirin fix is due to a previously too high evasion boost, Jimmayus has estimated a base evasion of 373 (before bonuses), this was previously 424.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
