### PR TITLE
Fix dyna tav shard spawning and mobskill

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -2144,7 +2144,6 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
             end },
 
             ["onMobWeaponSkill"] = { function(mobTarget, mob, skill)
-                xi.dynamis.onMobWeaponSkillDiabolosShard(mobTarget, mob, skill)
             end },
 
             ["onMobDeath"] = { function(mob, player, optParams)

--- a/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
@@ -389,14 +389,26 @@ end
 xi.dynamis.onSpawnDiabolosShard = function(mob)
     xi.dynamis.setMegaBossStats(mob)
     xi.dynamis.setDiabolosCommonTraits(mob)
+
+    -- shards just use tp move and despawn
+    mob:setMagicCastingEnabled(false)
+    mob:setAutoAttackEnabled(false)
+    mob:setMobAbilityEnabled(false)
+
+    mob:addListener("WEAPONSKILL_STATE_ENTER", "SHARD_WEAPONSKILL_STATE_ENTER", function(mobArg, skillid)
+        -- wait about 4 seconds for the mobskill to be attempted then despawn
+        mobArg:timer(4200, function(mobAr)
+            DespawnMob(mobAr:getID())
+        end)
+    end)
 end
 
 xi.dynamis.onMobFightDiabolosShard = function(mob, mobTarget)
-    mob:useMobAbility(1903)
-end
-
-xi.dynamis.onMobWeaponSkillDiabolosShard = function(target, mob, skill)
-    mob:setHP(0)
+    -- make sure in close range
+    if mob:checkDistance(mobTarget) < 5 then
+        mob:setMobAbilityEnabled(true)
+        mob:useMobAbility(1903)
+    end
 end
 
 -- ToDo


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
None (part of dyna tav launch)

## What does this pull request do? (Please be technical)
This fix makes the dyna tav shard reliably perform the mobskill and then despawn. 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
