### PR TITLE
Fix a bug where Apoc Nigh is only letting you proceed to finish if yo…

### DIFF
--- a/scripts/quests/jeuno/Apocalypse_Nigh.lua
+++ b/scripts/quests/jeuno/Apocalypse_Nigh.lua
@@ -170,7 +170,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if
                         quest:getVar(player, 'Status') == 4 and
-                        player:getRank(player:getNation()) > 5
+                        player:getRank(player:getNation()) => 5
                     then
                         return quest:progressEvent(10057)
                     elseif quest:getVar(player, 'Status') == 5 then


### PR DESCRIPTION
…u are Rank 6 or above

https://www.bg-wiki.com/ffxi/Apocalypse_Nigh
https://ffxiclopedia.fandom.com/wiki/Apocalypse_Nigh

"You must be Rank 5 or higher in your current nation to receive this cutscene."

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fix a bug where Apoc Nigh is only letting you proceed to finish if you are Rank 6+ rather than Rank5+

## What does this pull request do? (Please be technical)

Fix a bug where Apoc Nigh is only letting you proceed to finish if you are Rank 6+ rather than Rank5+

## Steps to test these changes

N/A

## Special Deployment Considerations

