### PR TITLE
Fix pet magic burst message ID

### DIFF
--- a/scripts/enum/msg.lua
+++ b/scripts/enum/msg.lua
@@ -209,6 +209,7 @@ xi.msg.basic =
     STATUS_INCREASED       = 562, -- The status parameters of <target> have increased.
     PET_CANNOT_DO_ACTION   = 574, -- <player>'s pet is currently unable to perform that action.
     PET_NOT_ENOUGH_TP      = 575, -- <player>'s pet does not have enough TP to perform that action.
+    PET_MAGIC_BURST        = 747, -- <user> uses <skill>. Magic Burst! <target> takes <number> point(s) of damage.
     SPIRIT_BOND            = 800, -- Spirit Bond Activates. <Player> takes <number> points of damage. -- Wyvern Spirit bond
 
     -- Food

--- a/scripts/globals/abilities/pets/aerial_blast.lua
+++ b/scripts/globals/abilities/pets/aerial_blast.lua
@@ -31,7 +31,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/aero_ii.lua
+++ b/scripts/globals/abilities/pets/aero_ii.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/aero_iv.lua
+++ b/scripts/globals/abilities/pets/aero_iv.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/blizzard_ii.lua
+++ b/scripts/globals/abilities/pets/blizzard_ii.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.ICE)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/blizzard_iv.lua
+++ b/scripts/globals/abilities/pets/blizzard_iv.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.ICE)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/diamond_dust.lua
+++ b/scripts/globals/abilities/pets/diamond_dust.lua
@@ -31,7 +31,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.ICE)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/earthen_fury.lua
+++ b/scripts/globals/abilities/pets/earthen_fury.lua
@@ -31,7 +31,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.EARTH)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/fire_ii.lua
+++ b/scripts/globals/abilities/pets/fire_ii.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.FIRE)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/fire_iv.lua
+++ b/scripts/globals/abilities/pets/fire_iv.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.FIRE)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/geocrush.lua
+++ b/scripts/globals/abilities/pets/geocrush.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.EARTH)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/grand_fall.lua
+++ b/scripts/globals/abilities/pets/grand_fall.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.WATER)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/heavenly_strike.lua
+++ b/scripts/globals/abilities/pets/heavenly_strike.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.ICE)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/howling_moon.lua
+++ b/scripts/globals/abilities/pets/howling_moon.lua
@@ -31,7 +31,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/inferno.lua
+++ b/scripts/globals/abilities/pets/inferno.lua
@@ -31,7 +31,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.FIRE)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/judgment_bolt.lua
+++ b/scripts/globals/abilities/pets/judgment_bolt.lua
@@ -31,7 +31,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHTNING)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/meteor_strike.lua
+++ b/scripts/globals/abilities/pets/meteor_strike.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.FIRE)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/meteorite.lua
+++ b/scripts/globals/abilities/pets/meteorite.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHT)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/nether_blast.lua
+++ b/scripts/globals/abilities/pets/nether_blast.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.BREATH, xi.damageType.DARK, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.BREATH, xi.damageType.DARK)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/ruinous_omen.lua
+++ b/scripts/globals/abilities/pets/ruinous_omen.lua
@@ -56,7 +56,7 @@ abilityobject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damageTable.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/searing_light.lua
+++ b/scripts/globals/abilities/pets/searing_light.lua
@@ -31,7 +31,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHT)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/somnolence.lua
+++ b/scripts/globals/abilities/pets/somnolence.lua
@@ -39,7 +39,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
         xi.magic.applyAbilityResistance(pet, target, effectParams)
     end
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/stone_ii.lua
+++ b/scripts/globals/abilities/pets/stone_ii.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.EARTH)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/stone_iv.lua
+++ b/scripts/globals/abilities/pets/stone_iv.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.EARTH)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/thunder_ii.lua
+++ b/scripts/globals/abilities/pets/thunder_ii.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHTNING)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/thunder_iv.lua
+++ b/scripts/globals/abilities/pets/thunder_iv.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHTNING)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/thunderspark.lua
+++ b/scripts/globals/abilities/pets/thunderspark.lua
@@ -40,7 +40,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
         xi.magic.applyAbilityResistance(pet, target, effectParams)
     end
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/thunderstorm.lua
+++ b/scripts/globals/abilities/pets/thunderstorm.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHTNING)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/tidal_wave.lua
+++ b/scripts/globals/abilities/pets/tidal_wave.lua
@@ -31,7 +31,7 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.WATER)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/water_ii.lua
+++ b/scripts/globals/abilities/pets/water_ii.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.WATER)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/water_iv.lua
+++ b/scripts/globals/abilities/pets/water_iv.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.WATER)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end

--- a/scripts/globals/abilities/pets/wind_blade.lua
+++ b/scripts/globals/abilities/pets/wind_blade.lua
@@ -24,7 +24,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)
 
-    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, 379)
+    xi.magic.handleSMNBurstMsg(pet, target, skill, params.element, xi.msg.basic.PET_MAGIC_BURST)
 
     return totaldamage
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Magic-based bloodpacts that that can magic burst now give the correct message when bursting (and should no longer crash add-ons). (Tracent)

## What does this pull request do? (Please be technical)
This fix an issue where the wrong message ID was being sent to client thus showing only "Shiva uses ." and crashing add-ons, the message ID should now be the correct one.

## Steps to test these changes
Use various magical bloodpacts (Tier IVs, astral flows, etc.) to burst and using different addons like simple logs.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
