### PR TITLE
fix time checks when requesting new rings

### DIFF
--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -97,8 +97,19 @@ function utils.join(input1, input2)
     return result
 end
 
+-- For use alongside os.time()
 function utils.minutes(minutes)
     return minutes * 60
+end
+
+-- For use alongside os.time()
+function utils.hours(hours)
+    return hours * 60 * 60
+end
+
+-- For use alongside os.time()
+function utils.days(days)
+    return days * 60 * 60 * 24
 end
 
 -- Generates a random permutation of integers >= min_val and <= max_val

--- a/scripts/missions/cop/8_4_Dawn.lua
+++ b/scripts/missions/cop/8_4_Dawn.lua
@@ -72,14 +72,13 @@ end
 
 local ringFunction = function(player)
     local ringsTaken = mission:getVar(player, 'Rings')
-    local currentDay = tonumber(os.date('%j'))
-    local lastObtained = mission:getVar(player, 'Obtained')
+    local timeSinceDayObtained = os.time() - mission:getVar(player, 'Obtained')
 
     if ringsTaken == 0 then
         return mission:progressEvent(84, rings)
-    elseif ringsTaken == 1 then -- No Wait for 1st Throw
+    elseif ringsTaken == 1 and timeSinceDayObtained >= utils.days(1) then -- Cannot drop and re-obtain on the same day
         return mission:progressEvent(204, rings)
-    elseif ringsTaken > 1 and (currentDay - lastObtained) >= 28 then -- 28 Day Wait for New Ring
+    elseif ringsTaken > 1 and timeSinceDayObtained >= utils.days(28) then -- 28 Day Wait for New Ring
         return mission:progressEvent(204, rings)
     end
 end
@@ -91,7 +90,7 @@ local giveRings = function(player, csid, option)
         else
             local ringsTaken = mission:getVar(player, 'Rings')
             mission:setVar(player, 'Rings', ringsTaken + 1)
-            mission:setVar(player, 'Obtained', tonumber(os.date('%j')))
+            mission:setVar(player, 'Obtained', getMidnight() - utils.days(1)) -- midnight of the current day
             player:addItem(rings[option - 4])
             return mission:messageSpecial(zones[player:getZoneID()].text.ITEM_OBTAINED, rings[option - 4])
         end


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed an issue where CoP rings could not be reobtained after the new year (Haplo)

## What does this pull request do? (Please be technical)

The CoP ring check now uses os.time() instead of os.date('%j') so that when it rolls over from day 365 to day 0 it will no longer fail the 28-day-wait check (technically 27 days, but it's available at the start of the 28th).

I also noticed the wiki said "If the ring is discarded on the day it was obtained, you must wait until after Japanese Midnight before the cutscene will play." so I added a 1 day wait for the first drop.

The util functions for hours and days were pulled from LSB.

## Steps to test these changes

!addmission 6 850
Wasn't sure how to set mission status properly so I just commented out the check for mission:getVar(player, 'Status') > 5 in 8_4_Dawn.lua, and then checked a variety of cases messing with when the door would let me interact with it based on the times I set them to.

## Special Deployment Considerations

Technically it would be correct to update all the existing Mission[6][840]Obtained vars for each player, but it's not really necessary. This change will just treat all players as if they have waited the full 27 days even if they actually haven't, since their current value will be from 1-365 instead of 1.7 billion, and 1.7 billion > (365 + 28).
Once they re-obtain the ring it'll be set to the proper value.