### PR TITLE
Make sure DE Hydra as sleep immune

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -425,7 +425,8 @@ xi.dynamis.normalDynamicSpawn = function(oMob, oMobIndex, target)
                     -- Hydra mobs in Dynamis Beaucedine are immune to sleep
                     if
                         mobArg:getFamily() == 359 and
-                        mobArg:getZoneID() == xi.zone.DYNAMIS_BEAUCEDINE
+                        (mobArg:getZoneID() == xi.zone.DYNAMIS_BEAUCEDINE or
+                        mobArg:getZoneID() == xi.zone.DYNAMIS_TAVNAZIA)
                     then
                         mobArg:addImmunity(xi.immunity.SLEEP)
                     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Dynamic Entity Hydra in Dynamis Tav are now immune to sleep. (Tiberon)

## What does this pull request do? (Please be technical)

adds tav to the gating check that was previously just beauc 

## Steps to test these changes

pull hydra, cast sleep.

## Special Deployment Considerations

none
