### PR TITLE
Add Mailbreaker Desynthesis

### DIFF
--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -4788,6 +4788,9 @@ INSERT INTO `synth_recipes` VALUES (75531,0,0,0,0,0,0,0,0,10,0,4099,4241,2773,27
 INSERT INTO `synth_recipes` VALUES (75532,0,0,0,9,0,0,0,0,0,0,4100,4242,12432,0,0,0,0,0,0,0,649,850,850,850,1,1,1,1,'Faceguard_Desynth');-- Faceguard desynth
 INSERT INTO `synth_recipes` VALUES (75533,1,0,0,0,0,25,0,0,0,0,4100,4242,12722,0,0,0,0,0,0,0,834,819,819,819,2,5,6,7,'Bracers (desynth)'); -- FFXIclopedia
 
+INSERT INTO `synth_recipes` VALUES (75535,1,0,0,0,69,0,0,0,0,0,4100,4242,16514,0,0,0,0,0,0,0,744,744,651,745,1,1,1,1,'Mailbreaker (desynth)');
+INSERT INTO `synth_recipes` VALUES (75536,1,0,0,0,69,0,0,0,0,0,4100,4242,16618,0,0,0,0,0,0,0,744,744,651,745,1,1,1,1,'Mailbreaker +1 (desynth)');
+
 -- -----------
 -- RECIPES END
 


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Desynthesis recipe was added for Mailbreaker and Mailbreaker +1

## What does this pull request do? (Please be technical)

Adds desynthesis recipes for Mailbreaker and Mailbreaker +1

## Source

https://ffxiclopedia.fandom.com/wiki/Mailbreaker?oldid=171174

## Steps to test these changes

```
!setcraftrank goldsmithing veteran [your name]
!setskill goldsmithing 70 [your name]
!additem mailbreaker 10
!additem mailbreaker_+1 10
!additem lightning_crystal 10
!additem plasma_crystal 10

Test desynthing them
```

![image](https://github.com/AirSkyBoat/AirSkyBoat/assets/43099213/6e3aa5ac-0ec7-441c-94e7-1dcee4c4046e)

## Special Deployment Considerations

N/A
