### PR TITLE
Camouflage Enhancements

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1962,10 +1962,10 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
     // Handle Camouflage effects
     if (this->StatusEffectContainer->HasStatusEffect(EFFECT_CAMOUFLAGE, 0))
     {
-        int16 retainChance     = 40; // Estimate base ~30% chance to keep Camouflage on a ranged attack
-        uint8 rotAllowance     = 25; // Allow for some slight variance in direction faced to be "behind" or "beside" the mob
+        int16 retainChance = 40; // Estimate base ~30% chance to keep Camouflage on a ranged attack
+        uint8 rotAllowance = 25; // Allow for some slight variance in direction faced to be "behind" or "beside" the mob
         float distanceToTarget = distance(this->loc.p, PTarget->loc.p);
-        float meleeRange       = PTarget->GetMeleeRange();
+        float meleeRange = PTarget->GetMeleeRange();
 
         if (behind(this->loc.p, PTarget->loc.p, rotAllowance))
         {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1962,10 +1962,10 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
     // Handle Camouflage effects
     if (this->StatusEffectContainer->HasStatusEffect(EFFECT_CAMOUFLAGE, 0))
     {
-        int16 retainChance = 40; // Estimate base ~30% chance to keep Camouflage on a ranged attack
-        uint8 rotAllowance = 25; // Allow for some slight variance in direction faced to be "behind" or "beside" the mob
+        int16 retainChance     = 40; // Estimate base ~30% chance to keep Camouflage on a ranged attack
+        uint8 rotAllowance     = 25; // Allow for some slight variance in direction faced to be "behind" or "beside" the mob
         float distanceToTarget = distance(this->loc.p, PTarget->loc.p);
-        float meleeRange = PTarget->GetMeleeRange();
+        float meleeRange       = PTarget->GetMeleeRange();
 
         if (behind(this->loc.p, PTarget->loc.p, rotAllowance))
         {


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Camouflage was updated to better match retail behavior.

## What does this pull request do? (Please be technical)

Updates the logic for Camouflage to determine when it should or should not fall off, based on recent captures.

![image](https://github.com/user-attachments/assets/03b7c085-46ac-47fd-ab75-a161aab27e0a)

Testing Video:
https://beta.ffxivclock.com/camouflage_testing.mp4

## Steps to test these changes

```
!changejob rng 75
!additem loxley_bow
!additem kabura_arrow 99
Equip the Bow and Arrow
Use Camouflage
Shoot from various angles and distances
Use !reset to reset the Camouflage cooldown when needed
```

## Special Deployment Considerations

`N/A`