### PR TITLE
Fixes issue with furniture quest time cross over

### DIFF
--- a/scripts/globals/furniture_quests.lua
+++ b/scripts/globals/furniture_quests.lua
@@ -61,17 +61,19 @@ xi.furnitureQuests.onFurniturePlaced = function(player, item)
 
     -- Dont allow more than one reward from an item per player if not repeatable
     if
-        not itemLookup.repeatable and
-        player:getCharVar(string.format("[%s]%s", itemLookup.itemName, "received")) == 0
+        itemLookup.repeatable and
+        player:getCharVar(string.format("[%s]%s", itemLookup.itemName, "received")) ~= 0
     then
-        -- All furniture quests captured so far require zoning
-        player:setLocalVar(string.format("[%s]%s", itemLookup.itemName, "mustZone"), 1)
-        -- waitTime of -1 = conquestTally, otherwise its in seconds
-        if itemLookup.waitTime > 0 then
-            player:setCharVar(string.format("[%s]%s", itemLookup.itemName, "rewardTime"), VanadielTime() + itemLookup.waitTime)
-        else
-            player:setCharVar(string.format("[%s]%s", itemLookup.itemName, "rewardTime"), getConquestTally())
-        end
+        return
+    end
+
+    -- All furniture quests captured so far require zoning
+    player:setLocalVar(string.format("[%s]%s", itemLookup.itemName, "mustZone"), 1)
+    -- waitTime of -1 = conquestTally, otherwise its in seconds
+    if itemLookup.waitTime > 0 then
+        player:setCharVar(string.format("[%s]%s", itemLookup.itemName, "rewardTime"), os.time() + itemLookup.waitTime)
+    else
+        player:setCharVar(string.format("[%s]%s", itemLookup.itemName, "rewardTime"), getConquestTally())
     end
 end
 
@@ -99,7 +101,7 @@ xi.furnitureQuests.checkForFurnitureQuest = function(player)
         if
             rewardTime > 0 and -- player waiting to get reward
             player:getLocalVar(string.format("[%s]%s", fqInfo.itemName, "mustZone")) == 0 and -- player already zoned
-            rewardTime < VanadielTime() and -- reward is due
+            rewardTime < os.time() and -- reward is due
             player:getFameLevel(player:getNation()) >= fqInfo.fameReq -- meets fame required
         then
             triggeredQuestItem = itemID


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes an issue preventing players from completing furniture quests which have a conquest delay. (Tiberon)

## What does this pull request do? (Please be technical)

I incorrectly used VanadielTime() and getConquestTally() together in a comparison.
getConquestTally does not use vanadielTime, it uses base os.time.
Normally doing a comparison of "storedConquestTally < conquestTally" is suffcient however since I have mixed use cases, I was comparing directly to VanadielTime.

## Steps to test these changes

Place furniture
Check DB value
Note that it matches !exec printf("%s", getConquestTally())
Compare to os.time()
Compare to VanadielTime()
Note that VanadielTime will take a looooong time to hit that conquest Tally.

## Special Deployment Considerations

none.
Hotfixable.
