### PR TITLE
LSB cherrypick: set scouts beret to 25 recycle chance

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -25309,7 +25309,7 @@ INSERT INTO `item_mods` VALUES (15082,1,24);  -- DEF: 24
 INSERT INTO `item_mods` VALUES (15082,2,15);  -- HP: 15
 INSERT INTO `item_mods` VALUES (15082,13,4);  -- MND: 4
 INSERT INTO `item_mods` VALUES (15082,27,-3); -- ENMITY: -3
-INSERT INTO `item_mods` VALUES (15082,305,5); -- RECYCLE: 5
+INSERT INTO `item_mods` VALUES (15082,305,25); -- RECYCLE: 25
 
 -- Saotome Kabuto
 INSERT INTO `item_mods` VALUES (15083,1,25);  -- DEF: 25
@@ -26393,7 +26393,7 @@ INSERT INTO `item_mods` VALUES (15255,1,25);  -- DEF: 25
 INSERT INTO `item_mods` VALUES (15255,2,15);  -- HP: 15
 INSERT INTO `item_mods` VALUES (15255,13,5);  -- MND: 5
 INSERT INTO `item_mods` VALUES (15255,27,-4); -- ENMITY: -4
-INSERT INTO `item_mods` VALUES (15255,305,5); -- RECYCLE: 5
+INSERT INTO `item_mods` VALUES (15255,305,25); -- RECYCLE: 25
 
 -- Saotome Kabuto +1
 INSERT INTO `item_mods` VALUES (15256,1,26);  -- DEF: 26


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Adjusted Scout's Beret Recycle chance to the correct value (Haplo)

## What does this pull request do? (Please be technical)

Sets Scout's Beret and Scout's Beret +1 Recycle chance to 25% instead of 5%. This matches the existing entry for Scout's Beret +2 and more closely matches wiki values https://ffxiclopedia.fandom.com/wiki/Scout%27s_Beret?oldid=287928
https://github.com/LandSandBoat/server/pull/5015

## Steps to test these changes

!additem 15082
!additem 15255
Equip and fire a bunch of arrows and track ammo count

## Special Deployment Considerations
