### PR TITLE
Fix Tav TE Repopping

### DIFF
--- a/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
@@ -97,39 +97,49 @@ xi.dynamis.onMobEngagedNightmareWorm = function(mob, target)
 end
 
 xi.dynamis.tavQMSpawnCheck = function(mob, zone, zoneID)
+    local timeExtensionOneSpawned = zone:getLocalVar("timeExtensionOneSpawned")
+    local timeExtensionTwoSpawned = zone:getLocalVar("timeExtensionTwoSpawned")
     local timeNPCOne = GetNPCByID(xi.dynamis.dynaInfoEra[zoneID].timeExtensions[1])
     local timeNPCTwo = GetNPCByID(xi.dynamis.dynaInfoEra[zoneID].timeExtensions[2])
     local req = 0
     local reqT = 0
 
-    for _, eye in pairs(firstEyes) do
-        if zone:getLocalVar(eye) == 1 then
-            req = req + 1
+    if timeExtensionOneSpawned == 0 then
+        for _, eye in pairs(firstEyes) do
+            if zone:getLocalVar(eye) == 1 then
+                req = req + 1
+            end
         end
-    end
 
-    if req == 1 and timeNPCOne:getStatus() ~= xi.status.NORMAL then
-        local chance = math.random(1, 2)
-        if chance == 2 then
+        if req == 1 and timeNPCOne:getStatus() ~= xi.status.NORMAL then
+            local chance = math.random(1, 2)
+            if chance == 2 then
+                timeNPCOne:setStatus(xi.status.NORMAL) -- Make visible
+                zone:setLocalVar("timeExtensionOneSpawned", 1)
+            end
+        elseif req == 2 and timeNPCOne:getStatus() ~= xi.status.NORMAL then
             timeNPCOne:setStatus(xi.status.NORMAL) -- Make visible
-        end
-    elseif req == 2 and timeNPCOne:getStatus() ~= xi.status.NORMAL then
-        timeNPCOne:setStatus(xi.status.NORMAL) -- Make visible
-    end
-
-    for _, eye in pairs(secondEyes) do
-        if zone:getLocalVar(eye) == 1 then
-            reqT = reqT + 1
+            zone:setLocalVar("timeExtensionOneSpawned", 1)
         end
     end
 
-    if reqT == 1 and timeNPCTwo:getStatus() ~= xi.status.NORMAL then
-        local chance = math.random(1, 2)
-        if chance == 2 then
+    if timeExtensionTwoSpawned == 0 then
+        for _, eye in pairs(secondEyes) do
+            if zone:getLocalVar(eye) == 1 then
+                reqT = reqT + 1
+            end
+        end
+
+        if reqT == 1 and timeNPCTwo:getStatus() ~= xi.status.NORMAL then
+            local chance = math.random(1, 2)
+            if chance == 2 then
+                timeNPCTwo:setStatus(xi.status.NORMAL) -- Make visible
+                zone:setLocalVar("timeExtensionTwoSpawned", 1)
+            end
+        elseif reqT == 2 and timeNPCTwo:getStatus() ~= xi.status.NORMAL then
             timeNPCTwo:setStatus(xi.status.NORMAL) -- Make visible
+            zone:setLocalVar("timeExtensionTwoSpawned", 1)
         end
-    elseif reqT == 2 and timeNPCTwo:getStatus() ~= xi.status.NORMAL then
-        timeNPCTwo:setStatus(xi.status.NORMAL) -- Make visible
     end
 end
 
@@ -389,26 +399,15 @@ end
 xi.dynamis.onSpawnDiabolosShard = function(mob)
     xi.dynamis.setMegaBossStats(mob)
     xi.dynamis.setDiabolosCommonTraits(mob)
-
-    -- shards just use tp move and despawn
-    mob:setMagicCastingEnabled(false)
-    mob:setAutoAttackEnabled(false)
-    mob:setMobAbilityEnabled(false)
-
-    mob:addListener("WEAPONSKILL_STATE_ENTER", "SHARD_WEAPONSKILL_STATE_ENTER", function(mobArg, skillid)
-        -- wait about 4 seconds for the mobskill to be attempted then despawn
-        mobArg:timer(4200, function(mobAr)
-            DespawnMob(mobAr:getID())
-        end)
-    end)
 end
 
 xi.dynamis.onMobFightDiabolosShard = function(mob, mobTarget)
-    -- make sure in close range
-    if mob:checkDistance(mobTarget) < 5 then
-        mob:setMobAbilityEnabled(true)
-        mob:useMobAbility(1903)
-    end
+    --- if (distance(mobTarget, mob) < 5)
+    mob:useMobAbility(1903)
+end
+
+xi.dynamis.onMobWeaponSkillDiabolosShard = function(target, mob, skill)
+    mob:setHP(0)
 end
 
 -- ToDo


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Dyna Tav TEs will no longer double pop. (Tiberon)

## What does this pull request do? (Please be technical)

Gate the TE logic with zone local vars - since the mobs being checked for TE popping are part of the repops that the TE also pops.

## Steps to test these changes

Run Tav, get TE/Repop ???s from the eyes.
Kill repops.
Dont get ??? respwn.

## Special Deployment Considerations

None
