### PR TITLE
Sandpit ability fix for Sheep in Antlion's Clothing

### DIFF
--- a/scripts/zones/Boneyard_Gully/mobs/Tuchulcha.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Tuchulcha.lua
@@ -46,19 +46,20 @@ entity.onMobFight = function(mob, target)
     -- Every 25% of its HP Tuchulcha will bury itself under the sand
     -- accompanied by use of the ability Sandpit
     if
-        (mob:getHPP() < 75 and mob:getLocalVar('Sandpits') == 0) or
+        mob:actionQueueEmpty() and
+        ((mob:getHPP() < 75 and mob:getLocalVar('Sandpits') == 0) or
         (mob:getHPP() < 50 and mob:getLocalVar('Sandpits') == 1) or
-        (mob:getHPP() < 25 and mob:getLocalVar('Sandpits') == 2)
+        (mob:getHPP() < 25 and mob:getLocalVar('Sandpits') == 2))
     then
         mob:setLocalVar('Sandpits', mob:getLocalVar('Sandpits') + 1)
         mob:useMobAbility(276)
+        mob:setUntargetable(true)
         mob:timer(4000, function(tuchulcha)
             tuchulcha:disengage()
             tuchulcha:setMobMod(xi.mobMod.NO_MOVE, 1)
             local posIndex = tuchulcha:getLocalVar("sand_pit" .. tuchulcha:getLocalVar('Sandpits'))
             local coords = ID.sheepInAntlionsClothing[tuchulcha:getBattlefield():getArea()].ant_positions[posIndex]
             tuchulcha:setSpawn(coords[1], coords[2], coords[3], 0)
-
             tuchulcha:setPos(coords)
             local players = tuchulcha:getBattlefield():getPlayers()
             for _, char in pairs(players) do


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Fixes exploit where Tuchulcha would path back to player after using sandpit when hit with a well-timed pet ability. Prior to this change, if a pet ability was used immediately after the message for sandpit, the ability would land after Tuchulcha already moved. This resulted in Tuchulcha uncovering itself and aggroing on the pet. The change ensures that Tuchulcha is untargettable after initiating the sandpit ability, which prevents the pet ability from being used.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1850

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
