### PR TITLE
[Module]pet reward onUseAbility

### DIFF
--- a/modules/era/lua/era_pet_reward.lua
+++ b/modules/era/lua/era_pet_reward.lua
@@ -1,0 +1,141 @@
+-----------------------------------
+-- Era pet reward ability
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_pet_reward')
+
+m:addOverride('xi.actions.abilities.reward.onUseAbility', function(player, target, ability, action)
+    -- 1st need to get the pet food is equipped in the range slot.
+    local rangeObj         = player:getEquipID(xi.slot.AMMO)
+    local minimumHealing   = 0
+    local totalHealing     = 0
+    local playerMnd        = player:getStat(xi.mod.MND)
+    local rewardHealingMod = player:getMod(xi.mod.REWARD_HP_BONUS)
+    local regenAmount      = 1 -- 1 is the minimum.
+    local regenTime        = 180 -- 3 minutes
+    local pet              = player:getPet()
+    local petCurrentHP     = pet:getHP()
+    local petMaxHP         = pet:getMaxHP()
+
+    -- Need to start to calculate the HP to restore to the pet.
+    -- Please note that I used this as base for the calculations:
+    -- http://wiki.ffxiclopedia.org/wiki/Reward
+
+    -- TODO: Create lookup table for these switches
+    switch (rangeObj) : caseof {
+        [17016] = function() -- pet food alpha biscuit
+            minimumHealing = 20
+            regenAmount    = 1
+            totalHealing   = math.floor(minimumHealing + 2 * (playerMnd - 10))
+        end,
+
+        [17017] = function() -- pet food beta biscuit
+            minimumHealing = 50
+            regenAmount    = 2
+            totalHealing   = math.floor(minimumHealing + 1 * (playerMnd - 33))
+        end,
+
+        [17018] = function() -- pet food gamma biscuit
+            minimumHealing = 100
+            regenAmount    = 3
+            totalHealing   = math.floor(minimumHealing + 1 * (playerMnd - 35)) -- TO BE VERIFIED.
+        end,
+
+        [17019] = function() -- pet food delta biscuit
+            minimumHealing = 150
+            regenAmount    = 4
+            totalHealing   = math.floor(minimumHealing + 2 * (playerMnd - 40)) -- TO BE VERIFIED.
+        end,
+
+        [17020] = function() -- pet food epsilon biscuit
+            minimumHealing = 300
+            regenAmount    = 5
+            totalHealing   = math.floor(minimumHealing + 2 * (playerMnd - 45))
+        end,
+
+        [17021] = function() -- pet food zeta biscuit
+            minimumHealing = 350
+            regenAmount    = 6
+            totalHealing   = math.floor(minimumHealing + 3 * (playerMnd - 45))
+        end,
+
+        [17022] = function() -- pet food eta biscuit
+            minimumHealing = 1200
+            regenAmount    = 17
+            totalHealing   = math.floor(minimumHealing + 4 * (playerMnd - 50))
+        end,
+
+        [17023] = function() -- pet food theta biscuit
+            minimumHealing = 1600
+            regenAmount    = 20
+            totalHealing   = math.floor(minimumHealing + 4 * (playerMnd - 55))
+        end,
+    }
+
+    -- Now calculating the bonus based on gear.
+    switch (player:getEquipID(xi.slot.BODY)) : caseof {
+        [12646] = function() -- beast jackcoat
+            -- This will remove Paralyze, Poison and Blind from the pet.
+            pet:delStatusEffect(xi.effect.PARALYSIS)
+            pet:delStatusEffect(xi.effect.POISON)
+            pet:delStatusEffect(xi.effect.BLINDNESS)
+        end,
+
+        [14481] = function() -- beast jackcoat +1
+            -- This will remove Paralyze, Poison, Blind, Weight, Slow and Silence from the pet.
+            pet:delStatusEffect(xi.effect.PARALYSIS)
+            pet:delStatusEffect(xi.effect.POISON)
+            pet:delStatusEffect(xi.effect.BLINDNESS)
+            pet:delStatusEffect(xi.effect.WEIGHT)
+            pet:delStatusEffect(xi.effect.SLOW)
+            pet:delStatusEffect(xi.effect.SILENCE)
+        end,
+
+        [15095] = function() -- monster jackcoat
+            -- This will remove Weight, Slow and Silence from the pet.
+            pet:delStatusEffect(xi.effect.WEIGHT)
+            pet:delStatusEffect(xi.effect.SLOW)
+            pet:delStatusEffect(xi.effect.SILENCE)
+        end,
+
+        [14508] = function() -- monster jackcoat +1
+            -- This will remove Paralyze, Poison, Blind, Weight, Slow and Silence from the pet.
+            pet:delStatusEffect(xi.effect.PARALYSIS)
+            pet:delStatusEffect(xi.effect.POISON)
+            pet:delStatusEffect(xi.effect.BLINDNESS)
+            pet:delStatusEffect(xi.effect.WEIGHT)
+            pet:delStatusEffect(xi.effect.SLOW)
+            pet:delStatusEffect(xi.effect.SILENCE)
+        end,
+    }
+
+    -- Adding bonus to the total to heal.
+
+    if rewardHealingMod ~= nil and rewardHealingMod > 0 then
+        totalHealing = totalHealing + math.floor(totalHealing * rewardHealingMod / 100)
+    end
+
+    local diff = petMaxHP - petCurrentHP
+
+    if diff < totalHealing then
+        totalHealing = diff
+    end
+
+    pet:addHP(totalHealing)
+    pet:wakeUp()
+
+    -- Apply regen xi.effect.
+    if xi.settings.main.ENABLE_COP == 1 then
+        pet:delStatusEffect(xi.effect.REGEN)
+        pet:addStatusEffect(xi.effect.REGEN, regenAmount, 3, regenTime) -- 3 = tick, each 3 seconds.
+    end
+
+    player:removeAmmo()
+
+    pet:updateEnmityFromCure(pet, totalHealing)
+
+    return totalHealing
+end)
+
+return m


### PR DESCRIPTION
Module for era reward.lua onUseAbility

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
Module for replacing onUseAbility for reward.lua.
<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

## What does this pull request do? (Please be technical)
Creates a module for era calculations for abilities/reward.lua in the function onUseAbility.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
edit module/init.txt 
era/lua/era_pet_reward.lua
<!-- Clear and detailed steps to test your changes here. -->

## Special Deployment Considerations
None
<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
