### PR TITLE
Fix win condition for Snoll Tzar fight

### DIFF
--- a/scripts/zones/Bearclaw_Pinnacle/mobs/Snoll_Tzar.lua
+++ b/scripts/zones/Bearclaw_Pinnacle/mobs/Snoll_Tzar.lua
@@ -72,19 +72,19 @@ entity.onMobFight = function(mob, player, target)
         mob:getBattleTime() - changeTime > 12
     then
         mob:useMobAbility(1644)
-        mob:setLocalVar("changeTime", mob:getBattleTime())
+        mob:setLocalVar("selfDestructed", 1)
     end
 end
 
 entity.onMobDeath = function(mob, player, optParams)
     local bf = mob:getBattlefield()
-    local changeTime = mob:getLocalVar("changeTime")
     local gameOver = mob:getLocalVar("gameover")
+    local selfDestructed = mob:getLocalVar("selfDestructed")
 
     -- end BCNM
     if
         gameOver == 1 and
-        mob:getBattleTime() - changeTime > 3
+        selfDestructed == 1
     then
         mob:setAnimationSub(4)
         bf:lose()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Players will lose the battlefield if Snoll Tzar is allowed to self-destruct.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1815

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
