### PR TITLE
Changes combat music in Dyna Tav in addition to background music

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis.lua
@@ -1511,6 +1511,8 @@ xi.dynamis.timeExtensionOnTrigger = function(player, npc)
     for _, member in pairs(zone:getPlayers()) do
         member:changeMusic(0, 227) -- 0 Background Music (Sunbreeze Music)
         member:changeMusic(1, 227) -- 1 Background Music (Sunbreeze Music)
+        member:changeMusic(2, 227) -- 2 Combat Music (Sunbreeze Music)
+        member:changeMusic(3, 227) -- 3 Combat Music (Sunbreeze Music)
     end
 
     if npc:getID() == 16949396 then

--- a/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
@@ -187,6 +187,8 @@ xi.dynamis.onMobEngagedUmbralDiabolos = function(mob, target)
         for _, member in pairs(zone:getPlayers()) do
             member:changeMusic(0, 239) -- 0 Background Music (Starlight Celebration Music)
             member:changeMusic(1, 239) -- 1 Background Music (Starlight Celebration Music)
+            member:changeMusic(2, 239) -- 2 Combat Music (Starlight Celebration Music)
+            member:changeMusic(3, 239) -- 3 Combat Music (Starlight Celebration Music)
         end
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Dyna Tav Sunbreeze and Starlight music should now persist through combat and aggro (Tiberon).

## What does this pull request do? (Please be technical)

Sets music type 3 and 4 in addition to 1 and 2.
Consideration can be given to using Zone set music instead of doing this on a per char basis in the future.

## Steps to test these changes

Trigger exstension or aggro an umbral to get a music change.
Engage in battle/get aggro - see that combat music does not override the festival musics.

## Special Deployment Considerations

None
