### PR TITLE
Change the 4 core synths to be CoP Era instead of ToAU Era

### DIFF
--- a/modules/era/sql/synth_recipes_era.sql
+++ b/modules/era/sql/synth_recipes_era.sql
@@ -121,7 +121,11 @@ UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Hellfire' AND 
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Zanbato' AND ID = 14037;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Hauberk' AND ID = 14038;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ID = 14041;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Frigid Core' AND ID = 14042;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Adaman Ingot' AND ID = 14043;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Luminous Core' AND ID = 14044;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Spirit Core' AND ID = 14045;
+UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Inferno Core' AND ID = 14046;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Kunwu Iron' AND ID = 14047;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Adaman Ingot' AND ID = 14501;
 UPDATE `synth_recipes` SET ContentTag = 'COP' WHERE ResultName = 'Gully' AND ID = 14503;
@@ -1441,10 +1445,6 @@ UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Hexagun' AND 
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Regiment Kheten' AND ID = 13532;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Dark Amood' AND ID = 13539;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Troll Bronze Sheet' AND ID = 14007;
-UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Frigid Core' AND ID = 14042;
-UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Luminous Core' AND ID = 14044;
-UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Spirit Core' AND ID = 14045;
-UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Inferno Core' AND ID = 14046;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Jadagna' AND ID = 14504;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Ponderous Gully' AND ID = 14521;
 UPDATE `synth_recipes` SET ContentTag = 'TOAU' WHERE ResultName = 'Adaman Kilij' AND ID = 14540;


### PR DESCRIPTION
Changed tag of Luminous Core, Inferno Core, Spirit Core, and Frigid Core to CoP per http://ffxi.somepage.com/news/197

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Changes the expansion tag of these 4 items added during the CoP expansion from ToAU to CoP to allow them to be crafted on CoP Era servers.

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)

Make the 4 items CoP era instead of ToAU era.

http://ffxi.somepage.com/news/197

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
