### PR TITLE
Fix taurus to not drop hundos

### DIFF
--- a/modules/era/sql_dynamis/era_dyna_sql.sql
+++ b/modules/era/sql_dynamis/era_dyna_sql.sql
@@ -2066,7 +2066,7 @@ REPLACE INTO `mob_droplist` VALUES (2854,1,6,@COMMON,1452,334); -- Bronzepiece
 REPLACE INTO `mob_droplist` VALUES (2854,2,0,1000,1455,0); -- Byne Bill (Steal)
 REPLACE INTO `mob_droplist` VALUES (2854,2,0,1000,1449,0); -- Whiteshell (Steal)
 REPLACE INTO `mob_droplist` VALUES (2854,2,0,1000,1452,0); -- Bronzepiece (Steal)
-REPLACE INTO `mob_droplist` VALUES (2854,0,0,1000,1450,@SRARE); -- Jadeshell
+
 --             Regular           --
 DELETE FROM `mob_droplist` WHERE dropid = "1342"; -- Hydra ** NOTE THESE ARE THE SAME DROP RATES AT Dynamis-Beac **
 REPLACE INTO `mob_droplist` VALUES (1342,1,1,@RARE,15117,66); -- WAR Legs


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
None (before dyna-tav release)

## What does this pull request do? (Please be technical)
Nightmare Taurus should not drop hundos (see [here](http://www.ffxidb.com/zones/42/nightmare-taurus) where the 1 that dropped out of 42K is probably an error)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
