### PR TITLE
Only apply ranged distance penalty to base stats

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -803,12 +803,24 @@ uint16 CBattleEntity::RATT(uint8 skill, float distance, uint16 bonusSkill)
         return 0;
     }
 
-    int32 ATT = 8 + GetSkill(skill == 48 ? 0 : skill) + bonusSkill + m_modStat[Mod::RATT] + battleutils::GetRangedAttackBonuses(this) + STR() / 2;
+    int32 ATT = 8 + GetSkill(skill == 48 ? 0 : skill) + bonusSkill;
+    ATT += std::clamp((int32)stats.STR, 0, 999) / 2;
 
     if ((this->objtype == TYPE_PC) || (this->objtype == TYPE_PET && this->PMaster->objtype == TYPE_PC && ((CPetEntity*)this)->getPetType() == PET_TYPE::AUTOMATON)) // PC or PC Automaton
     {
         ATT = int32((float)ATT * battleutils::GetRangedDistanceCorrection(this, distance, true));
     }
+
+    if (stats.STR + m_modStat[Mod::STR] > STR())
+    {
+        ATT += std::max<int16>((999 - stats.STR) / 2, 0);
+    }
+    else
+    {
+        ATT += m_modStat[Mod::STR] / 2;
+    }
+
+    ATT += m_modStat[Mod::RATT] + battleutils::GetRangedAttackBonuses(this);
 
     return std::clamp(ATT + (ATT * m_modStat[Mod::RATTP] / 100) + std::min<int16>((ATT * m_modStat[Mod::FOOD_RATTP] / 100), m_modStat[Mod::FOOD_RATT_CAP]), 0, 65535);
 }
@@ -845,9 +857,7 @@ uint16 CBattleEntity::RACC(uint8 skill, float distance, uint16 bonusSkill)
         acc = (int16)(200 + (skill_level - 200) * 0.9);
     }
 
-    acc += getMod(Mod::RACC);
-    acc += battleutils::GetRangedAccuracyBonuses(this);
-    acc += AGI() / 2;
+    acc += std::clamp((int32)stats.AGI, 0, 999) / 2;
 
     if ((this->objtype == TYPE_PC) || (this->objtype == TYPE_PET && this->PMaster->objtype == TYPE_PC && ((CPetEntity*)this)->getPetType() == PET_TYPE::AUTOMATON)) // PC or PC Automaton
     {
@@ -856,6 +866,18 @@ uint16 CBattleEntity::RACC(uint8 skill, float distance, uint16 bonusSkill)
             acc = int16((float)acc * battleutils::GetRangedDistanceCorrection(this, distance, false));
         }
     }
+
+    if (stats.AGI + m_modStat[Mod::AGI] > AGI())
+    {
+        acc += std::max<int16>((999 - stats.AGI) / 2, 0);
+    }
+    else
+    {
+        acc += m_modStat[Mod::AGI] / 2;
+    }
+
+    acc += getMod(Mod::RACC);
+    acc += battleutils::GetRangedAccuracyBonuses(this);
 
     return std::clamp(acc + std::min<int16>(((100 + getMod(Mod::FOOD_RACCP) * acc) / 100), getMod(Mod::FOOD_RACC_CAP)), 0, 65535);
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

The distance correction penalty is only applied to base stats, and no longer impacts stats from gear/buffs/food.

## What does this pull request do? (Please be technical)

Updates the Ranged Accuracy and Ranged Accuracy calculations to apply the distance correction penalty before any stats from gear/buffs is taken into account.

## Source
http://www.playonline.com/pcd/update/ff11us/20061017UJ0a71/detail.html
![image](https://github.com/user-attachments/assets/2a80e257-98c4-455e-b314-c622154ed9c5)


## Steps to test these changes

Add logging to `battleentity.cpp` and test ranged attacks from various distances.

```cpp
printf("Distance Penalty: %f", battleutils::GetRangedDistanceCorrection(this, distance, false));
printf("Base RATT: %d", GetBaseRATT(skill, bonusSkill));
printf("Final RATT: %d", std::clamp(ATT + (ATT * m_modStat[Mod::RATTP] / 100) + std::min<int16>((ATT * m_modStat[Mod::FOOD_RATTP] / 100), m_modStat[Mod::FOOD_RATT_CAP]), 0, 65535));
```

```cpp
printf("Distance Penalty: %f", battleutils::GetRangedDistanceCorrection(this, distance, false));
printf("Base RACC: %d", GetBaseRACC(skill, bonusSkill));
printf("Final RACC: %d", std::clamp(acc + std::min<int16>(((100 + getMod(Mod::FOOD_RACCP) * acc) / 100), getMod(Mod::FOOD_RACC_CAP)), 0, 65535));
```

## Testing
![image](https://github.com/user-attachments/assets/f1773663-2aa5-4728-8b50-fbe5db559faa)

**Before:**
```
Distance Penalty: 0.657272

Base RACC: 411
Final RACC: 270

Base RATT: 428
Final RATT: 264
```

**After:**
```
Distance Penalty: 0.652679

Base RACC: 411
Final RACC: 305

Base RATT: 428
Final RATT: 292
```

## Special Deployment Considerations
N/A
