### PR TITLE
[Quest] check inventory space and use messageName in A Squires Test

### DIFF
--- a/scripts/quests/sandoria/A_Squires_Test.lua
+++ b/scripts/quests/sandoria/A_Squires_Test.lua
@@ -78,7 +78,7 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if quest:getVar(player, 'Prog') == 1 then
-                        return quest:messageSpecial(ID.text.REVIVAL_TREE_ROOT, xi.items.REVIVAL_TREE_ROOT)
+                        return quest:messageName(ID.text.REVIVAL_TREE_ROOT, xi.items.REVIVAL_TREE_ROOT)
                     end
                 end,
 
@@ -87,7 +87,11 @@ quest.sections =
                         quest:getVar(player, 'Prog') == 1 and
                         npcUtil.tradeHasExactly(trade, xi.items.REVIVAL_TREE_ROOT)
                     then
-                        return quest:progressEvent(617)
+                        if player:getFreeSlotsCount() > 0 then -- confirm player has inventory space
+                            return quest:progressEvent(617)
+                        else
+                            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, xi.items.SPATHA)
+                        end
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes bug where players with a full inventory would not receive Spatha from Balasiel.

## What does this pull request do? (Please be technical)

Placed a free space check prior to quest turn in. Also changed messageSpecial to messageName to get that sweet sweet Balasiel nametag on his text.

Fixes: https://discord.com/channels/933423693848260678/1205819249805893662

## Steps to test these changes

!addquest 0 10
!setquestvar <name> 0 10 Prog 1
!addItem 940

Speak to Balasiel (to see name tag)
Trade Balasiel 1 revival root with a full inventory to confirm warning message and no progress.
Then free up inventory space and trade again to complete quest and receive Spatha

Complete quest 

## Special Deployment Considerations

