### PR TITLE
Fix Ghrahs reducing their attack to zero and tp moves.

### DIFF
--- a/modules/era/scripts/globals/mobskills/onMobWeaponSkill.lua
+++ b/modules/era/scripts/globals/mobskills/onMobWeaponSkill.lua
@@ -3175,9 +3175,10 @@ end)
 
 m:addOverride("xi.globals.mobskills.core_meltdown.onMobWeaponSkill", function(target, mob, skill)
     local dmgmod = 1
+    local damage = skill:getMobHP() / 2
 
-    -- TODO: The damage type should be based off of the Ghrah's element
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * math.random(7, 15), xi.magic.ele.NONE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    -- TODO: The damage type should be based off of the Ghrah's element <-- needs verification
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.magic.ele.NONE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     mob:setHP(0)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)
@@ -13056,7 +13057,16 @@ m:addOverride("xi.globals.mobskills.sickle_slash.onMobWeaponSkill", function(tar
     local crit = 0.4
     local attmod = 1.5
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, 1, xi.mobskills.physicalTpBonus.CRIT_VARIES, 1, 1.5, 2, crit, attmod)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
+    local shadows = info.hitslanded
+
+    if
+        mob:getFamily() >= 122 and -- Ghrah
+        mob:getFamily() <= 124
+    then
+        shadows = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    end
+
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, shadows)
 
     if not skill:hasMissMsg() then
         target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
@@ -16222,7 +16232,16 @@ m:addOverride("xi.globals.mobskills.vorpal_blade.onMobWeaponSkill", function(tar
     local accmod = 1
     local dmgmod = 1.25
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.CRIT_VARIES, 1.1, 1.2, 1.3)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
+    local shadows = info.hitslanded
+
+    if
+        mob:getFamily() >= 122 and -- Ghrah
+        mob:getFamily() <= 124
+    then
+        shadows = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    end
+
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, shadows)
 
     if not skill:hasMissMsg() then
         -- AA EV: Approx 900 damage to 75 DRG/35 THF.  400 to a NIN/WAR in Arhat, but took shadows.

--- a/scripts/globals/mobskills/core_meltdown.lua
+++ b/scripts/globals/mobskills/core_meltdown.lua
@@ -21,9 +21,10 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
+    local damage = skill:getMobHP() / 2
 
-    -- TODO: The damage type should be based off of the Ghrah's element
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * math.random(7, 15), xi.magic.ele.NONE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    -- TODO: The damage type should be based off of the Ghrah's element <-- needs verification
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, damage, xi.magic.ele.NONE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     mob:setHP(0)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)

--- a/scripts/globals/mobskills/sickle_slash.lua
+++ b/scripts/globals/mobskills/sickle_slash.lua
@@ -28,7 +28,16 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local crit = 0.4
     local attmod = 1.5
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, 1, xi.mobskills.physicalTpBonus.CRIT_VARIES, 1, 1.5, 2, crit, attmod)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
+    local shadows = info.hitslanded
+
+    if
+        mob:getFamily() >= 122 and -- Ghrah
+        mob:getFamily() <= 124
+    then
+        shadows = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    end
+
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, shadows)
 
     if not skill:hasMissMsg() then
         target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)

--- a/scripts/globals/mobskills/vorpal_blade.lua
+++ b/scripts/globals/mobskills/vorpal_blade.lua
@@ -39,7 +39,16 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local accmod = 1
     local dmgmod = 1.25
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.CRIT_VARIES, 1.1, 1.2, 1.3)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
+    local shadows = info.hitslanded
+
+    if
+        mob:getFamily() >= 122 and -- Ghrah
+        mob:getFamily() <= 124
+    then
+        shadows = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    end
+
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, shadows)
 
     if not skill:hasMissMsg() then
         -- AA EV: Approx 900 damage to 75 DRG/35 THF.  400 to a NIN/WAR in Arhat, but took shadows.

--- a/scripts/mixins/families/ghrah.lua
+++ b/scripts/mixins/families/ghrah.lua
@@ -9,7 +9,8 @@ g_mixins.families.ghrah = function(ghrahMob)
         mob:setAnimationSub(0)
         mob:setAggressive(false)
         mob:setLocalVar("roamTime", os.time())
-        if mob:getXPos() > 0 then
+        local spawnPos = mob:getSpawnPos()
+        if spawnPos.x > 0 then
             mob:setLocalVar("form2", 2)
         else
             mob:setLocalVar("form2", 3)
@@ -88,16 +89,21 @@ g_mixins.families.ghrah = function(ghrahMob)
             mob:setAggressive(true)
 
             if mob:getAnimationSub() == 2 then
-                mob:addMod(xi.mod.ATTP, 50) -- spider form att+
+                --mob:addMod(xi.mod.ATTP, 50) -- spider form att+
+                mob:setMobMod(xi.mobMod.WEAPON_BONUS, mob:getWeaponDmg()) -- entering spider form base dmg+
             end
         elseif
             mob:getAnimationSub() == mob:getLocalVar("form2") and
             os.time() - roamTime > 60
         then
+            if mob:getAnimationSub() == 2 then
+                -- mob:delMod(xi.mod.ATTP, 50) -- coming out of spider form att-
+                mob:setMobMod(xi.mobMod.WEAPON_BONUS, 0) -- exiting spider form base dmg+
+            end
+
             mob:setAnimationSub(0)
             mob:setAggressive(false)
             mob:setLocalVar("roamTime", os.time())
-            mob:delMod(xi.mod.ATTP, 50)
         end
 
         -- TODO: Merge with Empty mixin
@@ -183,16 +189,21 @@ g_mixins.families.ghrah = function(ghrahMob)
             mob:setLocalVar("changeTime", mob:getBattleTime())
 
             if mob:getAnimationSub() == 2 then
-                mob:addMod(xi.mod.ATTP, 50) -- spider form att+
+                --mob:addMod(xi.mod.ATTP, 50) -- spider form att+
+                mob:setMobMod(xi.mobMod.WEAPON_BONUS, mob:getWeaponDmg()) -- entering spider form base dmg+
             end
         elseif
             mob:getAnimationSub() == mob:getLocalVar("form2") and
             mob:getBattleTime() - changeTime > 60
         then
+            if mob:getAnimationSub() == 2 then
+                --mob:delMod(xi.mod.ATTP, 50) -- coming out of spider form att-
+                mob:setMobMod(xi.mobMod.WEAPON_BONUS, 0) -- exiting spider form base dmg-
+            end
+
             mob:setAnimationSub(0)
             mob:setAggressive(false)
             mob:setLocalVar("changeTime", mob:getBattleTime())
-            mob:delMod(xi.mod.ATTP, 50)
         end
     end)
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Ghrahs will no longer reduce their own attack each time they change forms, resulting in 0 attack Ghrahs.  (Tiberon)
Spider Ghrahs are now terrifying, and correctly recieve their large boost to base dmg.
Ghrah Sickle Slash and Vorpal Blade now correctly bypass shadows.
Ghrah Core Meltdown has been adjusted from using mob's base weapon dmg + a random factor to 50% of remaining of HP converted to base damage.

## What does this pull request do? (Please be technical)

adds a logical gate around the attack reduction being applied by ghrahs when moving out of spider form.
Double spiders modes base dmg per [Monster Stats](https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit#gid=57955395)

Updated mob skills as described above.
Fixed an issue (described below) that was causing ghrahs to spawn in on server start as bird types only

## Steps to test these changes

Talking with Jimmay - there is no attack boost.
Instead there is base dmg boost.  This is achieved by using !getmobmod weapon_bonus.
For all forms but spider - this value should be 0.
For spider the value will vary, but it should be equivalent to mobLevel +2.

Find a Ghrah, any Ghrah - like `16920958` (this is a birb ghrah)
`!getmobmod weapon_bonus` should be 0 on all non-spiders.
For spider the value will vary, but it should be equivalent to mobLevel +2.
Watch it change forms
`!getmobmod weapon_bonus` should be 0 on all non-spiders.
For spider the value will vary, but it should be equivalent to mobLevel +2.

To verify spider - id `16916729` works.

~~Note: There seems to be an issue on zone up with the spider grahs.  The logic is listening to a spawn indicator then using the mob's x position to determine spider vs birb.
However on the first spawn - there is not an assigned position so it always defaults to birb.
Killing/despawning the ghrah then respawning will allow the shift to spider mode.
I'll see about fixing that too while im here but will have to see - its currently not in this PR.~~
Fixed the above - no more short term birbs.  if you are a spider you are a spider.

[CMobEntity::Spawn, which calls BattleEntity::Spawn](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/src/map/entities/mobentity.cpp#L603C9-L603C9)
[BattleEntity::Spawn calls CBaseEntity::Spawn which triggers the listener](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/src/map/entities/baseentity.cpp#L70)
[Back in CMobEntity::Spawn - After the listener is triggered the location is set](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/src/map/entities/mobentity.cpp#L631)

~~So for the first spawn only (since these locations dont get cleared or modified normaly) - the location is 0,0,0 - and everything is a birb.~~

75 war, no protect, dia ii on (283 def)
![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/105882290/7cde33b6-4cd5-46de-aa81-161f25c3d7b7)


## Special Deployment Considerations

None
