### PR TITLE
[cpp/sql/lua] Add weather condition latent check + add sunshine pole latent region

### DIFF
--- a/scripts/enum/latent.lua
+++ b/scripts/enum/latent.lua
@@ -43,7 +43,7 @@ xi.latent =
     JOB_MULTIPLE_AT_NIGHT      = 39, -- PARAM: 0: ODD, 2: EVEN, 3-99: DIVISOR
     EQUIPPED_IN_SLOT           = 40, -- When item is equipped in the specified slot (e.g. Dweomer Knife, Erlking's Sword, etc.) PARAM: slotID
     -- 41 free to use
-    -- 42 free to use
+    WEATHER_CONDITION          = 42, -- See weather.lua for xi.weather enum
     WEAPON_DRAWN_HP_UNDER      = 43, -- PARAM: HP PERCENT
     HP_BASE_UNDER_TP_UNDER_100 = 44, -- Base HP (no convert or +% taken into account) <= %, TP < 100\
     MP_UNDER_VISIBLE_GEAR      = 45, -- mp less than or equal to %, calculated using MP bonuses from visible gear only

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2321,9 +2321,14 @@ INSERT INTO `item_latents` VALUES (17527,15,-10,47,0);
 INSERT INTO `item_latents` VALUES (17527,21,-10,47,0);
 
 -- -------------------------------------------------------
+-- Sunlight Pole
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES (17529,370,1,42,1);     -- Regen 1/tick during Sunny weather
+
+-- -------------------------------------------------------
 -- Master Caster's Pole
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES (17530,71,8,70,2);    -- Citizens of Windurst: hMP +8
+INSERT INTO `item_latents` VALUES (17530,71,8,70,2);     -- Citizens of Windurst: hMP +8
 
 -- -------------------------------------------------------
 -- Ramuh's Staff

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -71,7 +71,7 @@ enum class LATENT : uint16
     JOB_MULTIPLE_AT_NIGHT  = 39, // PARAM: 0: ODD, 2: EVEN, 3-X: DIVISOR
     EQUIPPED_IN_SLOT       = 40, // When item is equipped in the specified slot (e.g. Dweomer Knife, Erlking's Sword, etc.) PARAM: slotID
     // 41 free to use
-    // 42 free to use
+    WEATHER_CONDITION          = 42, // See Weather.h for WEATHER enum
     WEAPON_DRAWN_HP_UNDER      = 43, // PARAM: HP PERCENT
     HP_BASE_UNDER_TP_UNDER_100 = 44, // Base HP (no convert or +% taken into account) <= %, TP < 100
     MP_UNDER_VISIBLE_GEAR      = 45, // mp less than or equal to %, calculated using MP bonuses from visible gear only

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -267,6 +267,7 @@ void CLatentEffectContainer::CheckLatentsStatusEffect()
         switch (latentEffect.GetConditionsID())
         {
             case LATENT::STATUS_EFFECT_ACTIVE:
+            case LATENT::WEATHER_CONDITION:
             case LATENT::WEATHER_ELEMENT:
             case LATENT::NATION_CONTROL:
                 return ProcessLatentEffect(latentEffect);
@@ -574,6 +575,7 @@ void CLatentEffectContainer::CheckLatentsZone()
             case LATENT::ZONE:
             case LATENT::IN_ASSAULT:
             case LATENT::IN_DYNAMIS:
+            case LATENT::WEATHER_CONDITION:
             case LATENT::WEATHER_ELEMENT:
             case LATENT::NATION_CONTROL:
             case LATENT::ZONE_HOME_NATION:
@@ -603,6 +605,11 @@ void CLatentEffectContainer::CheckLatentsWeather(uint16 weather)
         if (latent.GetConditionsID() == LATENT::WEATHER_ELEMENT && owner != nullptr)
         {
             auto element = zoneutils::GetWeatherElement(battleutils::GetWeather(owner, false, weather));
+            return ApplyLatentEffect(latent, latent.GetConditionsValue() == element);
+        }
+        else if (latent.GetConditionsID() == LATENT::WEATHER_CONDITION && owner != nullptr)
+        {
+            auto element = battleutils::GetWeather(owner, false, weather);
             return ApplyLatentEffect(latent, latent.GetConditionsValue() == element);
         }
         return false;
@@ -1021,6 +1028,9 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
             break;
         case LATENT::JOB_LEVEL_ABOVE:
             expression = m_POwner->GetMLevel() >= latentEffect.GetConditionsValue();
+            break;
+        case LATENT::WEATHER_CONDITION:
+            expression = latentEffect.GetConditionsValue() == battleutils::GetWeather((CBattleEntity*)m_POwner, false);
             break;
         case LATENT::WEATHER_ELEMENT:
             expression = latentEffect.GetConditionsValue() == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false));


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes Sunshine Pole regen latent effect

## What does this pull request do? (Please be technical)

Implements a weather condition check during latent effect checks for NONE, SUNSHINE, CLOUDS, FOG
Updates Sunshine Pole latent effect with [1/tick regen during sunny weather](https://ffxiclopedia.fandom.com/wiki/Sunlight_Pole?oldid=1115539).

Fixes:
https://discord.com/channels/933423693848260678/1269687049338749035

## Steps to test these changes

!additem 17529 -- Sunlight Pole

!setweather 1 -- Sunshine

## Special Deployment Considerations

Build map
update item_latents.sql with dbtool
