### PR TITLE
[Quest] Northward - Remove out of ERA rewards

### DIFF
--- a/scripts/quests/jeuno/Northward.lua
+++ b/scripts/quests/jeuno/Northward.lua
@@ -14,10 +14,8 @@ local quest = Quest:new(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.NORTHWARD)
 
 quest.reward =
 {
-    exp      = 2000,
     fame     = 30,
     fameArea = xi.quest.fame_area.JEUNO,
-    gil      = 2000,
     keyItem  = xi.ki.MAP_OF_CASTLE_ZVAHL,
     title    = xi.title.ENVOY_TO_THE_NORTH,
 }


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Removed out of Era Rewards from the quest.

## What does this pull request do? (Please be technical)

Removes the GIL and XP rewards from the Northward map quest.
Closes HorizonXI Issue # 1882
https://github.com/HorizonFFXI/HorizonXI-Issues/issues/1882

## Steps to test these changes

Have Jeuno rep of >= 4
Start quest at Radeivepart !pos 5 9 -39 243
!giveitem <NAME> 16522
Trade "flame degen" to Radeivepart

Get rewards

## Sources
All wikis going back to era indicate that there was no xp or gil reward. Gil and xp reward was added sometime in 2017 or later.

https://ffxi.allakhazam.com/db/quests.html?fquest=249
https://www.bg-wiki.com/index.php?title=Northward&diff=543172&oldid=272516
JP wiki says that the gil and xp rewards were added back in 2013.
https://wiki.ffo.jp/html/3820.html
https://ffxiclopedia.fandom.com/wiki/Northward?diff=1741578&oldid=1581678

## Special Deployment Considerations

N/A