### PR TITLE
Convert a few ENMs to Interaction Framework

### DIFF
--- a/scripts/battlefields/Chamber_of_Oracles/cactuar_suave.lua
+++ b/scripts/battlefields/Chamber_of_Oracles/cactuar_suave.lua
@@ -1,0 +1,81 @@
+-----------------------------------
+-- Cactuar Suave
+-- Chamber of Oracles KSNM30, Clotho Orb
+-- !additem 1175
+-----------------------------------
+local chamberOfOraclesID = zones[xi.zone.CHAMBER_OF_ORACLES]
+-----------------------------------
+
+local content = Battlefield:new({
+    zoneId           = xi.zone.CHAMBER_OF_ORACLES,
+    battlefieldId    = xi.battlefield.id.CACTUAR_SUAVE,
+    maxPlayers       = 6,
+    timeLimit        = utils.minutes(30),
+    index            = 5,
+    entryNpc         = 'SC_Entrance',
+    exitNpc          = 'Shimmering_Circle',
+    requiredItems    = { xi.item.CLOTHO_ORB, wearMessage = chamberOfOraclesID.text.A_CRACK_HAS_FORMED, wornMessage = chamberOfOraclesID.text.ORB_IS_CRACKED },
+    armouryCrates    =
+    {
+        chamberOfOraclesID.mob.SECUTOR_XI_XXXII + 4,
+        chamberOfOraclesID.mob.SECUTOR_XI_XXXII + 9,
+        chamberOfOraclesID.mob.SECUTOR_XI_XXXII + 14,
+    },
+})
+
+content:addEssentialMobs({ 'Sabotender_Campeon', 'Sabotender_Amante' })
+
+content.loot =
+{
+    {
+        { item = 916,  weight = 700 }, -- Cactuar Needle
+        { item = 1236, weight = 250 }, -- Cactus Stems
+        { item = 1592, weight =  50 }, -- Cactuar Root
+    },
+    {
+        { item = 15152, weight = 250 }, -- Cactuar Ribbon
+        { item = 17577, weight = 250 }, -- Capricorn staff
+        { item = 17997, weight = 250 }, -- Argent Dagger
+        { item = 18372, weight = 250 }, -- Balan's Sword
+    },
+    {
+        { item = 17246, weight = 200 }, -- Ziska's Crossbow
+        { item = 17825, weight = 200 }, -- Honebami
+        { item = 17790, weight = 200 }, -- Unji
+        { item = 17999, weight = 200 }, -- Taillefer's Dagger
+        { item = 18089, weight = 200 }, -- Schiltron Spear
+    },
+    {
+        { item = 644,  weight = 50 }, -- Chunk Of Mythril Ore
+        { item = 645,  weight = 50 }, -- Chunk Of Darksteel Ore
+        { item = 700,  weight = 50 }, -- Mahogany Log
+        { item = 702,  weight = 50 }, -- Ebony Log
+        { item = 703,  weight = 50 }, -- Petrified Log
+        { item = 823,  weight = 50 }, -- Spool Of Gold Thread
+        { item = 830,  weight = 50 }, -- Square Of Rainbow Cloth
+        { item = 844,  weight = 50 }, -- Phoenix Feather
+        { item = 866,  weight = 50 }, -- Handful Of Wyvern Scales
+        { item = 887,  weight = 50 }, -- Coral Fragment
+        { item = 895,  weight = 50 }, -- Ram Horn
+        { item = 902,  weight = 50 }, -- Demon Horn
+        { item = 942,  weight = 50 }, -- Philosophers Stone
+        { item = 1465, weight = 50 }, -- Slab Of Granite
+        { item = 1132, weight = 50 }, -- Square Of Raxa
+        { item = 4174, weight = 50 }, -- Vile Elixir
+        { item = 4175, weight = 50 }, -- Vile Elixir +1
+        { item = 4613, weight = 50 }, -- Cure V
+        { item = 4659, weight = 50 }, -- Shell IV
+        { item = 4774, weight = 50 }, -- Thunder III
+    },
+    {
+        { item = 0,    weight = 250 }, -- Nothing
+        { item = 658,  weight = 100 }, -- Damascus Ingot
+        { item = 836,  weight = 150 }, -- Square Of Damascene Cloth
+        { item = 837,  weight = 100 }, -- Spool Of Malboro Fiber
+        { item = 942,  weight = 100 }, -- Philosophers Stone
+        { item = 844,  weight =  50 }, -- Phoenix Feather
+        { item = 1132, weight = 250 }, -- Square Of Raxa
+    },
+}
+
+return content:register()

--- a/scripts/battlefields/Chamber_of_Oracles/the_scarlet_king.lua
+++ b/scripts/battlefields/Chamber_of_Oracles/the_scarlet_king.lua
@@ -1,0 +1,85 @@
+-----------------------------------
+-- The Scarlet King
+-- Chamber of Oracles KSNM30, Atropos Orb
+-- !additem 1175
+-----------------------------------
+local chamberOfOraclesID = zones[xi.zone.CHAMBER_OF_ORACLES]
+-----------------------------------
+
+local content = Battlefield:new({
+    zoneId           = xi.zone.CHAMBER_OF_ORACLES,
+    battlefieldId    = xi.battlefield.id.SCARLET_KING,
+    maxPlayers       = 6,
+    timeLimit        = utils.minutes(30),
+    index            = 7,
+    entryNpc         = 'SC_Entrance',
+    exitNpc          = 'Shimmering_Circle',
+    requiredItems    = { xi.item.ATROPOS_ORB, wearMessage = chamberOfOraclesID.text.A_CRACK_HAS_FORMED, wornMessage = chamberOfOraclesID.text.ORB_IS_CRACKED },
+    armouryCrates    =
+    {
+        chamberOfOraclesID.mob.SECUTOR_XI_XXXII + 4,
+        chamberOfOraclesID.mob.SECUTOR_XI_XXXII + 9,
+        chamberOfOraclesID.mob.SECUTOR_XI_XXXII + 14,
+    },
+})
+
+content:addEssentialMobs({ 'Purson' })
+
+content.loot =
+{
+    {
+        { item = 1116, weight = 1000 }, -- Manticore Hair
+    },
+    {
+        { item = 1163, weight = 1000 }, -- Manticore Hide
+    },
+    {
+        { item = 1110,  weight = 200 }, -- Beetle Blood
+        { item = 17579, weight = 200 }, -- WWyvern Perch
+        { item = 17825, weight = 200 }, -- Honebami
+        { item = 17997, weight = 200 }, -- Argent Dagger
+        { item = 17998, weight = 200 }, -- Thanatos Baselard
+    },
+    {
+        { item = 4659,  weight = 250 }, -- Shell IV
+        { item = 17577, weight = 150 }, -- Capricorn Staff
+        { item = 17938, weight = 150 }, -- Woodville's Axe
+        { item = 18048, weight = 150 }, -- King Maker
+        { item = 18211, weight = 150 }, -- Gawain's Axe
+        { item = 18372, weight = 150 }, -- Balan's Sword
+    },
+    {
+        { item =  4174,  weight = 350 }, -- Vile Elixir
+        { item =  4175,  weight = 100 }, -- Vile Elixir +1
+        { item =  4613,  weight = 100 }, -- Cure V
+        { item = 19025,  weight = 250 }, -- Pole Grip
+        { item = 19026,  weight = 100 }, -- Spear Strap
+        { item = 19027,  weight = 100 }, -- Claymore Grip
+    },
+    {
+        { item = 645,  weight =  50 }, -- Chunk Of Darksteel Ore
+        { item = 646,  weight =  50 }, -- Chunk Of Adaman Ore
+        { item = 700,  weight = 100 }, -- Mahogany Log
+        { item = 703,  weight = 100 }, -- Petrified Log
+        { item = 738,  weight =  50 }, -- Chunk Of Platinum Ore
+        { item = 739,  weight =  50 }, -- Chunk Of Orichalcum Ore
+        { item = 745,  weight =  25 }, -- Gold Ingot
+        { item = 746,  weight =  50 }, -- Chunk Of Gold Ore
+        { item = 830,  weight =  25 }, -- Square Of Rainbow Cloth
+        { item = 844,  weight = 100 }, -- Phoenix Feather
+        { item = 1132, weight = 100 }, -- Square Of Raxa
+        { item = 4172, weight = 100 }, -- Reraiser
+        { item = 4173, weight =  50 }, -- Hi-reraiser
+        { item = 4774, weight = 150 }, -- Thunder III
+    },
+    {
+        { item = 0,    weight = 650 }, -- Nothing
+        { item = 658,  weight = 100 }, -- Damascus Ingot
+        { item = 836,  weight =  50 }, -- Square Of Damascene Cloth
+        { item = 837,  weight =  50 }, -- Spool Of Malboro Fiber
+        { item = 942,  weight =  50 }, -- Philosophers Stone
+        { item = 1132, weight = 100 }, -- Square Of Raxa
+    }
+}
+
+return content:register()

--- a/scripts/battlefields/Mine_Shaft_2716/bionic_bug.lua
+++ b/scripts/battlefields/Mine_Shaft_2716/bionic_bug.lua
@@ -1,0 +1,52 @@
+-----------------------------------
+-- Bionic Bug
+-- Mine Shaft #2716 battlefield
+-----------------------------------
+local ID = zones[xi.zone.MINE_SHAFT_2716]
+-----------------------------------
+
+local content = Battlefield:new({
+    zoneId           = xi.zone.MINE_SHAFT_2716,
+    battlefieldId    = xi.battlefield.id.BIONIC_BUG,
+    maxPlayers       = 18,
+    levelCap         = 75,
+    timeLimit        = utils.minutes(30),
+    index            = 2,
+    entryNpc         = '_0d0',
+    exitNpc          = { '_0d1', '_0d2', '_0d3' }, -- copied from existing mine shaft 2716 battlefield
+    requiredKeyItems = { xi.ki.SHAFT_2716_OPERATING_LEVER, message = ID.text.THE_PARTY_WILL_BE_REMOVED + 8 },
+    experimental     = true,
+})
+
+content:addEssentialMobs({ 'Bugboy' })
+
+content.loot =
+{
+    {
+        {item =    0, weight = 900}, -- Nothing
+        {item = 1842, weight = 100}, -- Cloud Evoker
+    },
+    {
+        {item = 1767, weight = 333}, -- Eltoro Leather
+        {item = 1762, weight = 333}, -- Cassia Lumber
+        {item = 1771, weight = 334}, -- Dragon Bone
+    },
+    {
+        {item =     0, weight = 625}, -- nothing
+        {item = 18009, weight =  75}, -- Martial Knife
+        {item = 18056, weight =  75}, -- Martial Scythe
+        {item = 13695, weight =  75}, -- Commander's Cape
+        {item = 15195, weight = 100}, -- Faerie Hairpin
+        {item =  4748, weight =  50}, -- Raise III
+    },
+    {
+        {item =     0, weight = 625}, -- nothing
+        {item = 18009, weight =  75}, -- Martial Knife
+        {item = 18056, weight =  75}, -- Martial Scythe
+        {item = 13695, weight =  75}, -- Commander's Cape
+        {item = 15195, weight = 100}, -- Faerie Hairpin
+        {item =  4748, weight =  50}, -- Raise III
+    },
+}
+
+return content:register()

--- a/scripts/battlefields/Mine_Shaft_2716/bionic_bug.lua
+++ b/scripts/battlefields/Mine_Shaft_2716/bionic_bug.lua
@@ -13,7 +13,7 @@ local content = Battlefield:new({
     timeLimit        = utils.minutes(30),
     index            = 2,
     entryNpc         = '_0d0',
-    exitNpc          = { '_0d1', '_0d2', '_0d3' }, -- copied from existing mine shaft 2716 battlefield
+    exitNpc          = { '_0d1', '_0d2', '_0d3'  }, -- copied from existing mine shaft 2716 battlefield
     requiredKeyItems = { xi.ki.SHAFT_2716_OPERATING_LEVER, message = ID.text.THE_PARTY_WILL_BE_REMOVED + 8 },
     experimental     = true,
 })
@@ -23,29 +23,29 @@ content:addEssentialMobs({ 'Bugboy' })
 content.loot =
 {
     {
-        {item =    0, weight = 900}, -- Nothing
-        {item = 1842, weight = 100}, -- Cloud Evoker
+        { item =    0, weight = 900 }, -- Nothing
+        { item = 1842, weight = 100 }, -- Cloud Evoker
     },
     {
-        {item = 1767, weight = 333}, -- Eltoro Leather
-        {item = 1762, weight = 333}, -- Cassia Lumber
-        {item = 1771, weight = 334}, -- Dragon Bone
+        { item = 1767, weight = 333 }, -- Eltoro Leather
+        { item = 1762, weight = 333 }, -- Cassia Lumber
+        { item = 1771, weight = 334 }, -- Dragon Bone
     },
     {
-        {item =     0, weight = 625}, -- nothing
-        {item = 18009, weight =  75}, -- Martial Knife
-        {item = 18056, weight =  75}, -- Martial Scythe
-        {item = 13695, weight =  75}, -- Commander's Cape
-        {item = 15195, weight = 100}, -- Faerie Hairpin
-        {item =  4748, weight =  50}, -- Raise III
+        { item =     0, weight = 625 }, -- nothing
+        { item = 18009, weight =  75 }, -- Martial Knife
+        { item = 18056, weight =  75 }, -- Martial Scythe
+        { item = 13695, weight =  75 }, -- Commander's Cape
+        { item = 15195, weight = 100 }, -- Faerie Hairpin
+        { item =  4748, weight =  50 }, -- Raise III
     },
     {
-        {item =     0, weight = 625}, -- nothing
-        {item = 18009, weight =  75}, -- Martial Knife
-        {item = 18056, weight =  75}, -- Martial Scythe
-        {item = 13695, weight =  75}, -- Commander's Cape
-        {item = 15195, weight = 100}, -- Faerie Hairpin
-        {item =  4748, weight =  50}, -- Raise III
+        { item =     0, weight = 625 }, -- nothing
+        { item = 18009, weight =  75 }, -- Martial Knife
+        { item = 18056, weight =  75 }, -- Martial Scythe
+        { item = 13695, weight =  75 }, -- Commander's Cape
+        { item = 15195, weight = 100 }, -- Faerie Hairpin
+        { item =  4748, weight =  50 }, -- Raise III
     },
 }
 

--- a/scripts/battlefields/Mine_Shaft_2716/pulling_the_strings.lua
+++ b/scripts/battlefields/Mine_Shaft_2716/pulling_the_strings.lua
@@ -1,0 +1,72 @@
+-----------------------------------
+-- Pulling the Strings
+-- Mine Shaft #2716 battlefield
+-----------------------------------
+local ID = zones[xi.zone.MINE_SHAFT_2716]
+-----------------------------------
+
+local content = Battlefield:new({
+    zoneId           = xi.zone.MINE_SHAFT_2716,
+    battlefieldId    = xi.battlefield.id.PULLING_THE_STRINGS,
+    maxPlayers       = 1,
+    levelCap         = 60,
+    allowSubjob      = false,
+    timeLimit        = utils.minutes(15),
+    index            = 3,
+    grantXP          = 2000,
+    entryNpc         = '_0d0',
+    exitNpc          = { '_0d1', '_0d2', '_0d3' }, -- copied from existing mine shaft 2716 battlefield
+    requiredKeyItems = { xi.ki.SHAFT_GATE_OPERATING_DIAL, message = ID.text.THE_PARTY_WILL_BE_REMOVED + 8 },
+    experimental     = false,
+})
+
+function content:checkRequirements(player, npc, registrant, trade)
+    for i = xi.job.WAR, xi.job.PUP do
+        if player:getMainJob() == i then
+            return true
+        end
+    end
+end
+
+content:addEssentialMobs({ 'Fantoccini' })
+
+content.groups =
+{
+    {
+        mobs = { 'Moblin_Fantocciniman' },
+        stationary = true,
+        superlink = true,
+    },
+    {
+        mobs = { 'Fantoccini_Monster' },
+        spawned = false,
+        superlink = true,
+    },
+    {
+        mobs = { 'Fantoccini_Wyvern' },
+        spawned = false,
+        superlink = true,
+    },
+    {
+        mobs = { 'Fantoccini_Avatar' },
+        spawned = false,
+        superlink = true,
+    },
+    {
+        mobs = { 'Fantoccini_Puppet' },
+        spawned = false,
+        superlink = true,
+    },
+    {
+        mobs = { 'Fantoccini_Automaton' },
+        spawned = false,
+        superlink = true,
+    },
+    {
+        mobs = { 'Fantoccini' },
+        superlink = true,
+        death = utils.bind(content.handleAllMonstersDefeated, content),
+    },
+}
+
+return content:register()

--- a/scripts/battlefields/Spire_of_Dem/you_are_what_you_eat.lua
+++ b/scripts/battlefields/Spire_of_Dem/you_are_what_you_eat.lua
@@ -1,0 +1,115 @@
+-----------------------------------
+-- ENM: You Are What You Eat
+-- Spire of Dem
+-----------------------------------
+require('scripts/missions/cop/helpers')
+local spireOfDemID = zones[xi.zone.SPIRE_OF_DEM]
+-----------------------------------
+
+local content = Battlefield:new({
+    zoneId        = xi.zone.SPIRE_OF_DEM,
+    battlefieldId = xi.battlefield.id.YOU_ARE_WHAT_YOU_EAT,
+    isMission     = true,
+    maxPlayers    = 18,
+    levelCap      = 30,
+    timeLimit     = utils.minutes(30),
+    index         = 1,
+    entryNpc      = '_0j0',
+    exitNpcs      = { '_0j1', '_0j2', '_0j3' },
+    requiredKeyItems = { xi.ki.CENSER_OF_ANTIPATHY, message = spireOfDemID.text.THE_PARTY_WILL_BE_REMOVED + 8 },
+    grantXP = 1500,
+    armouryCrates    =
+    {
+        spireOfDemID.mob.PROGENERATOR + 20,
+        spireOfDemID.mob.PROGENERATOR + 26,
+        spireOfDemID.mob.PROGENERATOR + 32,
+    },
+})
+
+function content:entryRequirement(player, npc, isRegistrant, trade)
+    local currentRequirements = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
+    return currentRequirements
+end
+
+function content:checkSkipCutscene(player)
+    return player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
+end
+
+content:addEssentialMobs({ 'Ingester'})
+
+content.groups =
+{
+    {
+        mobs = { 'Ingester' },
+        superlink = true,
+        spawned = true,
+        death = utils.bind(content.handleAllMonstersDefeated, content),
+    },
+    {
+        mobs = { 'Neosatiator' },
+        superlink = true,
+        spawned = false,
+    },
+    {
+        mobs = { 'Neogorger' },
+        superlink = true,
+        spawned = false,
+    },
+    {
+        mobs = { 'Neoingester' },
+        superlink = true,
+        spawned = false,
+    },
+    {
+        mobs = { 'Wanderer' },
+        superlink = true,
+        spawned = false,
+    },
+}
+
+content.loot =
+{
+    {
+        {item =    0, weight = 200}, -- Nothing
+        {item = 5287, weight = 100}, -- Bitter Cluster
+        {item = 5286, weight = 100}, -- Burning Cluster
+        {item = 5288, weight = 100}, -- Fleeting Cluster
+        {item = 5293, weight = 100}, -- Malevolent Cluster
+        {item = 5289, weight = 100}, -- Profane Cluster
+        {item = 5292, weight = 100}, -- Radiant Cluster
+        {item = 5291, weight = 100}, -- Somber Cluster
+        {item = 5290, weight = 100}, -- Startling Cluster
+    },
+    {
+        {item =    0, weight = 200}, -- Nothing
+        {item = 5287, weight = 100}, -- Bitter Cluster
+        {item = 5286, weight = 100}, -- Burning Cluster
+        {item = 5288, weight = 100}, -- Fleeting Cluster
+        {item = 5293, weight = 100}, -- Malevolent Cluster
+        {item = 5289, weight = 100}, -- Profane Cluster
+        {item = 5292, weight = 100}, -- Radiant Cluster
+        {item = 5291, weight = 100}, -- Somber Cluster
+        {item = 5290, weight = 100}, -- Startling Cluster
+    },
+    {
+        {item =    0, weight = 200}, -- Nothing
+        {item = 5287, weight = 100}, -- Bitter Cluster
+        {item = 5286, weight = 100}, -- Burning Cluster
+        {item = 5288, weight = 100}, -- Fleeting Cluster
+        {item = 5293, weight = 100}, -- Malevolent Cluster
+        {item = 5289, weight = 100}, -- Profane Cluster
+        {item = 5292, weight = 100}, -- Radiant Cluster
+        {item = 5291, weight = 100}, -- Somber Cluster
+        {item = 5290, weight = 100}, -- Startling Cluster
+    },
+    {
+        {item =    0, weight = 500}, -- Nothing
+        {item = 1800, weight = 100}, -- Violent Vision (Buckler Earring)
+        {item = 1803, weight = 100}, -- Painful Vision (Dark Earring)
+        {item = 1805, weight = 100}, -- Timorous Vision (Enfeebling Earring)
+        {item = 1808, weight = 100}, -- Brilliant Vision (Summoning earring)
+        {item = 1811, weight = 100}, -- Venerable Vision (String Earring)
+    },    
+}
+
+return content:register()

--- a/scripts/battlefields/Spire_of_Dem/you_are_what_you_eat.lua
+++ b/scripts/battlefields/Spire_of_Dem/you_are_what_you_eat.lua
@@ -9,7 +9,6 @@ local spireOfDemID = zones[xi.zone.SPIRE_OF_DEM]
 local content = Battlefield:new({
     zoneId        = xi.zone.SPIRE_OF_DEM,
     battlefieldId = xi.battlefield.id.YOU_ARE_WHAT_YOU_EAT,
-    isMission     = true,
     maxPlayers    = 18,
     levelCap      = 30,
     timeLimit     = utils.minutes(30),
@@ -18,7 +17,7 @@ local content = Battlefield:new({
     exitNpcs      = { '_0j1', '_0j2', '_0j3' },
     requiredKeyItems = { xi.ki.CENSER_OF_ANTIPATHY, message = spireOfDemID.text.THE_PARTY_WILL_BE_REMOVED + 8 },
     grantXP = 1500,
-    armouryCrates    =
+    armouryCrates =
     {
         spireOfDemID.mob.PROGENERATOR + 20,
         spireOfDemID.mob.PROGENERATOR + 26,
@@ -27,7 +26,7 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    local currentRequirements = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
+    local currentRequirements = not player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
     return currentRequirements
 end
 
@@ -35,7 +34,7 @@ function content:checkSkipCutscene(player)
     return player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
 end
 
-content:addEssentialMobs({ 'Ingester'})
+content:addEssentialMobs({ 'Ingester' })
 
 content.groups =
 {
@@ -70,46 +69,46 @@ content.groups =
 content.loot =
 {
     {
-        {item =    0, weight = 200}, -- Nothing
-        {item = 5287, weight = 100}, -- Bitter Cluster
-        {item = 5286, weight = 100}, -- Burning Cluster
-        {item = 5288, weight = 100}, -- Fleeting Cluster
-        {item = 5293, weight = 100}, -- Malevolent Cluster
-        {item = 5289, weight = 100}, -- Profane Cluster
-        {item = 5292, weight = 100}, -- Radiant Cluster
-        {item = 5291, weight = 100}, -- Somber Cluster
-        {item = 5290, weight = 100}, -- Startling Cluster
+        { item =    0, weight = 200 }, -- Nothing
+        { item = 5287, weight = 100 }, -- Bitter Cluster
+        { item = 5286, weight = 100 }, -- Burning Cluster
+        { item = 5288, weight = 100 }, -- Fleeting Cluster
+        { item = 5293, weight = 100 }, -- Malevolent Cluster
+        { item = 5289, weight = 100 }, -- Profane Cluster
+        { item = 5292, weight = 100 }, -- Radiant Cluster
+        { item = 5291, weight = 100 }, -- Somber Cluster
+        { item = 5290, weight = 100 }, -- Startling Cluster
     },
     {
-        {item =    0, weight = 200}, -- Nothing
-        {item = 5287, weight = 100}, -- Bitter Cluster
-        {item = 5286, weight = 100}, -- Burning Cluster
-        {item = 5288, weight = 100}, -- Fleeting Cluster
-        {item = 5293, weight = 100}, -- Malevolent Cluster
-        {item = 5289, weight = 100}, -- Profane Cluster
-        {item = 5292, weight = 100}, -- Radiant Cluster
-        {item = 5291, weight = 100}, -- Somber Cluster
-        {item = 5290, weight = 100}, -- Startling Cluster
+        { item =    0, weight = 200 }, -- Nothing
+        { item = 5287, weight = 100 }, -- Bitter Cluster
+        { item = 5286, weight = 100 }, -- Burning Cluster
+        { item = 5288, weight = 100 }, -- Fleeting Cluster
+        { item = 5293, weight = 100 }, -- Malevolent Cluster
+        { item = 5289, weight = 100 }, -- Profane Cluster
+        { item = 5292, weight = 100 }, -- Radiant Cluster
+        { item = 5291, weight = 100 }, -- Somber Cluster
+        { item = 5290, weight = 100 }, -- Startling Cluster
     },
     {
-        {item =    0, weight = 200}, -- Nothing
-        {item = 5287, weight = 100}, -- Bitter Cluster
-        {item = 5286, weight = 100}, -- Burning Cluster
-        {item = 5288, weight = 100}, -- Fleeting Cluster
-        {item = 5293, weight = 100}, -- Malevolent Cluster
-        {item = 5289, weight = 100}, -- Profane Cluster
-        {item = 5292, weight = 100}, -- Radiant Cluster
-        {item = 5291, weight = 100}, -- Somber Cluster
-        {item = 5290, weight = 100}, -- Startling Cluster
+        { item =    0, weight = 200 }, -- Nothing
+        { item = 5287, weight = 100 }, -- Bitter Cluster
+        { item = 5286, weight = 100 }, -- Burning Cluster
+        { item = 5288, weight = 100 }, -- Fleeting Cluster
+        { item = 5293, weight = 100 }, -- Malevolent Cluster
+        { item = 5289, weight = 100 }, -- Profane Cluster
+        { item = 5292, weight = 100 }, -- Radiant Cluster
+        { item = 5291, weight = 100 }, -- Somber Cluster
+        { item = 5290, weight = 100 }, -- Startling Cluster
     },
     {
-        {item =    0, weight = 500}, -- Nothing
-        {item = 1800, weight = 100}, -- Violent Vision (Buckler Earring)
-        {item = 1803, weight = 100}, -- Painful Vision (Dark Earring)
-        {item = 1805, weight = 100}, -- Timorous Vision (Enfeebling Earring)
-        {item = 1808, weight = 100}, -- Brilliant Vision (Summoning earring)
-        {item = 1811, weight = 100}, -- Venerable Vision (String Earring)
-    },    
+        { item =    0, weight = 500 }, -- Nothing
+        { item = 1800, weight = 100 }, -- Violent Vision (Buckler Earring)
+        { item = 1803, weight = 100 }, -- Painful Vision (Dark Earring)
+        { item = 1805, weight = 100 }, -- Timorous Vision (Enfeebling Earring)
+        { item = 1808, weight = 100 }, -- Brilliant Vision (Summoning earring)
+        { item = 1811, weight = 100 }, -- Venerable Vision (String Earring)
+    },
 }
 
 return content:register()

--- a/scripts/battlefields/Spire_of_Holla/simulant.lua
+++ b/scripts/battlefields/Spire_of_Holla/simulant.lua
@@ -1,0 +1,100 @@
+-----------------------------------
+-- ENM: Simulant
+-- Spire of Holla
+-----------------------------------
+require('scripts/missions/cop/helpers')
+local spireOfDemID = zones[xi.zone.SPIRE_OF_HOLLA]
+-----------------------------------
+
+local content = Battlefield:new({
+    zoneId        = xi.zone.SPIRE_OF_HOLLA,
+    battlefieldId = xi.battlefield.id.SIMULANT,
+    isMission     = true,
+    maxPlayers    = 18,
+    levelCap      = 30,
+    timeLimit     = utils.minutes(30),
+    index         = 1,
+    entryNpc      = '_0j0',
+    exitNpcs      = { '_0j1', '_0j2', '_0j3' },
+    requiredKeyItems = { xi.ki.CENSER_OF_ABANDONMENT, message = spireOfDemID.text.THE_PARTY_WILL_BE_REMOVED + 8 },
+    grantXP = 1500,
+    armouryCrates    =
+    {
+        spireOfDemID.mob.WREAKER + 7,
+        spireOfDemID.mob.WREAKER + 12,
+        spireOfDemID.mob.WREAKER + 17,
+    },
+})
+
+function content:entryRequirement(player, npc, isRegistrant, trade)
+    local currentRequirements = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
+    return currentRequirements
+end
+
+function content:checkSkipCutscene(player)
+    return player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
+end
+
+content:addEssentialMobs({ 'Cogitator' })
+
+content.groups =
+{
+    {
+        mobs = { 'Cogitator' },
+        superlink = true,
+        spawned = true,
+        death = utils.bind(content.handleAllMonstersDefeated, content),
+    },
+    {
+        mobs = { 'Weeper' },
+        superlink = true,
+        spawned = false,
+    },
+}
+
+content.loot =
+{
+    {
+        {item =    0, weight = 200}, -- Nothing
+        {item = 5287, weight = 100}, -- Bitter Cluster
+        {item = 5286, weight = 100}, -- Burning Cluster
+        {item = 5288, weight = 100}, -- Fleeting Cluster
+        {item = 5289, weight = 100}, -- Profane Cluster
+        {item = 5290, weight = 100}, -- Startling Cluster
+        {item = 5291, weight = 100}, -- Somber Cluster
+        {item = 5292, weight = 100}, -- Radiant Cluster
+        {item = 5293, weight = 100}, -- Malevolent Cluster
+    },
+    {
+        {item =    0, weight = 200}, -- Nothing
+        {item = 5287, weight = 100}, -- Bitter Cluster
+        {item = 5286, weight = 100}, -- Burning Cluster
+        {item = 5288, weight = 100}, -- Fleeting Cluster
+        {item = 5293, weight = 100}, -- Malevolent Cluster
+        {item = 5289, weight = 100}, -- Profane Cluster
+        {item = 5292, weight = 100}, -- Radiant Cluster
+        {item = 5291, weight = 100}, -- Somber Cluster
+        {item = 5290, weight = 100}, -- Startling Cluster
+    },
+    {
+        {item =    0, weight = 200}, -- Nothing
+        {item = 5287, weight = 100}, -- Bitter Cluster
+        {item = 5286, weight = 100}, -- Burning Cluster
+        {item = 5288, weight = 100}, -- Fleeting Cluster
+        {item = 5293, weight = 100}, -- Malevolent Cluster
+        {item = 5289, weight = 100}, -- Profane Cluster
+        {item = 5292, weight = 100}, -- Radiant Cluster
+        {item = 5291, weight = 100}, -- Somber Cluster
+        {item = 5290, weight = 100}, -- Startling Cluster
+    },
+    {
+        {item =    0, weight = 500}, -- Nothing
+        {item = 1798, weight = 100}, -- Vernal Vision (Evasion Earring)
+        {item = 1799, weight = 100}, -- Punctilious Vision (Parrying Earring)
+        {item = 1802, weight = 100}, -- Audacious Vision (Divine Earring)
+        {item = 1807, weight = 100}, -- Vivid Vision (Healing Earring)
+        {item = 1810, weight = 100}, -- Endearing Vision (Singing Earring)
+    },
+}
+
+return content:register()

--- a/scripts/battlefields/Spire_of_Holla/simulant.lua
+++ b/scripts/battlefields/Spire_of_Holla/simulant.lua
@@ -9,7 +9,6 @@ local spireOfDemID = zones[xi.zone.SPIRE_OF_HOLLA]
 local content = Battlefield:new({
     zoneId        = xi.zone.SPIRE_OF_HOLLA,
     battlefieldId = xi.battlefield.id.SIMULANT,
-    isMission     = true,
     maxPlayers    = 18,
     levelCap      = 30,
     timeLimit     = utils.minutes(30),
@@ -18,7 +17,7 @@ local content = Battlefield:new({
     exitNpcs      = { '_0j1', '_0j2', '_0j3' },
     requiredKeyItems = { xi.ki.CENSER_OF_ABANDONMENT, message = spireOfDemID.text.THE_PARTY_WILL_BE_REMOVED + 8 },
     grantXP = 1500,
-    armouryCrates    =
+    armouryCrates =
     {
         spireOfDemID.mob.WREAKER + 7,
         spireOfDemID.mob.WREAKER + 12,
@@ -27,7 +26,7 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    local currentRequirements = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
+    local currentRequirements = not player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
     return currentRequirements
 end
 
@@ -55,45 +54,45 @@ content.groups =
 content.loot =
 {
     {
-        {item =    0, weight = 200}, -- Nothing
-        {item = 5287, weight = 100}, -- Bitter Cluster
-        {item = 5286, weight = 100}, -- Burning Cluster
-        {item = 5288, weight = 100}, -- Fleeting Cluster
-        {item = 5289, weight = 100}, -- Profane Cluster
-        {item = 5290, weight = 100}, -- Startling Cluster
-        {item = 5291, weight = 100}, -- Somber Cluster
-        {item = 5292, weight = 100}, -- Radiant Cluster
-        {item = 5293, weight = 100}, -- Malevolent Cluster
+        { item =    0, weight = 200 }, --  Nothing
+        { item = 5287, weight = 100 }, --  Bitter Cluster
+        { item = 5286, weight = 100 }, --  Burning Cluster
+        { item = 5288, weight = 100 }, --  Fleeting Cluster
+        { item = 5289, weight = 100 }, --  Profane Cluster
+        { item = 5290, weight = 100 }, --  Startling Cluster
+        { item = 5291, weight = 100 }, --  Somber Cluster
+        { item = 5292, weight = 100 }, --  Radiant Cluster
+        { item = 5293, weight = 100 }, --  Malevolent Cluster
     },
     {
-        {item =    0, weight = 200}, -- Nothing
-        {item = 5287, weight = 100}, -- Bitter Cluster
-        {item = 5286, weight = 100}, -- Burning Cluster
-        {item = 5288, weight = 100}, -- Fleeting Cluster
-        {item = 5293, weight = 100}, -- Malevolent Cluster
-        {item = 5289, weight = 100}, -- Profane Cluster
-        {item = 5292, weight = 100}, -- Radiant Cluster
-        {item = 5291, weight = 100}, -- Somber Cluster
-        {item = 5290, weight = 100}, -- Startling Cluster
+        { item =    0, weight = 200 }, --  Nothing
+        { item = 5287, weight = 100 }, --  Bitter Cluster
+        { item = 5286, weight = 100 }, --  Burning Cluster
+        { item = 5288, weight = 100 }, --  Fleeting Cluster
+        { item = 5293, weight = 100 }, --  Malevolent Cluster
+        { item = 5289, weight = 100 }, --  Profane Cluster
+        { item = 5292, weight = 100 }, --  Radiant Cluster
+        { item = 5291, weight = 100 }, --  Somber Cluster
+        { item = 5290, weight = 100 }, --  Startling Cluster
     },
     {
-        {item =    0, weight = 200}, -- Nothing
-        {item = 5287, weight = 100}, -- Bitter Cluster
-        {item = 5286, weight = 100}, -- Burning Cluster
-        {item = 5288, weight = 100}, -- Fleeting Cluster
-        {item = 5293, weight = 100}, -- Malevolent Cluster
-        {item = 5289, weight = 100}, -- Profane Cluster
-        {item = 5292, weight = 100}, -- Radiant Cluster
-        {item = 5291, weight = 100}, -- Somber Cluster
-        {item = 5290, weight = 100}, -- Startling Cluster
+        { item =    0, weight = 200 }, --  Nothing
+        { item = 5287, weight = 100 }, --  Bitter Cluster
+        { item = 5286, weight = 100 }, --  Burning Cluster
+        { item = 5288, weight = 100 }, --  Fleeting Cluster
+        { item = 5293, weight = 100 }, --  Malevolent Cluster
+        { item = 5289, weight = 100 }, --  Profane Cluster
+        { item = 5292, weight = 100 }, --  Radiant Cluster
+        { item = 5291, weight = 100 }, --  Somber Cluster
+        { item = 5290, weight = 100 }, --  Startling Cluster
     },
     {
-        {item =    0, weight = 500}, -- Nothing
-        {item = 1798, weight = 100}, -- Vernal Vision (Evasion Earring)
-        {item = 1799, weight = 100}, -- Punctilious Vision (Parrying Earring)
-        {item = 1802, weight = 100}, -- Audacious Vision (Divine Earring)
-        {item = 1807, weight = 100}, -- Vivid Vision (Healing Earring)
-        {item = 1810, weight = 100}, -- Endearing Vision (Singing Earring)
+        { item =    0, weight = 500 }, --  Nothing
+        { item = 1798, weight = 100 }, --  Vernal Vision (Evasion Earring)
+        { item = 1799, weight = 100 }, --  Punctilious Vision (Parrying Earring)
+        { item = 1802, weight = 100 }, --  Audacious Vision (Divine Earring)
+        { item = 1807, weight = 100 }, --  Vivid Vision (Healing Earring)
+        { item = 1810, weight = 100 }, --  Endearing Vision (Singing Earring)
     },
 }
 

--- a/scripts/battlefields/Spire_of_Mea/playing_host.lua
+++ b/scripts/battlefields/Spire_of_Mea/playing_host.lua
@@ -1,0 +1,100 @@
+-----------------------------------
+-- ENM: Playing Host
+-- Spire of Mea
+-----------------------------------
+require('scripts/missions/cop/helpers')
+local spireOfMeaID = zones[xi.zone.SPIRE_OF_MEA]
+-----------------------------------
+
+local content = Battlefield:new({
+    zoneId        = xi.zone.SPIRE_OF_MEA,
+    battlefieldId = xi.battlefield.id.PLAYING_HOST,
+    isMission     = true,
+    maxPlayers    = 18,
+    levelCap      = 30,
+    timeLimit     = utils.minutes(30),
+    index         = 1,
+    entryNpc      = '_0j0',
+    exitNpcs      = { '_0j1', '_0j2', '_0j3' },
+    requiredKeyItems = { xi.ki.CENSER_OF_ANIMUS, message = spireOfMeaID.text.THE_PARTY_WILL_BE_REMOVED + 8 },
+    grantXP = 1500,
+    armouryCrates    =
+    {
+        spireOfMeaID.mob.DELVER + 7,
+        spireOfMeaID.mob.DELVER + 12,
+        spireOfMeaID.mob.DELVER + 17,
+    },
+})
+
+function content:entryRequirement(player, npc, isRegistrant, trade)
+    local currentRequirements = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
+    return currentRequirements
+end
+
+function content:checkSkipCutscene(player)
+    return player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
+end
+
+content:addEssentialMobs({ 'Envier' })
+
+content.groups =
+{
+    {
+        mobs = { 'Envier' },
+        superlink = true,
+        spawned = true,
+        death = utils.bind(content.handleAllMonstersDefeated, content),
+    },
+    {
+        mobs = { 'Seether' },
+        superlink = true,
+        spawned = false,
+    },
+}
+
+content.loot =
+{
+    {
+        {item =    0, weight = 200}, -- Nothing
+        {item = 5287, weight = 100}, -- Bitter Cluster
+        {item = 5286, weight = 100}, -- Burning Cluster
+        {item = 5288, weight = 100}, -- Fleeting Cluster
+        {item = 5293, weight = 100}, -- Malevolent Cluster
+        {item = 5289, weight = 100}, -- Profane Cluster
+        {item = 5292, weight = 100}, -- Radiant Cluster
+        {item = 5291, weight = 100}, -- Somber Cluster
+        {item = 5290, weight = 100}, -- Startling Cluster
+    },
+    {
+        {item =    0, weight = 200}, -- Nothing
+        {item = 5287, weight = 100}, -- Bitter Cluster
+        {item = 5286, weight = 100}, -- Burning Cluster
+        {item = 5288, weight = 100}, -- Fleeting Cluster
+        {item = 5293, weight = 100}, -- Malevolent Cluster
+        {item = 5289, weight = 100}, -- Profane Cluster
+        {item = 5292, weight = 100}, -- Radiant Cluster
+        {item = 5291, weight = 100}, -- Somber Cluster
+        {item = 5290, weight = 100}, -- Startling Cluster
+    },
+    {
+        {item =    0, weight = 200}, -- Nothing
+        {item = 5287, weight = 100}, -- Bitter Cluster
+        {item = 5286, weight = 100}, -- Burning Cluster
+        {item = 5288, weight = 100}, -- Fleeting Cluster
+        {item = 5293, weight = 100}, -- Malevolent Cluster
+        {item = 5289, weight = 100}, -- Profane Cluster
+        {item = 5292, weight = 100}, -- Radiant Cluster
+        {item = 5291, weight = 100}, -- Somber Cluster
+        {item = 5290, weight = 100}, -- Startling Cluster
+    },
+    {
+        {item =    0, weight = 500}, -- Nothing
+        {item = 1801, weight = 100}, -- Solemn Vision (Guarding Earring)
+        {item = 1804, weight = 100}, -- Valiant Vision (Augmenting Earring)
+        {item = 1806, weight = 100}, -- Pretentious Vision (Elemental Earring)
+        {item = 1809, weight = 100}, -- Malicious Vision (Ninjutsu Earring)
+        {item = 1812, weight = 100}, -- Pristine Vision (Wind Earring)
+    },    
+}
+
+return content:register()

--- a/scripts/battlefields/Spire_of_Mea/playing_host.lua
+++ b/scripts/battlefields/Spire_of_Mea/playing_host.lua
@@ -9,7 +9,6 @@ local spireOfMeaID = zones[xi.zone.SPIRE_OF_MEA]
 local content = Battlefield:new({
     zoneId        = xi.zone.SPIRE_OF_MEA,
     battlefieldId = xi.battlefield.id.PLAYING_HOST,
-    isMission     = true,
     maxPlayers    = 18,
     levelCap      = 30,
     timeLimit     = utils.minutes(30),
@@ -18,7 +17,7 @@ local content = Battlefield:new({
     exitNpcs      = { '_0j1', '_0j2', '_0j3' },
     requiredKeyItems = { xi.ki.CENSER_OF_ANIMUS, message = spireOfMeaID.text.THE_PARTY_WILL_BE_REMOVED + 8 },
     grantXP = 1500,
-    armouryCrates    =
+    armouryCrates =
     {
         spireOfMeaID.mob.DELVER + 7,
         spireOfMeaID.mob.DELVER + 12,
@@ -27,7 +26,7 @@ local content = Battlefield:new({
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    local currentRequirements = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
+    local currentRequirements = not player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS)
     return currentRequirements
 end
 
@@ -55,46 +54,46 @@ content.groups =
 content.loot =
 {
     {
-        {item =    0, weight = 200}, -- Nothing
-        {item = 5287, weight = 100}, -- Bitter Cluster
-        {item = 5286, weight = 100}, -- Burning Cluster
-        {item = 5288, weight = 100}, -- Fleeting Cluster
-        {item = 5293, weight = 100}, -- Malevolent Cluster
-        {item = 5289, weight = 100}, -- Profane Cluster
-        {item = 5292, weight = 100}, -- Radiant Cluster
-        {item = 5291, weight = 100}, -- Somber Cluster
-        {item = 5290, weight = 100}, -- Startling Cluster
+        { item =    0, weight = 200 }, -- Nothing
+        { item = 5287, weight = 100 }, -- Bitter Cluster
+        { item = 5286, weight = 100 }, -- Burning Cluster
+        { item = 5288, weight = 100 }, -- Fleeting Cluster
+        { item = 5293, weight = 100 }, -- Malevolent Cluster
+        { item = 5289, weight = 100 }, -- Profane Cluster
+        { item = 5292, weight = 100 }, -- Radiant Cluster
+        { item = 5291, weight = 100 }, -- Somber Cluster
+        { item = 5290, weight = 100 }, -- Startling Cluster
     },
     {
-        {item =    0, weight = 200}, -- Nothing
-        {item = 5287, weight = 100}, -- Bitter Cluster
-        {item = 5286, weight = 100}, -- Burning Cluster
-        {item = 5288, weight = 100}, -- Fleeting Cluster
-        {item = 5293, weight = 100}, -- Malevolent Cluster
-        {item = 5289, weight = 100}, -- Profane Cluster
-        {item = 5292, weight = 100}, -- Radiant Cluster
-        {item = 5291, weight = 100}, -- Somber Cluster
-        {item = 5290, weight = 100}, -- Startling Cluster
+        { item =    0, weight = 200 }, -- Nothing
+        { item = 5287, weight = 100 }, -- Bitter Cluster
+        { item = 5286, weight = 100 }, -- Burning Cluster
+        { item = 5288, weight = 100 }, -- Fleeting Cluster
+        { item = 5293, weight = 100 }, -- Malevolent Cluster
+        { item = 5289, weight = 100 }, -- Profane Cluster
+        { item = 5292, weight = 100 }, -- Radiant Cluster
+        { item = 5291, weight = 100 }, -- Somber Cluster
+        { item = 5290, weight = 100 }, -- Startling Cluster
     },
     {
-        {item =    0, weight = 200}, -- Nothing
-        {item = 5287, weight = 100}, -- Bitter Cluster
-        {item = 5286, weight = 100}, -- Burning Cluster
-        {item = 5288, weight = 100}, -- Fleeting Cluster
-        {item = 5293, weight = 100}, -- Malevolent Cluster
-        {item = 5289, weight = 100}, -- Profane Cluster
-        {item = 5292, weight = 100}, -- Radiant Cluster
-        {item = 5291, weight = 100}, -- Somber Cluster
-        {item = 5290, weight = 100}, -- Startling Cluster
+        { item =    0, weight = 200 }, -- Nothing
+        { item = 5287, weight = 100 }, -- Bitter Cluster
+        { item = 5286, weight = 100 }, -- Burning Cluster
+        { item = 5288, weight = 100 }, -- Fleeting Cluster
+        { item = 5293, weight = 100 }, -- Malevolent Cluster
+        { item = 5289, weight = 100 }, -- Profane Cluster
+        { item = 5292, weight = 100 }, -- Radiant Cluster
+        { item = 5291, weight = 100 }, -- Somber Cluster
+        { item = 5290, weight = 100 }, -- Startling Cluster
     },
     {
-        {item =    0, weight = 500}, -- Nothing
-        {item = 1801, weight = 100}, -- Solemn Vision (Guarding Earring)
-        {item = 1804, weight = 100}, -- Valiant Vision (Augmenting Earring)
-        {item = 1806, weight = 100}, -- Pretentious Vision (Elemental Earring)
-        {item = 1809, weight = 100}, -- Malicious Vision (Ninjutsu Earring)
-        {item = 1812, weight = 100}, -- Pristine Vision (Wind Earring)
-    },    
+        { item =    0, weight = 500 }, -- Nothing
+        { item = 1801, weight = 100 }, -- Solemn Vision (Guarding Earring)
+        { item = 1804, weight = 100 }, -- Valiant Vision (Augmenting Earring)
+        { item = 1806, weight = 100 }, -- Pretentious Vision (Elemental Earring)
+        { item = 1809, weight = 100 }, -- Malicious Vision (Ninjutsu Earring)
+        { item = 1812, weight = 100 }, -- Pristine Vision (Wind Earring)
+    },
 }
 
 return content:register()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description
There shouldn't really be any player facing announcements, as these ENM's should already be available on ASB (staging).

## What does this pull request do? (Please be technical)
_I cherry picked a few of your fights for my server in the past, and as upstream has been converting battlefields to use the Interaction Framework, i figured this presented an opportunity to contribute back to you and hopefully save you a little work._

I have the mob, skills, and sql modules as well, but I don't think you accept those in this repo. Happy to hand them over privately to whomever if you reach out.

Converts a few of your existing ENMs to use the Interaction Framework.
Please note that I did not include a loot table for 'Pulling the Strings'.
Something weird happens with the global handleLootRolls function for this battlefield, because the loot is indexed by job. I tried to consult with upstream for a solution, but sadly didn't get anywhere. In any case this will hopefully be a good starting point for you to build off of. We handle the loot for this battlefield using a custom util.

## Steps to test these changes
!togglegm
!zone Spire of Whatever, or Mine Shaft 2716 and trigger the Entry NPC

