### PR TITLE
[Quest] Fixes Toraimorai Turmoil Repeatable

### DIFF
--- a/scripts/quests/windurst/Toraimarai_Turmoil.lua
+++ b/scripts/quests/windurst/Toraimarai_Turmoil.lua
@@ -1,8 +1,11 @@
 -----------------------------------
 -- Toraimarai Turmoil
 -----------------------------------
--- !addquest 2 16
+-- !addquest 2 80
 -- Ohbiru-Dohbiru : !pos 23 -5 -193 238
+-- Leepe-Hoppe    ! !pos -131 20 -174 238
+-- Polikal-Ramikal: !pos 15 -18 195 239
+-- Yoran-Oran     : !pos -110 -14 203 239
 -- Giddeus Spring : !pos -258 -2 -249 145
 -----------------------------------
 require('scripts/globals/interaction/quest')
@@ -60,10 +63,18 @@ quest.sections =
                 onTrigger = function(player, npc)
                     return quest:event(786, 4500, xi.keyItem.RHINOSTERY_CERTIFICATE, xi.items.STARMITE_SHELL) -- Reminder text.
                 end,
+
                 onTrade = function(player, npc, trade)
                     if npcUtil.tradeHasExactly(trade, { { xi.items.STARMITE_SHELL, 3 } }) then
                         return quest:progressEvent(791)
                     end
+                end,
+            },
+
+            ['Leepe-Hoppe'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(790, 0, xi.ki.RHINOSTERY_CERTIFICATE)
                 end,
             },
 
@@ -73,6 +84,23 @@ quest.sections =
                     if quest:complete(player) then
                         player:confirmTrade()
                     end
+                end,
+            },
+        },
+
+        [xi.zone.WINDURST_WALLS] =
+        {
+            ['Polikal-Ramikal'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(391)
+                end,
+            },
+
+            ['Yoran-Oran'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(392)
                 end,
             },
         },
@@ -91,6 +119,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     return quest:event(795, 4500, 0, xi.items.STARMITE_SHELL) --dialog for repeat
                 end,
+
                 onTrade = function(player, npc, trade)
                     if npcUtil.tradeHasExactly(trade, { { xi.items.STARMITE_SHELL, 3 } }) then
                         return quest:progressEvent(791)
@@ -102,9 +131,13 @@ quest.sections =
             {
                 [791] = function(player, csid, option, npc)
                     player:confirmTrade()
+
+                    local gilReward = 4500
                     --From previous implementation, award 100 fame on first completion,
                     -- and 50 fame for any subsequent trade.
                     player:addFame(xi.quest.fame_area.WINDURST, 50)
+                    player:addGil(gilReward)
+                    player:messageSpecial(zones[player:getZoneID()].text.GIL_OBTAINED, gilReward)
                 end,
             },
         },


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes Toraimorai Turmoil repeat reward and optional dialogs

## What does this pull request do? (Please be technical)

Adds missing (optional) dialog and adds 4500 gil reward on repeat

4500 gil reward on repeat noted here:
https://wiki.ffo.jp/html/5421.html
https://ffxiclopedia.fandom.com/wiki/Toraimarai_Turmoil
https://classicffxi.fandom.com/wiki/Toraimarai_Turmoil
https://ffxi.allakhazam.com/db/quests.html?fquest=401

## Steps to test these changes

Repeat Toraimorai Turmoil and receive 4500g reward
