### PR TITLE
Backport update to Umbral Pathing

### DIFF
--- a/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
+++ b/modules/era/lua_dynamis/mobs/era_tavnazia_mobs.lua
@@ -186,6 +186,13 @@ xi.dynamis.onSpawnUmbralDiabolos = function(mob)
     mob:addStatusEffect(xi.effect.BATTLEFIELD, 1, 0, 0, true)
     mob:setMobMod(xi.mobMod.DETECTION, xi.detects.SIGHT)
     mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
+    -- Roam Cool and Roam Turns are staying the same (default) but now locked in, in case other changes happen in the future
+    mob:setMobMod(xi.mobMod.ROAM_COOL, 20)
+    mob:setMobMod(xi.mobMod.ROAM_TURNS, 1)
+    -- Roam Rate changed from 15 to 1 - removing the snap turns that can happen
+    mob:setMobMod(xi.mobMod.ROAM_RATE, 1)
+    -- Reducing range
+    mob:setMobMod(xi.mobMod.SIGHT_RANGE, 12)
 end
 
 xi.dynamis.onMobEngagedUmbralDiabolos = function(mob, target)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Umbral Diabolos mobs habe been updated to make reaching the Diabolos Cards more player skill based. (Tiberon)

## What does this pull request do? (Please be technical)

Backported from Horizon code base.

## Steps to test these changes
Enter Tav and watch the Umbrals.
Use !getmobmod, see expected values

Run the gauntlet a few times and notice when you are caught, it feels more like player error vs a fight with RNGesus.