### PR TITLE
Fix Tarasque spawn and spikes

### DIFF
--- a/scripts/zones/Ifrits_Cauldron/mobs/Tarasque.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Tarasque.lua
@@ -6,10 +6,14 @@ require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.AUTO_SPIKES, 1)
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+end
+
+entity.onAdditionalEffect = function(mob, target, damage)
     mob:addStatusEffect(xi.effect.BLAZE_SPIKES, 35, 0, 0)
     mob:getStatusEffect(xi.effect.BLAZE_SPIKES):setFlag(xi.effectFlag.DEATH)
+    mob:setMobMod(xi.mobMod.ADD_EFFECT, 0)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Ifrits_Cauldron/npcs/qm1.lua
+++ b/scripts/zones/Ifrits_Cauldron/npcs/qm1.lua
@@ -12,7 +12,7 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     if
         npcUtil.tradeHas(trade, xi.items.RATTLING_EGG) and
-        npcUtil.popFromQM(player, npc, ID.mob.TARASQUE, { claim = false, look = true })
+        npcUtil.popFromQM(player, npc, ID.mob.TARASQUE, { claim = true, look = true })
     then
         player:confirmTrade()
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Tarasque will now spawn aggressive and claimed to the spawner per capture.  Tarasque will no longer start with a blaze spikes effect that does not do damage.  Instead Tarasque will behave as expected and only gain blaze spikes if it hits a target.  (Tiberon)

## What does this pull request do? (Please be technical)

Instead of using Auto_Spikes which triggers a spike effect to be processed by the mob script - now uses Add_Effect which enabled the mob script to handle an additional effect.
Tarasque's additional effect is to apply an blaze spikes to himself.

## Steps to test these changes

Spawn tarasque with PD on your char (so it cant hit you)
`!addeffect perfect_dodge 1 2000`
`!spawnmob 17617164`
Fight for a bit - no blaze spikes.
`!deleffect perfect_dodge` (targeting yourself)
Let tarasque hit you
Boom, blaze spikes
Try to dispel em - nope
Let him deaggro - no change.

## Special Deployment Considerations

None
