### PR TITLE
Correcting bind to have min duration of 5sec if not fully resisted

### DIFF
--- a/scripts/globals/spells/black/bind.lua
+++ b/scripts/globals/spells/black/bind.lua
@@ -20,9 +20,10 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     -- Duration not impacted by any non-random effects
     -- Duration from normal distribution with mean of 30 and std dev of 12 based on retail testing
+    -- Duration has a floor of 5 seconds if not fully resisted. Max partial resist is randomDuration * 0.5, so set min_val here to 10
     -- Use the Box-Muller transform to sample from the distribution
     local z0 = math.sqrt(-2 * math.log(math.random())) * math.cos(2 * math.pi * math.random())
-    local randomDuration = utils.clamp(math.floor(30 + z0 * 12), 1, 60)
+    local randomDuration = utils.clamp(math.floor(30 + z0 * 12), 10, 60)
 
     -- Resist
     local params = {}

--- a/scripts/globals/spells/black/bindga.lua
+++ b/scripts/globals/spells/black/bindga.lua
@@ -20,9 +20,10 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     -- Duration not impacted by any non-random effects
     -- Duration from normal distribution with mean of 30 and std dev of 12 based on retail testing
+    -- Duration has a floor of 5 seconds if not fully resisted. Max partial resist is randomDuration * 0.5, so set min_val here to 10
     -- Use the Box-Muller transform to sample from the distribution
     local z0 = math.sqrt(-2 * math.log(math.random())) * math.cos(2 * math.pi * math.random())
-    local randomDuration = utils.clamp(math.floor(30 + z0 * 12), 1, 60)
+    local randomDuration = utils.clamp(math.floor(30 + z0 * 12), 10, 60)
 
     -- Resist
     local params = {}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->

Adjusted the spells bind and bindga to have a minimum duration of 5 seconds if the spell is not fully resistant. This effectively means that bind will last for between 5 and 60 seconds.

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Closes bug report noted in horizonxi discord: https://discord.com/channels/933423693848260678/1180272981210046504

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
Cast bind on a monster, wait for the bind to wear naturally (do no damage to the monster).
Verify the bind wore off between 5-60s time.
Repeat many many times to verify.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->
No special deployment considerations.
