### PR TITLE
Fix immunities on several ENM mobs

### DIFF
--- a/scripts/zones/Boneyard_Gully/mobs/Bladmall.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Bladmall.lua
@@ -12,6 +12,10 @@ local entity = {}
 entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.HP_STANDBACK, 1)
     mob:setMod(xi.mod.MDEF, 50)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.SLEEP)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.GRAVITY)
 end
 
 entity.onMobFight = function(mob, target)
@@ -50,7 +54,8 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     -- Adds die with parent
-    if optParams.isKiller then
+    if mob:getLocalVar("despawnedAdds") == 0 then
+        mob:setLocalVar("despawnedAdds", 1)
         local bfID = mob:getBattlefield():getArea()
         for _, petId in ipairs(ID.shellWeDance[bfID].BLADMALL_PET_IDS) do
             local pet = GetMobByID(petId)

--- a/scripts/zones/Boneyard_Gully/mobs/Nepionic_Bladmall.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Nepionic_Bladmall.lua
@@ -8,6 +8,7 @@ require("scripts/globals/titles")
 local entity = {}
 
 entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.HP_STANDBACK, 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Boneyard_Gully/mobs/Nepionic_Parata.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Nepionic_Parata.lua
@@ -8,6 +8,7 @@ require("scripts/globals/titles")
 local entity = {}
 
 entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.REGAIN, 100)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Boneyard_Gully/mobs/Parata.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Parata.lua
@@ -12,6 +12,12 @@ local entity = {}
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.REGAIN, 100)
     mob:setMod(xi.mod.MDEF, 50)
+    mob:setMobMod(xi.mobMod.WEAPON_BONUS, 25)
+    mob:setMod(xi.mod.ATT, 430)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.SLEEP)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.GRAVITY)
 end
 
 entity.onMobFight = function(mob, target)
@@ -56,15 +62,20 @@ end
 entity.onMobWeaponSkill = function(target, mob, skill)
     -- Under 10%, Parata will 2hr dust cloud and chain Suctorial Tentacle > Painful Whip
     if skill:getID() == 603 and mob:getLocalVar("lastBreath") == 0 then
-        mob:queue(10, function(mobArg) mobArg:useMobAbility(508) end)
+        mob:queue(10, function(mobArg)
+            mobArg:useMobAbility(508)
+        end)
     elseif skill:getID() == 508 and mob:getLocalVar("lastBreath") == 0 then
-        mob:queue(10, function(mobArg) mobArg:useMobAbility(507) end)
+        mob:queue(10, function(mobArg)
+            mobArg:useMobAbility(507)
+        end)
     end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
     -- Adds die with parent
-    if optParams.isKiller then
+    if mob:getLocalVar("despawnedAdds") == 0 then
+        mob:setLocalVar("despawnedAdds", 1)
         local bfID = mob:getBattlefield():getArea()
         for _, petId in ipairs(ID.shellWeDance[bfID].PARATA_PET_IDS) do
             local pet = GetMobByID(petId)

--- a/scripts/zones/Boneyard_Gully/mobs/Tuchulcha.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Tuchulcha.lua
@@ -12,6 +12,11 @@ entity.onMobSpawn = function(mob)
     -- Aggros via ambush, not superlinking
     mob:setMobMod(xi.mobMod.SUPERLINK, 0)
     mob:setMobMod(xi.mobMod.NO_REST, 1)
+    mob:addImmunity(xi.immunity.SLEEP)
+    mob:addImmunity(xi.immunity.GRAVITY)
+    mob:addImmunity(xi.immunity.BIND)
+    mob:addImmunity(xi.immunity.STUN)
+    mob:addImmunity(xi.immunity.PARALYZE)
 
     -- Used with HPP to keep track of the number of Sandpits
     mob:setLocalVar("Sandpits", 0)

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -87,9 +87,6 @@ INSERT INTO `mob_pool_mods` VALUES (387,59,37,1); -- WEAPON_BONUS: 37
 -- Biast
 INSERT INTO `mob_pool_mods` VALUES (410,236,20,0); -- HUMANOID_KILLER: 20
 
--- Bladmall
-INSERT INTO `mob_pool_mods` VALUES (444,23,23,1); -- IMMUNITY: 23
-
 -- Bloodlapper
 INSERT INTO `mob_pool_mods` VALUES (459,23,50,0);  -- ATT: 50
 INSERT INTO `mob_pool_mods` VALUES (459,73,25,0);  -- STORETP: 25
@@ -385,9 +382,6 @@ INSERT INTO `mob_pool_mods` VALUES (2973,59,10,1); -- WEAPON_BONUS: 10 ( base da
 -- Ore Golem
 INSERT INTO `mob_pool_mods` VALUES (3051,4,4,1); -- SIGHT_RANGE: 4
 
--- Parata
-INSERT INTO `mob_pool_mods` VALUES (3099,23,23,1); -- IMMUNITY: 23
-
 -- Pey
 INSERT INTO `mob_pool_mods` VALUES (3124,48,307,1); -- SHARE_TARGET: 307
 INSERT INTO `mob_pool_mods` VALUES (3124,1152,100,0); -- LULLABYRESBUILD: 100
@@ -506,9 +500,6 @@ INSERT INTO `mob_pool_mods` VALUES (3916,254,100,0); -- LULLABYRES: 100
 
 -- Tombstone Prototype
 INSERT INTO `mob_pool_mods` VALUES (3941,163,-100,0); -- DMGMAGIC: -100
-
--- Tuchulcha
-INSERT INTO `mob_pool_mods` VALUES (4046,23,6191,1); -- IMMUNITY: 6191
 
 -- Ullikummi
 INSERT INTO `mob_pool_mods` VALUES (4082,4,4,1); -- SIGHT_RANGE: 4


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

- Parata, Bladmall, and Tuchulcha should now have retail accurate immunities to status effects. (Tracent)
- Parata should now have more retail accurate weapon damage and attack, Nepionic Parata should now have retail accurate regain, and Nepionic Bladmall should now stand back (similar to Bladmall). (Tracent)

## What does this pull request do? (Please be technical)
The immunities fix is the most important and needed because adding immunities via an IMMUNITY mod in the database does not currently work for such battlefield mobs. In current ASB this only impacts these three mobs but probably needs to be fixed upstream in core eventually.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1849

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
