### PR TITLE
Out Of The Depths overflow fix

### DIFF
--- a/scripts/quests/bastok/Out_of_the_Depths.lua
+++ b/scripts/quests/bastok/Out_of_the_Depths.lua
@@ -16,6 +16,9 @@ local ID = require('scripts/zones/Bastok_Markets/IDs')
 -----------------------------------
 local quest = Quest:new(xi.quest.log_id.BASTOK, xi.quest.id.bastok.OUT_OF_THE_DEPTHS)
 
+local currentProg = quest:getVar(player, 'Prog')
+local maxProg = 6 --prevents repeatable aspects of quest from overflowing and blocking progression
+
 quest.reward =
 {
     fame = 80,
@@ -89,19 +92,27 @@ quest.sections =
                     if option == 1 then
                         npcUtil.giveCurrency(player, 'gil', 100)
                         player:delKeyItem(xi.ki.DUSTY_TOME)
-                        quest:setVar(player, 'Prog', quest:getVar(player, 'Prog') + 1)
+                        if currentProg < maxProg then
+                            quest:setVar(player, 'Prog', currentProg + 1)
+                        end
                     elseif option == 2 then
                         npcUtil.giveCurrency(player, 'gil', 200)
                         player:delKeyItem(xi.ki.POINTED_JUG)
-                        quest:setVar(player, 'Prog', quest:getVar(player, 'Prog') + 1)
+                        if currentProg < maxProg then
+                            quest:setVar(player, 'Prog', currentProg + 1)
+                        end
                     elseif option == 3 then
                         npcUtil.giveCurrency(player, 'gil', 300)
                         player:delKeyItem(xi.ki.CRACKED_CLUB)
-                        quest:setVar(player, 'Prog', quest:getVar(player, 'Prog') + 1)
+                        if currentProg < maxProg then
+                            quest:setVar(player, 'Prog', currentProg + 1)
+                        end
                     elseif option == 4 then
                         npcUtil.giveCurrency(player, 'gil', 400)
                         player:delKeyItem(xi.ki.PEELING_HAIRPIN)
-                        quest:setVar(player, 'Prog', quest:getVar(player, 'Prog') + 1)
+                        if currentProg < maxProg then
+                            quest:setVar(player, 'Prog', currentProg + 1)
+                        end
                     elseif option == 5 then
                         player:delKeyItem(xi.ki.OLD_NAMETAG)
                         quest:setVar(player, 'Prog', 8)

--- a/scripts/quests/bastok/Out_of_the_Depths.lua
+++ b/scripts/quests/bastok/Out_of_the_Depths.lua
@@ -16,9 +16,6 @@ local ID = require('scripts/zones/Bastok_Markets/IDs')
 -----------------------------------
 local quest = Quest:new(xi.quest.log_id.BASTOK, xi.quest.id.bastok.OUT_OF_THE_DEPTHS)
 
-local currentProg = quest:getVar(player, 'Prog')
-local maxProg = 6 --prevents repeatable aspects of quest from overflowing and blocking progression
-
 quest.reward =
 {
     fame = 80,
@@ -89,6 +86,8 @@ quest.sections =
                 end,
 
                 [309] = function(player, csid, option, npc)
+                    local currentProg = quest:getVar(player, 'Prog')
+                    local maxProg = 6 --prevents repeatable aspects of quest from overflowing and blocking progression
                     if option == 1 then
                         npcUtil.giveCurrency(player, 'gil', 100)
                         player:delKeyItem(xi.ki.DUSTY_TOME)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixed an issue with 'Out Of The Depths' becoming softlocked if you turned in more than 4 repeatable key items.

## What does this pull request do? (Please be technical)

Fixes an issue where 'Out Of The Depths' becomes softlocked if you turn in more than 4 of any combination of 'Dusty Tome', 'Pointed Jug', 'Cracked Club' and/or 'Peeling Hairpin' key items.

This change puts an upper cap on the incrementation of the prog variable, capping out at 6.

## Steps to test these changes

1. !addquest 1 75 < me > 
2. !setquestvar < me > 1 75 Prog 2
3. !addkeyitem 597, 598, 599 & 600
4. !gotoid 17744015 (Ravorara)
5. talk to them 4 times, turning in the 4 key items.
6. !getquestvar < me > 1 75 Prog --> Should now return as 6.
7. add another key item 597, 598, 599 or 600
8. Turn in the key item(s) to Ravorara again
9. !getquestvar < me > 1 75 Prog --> Should still return as 6.

Rest of quest is unchanged (was unable to resolve known trade issue with Brakobrik)

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
