### PR TITLE
set jeunoan tree element to ice

### DIFF
--- a/sql/item_furnishing.sql
+++ b/sql/item_furnishing.sql
@@ -102,7 +102,7 @@ INSERT INTO `item_furnishing` VALUES (134, 'copy_of_emeralda', 1, 530, 5, 9);
 INSERT INTO `item_furnishing` VALUES (135, 'magic_tome_set', 1, 513, 2, 2);
 INSERT INTO `item_furnishing` VALUES (136, 'set_of_kaiserin_cosmetics', 1, 513, 2, 1);
 INSERT INTO `item_furnishing` VALUES (137, 'cordon_bleu_cooking_set', 1, 531, 3, 9);
-INSERT INTO `item_furnishing` VALUES (138, 'jeunoan_tree', 4, 532, 5, 3);
+INSERT INTO `item_furnishing` VALUES (138, 'jeunoan_tree', 4, 532, 2, 3);
 INSERT INTO `item_furnishing` VALUES (139, 'star_globe', 1, 533, 8, 9);
 INSERT INTO `item_furnishing` VALUES (140, 'dream_platter', 2, 522, 5, 3);
 INSERT INTO `item_furnishing` VALUES (141, 'dream_coffer', 2, 522, 5, 3);


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Jeunoan Tree is now ice element instead of thunder element (Haplo)

## What does this pull request do? (Please be technical)

Jeunoan Tree was incorrectly using element 5 (thunder) instead of element 2 (ice). The DAT shows the ice symbol. The moghancement and aura strength seem correct.

## Steps to test these changes

!additem 208 2
!additem 138
place all in mog house, should give 4 ice element (2x2) from lamps and 3 ice element from tree resulting in Conquest moghancement. with incorrect thunder element, it would give Ice moghancement from lamps

## Special Deployment Considerations