### PR TITLE
LSB cherrypick: fix SATA stat mods not working under 100

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -450,13 +450,13 @@ void CAttack::ProcessDamage(bool isCritical, bool isGuarded, bool isKick)
         (behind(m_attacker->loc.p, m_victim->loc.p, 64) || m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE) ||
          m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_DOUBT)))
     {
-        m_trickAttackDamage += m_attacker->DEX() * (1 + m_attacker->getMod(Mod::SNEAK_ATK_DEX) / 100);
+        m_trickAttackDamage += m_attacker->DEX() * (1.0f + m_attacker->getMod(Mod::SNEAK_ATK_DEX) / 100.0f);
     }
 
     // Trick attack.
     if (m_attacker->GetMJob() == JOB_THF && m_isFirstSwing && m_attackRound->GetTAEntity() != nullptr)
     {
-        m_trickAttackDamage += m_attacker->AGI() * (1 + m_attacker->getMod(Mod::TRICK_ATK_AGI) / 100);
+        m_trickAttackDamage += m_attacker->AGI() * (1.0f + m_attacker->getMod(Mod::TRICK_ATK_AGI) / 100.0f);
     }
 
     SLOTTYPE slot = (SLOTTYPE)GetWeaponSlot();


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Rogue's Armlets +1 will now properly increase Trick Attack damage (Haplo)

## What does this pull request do? (Please be technical)

Fixes an integer division bug for TRICK_ATK_AGI and SNEAK_ATK_DEX that caused them to not work properly.

## Steps to test these changes

!additem 14895
!additem 23224
Try to trick attack or sneak attack onto mobs with and without the appropriate armlets equipped and hopefully notice a small difference in damage

## Special Deployment Considerations
