### PR TITLE
Fixing Dynamic ID access for Dyna Tav

### DIFF
--- a/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
@@ -422,31 +422,53 @@ xi.dynamis.mobOnDeathDiabolos = function(mob, player, optParams)
     end
 
     local allDead = true
+    mob:getID()
 
-    local aliveDiabolos = {}
-    if zone:getLocalVar("DiabolosClub") > 0 then
-        table.insert(aliveDiabolos, GetMobByID(zone:getLocalVar("DiabolosClub")))
+    -- Dynamic IDs - cannot trust a mob's ID outside the scope of its life
+    -- So we require another layer of indirection for persistence
+    if mob:getID() == zone:getLocalVar("DiabolosClub") then
+        zone:setLocalVar("DiabolosClubDeath", 1)
     end
 
-    if zone:getLocalVar("DiabolosHeart") > 0 then
-        table.insert(aliveDiabolos, GetMobByID(zone:getLocalVar("DiabolosHeart")))
+    if mob:getID() == zone:getLocalVar("DiabolosHeart") then
+        zone:setLocalVar("DiabolosHeartDeath", 1)
     end
 
-    if zone:getLocalVar("DiabolosSpade") > 0 then
-        table.insert(aliveDiabolos, GetMobByID(zone:getLocalVar("DiabolosSpade")))
+    if mob:getID() == zone:getLocalVar("DiabolosSpade") then
+        zone:setLocalVar("DiabolosSpadeDeath", 1)
     end
 
-    if zone:getLocalVar("DiabolosDiamond") > 0 then
-        table.insert(aliveDiabolos, GetMobByID(zone:getLocalVar("DiabolosDiamond")))
+    if mob:getID() == zone:getLocalVar("DiabolosDiamond") then
+        zone:setLocalVar("DiabolosDiamondDeath", 1)
     end
 
-    for _, v in pairs(aliveDiabolos) do
-        if
-            v ~= nil and
-            v:isAlive()
-        then
-            allDead = false
-        end
+    -- Check that each mob is dead
+    if
+        zone:getLocalVar("DiabolosClub") > 0 and
+        zone:getLocalVar("DiabolosClubDeath") == 0
+    then
+        allDead = false
+    end
+
+    if
+        zone:getLocalVar("DiabolosHeart") > 0 and
+        zone:getLocalVar("DiabolosHeartDeath") == 0
+    then
+        allDead = false
+    end
+
+    if
+        zone:getLocalVar("DiabolosSpade") > 0 and
+        zone:getLocalVar("DiabolosSpadeDeath") == 0
+    then
+        allDead = false
+    end
+
+    if
+        zone:getLocalVar("DiabolosDiamond") > 0 and
+        zone:getLocalVar("DiabolosDiamondDeath") == 0
+    then
+        allDead = false
     end
 
     if allDead then
@@ -464,48 +486,85 @@ xi.dynamis.mobOnDeathDiabolos = function(mob, player, optParams)
 end
 
 xi.dynamis.onMobEngagedDiabolos = function(mob, mobTarget)
+    local zone = mob:getZone()
     mob:setLocalVar("hasEngaged", 1)
+    if mob:getID() == zone:getLocalVar("DiabolosClub") then
+        zone:setLocalVar("DiabolosClubEngaged", 1)
+    end
+
+    if mob:getID() == zone:getLocalVar("DiabolosHeart") then
+        zone:setLocalVar("DiabolosHeartEngaged", 1)
+    end
+
+    if mob:getID() == zone:getLocalVar("DiabolosSpade") then
+        zone:setLocalVar("DiabolosSpadeEngaged", 1)
+    end
+
+    if mob:getID() == zone:getLocalVar("DiabolosDiamond") then
+        zone:setLocalVar("DiabolosDiamondEngaged", 1)
+    end
 end
 
 xi.dynamis.onMobRoamDiabolos = function(mob)
+    local zone = mob:getZone()
+    local noHate = true
+
+    -- do nothing if never engaged
     if mob:getLocalVar("hasEngaged") == 0 then
         return
     end
 
-    local zone = mob:getZone()
-    local noHate = true
-    local spawnedDiabolos = {}
-    if zone:getLocalVar("DiabolosClub") > 0 then
-        table.insert(spawnedDiabolos, GetMobByID(zone:getLocalVar("DiabolosClub")))
+    -- set engaged variables
+    if mob:getID() == zone:getLocalVar("DiabolosClub") then
+        zone:setLocalVar("DiabolosClubEngaged", 0)
     end
 
-    if zone:getLocalVar("DiabolosHeart") > 0 then
-        table.insert(spawnedDiabolos, GetMobByID(zone:getLocalVar("DiabolosHeart")))
+    if mob:getID() == zone:getLocalVar("DiabolosHeart") then
+        zone:setLocalVar("DiabolosHeartEngaged", 0)
     end
 
-    if zone:getLocalVar("DiabolosSpade") > 0 then
-        table.insert(spawnedDiabolos, GetMobByID(zone:getLocalVar("DiabolosSpade")))
+    if mob:getID() == zone:getLocalVar("DiabolosSpade") then
+        zone:setLocalVar("DiabolosSpadeEngaged", 0)
     end
 
-    if zone:getLocalVar("DiabolosDiamond") > 0 then
-        table.insert(spawnedDiabolos, GetMobByID(zone:getLocalVar("DiabolosDiamond")))
+    if mob:getID() == zone:getLocalVar("DiabolosDiamond") then
+        zone:setLocalVar("DiabolosDiamondEngaged", 0)
     end
 
-    for _, v in pairs(spawnedDiabolos) do
-        if
-            v ~= nil and
-            v:isEngaged()
-        then
-            noHate = false
-        end
+    -- Check all for hate
+    if
+        zone:getLocalVar("DiabolosClub") > 0 and
+        zone:getLocalVar("DiabolosDiamondEngaged") == 1
+    then
+        noHate = false
     end
 
-    mob:messageText(mob, ID.text.NOW_I_WILL_JOIN_THEM)
+    if
+        zone:getLocalVar("DiabolosHeart") > 0 and
+        zone:getLocalVar("DiabolosClubEngaged") == 1
+    then
+        noHate = false
+    end
+
+    if
+        zone:getLocalVar("DiabolosSpade") > 0 and
+        zone:getLocalVar("DiabolosSpadeEngaged") == 1
+    then
+        noHate = false
+    end
+
+    if
+        zone:getLocalVar("DiabolosDiamond") > 0 and
+        zone:getLocalVar("DiabolosDiamondEngaged") == 1
+    then
+        noHate = false
+    end
 
     if noHate then
-        for _, v in pairs(spawnedDiabolos) do
-            DespawnMob(v:getID())
-        end
+        mob:messageText(mob, ID.text.NOW_I_WILL_JOIN_THEM)
+
+        -- this will trigger on each on roam
+        DespawnMob(mob:getID())
 
         for i = 106, 109 do
             local mobID = zone:getLocalVar(string.format("%s", i))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Summoned pets will no longer accidentally impact the win conditions for Dynamis Tav.

## What does this pull request do? (Please be technical)

Changes from relying upon Diabolos mob IDs to just relying on local vars to track state.

## Steps to test these changes

1. Enter Dyna Tav
2. Kill Diaboloses, Kill one at a time, Kill with a -ga all at once, kill with dots, kill with pets
3. Get win ???, extra Umbrals despawn

---
1. Entry Dyna Tav
2. Wipe to Diabolos - so no diabolos has hate
3. Diaboloses despawn, extra Umbrals despawn, no win ???

## Special Deployment Considerations

None - you could hot fix this if you really wanted to


# Special Thanks To Beasty - he cracked the code of why this rarely but randomly happened