### PR TITLE
[core] Remove left over operator overrides

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -79,27 +79,6 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include <io.h>
 #endif
 
-#ifdef TRACY_ENABLE
-void* operator new(std::size_t count)
-{
-    auto ptr = malloc(count);
-    TracyAlloc(ptr, count);
-    return ptr;
-}
-
-void operator delete(void* ptr) noexcept
-{
-    TracyFree(ptr);
-    free(ptr);
-}
-
-void operator delete(void* ptr, std::size_t count)
-{
-    TracyFree(ptr);
-    free(ptr);
-}
-#endif // TRACY_ENABLE
-
 const char* MAP_CONF_FILENAME = nullptr;
 
 int8* g_PBuff   = nullptr; // Global packet clipboard


### PR DESCRIPTION
Fixes tracy builds

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

None

## What does this pull request do? (Please be technical)

Fixes Tracy builds

## Steps to test these changes

[Performance Profiling with Tracy](https://github.com/LandSandBoat/server/wiki/Performance-Profiling-with-Tracy)

## Special Deployment Considerations

None
