### PR TITLE
Windurst Mission 8-2: Fix optional Shantotto Dialog with Key Item reference

### DIFF
--- a/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
+++ b/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
@@ -13,7 +13,7 @@
 -- Tosuka-Porika    : !pos -26 -6 103 238
 -- Kupipi           : !pos 2 0.1 30 242
 -- Shantotto        : !pos 122 -2 112 239
--- _5e5 (Cr. Wall)  : !pos -424.255 -1.909 619.995 194
+-- _5e5 (Cr. Wall)  : !pos -423 0 619.75 194
 -- _5cb (Gate. Drk) : !pos -228 0 99 192
 require('scripts/globals/interaction/mission')
 require('scripts/globals/missions')
@@ -341,7 +341,7 @@ mission.sections =
 
         [xi.zone.WINDURST_WALLS] =
         {
-            ['Shantotto'] = mission:progressEvent(399, 0, 0, 282),
+            ['Shantotto'] = mission:progressEvent(399, 0, 0, 0, 282),
 
             onEventFinish =
             {


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Corrects mission Key Item reference in Shantotto dialog for option cutscene. Now the Cs correctly shows Glove of Perpetual Twilight

## What does this pull request do? (Please be technical)

Corrects the arg position of the Key Item Glove of Perpetual Twilight in the Optional CS for Windurst Mission 8-2 from Shantotto. Additionally updates the !pos hint for cracked wall which previously would position you inside of the wall.

Previously:
`['Shantotto'] = mission:progressEvent(399, 0, 0, 282),`
Fix:
`['Shantotto'] = mission:progressEvent(399, 0, 0, 0, 282),`

Closes #3632

## Steps to test these changes

Run through Windurst Mission 8-2, upon completion talk to Shantotto for optional CS with key item reference.

## Considerations

While this does correct the mission Key Item dialog, I've not stumbled across a capture indicating this is the correct fix. I'm unsure if arg0, arg1, and arg2 should actually be 0. This correction simply fixes the existing dialog error.
