### PR TITLE
[QUEST]Removes questvar for test of true love

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -394,7 +394,6 @@ xi.treasure.treasureInfo =
 
                         code = function(player)
                             npcUtil.giveKeyItem(player, xi.ki.UN_MOMENT)
-                            player:incrementCharVar("Quest[1][62]Prog", 1)
                         end,
                     },
                 },
@@ -435,7 +434,6 @@ xi.treasure.treasureInfo =
 
                         code = function(player)
                             npcUtil.giveKeyItem(player, xi.ki.UN_MOMENT)
-                            player:incrementCharVar("Quest[1][62]Prog", 1)
                         end,
                     },
                 },
@@ -471,7 +469,6 @@ xi.treasure.treasureInfo =
 
                         code = function(player)
                             npcUtil.giveKeyItem(player, xi.ki.LEPHEMERE)
-                            player:incrementCharVar("Quest[1][62]Prog", 1)
                         end,
                     },
                 },
@@ -855,7 +852,6 @@ xi.treasure.treasureInfo =
 
                         code = function(player)
                             npcUtil.giveKeyItem(player, xi.ki.LANCIENNE)
-                            player:incrementCharVar("Quest[1][62]Prog", 1)
                         end,
                     },
                 },


### PR DESCRIPTION
Removes player:incrementCharVar("Quest[1][62]Prog", 1) from treasure.lua which is no longer needed to progess quest.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Remove the error within treasure.lua that increments a players var for Quest[1][62] wherein the Player would reach var 3 and not be able to complete the quest.
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!addquest 1 62 - goto Onzozo, pop chest -
!checkvar Quest[1][62] - should not increment.

feel free to do the other 3 locations,

Castle Zvhal Baileys/Keep
SSG
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
