### PR TITLE
Flee effect on Chicken Knife now overrides itself

### DIFF
--- a/scripts/globals/items/chicken_knife.lua
+++ b/scripts/globals/items/chicken_knife.lua
@@ -12,10 +12,11 @@ itemObject.onItemEquip = function(player, item)
         if dLvl >= 1 then
             -- exponential approx to data points from retail capture
             local chance = utils.clamp(100 * 0.0096906 * math.exp(0.176839 * dLvl), 1.33, 33)
-            if
-                math.random(1, 100) <= chance and
-                not playerArg:hasStatusEffect(xi.effect.FLEE)
-            then
+            if math.random(1, 100) <= chance then
+                if playerArg:hasStatusEffect(xi.effect.FLEE) then
+                    playerArg:delStatusEffect(xi.effect.FLEE)
+                end
+
                 playerArg:addStatusEffect(xi.effect.FLEE, 100, 0, 30)
             end
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Flee effect on Chicken Knife now overrides itself

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1863

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
