### PR TITLE
Fix nil error with Jeuno Conquest Guards

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1456,7 +1456,10 @@ xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, 
             end
 
             player:delCP(price)
-            if stock.rank ~= nil then
+            if
+                stock.rank ~= nil and
+                guardNation < 3 -- xi.nation.BEASTMEN and xi.nation.OTHER have no known title mappings
+            then
                 player:setTitle(titlesGranted[guardNation][stock.rank])
             end
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

No Player facing Impact.  Preventing nil errors in interactions, which fortinuately were the last possible line in the processing.

## What does this pull request do? (Please be technical)

prevents conquest.lua from attempting to access a nil index.
```
luautils::onEventFinish .\scripts/globals/conquest.lua:1461: attempt to index a nil value
stack traceback:
    .\scripts/globals/conquest.lua:1461: in function 'overseerOnEventFinish'
    ./scripts/zones/Port_Jeuno/npcs/Kochahy-Muwachahy.lua:27: in function 'fallbackHandler'
    .\scripts/globals/interaction/interaction_lookup.lua:400: in function <.\scripts/globals/interaction/interaction_lookup.lua:378>
```

## Steps to test these changes

Triggers a CS interaction with a jeuno conquest guard.

## Special Deployment Considerations

None
