### PR TITLE
add mythril pick desynth

### DIFF
--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -4254,7 +4254,7 @@ INSERT INTO `synth_recipes` VALUES (69920,1,0,0,0,0,0,0,0,86,0,4100,4242,16858,0
 INSERT INTO `synth_recipes` VALUES (69921,1,0,0,0,0,0,0,0,83,0,4100,4242,16860,0,0,0,0,0,0,0,4154,715,1226,1226,1,2,10,10,'Holy Lance (desynth)');
 INSERT INTO `synth_recipes` VALUES (69922,1,0,0,0,0,0,0,0,55,0,4100,4242,17041,0,0,0,0,0,0,0,4154,716,1226,653,1,1,10,2,'Holy Mace (desynth)');
 INSERT INTO `synth_recipes` VALUES (69923,1,0,0,0,0,0,0,0,78,0,4100,4242,12434,0,0,0,0,0,0,0,850,850,850,850,1,1,1,1,'Genbu\'s Kabuto (desynth)');  -- possible HQ1=ram leather x1 HQ2=cermet chip x1.  Only JP site showed level.
-INSERT INTO `synth_recipes` VALUES (69924,1,0,0,47,0,0,0,0,0,0,4100,4242,16651,0,0,0,0,0,0,0,707,707,1226,1226,1,1,4,6,'Mythril Pick (desynth)');  
+INSERT INTO `synth_recipes` VALUES (69924,1,0,8,47,0,0,0,0,0,0,4100,4242,16651,0,0,0,0,0,0,0,707,707,1226,1226,1,1,4,6,'Mythril Pick (desynth)');  
 INSERT INTO `synth_recipes` VALUES (70001,0,0,0,0,0,0,0,0,0,1,4101,4243,2203,2203,2343,4362,4509,0,0,0,2209,2209,2209,2209,2,4,6,8,'Worm Paste');
 INSERT INTO `synth_recipes` VALUES (70002,0,0,0,0,0,0,0,0,0,1,4103,4245,727,4378,0,0,0,0,0,0,5575,5575,5575,5575,4,6,9,12,'Yogurt');
 INSERT INTO `synth_recipes` VALUES (70003,0,0,0,0,0,0,0,0,0,2,4101,4243,5465,0,0,0,0,0,0,0,2397,2397,2397,2397,1,1,1,1,'Foulweather Frog');

--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -4254,6 +4254,7 @@ INSERT INTO `synth_recipes` VALUES (69920,1,0,0,0,0,0,0,0,86,0,4100,4242,16858,0
 INSERT INTO `synth_recipes` VALUES (69921,1,0,0,0,0,0,0,0,83,0,4100,4242,16860,0,0,0,0,0,0,0,4154,715,1226,1226,1,2,10,10,'Holy Lance (desynth)');
 INSERT INTO `synth_recipes` VALUES (69922,1,0,0,0,0,0,0,0,55,0,4100,4242,17041,0,0,0,0,0,0,0,4154,716,1226,653,1,1,10,2,'Holy Mace (desynth)');
 INSERT INTO `synth_recipes` VALUES (69923,1,0,0,0,0,0,0,0,78,0,4100,4242,12434,0,0,0,0,0,0,0,850,850,850,850,1,1,1,1,'Genbu\'s Kabuto (desynth)');  -- possible HQ1=ram leather x1 HQ2=cermet chip x1.  Only JP site showed level.
+INSERT INTO `synth_recipes` VALUES (69924,1,0,0,47,0,0,0,0,0,0,4100,4242,16651,0,0,0,0,0,0,0,707,707,1226,1226,1,1,4,6,'Mythril Pick (desynth)');  
 INSERT INTO `synth_recipes` VALUES (70001,0,0,0,0,0,0,0,0,0,1,4101,4243,2203,2203,2343,4362,4509,0,0,0,2209,2209,2209,2209,2,4,6,8,'Worm Paste');
 INSERT INTO `synth_recipes` VALUES (70002,0,0,0,0,0,0,0,0,0,1,4103,4245,727,4378,0,0,0,0,0,0,5575,5575,5575,5575,4,6,9,12,'Yogurt');
 INSERT INTO `synth_recipes` VALUES (70003,0,0,0,0,0,0,0,0,0,2,4101,4243,5465,0,0,0,0,0,0,0,2397,2397,2397,2397,1,1,1,1,'Foulweather Frog');


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Mythril Pick can now be desynthed

## What does this pull request do? (Please be technical)

Adds desynth recipe to synth_recipes.sql
Closes: https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1793

http://ffxi.somepage.com/itemdb/353

## Steps to test these changes

!setskill smithing 47
!setskill woodworking 8
!additem 16651
!additem 4100

Synthesis Lightning Crystal + Mythril Pick

## Special Deployment Considerations

Update sql file (synth_recipes.sql) using dbtool
