### PR TITLE
Fixed bug where healing allied mobs would claim them

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5290,8 +5290,9 @@ namespace battleutils
     void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
     {
         TracyZoneScoped;
-
-        if (PDefender == nullptr || (PDefender && PDefender->objtype != ENTITYTYPE::TYPE_MOB)) // Do not try to claim anything but mobs (trusts, pets, players don't count)
+        if (PDefender == nullptr ||
+            (PDefender && PDefender->objtype != ENTITYTYPE::TYPE_MOB) ||                                                   // Do not try to claim anything but mobs (trusts, pets, players don't count)
+            (PDefender && PDefender->objtype == ENTITYTYPE::TYPE_MOB && PDefender->allegiance == ALLEGIANCE_TYPE::PLAYER)) // Added mobs that are in allied with player
         {
             return;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
- Players can now heal escort NPC's (sarca571ca)

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
I couldn't find any issues listed for this bug but it's known on horizonxi.
Basically changed how claims work on mobs that are allied to the player (escort mobs -> Quasilumin for CoP 8-2). Currently when you heal the dynamic_entity it  claims it to the player and locks the AI. Escort npc are actually mob type entities to enable them to be attacked by other mobs when allied to the player. This change is already live on LSB.
https://github.com/LandSandBoat/server/pull/5471

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
I'm going to fix a bug with the Quasilumin in another PR as currently the Quasilumin has the wrong familyid set in mog_pools.sql
Go to Grand Palace of HuXzoi and spawn the Quasilumin and try to heal the mob you'll see the mob continue as normal.
## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
Need to rebuild xi_map as its a core change.