### PR TITLE
fix moonPhases weighting for ore

### DIFF
--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -1015,7 +1015,7 @@ local function getChocoboDiggingItem(player)
             local moonPhases =
             {
                 {  7,  9, 0.7 },
-                { 15, 21, 0.9 },
+                { 15, 20, 0.9 },
                 { 21, 24, 0.5 },
             }
 
@@ -1062,7 +1062,7 @@ local function getChocoboDiggingItem(player)
         local moonPhases =
         {
             {  7,  9, 0.7 },
-            { 15, 21, 0.9 },
+            { 15, 20, 0.9 },
             { 21, 24, 0.5 },
         }
 


### PR DESCRIPTION
Fix 21% moon being hit twice with itemWeight modifier in for loop.

Wiki states "most of the elemental ores tend to come in the 10% through 14% part of the moon phase. It is rare to see an elemental ore at 21% or 24% waxing crescent."  so setting 21% moon to the .5 modifier.

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed elemental ore having lower than intended weight during 21% moon.

## What does this pull request do? (Please be technical)

item ID 1255 was being hit twice in for loops (lines 1022-1028 and lines 1069-1075) when moon percentage is 21% causing it to have reduced weighting.

### Rank 10 digger at 21% moon phase
**Before**
| itemId | weight |
|--------|---------|
| 1255 | 7.3300258204985 |

**After**
| itemId | weight |
|--------|---------|
| 1255 | 8.1444731338872 |

## Steps to test these changes

Weight adjustment behavior verified via lua runtime execution.  Verified chocobo digging functions as expected in test environment.

## Special Deployment Considerations

None.
