### PR TITLE
Adds 90s timer to allow for dyna cleanup script to run

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis.lua
@@ -993,7 +993,7 @@ xi.dynamis.handleDynamis = function(zone)
             then
                 SetServerVariable(string.format("[DYNA]ZoneCooldown_%s", xi.dynamis.dynaIDLookup[zoneID].entryZone), os.time() + 90) -- Set a 90s timer for cleanup
             end
-            
+
             xi.dynamis.cleanupDynamis(zone) -- Runs cleanup function.
             return
         end

--- a/modules/era/lua_dynamis/globals/era_dynamis.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis.lua
@@ -218,6 +218,7 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
     --     {
     --         NO_LONGER_HAVE_CLEARANCE = 7061,
     --     },
+    --     entryZone = -- for tracking/setting cooldown for cleanup script
     -- },
 
     [xi.zone.DYNAMIS_BASTOK] = -- zoneID for array lookup
@@ -226,6 +227,7 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
         {
             NO_LONGER_HAVE_CLEARANCE = 7064,
         },
+        entryZone = xi.zone.BASTOK_MINES,
     },
 
     [xi.zone.DYNAMIS_BEAUCEDINE] = -- zoneID for array lookup
@@ -234,6 +236,7 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
         {
             NO_LONGER_HAVE_CLEARANCE = 7164,
         },
+        entryZone = xi.zone.BEAUCEDINE_GLACIER,
     },
     [xi.zone.DYNAMIS_BUBURIMU] = -- zoneID for array lookup
     {
@@ -241,6 +244,7 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
         {
             NO_LONGER_HAVE_CLEARANCE = 7323,
         },
+        entryZone = xi.zone.BUBURIMU_PENINSULA,
     },
     [xi.zone.DYNAMIS_JEUNO] = -- zoneID for array lookup
     {
@@ -248,6 +252,7 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
         {
             NO_LONGER_HAVE_CLEARANCE = 7064,
         },
+        entryZone = xi.zone.RULUDE_GARDENS,
     },
     [xi.zone.DYNAMIS_QUFIM] = -- zoneID for array lookup
     {
@@ -255,6 +260,7 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
         {
             NO_LONGER_HAVE_CLEARANCE = 7323,
         },
+        entryZone = xi.zone.QUFIM_ISLAND,
     },
     [xi.zone.DYNAMIS_SAN_DORIA] = -- zoneID for array lookup
     {
@@ -262,6 +268,7 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
         {
             NO_LONGER_HAVE_CLEARANCE = 7064,
         },
+        entryZone = xi.zone.SOUTHERN_SAN_DORIA,
     },
     [xi.zone.DYNAMIS_TAVNAZIA] = -- zoneID for array lookup
     {
@@ -269,6 +276,7 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
         {
             NO_LONGER_HAVE_CLEARANCE = 7323,
         },
+        entryZone = xi.zone.TAVNAZIAN_SAFEHOLD,
     },
     [xi.zone.DYNAMIS_VALKURM] = -- zoneID for array lookup
     {
@@ -276,6 +284,7 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
         {
             NO_LONGER_HAVE_CLEARANCE = 7323,
         },
+        entryZone = xi.zone.VALKURM_DUNES,
     },
     [xi.zone.DYNAMIS_WINDURST] = -- zoneID for array lookup
     {
@@ -287,7 +296,8 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
         {
             xi.dynamis.YING,
             xi.dynamis.YANG,
-        }
+        },
+        entryZone = xi.zone.WINDURST_WALLS,
     },
     [xi.zone.DYNAMIS_XARCABARD] = -- zoneID for array lookup
     {
@@ -295,6 +305,7 @@ xi.dynamis.dynaIDLookup = -- Used to check for different IDs based on zoneID. Re
         {
             NO_LONGER_HAVE_CLEARANCE = 7064,
         },
+        entryZone = xi.zone.XARCABARD,
     },
 }
 
@@ -941,6 +952,12 @@ xi.dynamis.handleDynamis = function(zone)
         end
 
         if zoneExpireRoutine ~= 0 and zoneExpireRoutine <= os.time() then -- Checks to see if 30s passed between start and now.
+            if
+                GetServerVariable(string.format("[DYNA]ZoneCooldown_%s", xi.dynamis.dynaIDLookup[zoneID].entryZone)) == 0 -- if no cleanup timer is set
+            then
+                SetServerVariable(string.format("[DYNA]ZoneCooldown_%s", xi.dynamis.dynaIDLookup[zoneID].entryZone), os.time() + 90) -- Set a 90s timer for cleanup
+            end
+
             xi.dynamis.cleanupDynamis(zone) -- Runs cleanup function.
         end
     end
@@ -971,7 +988,13 @@ xi.dynamis.handleDynamis = function(zone)
 
     if zone:getLocalVar(string.format("[DYNA]NoPlayersInZone_%s", zoneID)) ~= 0 then
         if zone:getLocalVar(string.format("[DYNA]NoPlayersInZone_%s", zoneID)) <= os.time() then -- If cooldown period eclipses current OS time, cleanup.
-            xi.dynamis.cleanupDynamis(zone)
+            if
+                GetServerVariable(string.format("[DYNA]ZoneCooldown_%s", xi.dynamis.dynaIDLookup[zoneID].entryZone)) == 0 -- if no cleanup timer is set
+            then
+                SetServerVariable(string.format("[DYNA]ZoneCooldown_%s", xi.dynamis.dynaIDLookup[zoneID].entryZone), os.time() + 90) -- Set a 90s timer for cleanup
+            end
+            
+            xi.dynamis.cleanupDynamis(zone) -- Runs cleanup function.
             return
         end
     end
@@ -1356,7 +1379,10 @@ xi.dynamis.entryNpcOnTrade = function(player, npc, trade)
             local span = os.time() - playerRes
             span = span / 60
             player:messageSpecial(zones[zoneID].text.YOU_CANNOT_ENTER_DYNAMIS, math.ceil(span), xi.dynamis.entryInfoEra[zoneID].csBit)
+        elseif GetServerVariable(string.format("[DYNA]ZoneCooldown_%s", zoneID)) > os.time() then
+            player:messageSpecial(xi.dynamis.dynaIDLookup[zoneID].text.ANOTHER_GROUP, xi.dynamis.entryInfoEra[zoneID].csBit)
         else -- Proceed in starting new dynamis.
+            SetServerVariable(string.format("[DYNA]ZoneCooldown_%s", zoneID), 0)
             player:startEvent(xi.dynamis.entryInfoEra[zoneID].csRegisterGlass, xi.dynamis.entryInfoEra[zoneID].csBit, entered == 1 and 0 or 1, dynamisReservationCancel, dynamisReentryDays, xi.dynamis.entryInfoEra[zoneID].maxCapacity, xi.ki.VIAL_OF_SHROUDED_SAND, dynamisTimelessHourglass, dynamisPerpetual)
         end
     elseif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Added a 90s cooldown to dynamis zones before a new hourglass can be traded to allow for the zone to be reset properly. (Beasty)

## What does this pull request do? (Please be technical)
Adds a 90s timer to dynamis right before the cleanup script is run to allow for the cleanup to complete entirely before a new hourglass is traded.  This is done to prevent players from entering dynamis while the cleanup is still being performed.

The 90s cooldown is to allow for 30s from the unauthorized message to appear and transport the existing group outside, followed by 60s to allow the script to finish before starting up again.
Players that trade an hourglass during this cleanup period will receive a message stating that another group is still occupying the zone.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
1 - `!additem timeless_hourglass`
2 - Enter any dynamis zone
3 - Expire the zone: `!adddynatime bastok -60`
4 - Wait 30s for the character to get removed
5 - `!additem timeless_hourglass`
6 - Attempt to trade the new hourglass to the markings within 60s
7 - Receive a message about the zone still being in use
8 - After 60s has passed, trade the hourglass and the cleanup lockout will have been removed.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->

This can be applied as a hotfix.