### PR TITLE
[Module]Era Quest Timers

### DIFF
--- a/modules/era/lua/era_quest_timers.lua
+++ b/modules/era/lua/era_quest_timers.lua
@@ -1,0 +1,50 @@
+-----------------------------------
+-- Module to revert to era quest timers
+-----------------------------------
+require("modules/module_utils")
+require('scripts/globals/quests')
+require('scripts/globals/npc_util')
+require('scripts/globals/interaction/quest')
+-----------------------------------
+-- put the required era time change in the appropriate comment below to keep organized.
+local m = Module:new("era_quest_timers")
+----ahtUrhgan-----------------------
+----COR AF2 Navigation the Unfriendly Seas Timer from 60 seconds to JP Midnight as per era
+----Quest 6 25
+local wajaomID = require("scripts/zones/Wajaom_Woodlands/IDs")
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/ahtUrhgan/COR_AF2_Navigating_the_Unfriendly_Seas', function(quest)
+    quest.sections[2][xi.zone.WAJAOM_WOODLANDS]['Leypoint'].onTrade = function(player, npc, trade)
+        if
+            npcUtil.tradeHasExactly(trade, xi.items.HYDROGAUGE) and
+            quest:getVar(player, 'Prog') == 1
+        then
+            player:confirmTrade()
+            quest:setVar(player, 'Prog', 2)
+            quest:setVar(player, 'leypointTimer', getMidnight())
+            return quest:messageSpecial(wajaomID.text.PLACE_HYDROGAUGE, xi.items.HYDROGAUGE)
+        end
+    end
+end)----End of COR_AF2_Navigating_the_Unfriendly_Seas
+
+----End of ahtUrhgan
+----bastokQuests--------------------
+----End of bastokQuests
+----hiddenQuests-------------------
+----End of hiddenQuests
+----jeunoQuests---------------------
+----End of jeunoQuests
+----otherAreas----------------------
+----End of otherAreas
+----outlands------------------------
+----End of outlands
+----sandoria------------------------
+----End of sandoria
+----windurst------------------------
+----End of windurst
+end) -- end of module
+
+return m -- eof

--- a/scripts/quests/ahtUrhgan/COR_AF2_Navigating_the_Unfriendly_Seas.lua
+++ b/scripts/quests/ahtUrhgan/COR_AF2_Navigating_the_Unfriendly_Seas.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Navigating the Unfriendly Seas
 -- qm6 (H-10/Boat)  : !pos 468.767 -12.292 111.817 54
+-- Leleroon !pos -12.652 0 26.8 53
 -- Leypoint : !pos -200.027 -8.500 80.058 51
 -----------------------------------
 require('scripts/globals/quests')
@@ -86,7 +87,7 @@ quest.sections =
                     then
                         player:confirmTrade()
                         quest:setVar(player, 'Prog', 2)
-                        quest:setVar(player, 'leypointTimer', getMidnight())
+                        quest:setVar(player, 'leypointTimer', os.time() + 60) -- retail timer - era replaced in era_quest_timers module
                         return quest:messageSpecial(wajaomID.text.PLACE_HYDROGAUGE, xi.items.HYDROGAUGE)
                     end
                 end,


### PR DESCRIPTION
Provides module to replace era timers by using modifyInteractionEntry

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
N/A
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Allows for era quests timers to be implemented in a consolidated module. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Use the mom_the_missable_adventurer/COR_AF2_Navigating_the_friendly_seas as a guide to implement future quests/missions that require a different timer due to era.

Created an area for each scripts/quest/[ZONE] section to keep it organized. 
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
NONE
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
