### PR TITLE
Fix Diablos Shard and Valk Boss

### DIFF
--- a/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
+++ b/modules/era/lua_dynamis/globals/era_dynamis_spawning.lua
@@ -2145,6 +2145,7 @@ xi.dynamis.nmDynamicSpawn = function(mobIndex, oMobIndex, forceLink, zoneID, tar
             end },
 
             ["onMobWeaponSkill"] = { function(mobTarget, mob, skill)
+                xi.dynamis.onMobWeaponSkillDiabolosShard(mobTarget, mob, skill)
             end },
 
             ["onMobDeath"] = { function(mob, player, optParams)

--- a/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
@@ -401,15 +401,25 @@ end
 xi.dynamis.onSpawnDiabolosShard = function(mob)
     xi.dynamis.setMegaBossStats(mob)
     xi.dynamis.setDiabolosCommonTraits(mob)
+    mob:setLocalVar('usedTP', 0)  -- Set local var so we only use TP once
 end
 
 xi.dynamis.onMobFightDiabolosShard = function(mob, mobTarget)
-    --- if (distance(mobTarget, mob) < 5)
-    mob:useMobAbility(1903)
+    if -- If we havent used TP, and we have a target in range
+        mob:checkDistance(mobTarget) < mob:getAbilityDistance(1903) and
+        mob:getLocalVar('usedTP') == 0
+    then -- Use the TP Skill and then turn the flag on so we dont spam the WS
+        mob:useMobAbility(1903)
+        mob:setLocalVar('usedTP', 1)
+    end
 end
 
 xi.dynamis.onMobWeaponSkillDiabolosShard = function(target, mob, skill)
-    mob:setHP(0)
+    if mob:getLocalVar('usedTP') == 1 then -- If the WS flag was set
+        mob:queue(3000, function(mobArg)  -- Queue the action so it doesnt instantly despawn and interrupt the WS
+            mobArg:setHP(0) -- Kill off the add now that the WS has been used
+        end)
+    end
 end
 
 -- ToDo

--- a/modules/era/lua_dynamis/mobs/era_valkurm_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_valkurm_mobs.lua
@@ -143,7 +143,7 @@ xi.dynamis.onFightCirrate = function(mob, target)
     end
 
     if mob:getTP() >= 2000 and zone:getLocalVar("cirrate_tp") == 0 then
-        zone:getLocalVar("cirrate_tp", 1)
+        zone:setLocalVar("cirrate_tp", 1)
         for skill, chance in pairs(skills) do
             if rand <= itTotal + chance then
                 return mob:useMobAbility(skill)
@@ -159,14 +159,13 @@ end
 
 xi.dynamis.onWeaponskillPrepNantina = function(mob)
     local charm = math.random(1, 100)
+    print('inside ws prep | RNG: ' .. charm)
 
     if charm <= 10 then
         return 1619 -- Attractant
+    elseif mob:getHPP() > 25 then
+        return 1617
     else
-        if mob:getHPP() > 25 then
-            return 1617
-        else
-            return 1618
-        end
+        return 1618
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
Diablos Shards in Dynamis-Tavnazia will now properly despawn after using their TP.  (Beasty)
An issue with Cirrate Christelle in Dynamis-Valkurm was fixed and will now use TP slightly less often.  (Beasty)

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixed issue with mob onWeaponSkill was not triggered on Diablos Shards and added additional logic to ensure that they use their skill once before despawning.
Fixed a mob local var being improperly set on Dyna-Valk Boss that was allowing for TP moves to go off too often.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
1 - Enter Dynamis Valkurm
2 - Engage the boss
3 - Notice that the TP moves are not spammed, but only happening 3-5 seconds

1 - Enter Dynamis Tavnazia
2 - Aggro Umbral Diabolos until Diablos Club spawns
3 - Engage Diablos Club and take its HP down till it spawns the first add
4 - Notice that the add now properly despawns after using its TP
5 - Continue dropping Diablos Club HP until its summons another add
6 - Attempt to run away from the add
7 - Notice that the add now paths to the target and then uses the TP move before despawning.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
Can be Hotfixed